### PR TITLE
Make deepcopy of values returned from ExternalTasksJSONStorage

### DIFF
--- a/docs/source/tutorials/dummy_model.md
+++ b/docs/source/tutorials/dummy_model.md
@@ -11,7 +11,7 @@ If you create ML backend by using Label Studio's ML SDK, you have to follow the 
 - created model class should be inherited from `label_studio.ml.LabelStudioMLBase`
 - 2 methods should be overrided:
     - `predict()` takes [input tasks](/guide/tasks.html#Basic-format) and outputs [predictions](/guide/export.html#predictions) in a Label Studio format
-    - `train()` receives [completions](/guide/export.html#Basic-format) iterable and returns dictionary with created links and resources. This dictionary will be later used for model loading via `self.train_output` field.
+    - `fit()` receives [completions](/guide/export.html#Basic-format) iterable and returns dictionary with created links and resources. This dictionary will be later used for model loading via `self.train_output` field.
 
 Create a file `model.py` with the following content:
 

--- a/docs/source/tutorials/pytorch-image-transfer-learning.md
+++ b/docs/source/tutorials/pytorch-image-transfer-learning.md
@@ -23,7 +23,7 @@ If you create ML backend by using Label Studio's ML SDK, you have to follow the 
 - created model class should be inherited from `label_studio.ml.LabelStudioMLBase`
 - 2 methods should be overrided:
     - `predict()` takes [input tasks](/guide/tasks.html#Basic-format) and outputs [predictions](/guide/export.html#predictions) in a Label Studio format
-    - `train()` receives [completions](/guide/export.html#Basic-format) iterable and returns dictionary with created links and resources. This dictionary will be later used for model loading via `self.train_output` field.
+    - `fit()` receives [completions](/guide/export.html#Basic-format) iterable and returns dictionary with created links and resources. This dictionary will be later used for model loading via `self.train_output` field.
 
 Create a file `model.py` with the PyTorch model for ready for training and inference.
 

--- a/docs/source/tutorials/sklearn-text-classifier.md
+++ b/docs/source/tutorials/sklearn-text-classifier.md
@@ -24,7 +24,7 @@ If you create ML backend by using Label Studio's ML SDK, you have to follow the 
 - created model class should be inherited from `label_studio.ml.LabelStudioMLBase`
 - 2 methods should be overrided:
     - `predict()` takes [input tasks](/guide/tasks.html#Basic-format) and outputs [predictions](/guide/export.html#predictions) in a Label Studio format
-    - `train()` receives [completions](/guide/export.html#Basic-format) iterable and returns dictionary with created links and resources. This dictionary will be later used for model loading via `self.train_output` field.
+    - `fit()` receives [completions](/guide/export.html#Basic-format) iterable and returns dictionary with created links and resources. This dictionary will be later used for model loading via `self.train_output` field.
 
 Create a file `model.py` with the following content:
 

--- a/label_studio/storage/filesystem.py
+++ b/label_studio/storage/filesystem.py
@@ -1,6 +1,7 @@
 import json
 import os
 import logging
+from copy import deepcopy
 
 from label_studio.utils.io import json_load, delete_dir_content, iter_files
 from .base import BaseStorage, BaseForm, CloudStorage
@@ -183,7 +184,7 @@ class ExternalTasksJSONStorage(CloudStorage):
         return self.path
 
     def _get_value(self, key):
-        return self.data[int(key)]
+        return deepcopy(self.data[int(key)])
 
     def _set_value(self, key, value):
         self.data[int(key)] = value


### PR DESCRIPTION
otherwise it will replace resolved data url in memory and store that
resolved url in completions. That will not work with ml backends because
presigned urls expire.

Also this makes ExternalTasksJSONStorage semantically same as other
cloudstorages. Specifically you need to use "set" to make changes.