### PR TITLE
Maintain ordering in source.json and task.json

### DIFF
--- a/label_studio/storage/base.py
+++ b/label_studio/storage/base.py
@@ -12,6 +12,7 @@ from flask_wtf import FlaskForm
 from wtforms import StringField, BooleanField
 from wtforms.validators import InputRequired, Optional, ValidationError
 from collections import OrderedDict
+from ordered_set import OrderedSet
 
 from label_studio.utils.io import json_load
 
@@ -385,8 +386,8 @@ class CloudStorage(BaseStorage):
         new_ids_keys_map = {}
         new_keys_ids_map = {}
 
-        full = set(self.iter_full_keys())
-        intersect = full & set(self._keys_ids_map)
+        full = OrderedSet(self.iter_full_keys())
+        intersect = full & OrderedSet(self._keys_ids_map)
         exclusion = full - intersect
 
         for key in exclusion:

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ tqdm==4.40.2
 urllib3==1.25.7
 wasabi==0.4.2
 Werkzeug==0.16.0
+ordered-set==4.0.2
 orjson>=2.0.11
 rarfile==3.1
 flask_api>=2.0


### PR DESCRIPTION
The issue:

When a new project is created, a source.json file is created from a task.json file. It would be convenient if the ordering of id's in the task.json file is also maintained in the source.json file. Using an ordered set accomplishes this goal

behaviour in previous versions:
```
task.json:
[id1, id2, id3..., idn]

source.json:
{0 -> id1, 1 -> id2, 2-> id3, n-1 -> idn ...}
```

behaviour in current version:
```
task.json:
[id1, id2, id3..., idn]

source.json (random ordering due to set):
{0 -> id4, 1 -> id10, 2-> id111, n-1 -> id3 ...}
```

The changes in this PR revert the current behaviour to the previous behaviour, i.e. maintain the ordering.

If random ordering is required during annotation, then the sampling configuration should be used rather than changing the composition of the source.json file.