### PR TITLE
Specify click dependency with compatible version instead of specific

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ attrs==19.1.0
 blis==0.4.1
 certifi==2019.11.28
 chardet==3.0.4
-Click==7.0
+click~=7.0
 cymem==2.0.3
 Flask==1.1.1
 idna==2.8


### PR DESCRIPTION
Hey, I'm making this simple pull request in order to make the click dependency a bit more relaxed. Currently, this will essentially upgrade click from 7.0.0 to 7.1.2. It will also make it possible to install this package along with other packages (like black) in the same virtualenv which depends on later versions of click.