### PR TITLE
fix uploading multiple tasks

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
-    types: [opened, synchronize, reopened]
 
 jobs:
   build:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,6 +9,7 @@ on:
       - '*'
       - '*/*'
       - '!master'
+  pull_request:
 
 jobs:
   build:

--- a/label_studio/storage/base.py
+++ b/label_studio/storage/base.py
@@ -106,9 +106,9 @@ class BaseStorage(ABC):
     def set(self, id, value):
         pass
 
-    @abstractmethod
     def set_many(self, ids, values):
-        pass
+        for id, value in zip(ids, values):
+            self.set(id, value)
 
     @abstractmethod
     def ids(self):
@@ -353,9 +353,6 @@ class CloudStorage(BaseStorage):
 
         if self.create_local_copy:
             self._create_local(id, value)
-
-    def set_many(self, keys, values):
-        raise NotImplementedError
 
     def _create_local(self, id, value):
         local_file = os.path.join(self.objects_dir, str(id) + '.json')

--- a/label_studio/storage/filesystem.py
+++ b/label_studio/storage/filesystem.py
@@ -104,9 +104,6 @@ class DirJSONsStorage(BaseStorage):
         with open(filename, 'w', encoding='utf8') as fout:
             json.dump(value, fout, indent=2, sort_keys=True)
 
-    def set_many(self, keys, values):
-        raise NotImplementedError
-
     def ids(self):
         for f in iter_files(self.path, '.json'):
             yield int(os.path.splitext(os.path.basename(f))[0])


### PR DESCRIPTION
currently crashes when:

```
label_studio/server.py:    g.project.source_storage.set_many(new_tasks.keys(), new_tasks.values())
label_studio/server.py:        g.project.source_storage.set_many(tasks_with_predictions.keys(), tasks_with_predictions.values())
```

are called