### PR TITLE
Credentials on GCE

### DIFF
--- a/label_studio/utils/uri_resolver.py
+++ b/label_studio/utils/uri_resolver.py
@@ -1,16 +1,21 @@
 import boto3
 import logging
-import datetime
-
+import socket
+import google.auth
 
 from botocore.exceptions import ClientError
 from urllib.parse import urlparse
 from google.cloud import storage as gs
+from google.auth.transport import requests
+from google.auth import compute_engine
+from datetime import datetime, timedelta
 
 from label_studio.storage.s3 import get_client_and_resource
 
 
 logger = logging.getLogger(__name__)
+
+PRESIGNED_URL_TTL_MINUTES = 1
 
 
 def resolve_task_data_uri(task, **kwargs):
@@ -52,7 +57,21 @@ def resolve_gs(url, **kwargs):
     r = urlparse(url, allow_fragments=False)
     bucket_name = r.netloc
     key = r.path.lstrip('/')
-    return generate_download_signed_url_v4(bucket_name, key)
+    if is_gce_instance():
+        logger.debug('Generate signed URL for GCE instance')
+        return python_cloud_function_get_signed_url(bucket_name, key)
+    else:
+        logger.debug('Generate signed URL for local instance')
+        return generate_download_signed_url_v4(bucket_name, key)
+
+
+def is_gce_instance():
+    """Check if it's GCE instance via DNS lookup to metadata server"""
+    try:
+      socket.getaddrinfo('metadata.google.internal', 80)
+    except socket.gaierror:
+      return False
+    return True
 
 
 def generate_download_signed_url_v4(bucket_name, blob_name):
@@ -72,10 +91,31 @@ def generate_download_signed_url_v4(bucket_name, blob_name):
     url = blob.generate_signed_url(
         version="v4",
         # This URL is valid for 15 minutes
-        expiration=datetime.timedelta(minutes=15),
+        expiration=timedelta(minutes=PRESIGNED_URL_TTL_MINUTES),
         # Allow GET requests using this URL.
         method="GET",
     )
 
     logger.debug('Generated GCS signed url: ' + url)
     return url
+
+
+def python_cloud_function_get_signed_url(bucket_name, blob_name):
+    # https://gist.github.com/jezhumble/91051485db4462add82045ef9ac2a0ec
+    # Copyright 2019 Google LLC.
+    # SPDX-License-Identifier: Apache-2.0
+    # This snippet shows you how to use Blob.generate_signed_url() from within compute engine / cloud functions
+    # as described here: https://cloud.google.com/functions/docs/writing/http#uploading_files_via_cloud_storage
+    # (without needing access to a private key)
+    # Note: as described in that page, you need to run your function with a service account
+    # with the permission roles/iam.serviceAccountTokenCreator
+    auth_request = requests.Request()
+    credentials, project = google.auth.default()
+    storage_client = gs.Client(project, credentials)
+    data_bucket = storage_client.lookup_bucket(bucket_name)
+    signed_blob_path = data_bucket.blob(blob_name)
+    expires_at_ms = datetime.now() + timedelta(minutes=PRESIGNED_URL_TTL_MINUTES)
+    # This next line is the trick!
+    signing_credentials = compute_engine.IDTokenCredentials(auth_request, "", service_account_email=credentials.service_account_email)
+    signed_url = signed_blob_path.generate_signed_url(expires_at_ms, credentials=signing_credentials, version="v4")
+    return signed_url


### PR DESCRIPTION
- Workaround limitations with signed URLs generated on GCE instance (https://github.com/googleapis/google-auth-library-python/issues/50)