### PR TITLE
Fix completion saving bug when no task's json file found

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -193,8 +193,8 @@ def save_completion(task_id, completion):
     task = get_completions(task_id)
 
     # init completions if it's empty
-    if 'completions' not in task:
-        task['completions'] = []
+    if not task or 'completions' not in task:
+        task = {'completions': []}
 
     # update old completion
     updated = False


### PR DESCRIPTION
When I start `server.py` with default configuration (repository cloned today), there is an exception while I try to submit a completion for a task, which doesn't have completions yet.

This pull requests solves that bug.