### PR TITLE
Fixing path check when model_class is specified

### DIFF
--- a/label_studio/ml/server.py
+++ b/label_studio/ml/server.py
@@ -60,9 +60,6 @@ def create_dir(args):
     else:
         script_path = args.script
 
-    if not os.path.exists(script_path):
-        raise FileNotFoundError(script_path)
-
     if ':' not in script_path:
         model_classes = get_all_classes_inherited_LabelStudioMLBase(script_path)
         if len(model_classes) > 1:
@@ -73,6 +70,9 @@ def create_dir(args):
         model_class = model_classes[0]
     else:
         script_path, model_class = args.script.split(':')
+
+    if not os.path.exists(script_path):
+        raise FileNotFoundError(script_path)
 
     script_base_name = os.path.basename(script_path)
     local_script_path = os.path.join(output_dir, os.path.basename(script_path))


### PR DESCRIPTION
When the model_class is specified for a ML backend (aka format script.py:CLASS), server.py was checking too early that the filepath was existing (aka before calling split(":") on the argument)