### PR TITLE
Add while loop to check for more busy ports

### DIFF
--- a/label_studio/blueprint.py
+++ b/label_studio/blueprint.py
@@ -981,12 +981,13 @@ def main():
             ssl_context = (cert_file, key_file)
 
         # check port is busy
-        if not input_args.debug and check_port_in_use('localhost', port):
-            old_port = port
-            port = int(port) + 1
-            print('\n*** WARNING! ***\n* Port ' + str(old_port) + ' is in use.\n' +
-                  '* Trying to start at ' + str(port) +
-                  '\n****************\n')
+        if not input_args.debug:
+            while check_port_in_use('localhost', port):
+                old_port = port
+                port = int(port) + 1
+                print('\n*** WARNING! ***\n* Port ' + str(old_port) + ' is in use.\n' +
+                    '* Trying to start at ' + str(port) +
+                    '\n****************\n')
 
         # external hostname is used for data import paths, they must be absolute always,
         # otherwise machine learning backends couldn't access them

--- a/label_studio/blueprint.py
+++ b/label_studio/blueprint.py
@@ -993,7 +993,7 @@ def main():
                         ' to launch label studio. \n Last tested port was ' + str(port) +
                         '\n****************\n')
                 print('\n*** WARNING! ***\n* Port ' + str(old_port) + ' is in use.\n' +
-                    f'* Trying to start at ' + str(port) +
+                    '* Trying to start at ' + str(port) +
                     '\n****************\n')
 
         # external hostname is used for data import paths, they must be absolute always,

--- a/label_studio/blueprint.py
+++ b/label_studio/blueprint.py
@@ -990,10 +990,10 @@ def main():
                 if port - original_port >= 1000:
                     raise ConnectionError(
                         '\n*** WARNING! ***\n Could not find an available port\n' + 
-                        f' to launch label studio. \n Last tested port was {str(port)}' +
+                        ' to launch label studio. \n Last tested port was ' + str(port) +
                         '\n****************\n')
-                print(f'\n*** WARNING! ***\n* Port {str(old_port)} is in use.\n' +
-                    f'* Trying to start at {str(port)}' +
+                print('\n*** WARNING! ***\n* Port ' + str(old_port) + ' is in use.\n' +
+                    f'* Trying to start at ' + str(port) +
                     '\n****************\n')
 
         # external hostname is used for data import paths, they must be absolute always,

--- a/label_studio/blueprint.py
+++ b/label_studio/blueprint.py
@@ -990,7 +990,7 @@ def main():
                 if port - original_port >= 1000:
                     raise ConnectionError(
                         '\n*** WARNING! ***\n Could not find an available port\n' + 
-                        f' to launch label studio. \n Last tested port was {port}' +
+                        f' to launch label studio. \n Last tested port was {str(port)}' +
                         '\n****************\n')
                 print(f'\n*** WARNING! ***\n* Port {str(old_port)} is in use.\n' +
                     f'* Trying to start at {str(port)}' +

--- a/label_studio/blueprint.py
+++ b/label_studio/blueprint.py
@@ -982,11 +982,18 @@ def main():
 
         # check port is busy
         if not input_args.debug:
+            original_port = port
+            # try up to 1000 new ports
             while check_port_in_use('localhost', port):
                 old_port = port
                 port = int(port) + 1
-                print('\n*** WARNING! ***\n* Port ' + str(old_port) + ' is in use.\n' +
-                    '* Trying to start at ' + str(port) +
+                if port - original_port >= 1000:
+                    raise ConnectionError(
+                        '\n*** WARNING! ***\n Could not find an available port\n' + 
+                        f' to launch label studio. \n Last tested port was {port}' +
+                        '\n****************\n')
+                print(f'\n*** WARNING! ***\n* Port {str(old_port)} is in use.\n' +
+                    f'* Trying to start at {str(port)}' +
                     '\n****************\n')
 
         # external hostname is used for data import paths, they must be absolute always,


### PR DESCRIPTION
The current code ` if not input_args.debug and check_port_in_use('localhost', port):` is checking whether the port (e.g. default :5000) is in use and then adds +1, but checks only once. If a user has a range of ports in use, for example 5000-5002, `label studio` does not manage to find an open port.

Modified by moving `check_port_in_use()` into a while loop to continue the check until there is a free port `label studio` can use.

I also took the freedom to create a PR without opening an issue first, hope that is fine with you.