### PR TITLE
Improve/next task speed

### DIFF
--- a/label_studio/project.py
+++ b/label_studio/project.py
@@ -406,7 +406,7 @@ class Project(object):
         sampling = self.config.get('sampling', 'sequential')
 
         # Tasks are ordered ascending by their "id" fields. This is default mode.
-        task_iter = filter(lambda i: i not in self.target_storage, self.source_storage.ids())
+        task_iter = filter(lambda i: i not in completed_tasks_ids, self.source_storage.ids())
         if sampling == 'sequential':
             task_id = next(task_iter, None)
             if task_id is not None:


### PR DESCRIPTION
I have 3000 tasks. next_task takes around 20 seconds.

The reason is `i not in self.target_storage` invokes collecting files every iteration.

There is no reason of using self.target_storage. `completed_tasks_ids` already has the ids