### PR TITLE
Add support for resolving s3 uris in html embed tags

### DIFF
--- a/label_studio/storage/base.py
+++ b/label_studio/storage/base.py
@@ -176,7 +176,7 @@ class CloudStorage(BaseStorage):
 
     def __init__(
         self, prefix=None, regex=None, create_local_copy=True, use_blob_urls=True, data_key=None,
-        sync_in_thread=True, **kwargs
+        sync_in_thread=True, presign=True, **kwargs
     ):
         super(CloudStorage, self).__init__(**kwargs)
         self.prefix = prefix or ''
@@ -192,6 +192,7 @@ class CloudStorage(BaseStorage):
         self.use_blob_urls = use_blob_urls
         self.data_key = data_key
         self.sync_in_thread = sync_in_thread
+        self.presign = presign
 
         self.client = self._get_client()
         self.validate_connection()

--- a/label_studio/storage/s3.py
+++ b/label_studio/storage/s3.py
@@ -13,7 +13,7 @@ S3_REGION = os.environ.get('S3_REGION', 'us-east-1')
 
 
 def get_client_and_resource(
-    aws_access_key_id=None, aws_secret_access_key=None, aws_session_token=None, region=None
+    aws_access_key_id=None, aws_secret_access_key=None, aws_session_token=None, region=None, **kwargs
 ):
     session = boto3.Session(
         aws_access_key_id=aws_access_key_id,
@@ -49,7 +49,7 @@ class S3Storage(CloudStorage):
         self.aws_session_token = aws_session_token
         self.region = region
 
-        super(S3Storage, self).__init__(region=region, **kwargs)
+        super(S3Storage, self).__init__(region=region,  **kwargs)
 
     def _get_client(self):
         client, s3 = get_client_and_resource(

--- a/label_studio/storage/s3.py
+++ b/label_studio/storage/s3.py
@@ -49,7 +49,7 @@ class S3Storage(CloudStorage):
         self.aws_session_token = aws_session_token
         self.region = region
 
-        super(S3Storage, self).__init__(region=region,  **kwargs)
+        super(S3Storage, self).__init__(region=region, **kwargs)
 
     def _get_client(self):
         client, s3 = get_client_and_resource(

--- a/label_studio/tests/uri_regex_test.py
+++ b/label_studio/tests/uri_regex_test.py
@@ -1,0 +1,40 @@
+import pytest
+
+# label_studio
+from label_studio import blueprint as server
+from label_studio.blueprint import (
+    validation_error_handler,
+)
+from label_studio.tests.base import (
+    test_client, captured_templates, goc_project,
+)
+
+from label_studio.utils.uri_resolver import _get_uri_via_regex
+
+@pytest.fixture(autouse=True)
+def default_project(monkeypatch):
+    """
+        apply patch for
+        label_studio.server.project_get_or_create()
+        for all tests.
+    """
+    monkeypatch.setattr(server, 'project_get_or_create', goc_project)
+
+
+class TestUriRegex:
+    valid_uri_data = ["s3://my-labelstudio-s3-bucket/my-test-objects/my-object",
+                       "gs://my-labelstudio-gs-bucket/my-test-objects/my-object",
+                       "<embed src='s3://my-labelstudio-bucket/pdf/my-pdf.pdf'/>",
+                       "<embed iframe='gs://my-labelstudio-bucket/my-image.png'/>"]
+
+    invalid_uri_data = ["s3:///my-labelstudio-s3-bucket/my-test-objects/my-object",
+                       "gs://my-labelstudio-gs-bucket /my-test-objects/my-object",
+                       "<embed iframe='bs://my-labelstudio-bucket/my-image.png'/>"]
+
+    def test_valid_uri_regex(self):
+        for text in self.valid_uri_data:
+            assert _get_uri_via_regex(text) is not None
+
+    def test_invalid_uri_regex(self):
+        for text in self.invalid_uri_data:
+            assert _get_uri_via_regex(text) is None


### PR DESCRIPTION
This PR add support for embedding pdf files (or other media files) via the HyperText object tag from a cloud storage backend. The type of cloud storage backend (s3 or gs), bucket name and key name are determined via a regular expression. I've added a couple of tests for this regex. 

In addition, users can optionally set a new `presign` parameter via the `--source-params` flag, to indicate whether they want to generate presigned URLs to access their S3 objects and which defaults to true. If using presigned URLs is not deemed sufficiently secure, the `presign` parameter can be set to false, and the URIs are not exchanged for a presigned URL, but for a data string containing the base64-ecoded value of the object that can be rendered in an `<embed />` or `<iframe />` html tag. 

Not sure if this is a good approach or not, what do you think? Don't have that much experience with the GCS sdk, but if this approach is acceptable, I could also look into converting the GCS blobs to base64 data strings? 