### PR TITLE
Update path of /next endpoint, to match server-side naming

### DIFF
--- a/label_studio/static/js/lsb.js
+++ b/label_studio/static/js/lsb.js
@@ -10,7 +10,7 @@ const API_URL = {
   COMPLETIONS: "/completions",
   CANCEL: "/cancel",
   PROJECTS: "/projects",
-  NEXT: "/next",
+  NEXT: "/next/",
   EXPERT_INSRUCTIONS: "/expert_instruction",
 };
 


### PR DESCRIPTION
### Problem
We are running a container with the latest docker image of LabelStudio behind an ALB on AWS (HTTPS only).
We noticed that after adding tasks to LabelStudio, clicking on 'Labelling' or accessing the root of the application, a spinning wheel was shown and would not disappear, with the page failing to load.
Examining the Browser console, it was evident that upon accessing the root of the application, the front end was making a request to (HTTPS) /api/projects/1/next
LabelStudio responded with a 302 redirect, to (HTTP) /api/projects/1/next/
Note that the redirect was to a HTTP address, rather than HTTPS. This caused the browser (Chrome in our case), to prevent the request from being made - hence why the page failed to load.
It appears to be an underlying Flask dependency that is incorrectly producing the incorrect HTTP redirect URL.

### Fix
There are a couple of potential ways to fix this.
Option (1) is to update the endpoint path on the Flask side (server.py). However, I'm unsure of the endpoint naming conventions being followed - there appears to be a mixture of endpoints with a trailing slash, and some without.
Option (2) is to update the path of the API endpoint that the front end calls to load the page data.

This PR implements Option (2), which matches the front end API endpoint to what is implemented server side - avoiding the redirect in the first place.