### PR TITLE
Fix `--sampling=sequential`

### DIFF
--- a/label_studio/project.py
+++ b/label_studio/project.py
@@ -407,7 +407,7 @@ class Project(object):
         sampling = self.config.get('sampling', 'sequential')
 
         # Tasks are ordered ascending by their "id" fields. This is default mode.
-        task_iter = filter(lambda i: i not in completed_tasks_ids, self.source_storage.ids())
+        task_iter = filter(lambda i: i not in completed_tasks_ids, sorted(self.source_storage.ids()))
         if sampling == 'sequential':
             task_id = next(task_iter, None)
             if task_id is not None:


### PR DESCRIPTION
Currently, `--sampling=sequential` doesn't really order tasks by id. This PR fixes that.