### PR TITLE
Fix parse_input_args to accept json config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ build/
 dist/
 venv/
 tmp/
+server.json

--- a/label_studio/server.py
+++ b/label_studio/server.py
@@ -82,6 +82,7 @@ if os.path.exists('server.json'):
     try:
         with open('server.json') as f:
             input_args = SimpleNamespace(**json.load(f))
+            logger.debug("Successfully read server.json")
     except:
         pass
 
@@ -1101,11 +1102,16 @@ def main():
 
     app.jinja_env.filters['str2datetime'] = str2datetime
 
-    input_args = parse_input_args()
+    input_args = parse_input_args(existing_args=input_args)
 
     # setup logging level
     if input_args.log_level:
         logging.root.setLevel(input_args.log_level)
+
+    # print version
+    if args.version or args.command == 'version':
+        from label_studio import __version__
+        print('\nLabel Studio version:', __version__, '\n')
 
     # On `init` command, create directory args.project_name with initial project state and exit
     if input_args.command == 'init':

--- a/label_studio/server.py
+++ b/label_studio/server.py
@@ -1109,7 +1109,7 @@ def main():
         logging.root.setLevel(input_args.log_level)
 
     # print version
-    if args.version or args.command == 'version':
+    if input_args.version or input_args.command == 'version':
         from label_studio import __version__
         print('\nLabel Studio version:', __version__, '\n')
 


### PR DESCRIPTION
This intends to fix #478 . Functionality should not have changed as long as no server.json is provided.

If a server.json is provided and successfully read, it is now used to supply the base config. Any arguments provided in cmd line as well overwrite server.json arguments.

Let me know if you have questions about the implementation, or require me to issue the PR to a different branch.

Commit message: 
Also, custom arguments can now be provided if using custom label-studio
host solution or for debugging.

Printing version info was moved to main for consistency.

As long as no custom arguments or existing arguments are provided,
functionality has not changed.