### PR TITLE
Add xml config to api

### DIFF
--- a/docs/source/guide/api.md
+++ b/docs/source/guide/api.md
@@ -16,6 +16,13 @@ curl -X POST -H Content-Type:application/json http://localhost:8080/api/project/
 --data "{\"label_config\": \"<View>[...]</View>\"}"
 ```
 
+Or by reading from a local config.xml file:
+
+```
+curl -X POST -H Content-Type:application/xml http://localhost:8080/api/project/config \
+--data @config.xml
+```
+
 The backend should return status 201 if the config is valid and saved. 
 If errors occur the backend returns status 400 and the response body will be JSON dict: 
 ```

--- a/label_studio/blueprint.py
+++ b/label_studio/blueprint.py
@@ -531,10 +531,12 @@ def api_save_config():
     """ Save labeling config
     """
     label_config = None
-    if 'label_config' in request.form:
+    if request.form and 'label_config' in request.form:
         label_config = request.form['label_config']
-    elif 'label_config' in request.json:
+    elif request.json and 'label_config' in request.json:
         label_config = request.json['label_config']
+    elif request.content_type == "application/xml":
+        label_config = request.data.decode("utf-8")
 
     # check config before save
     try:


### PR DESCRIPTION
 I image most people will save their configs as XML files and then will want to post the XML via the API so I added the ability to post XML to the API.

Also added addition checks on the received API request.

Usage:
Curl Example post local config.xml
`curl -X POST -H Content-Type:application/xml http://localhost:8080/api/project/config \
--data @config.xml`

Python Example:
```
xml = """<View>

  <Header value="Select label and start to click on image"></Header>
  <Image name="image" value="$image"></Image>

  <PolygonLabels name="label" toName="image" strokeWidth="3" pointSize="small" opacity="0.9">
    <Label value="Airplane" background="red"></Label>
    <Label value="Car" background="blue"></Label>
  </PolygonLabels>

</View>"""
headers = {'Content-Type': 'application/xml'}
requests.post('http://localhost:8080/api/project/config', data=xml, headers=headers)
```
