### PR TITLE
Fix buttons "Start Predictions" and "Remove ML backend" for Firefox

### DIFF
--- a/label_studio/templates/model.html
+++ b/label_studio/templates/model.html
@@ -273,10 +273,11 @@
             method: 'POST',
             error: function(xhr, textStatus, thrownError) {
               alert(message_from_error(xhr));
+            },
+            success: function(res) {
+              location.reload();
             }
-          });
-          location.reload();
-          return false;
+          })
       }
 
       function remove_ml_backend(name) {
@@ -291,14 +292,13 @@
               contentType: "application/json; charset=utf-8",
               success: function (response) {
                 console.log(response);
+                location.reload();
               },
               error: function (xhr, ajaxOptions, thrownError) {
                 alert(message_from_error(xhr));
               }
-          });
+            })
           }
-          location.reload();
-          return false;
       }
   </script>
 


### PR DESCRIPTION
Under the page `Model`, button `Start Predictions` and the button that deletes a ML backend don't work in Firefox (they do work fine in Chrome): the POST request is not issued because the page is reloaded.
This PR fixes the UI to reload the page only after the POST completes successfully.