### PR TITLE
Azure Blob support

### DIFF
--- a/docs/source/guide/storage.md
+++ b/docs/source/guide/storage.md
@@ -153,3 +153,43 @@ If set true, the local copy of the remote storage will be created.
 #### use_blob_urls
 
 Generate task data with URLs pointed to your bucket objects(for resources like jpg, mp3, etc). If not selected, bucket objects will be interpreted as tasks in Label Studio JSON format, one object per task.
+
+
+## Azure Blob Storage
+
+To connect your [Azure Blob Storage](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction) container with Label Studio. For the integration to work, two Environment Variables have to be set:
+
+- AZURE_BLOB_ACCOUNT_NAME - The name of the storage account
+- AZURE_BLOB_ACCOUNT_KEY - The secret key to the storage account
+
+Which container is used will be configured using the UI or via the parameters.
+
+When you are storing BLOBs in your Azure Storage Container (like images or audio files), you might want to use then as is, by generating URLs pointing to those objects (e.g. `azure-blob://container-name/image.jpg`)
+Label Studio allows you to generate input tasks with corresponding URLs automatically on-the-fly. You can to this either specifying `--source-params` when launching app:
+
+```bash
+label-studio start my_project --init --source azure-blob --source-path my-az-container-name --source-params "{\"data_key\": \"my-object-tag-$value\", \"use_blob_urls\": true, \"regex\": ".*"}"
+```
+
+You can leave `"data_key"` empty (or skip it at all) then LS generates it automatically with the first task key from label config (it's useful when you have only one object tag exposed).
+
+
+### Optional parameters
+
+You can specify additional parameters with the command line escaped JSON string via `--source-params` / `--target-params` or from UI.
+
+#### prefix
+
+Prefix for finding/storing the files in the container, for example when working from a subfolder
+
+#### regex
+
+A regular expression for filtering bucket objects. Default is skipping all bucket objects (Use ".*" explicitly to collect all objects)
+
+#### create_local_copy
+
+If set true, the local copy of the remote storage will be created.
+
+#### use_blob_urls
+
+Generate task data with URLs pointed to your bucket objects(for resources like jpg, mp3, etc). If not selected, bucket objects will be interpreted as tasks in Label Studio JSON format, one object per task.

--- a/docs/source/guide/tasks.md
+++ b/docs/source/guide/tasks.md
@@ -28,7 +28,7 @@ Open the Label Studio app. On the **Setup** page, choose any of Audio annotation
 
 ### Cloud storage
 
-Assume you have GCP or S3 bucket you want to connect to stream your images from there. Read more [here](/guide/storage.html) how to connect common cloud storages.
+Assume you have GCP, S3 or Azure Blob bucket/container you want to connect to stream your images from there. Read more [here](/guide/storage.html) how to connect common cloud storages.
 
 
 ## Text files
@@ -70,7 +70,7 @@ Open the Label Studio app. On the **Setup** page, choose any of Audio annotation
 
 ### Cloud storage
 
-Assume you have GCP or S3 bucket you want to connect to stream your images from there. Read more [here](/guide/storage.html) how to connect common cloud storages.
+Assume you have GCP, S3 or Azure Blob bucket/container you want to connect to stream your images from there. Read more [here](/guide/storage.html) how to connect common cloud storages.
 
 
 
@@ -106,7 +106,7 @@ Go to the **Import** page. Drag-n-drop `time-series.txt` or select it via import
 
 ### Cloud storage
 
-Assume you have GCP or S3 bucket you want to connect to stream your images from there. Read more [here](/guide/storage.html) how to connect common cloud storages.
+Assume you have GCP, S3 or Azure Blob bucket/container you want to connect to stream your images from there. Read more [here](/guide/storage.html) how to connect common cloud storages.
 
 
 ## How to import preannotations

--- a/label_studio/project.py
+++ b/label_studio/project.py
@@ -134,11 +134,11 @@ class Project(object):
 
     @classmethod
     def get_available_source_storages(cls):
-        return ['tasks-json', 's3', 'gcs']
+        return ['tasks-json', 's3', 'gcs', 'azure-blob']
 
     @classmethod
     def get_available_target_storages(cls):
-        return ['completions-dir', 's3-completions', 'gcs-completions']
+        return ['completions-dir', 's3-completions', 'gcs-completions', 'azure-blob-completions']
 
     def get_available_source_storage_names(self):
         names = OrderedDict()

--- a/label_studio/storage/__init__.py
+++ b/label_studio/storage/__init__.py
@@ -2,6 +2,7 @@ from .base import create_storage, register_storage, get_available_storage_names,
 from .filesystem import JSONStorage, DirJSONsStorage, TasksJSONStorage, CompletionsDirStorage, ExternalTasksJSONStorage
 from .s3 import S3Storage, S3CompletionsStorage
 from .gcs import GCSStorage, GCSCompletionsStorage
+from .azure_blob import AzureBlobStorage, AzureBlobCompletionsStorage
 
 register_storage('json', JSONStorage)
 register_storage('dir-jsons', DirJSONsStorage)
@@ -11,3 +12,5 @@ register_storage('s3', S3Storage)
 register_storage('s3-completions', S3CompletionsStorage)
 register_storage('gcs', GCSStorage)
 register_storage('gcs-completions', GCSCompletionsStorage)
+register_storage('azure-blob', AzureBlobStorage)
+register_storage('azure-blob-completions', AzureBlobCompletionsStorage)

--- a/label_studio/storage/azure_blob.py
+++ b/label_studio/storage/azure_blob.py
@@ -1,0 +1,90 @@
+import json
+import logging
+import os
+
+from azure.storage.blob import BlobServiceClient
+
+from .base import CloudStorage, BaseStorageForm, StringField, BooleanField, Optional
+
+
+logger = logging.getLogger(__name__)
+logging.getLogger('azure.core.pipeline.policies.http_logging_policy').setLevel(logging.WARNING)
+AZURE_BLOB_ACCOUNT_NAME = os.getenv('AZURE_BLOB_ACCOUNT_NAME') 
+AZURE_BLOB_ACCOUNT_KEY = os.getenv('AZURE_BLOB_ACCOUNT_KEY') 
+
+class AzureBlobStorage(CloudStorage):
+
+    description = 'Azure Blob Storage'
+
+    @property
+    def url_prefix(self):
+        return 'azure-blob://'
+
+    @property
+    def readable_path(self):
+        return self.url_prefix + self.path + '/' + self.prefix
+
+    def _get_client(self):
+        if not AZURE_BLOB_ACCOUNT_NAME or not AZURE_BLOB_ACCOUNT_KEY:
+            raise ValueError('Azure account name and key must be set using environment variables AZURE_BLOB_ACCOUNT_NAME and AZURE_BLOB_ACCOUNT_KEY')
+
+        connection_string = "DefaultEndpointsProtocol=https;AccountName="+AZURE_BLOB_ACCOUNT_NAME+";AccountKey="+AZURE_BLOB_ACCOUNT_KEY+";EndpointSuffix=core.windows.net"
+        client = BlobServiceClient.from_connection_string(conn_str=connection_string)
+        container = client.get_container_client(self.path)
+        
+        return {
+            'client': client,
+            'container': container
+        }
+
+    def validate_connection(self):
+        pass
+
+    def _get_objects(self):
+        logger.debug('Getting Az blobs from ' + self.path + " with prefix " + self.prefix)
+        container = self.client['container']
+        files = container.list_blobs(name_starts_with=self.prefix)
+        return (f.name for f in files if f.name != (self.prefix.rstrip('/') + '/'))
+
+    def _get_value(self, key, inplace=False, validate=True):
+        container = self.client['container']
+        logger.debug('Getting Az blob with key ' + key + " container: "+ self.path + " with prefix " + self.prefix)
+        blob = container.download_blob(key)
+        blob_str = blob.content_as_text()
+        return json.loads(blob_str)
+
+    def _set_value(self, key, value):
+        if not isinstance(value, str):
+            value = json.dumps(value)
+        container = self.client['container']
+        blob = container.get_blob_client(key)
+        blob.upload_blob(value)
+
+
+class AzureBlobCompletionsStorageForm(BaseStorageForm):
+    prefix = StringField('Prefix', [Optional()], description='Azure Blob prefix')
+    create_local_copy = BooleanField('Create local copy', description='Create a local copy on your disk', default=True)
+
+    bound_params = dict(
+        prefix='prefix',
+        create_local_copy='create_local_copy',
+        **BaseStorageForm.bound_params
+    )
+
+
+class AzureBlobCompletionsStorage(AzureBlobStorage):
+
+    form = AzureBlobCompletionsStorageForm
+
+    def __init__(self, use_blob_urls=False, regex='.*', **kwargs):
+        """Completion Storages are unfiltered JSON storages"""
+        super(AzureBlobCompletionsStorage, self).__init__(use_blob_urls=False, regex='.*', **kwargs)
+
+    def _validate_object(self, key):
+        value = self._get_value(key)
+        if any((
+            'completions' not in value,
+            'id' not in value,
+            not isinstance(value['completions'], list)
+        )):
+            raise ValueError('Invalid completion format found by key ' + key)

--- a/label_studio/storage/azure_blob.py
+++ b/label_studio/storage/azure_blob.py
@@ -41,14 +41,12 @@ class AzureBlobStorage(CloudStorage):
         pass
 
     def _get_objects(self):
-        logger.debug('Getting Az blobs from ' + self.path + " with prefix " + self.prefix)
         container = self.client['container']
         files = container.list_blobs(name_starts_with=self.prefix)
         return (f.name for f in files if f.name != (self.prefix.rstrip('/') + '/'))
 
     def _get_value(self, key, inplace=False, validate=True):
         container = self.client['container']
-        logger.debug('Getting Az blob with key ' + key + " container: "+ self.path + " with prefix " + self.prefix)
         blob = container.download_blob(key)
         blob_str = blob.content_as_text()
         return json.loads(blob_str)

--- a/label_studio/storage/base.py
+++ b/label_studio/storage/base.py
@@ -49,7 +49,7 @@ class BaseForm(FlaskForm):
 
 
 class BaseStorageForm(BaseForm):
-    path = StringField('Path', [InputRequired()], description='Storage path (e.g. bucket name)')
+    path = StringField('Path', [InputRequired()], description='Storage path (e.g. bucket/container name)')
 
     # Bind here form fields to storage fields {"form field": "storage_field"}
     bound_params = dict(path='path')
@@ -152,8 +152,8 @@ class CloudStorageForm(BaseStorageForm):
     regex = StringField('Regex', [IsValidRegex()], description='File filter by regex, example: .* (If not specified, all files will be skipped)')  # noqa
     # data_key = StringField('Data key', [Optional()], description='Task tag key from your label config')
     use_blob_urls = BooleanField('Use BLOBs URLs', default=True,
-                                 description='Interpret each bucket object as resource file (jpg, mp3, txt, etc).<br>'
-                                             'Otherwise bucket objects will be interpreted as tasks '
+                                 description='Interpret each bucket/container object as resource file (jpg, mp3, txt, etc).<br>'
+                                             'Otherwise bucket/container objects will be interpreted as tasks '
                                              'in Label Studio JSON format')
     bound_params = dict(
         prefix='prefix',

--- a/label_studio/utils/argparser.py
+++ b/label_studio/utils/argparser.py
@@ -61,7 +61,7 @@ def parse_input_args():
         help='Source data storage type')
     root_parser.add_argument(
         '--source-path', dest='source_path',
-        help='Source bucket name')
+        help='Source bucket/container name')
     root_parser.add_argument(
         '--source-params', dest='source_params', type=json.loads, default={},
         help='JSON string representing source parameters')
@@ -70,7 +70,7 @@ def parse_input_args():
         help='Target data storage type')
     root_parser.add_argument(
         '--target-path', dest='target_path',
-        help='Target bucket name')
+        help='Target bucket/container name')
     root_parser.add_argument(
         '--target-params', dest='target_params', type=json.loads, default={},
         help='JSON string representing target parameters')

--- a/label_studio/utils/uri_resolver.py
+++ b/label_studio/utils/uri_resolver.py
@@ -6,7 +6,7 @@ import socket
 from datetime import datetime, timedelta
 from urllib.parse import urlparse
 
-from azure.storage.blob import BlobClient, generate_blob_sas, BlobSasPermissions
+from azure.storage.blob import generate_blob_sas, BlobSasPermissions
 import boto3
 import google.auth
 from botocore.exceptions import ClientError
@@ -199,5 +199,4 @@ def resolve_azure_blob(url, **kwargs):
                                 permission=BlobSasPermissions(read=True),
                                 expiry=expiry) 
 
-    url = 'https://'+AZURE_BLOB_ACCOUNT_NAME+'.blob.core.windows.net/'+container+'/'+blob+'?'+sas_token
-    return url
+    return 'https://' + AZURE_BLOB_ACCOUNT_NAME + '.blob.core.windows.net/' + container + '/' + blob + '?' + sas_token

--- a/label_studio/utils/uri_resolver.py
+++ b/label_studio/utils/uri_resolver.py
@@ -184,23 +184,6 @@ def python_cloud_function_get_signed_url(bucket_name, blob_name):
     return signed_url
 
 
-def _get_s3_params_from_project(project):
-    params = {}
-    if not hasattr(project, 'source_storage'):
-        return params
-    storage = project.source_storage
-    if hasattr(storage, 'aws_access_key_id'):
-        params['aws_access_key_id'] = storage.aws_access_key_id
-    if hasattr(storage, 'aws_secret_access_key'):
-        params['aws_secret_access_key'] = storage.aws_secret_access_key
-    if hasattr(storage, 'aws_session_token'):
-        params['aws_session_token'] = storage.aws_session_token
-    if hasattr(storage, 'region'):
-        params['region'] = storage.region
-    if hasattr(storage, 'presign'):
-        params['presign'] = storage.presign
-    return params
-
 def resolve_azure_blob(url, **kwargs):
     r = urlparse(url, allow_fragments=False) 
          

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ ujson==3.0.0
 Colorama==0.4.4
 boxing==0.1.4
 pyyaml>=5.3.1
+azure-storage-blob==12.6.0


### PR DESCRIPTION
Adding support for Azure Blob Containers as a Cloud Storage backend. Implementation is very similar to GCS and S3.

The current implementation expect the Azure Storage Account Name and Key to be in an environment variable. The other 2 cloud backends handle this as part of the SDK. I could also store these (secret) values in the project (like optional with AWS) if you like...

Documentation for Cloud Storages might be subject for a slimmer structure as there is quite some duplication...?

In Azure the concept of a bucket is called 'container' so I added it to some places as most Azure-only developers will get confused otherwise.

Related (but unfinished) work: #437