### PR TITLE
Require some input formats have label config

### DIFF
--- a/label_studio/server.py
+++ b/label_studio/server.py
@@ -641,6 +641,11 @@ def main():
         if input_args.init:
             Project.create_project_dir(input_args.project_name, input_args)
 
+        if not os.path.exists(input_args.project_name):
+            raise FileNotFoundError(
+                'Project directory "{pdir}" not found. '
+                'Did you miss create it first with `label-studio init {pdir}` ?'.format(pdir=input_args.project_name))
+
     # On `start` command, launch browser if --no-browser is not specified and start label studio server
     if input_args.command == 'start':
         if not input_args.no_browser:

--- a/label_studio/tasks.py
+++ b/label_studio/tasks.py
@@ -14,7 +14,7 @@ class Tasks(object):
 
     _allowed_extensions = {
         'Text': ('.txt',),
-        'Image': ('.png', '.jpg', '.jpeg', '.tiff', '.bmp', '.gif'),
+        'Image': ('.png', '.jpg', '.jpeg', '.tiff', '.tif', '.bmp', '.gif'),
         'Audio': ('.wav', '.aiff', '.mp3', '.au', '.flac')
     }
 

--- a/label_studio/utils/argparser.py
+++ b/label_studio/utils/argparser.py
@@ -54,7 +54,7 @@ def parse_input_args():
     root_parser.add_argument(
         '--input-format', dest='input_format',
         choices=('json', 'json-dir', 'text', 'text-dir', 'image-dir', 'audio-dir'), default='json',
-        help='Input path to task file or directory with tasks')
+        help='Input tasks format. Unless you are using "json" or "json-dir" format, --label-config option is required')
     root_parser.add_argument(
         '-o', '--output-dir', dest='output_dir', type=valid_filepath,
         help='Output directory for completions')


### PR DESCRIPTION
We can't initialize labeling project for some input formats: `text, text_dir, audio_dir, image_dir` if label config file is not explicitly defined