### PR TITLE
leadTime renamed to lead_time

### DIFF
--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -364,7 +364,7 @@ export default types
           const state = getSnapshot(c);
 
           const body = JSON.stringify({
-            leadTime: (new Date() - c.loadedDate) / 1000,
+            lead_time: (new Date() - c.loadedDate) / 1000,
             result: res,
           });
 

--- a/src/stores/CompletionStore.js
+++ b/src/stores/CompletionStore.js
@@ -456,7 +456,7 @@ export default types
         pk: c.id,
         createdAgo: c.created_ago,
         createdBy: c.created_username,
-        leadTime: c.leadTime,
+        leadTime: c.lead_time,
         honeypot: c.honeypot,
         root: root,
         userGenerate: false,


### PR DESCRIPTION
@shevchenkonik For python pep8 convention we should name variables like_this_style but not thisStyle. So, when you send to the server "lead_time" it will be automatically serialized to "completion.lead_time" in python model. The names must be the same. 