### PR TITLE
Relative paths to .js files

### DIFF
--- a/label_studio/templates/tasks.html
+++ b/label_studio/templates/tasks.html
@@ -1,9 +1,9 @@
 {% extends 'base.html' %}
 {% block body %}
 {% raw %}
-  <script src="/static/js/polyfill.min.js"></script>
-  <script src="/static/js/vue.js"></script>
-  <script src="/static/semantic/semantic-ui-vue.min.js"></script>
+  <script src="static/js/polyfill.min.js"></script>
+  <script src="static/js/vue.js"></script>
+  <script src="static/semantic/semantic-ui-vue.min.js"></script>
 
   <style>
     .visible-app {
@@ -310,7 +310,7 @@
 
   </div>
 
-  <script src="/static/js/components/animatedNumber.js"></script>
+  <script src="static/js/components/animatedNumber.js"></script>
   <script>
       Vue.use(SemanticUIVue);
 


### PR DESCRIPTION
In order for LS to work behind proxy on non-root url all resources should be loaded by relative paths. These are the only .js files left that use absolute path to load.