### PR TITLE
Update __init__.py

### DIFF
--- a/label_studio/ml/__init__.py
+++ b/label_studio/ml/__init__.py
@@ -1,3 +1,2 @@
 from .api import init_app
 from .model import LabelStudioMLBase
-from .helpers import LabelStudioMLChoices


### PR DESCRIPTION
Helper module does not exist.

Running the ml backend fails on `master` branch.
```
label-studio-ml init my_backend --script my_backend.py
```

fails with:
```
  File "my_venv\src\label-studio\label_studio\ml\__init__.py", line 3, in <module>
    from .helpers import LabelStudioMLChoices
ModuleNotFoundError: No module named 'label_studio.ml.helpers'
```