### PR TITLE
fix vulnerability in docs

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1793,13 +1793,63 @@
       }
     },
     "hexo-renderer-marked": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hexo-renderer-marked/-/hexo-renderer-marked-1.0.1.tgz",
-      "integrity": "sha512-oAOthvEYWJx4hvzD8WE7hOSYoTooOe5Vtb7mW6LtM3rEpQhXaWXPq7fOrEhCfdjgDr3DusSi7x19XgLIx+hcmQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hexo-renderer-marked/-/hexo-renderer-marked-2.0.0.tgz",
+      "integrity": "sha512-+LMjgPkJSUAOlWYHJnBXxUHwGqemGNlK/I+JNO4zA5rEHWNWZ9wNAZKd5g0lEVdMAZzAV54gCylXGURgMO4IAw==",
       "requires": {
-        "hexo-util": "^0.6.2",
-        "marked": "^0.6.1",
-        "strip-indent": "^2.0.0"
+        "hexo-util": "1.0.0",
+        "marked": "^0.7.0",
+        "strip-indent": "^3.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "hexo-util": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/hexo-util/-/hexo-util-1.0.0.tgz",
+          "integrity": "sha512-oV1/Y7ablc7e3d2kFFvQ/Ypi/BfL/uDSc1oNaMcxqr/UOH8F0QkHZ0Dmv+yLrEpFNYrrhBA0uavo3e+EqHNjnQ==",
+          "requires": {
+            "bluebird": "^3.5.2",
+            "camel-case": "^3.0.0",
+            "cross-spawn": "^6.0.5",
+            "highlight.js": "^9.13.1",
+            "html-entities": "^1.2.1",
+            "striptags": "^3.1.1"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        },
+        "strip-indent": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+          "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+          "requires": {
+            "min-indent": "^1.0.0"
+          }
+        },
+        "striptags": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
+          "integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
+        }
       }
     },
     "hexo-renderer-stylus": {
@@ -2212,9 +2262,9 @@
       }
     },
     "marked": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz",
-      "integrity": "sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ=="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
     },
     "micromatch": {
       "version": "3.1.10",
@@ -2253,6 +2303,11 @@
       "requires": {
         "mime-db": "1.40.0"
       }
+    },
+    "min-indent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
+      "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -2420,6 +2475,11 @@
           }
         }
       }
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "no-case": {
       "version": "2.3.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,7 +17,7 @@
     "hexo-generator-index": "^0.2.1",
     "hexo-generator-tag": "^0.2.0",
     "hexo-renderer-ejs": "^0.3.1",
-    "hexo-renderer-marked": "^1.0.1",
+    "hexo-renderer-marked": "^2.0.0",
     "hexo-renderer-stylus": "^0.3.3",
     "hexo-server": "^0.3.3"
   },


### PR DESCRIPTION
**Regular Expression Denial of Service (ReDoS)** - Medium Severity

Vulnerable module: marked
Introduced through: hexo-renderer-marked@1.0.1
Fixed in: 0.7.0

**Detailed paths and remediation**
- Introduced through: label-studio-documentation@0.0.1 › hexo-renderer-marked@1.0.1 › marked@0.6.3
- Remediation: Upgrade to hexo-renderer-marked@2.0.0