### PR TITLE
Small but critical initial configuration encoding error fixed.

### DIFF
--- a/label_studio/tests/e2e_actions.py
+++ b/label_studio/tests/e2e_actions.py
@@ -40,7 +40,7 @@ def action_config_test(test_client, case_config):
     """
     project = goc_project()
 
-    with open(project.config.get('label_config', None), 'r') as file:
+    with open(project.config.get('label_config', None), 'r', encoding='utf-8') as file:
         data = file.read()
         assert data == case_config['label_config']
 
@@ -82,7 +82,7 @@ def action_import_test(test_client, case_config):
         and tasks r created
     """
     project = goc_project()
-    with open(project.config.get('input_path', None), 'r') as file:
+    with open(project.config.get('input_path', None), 'r', encoding='utf-8') as file:
         data = file.read()
 
 

--- a/label_studio/utils/misc.py
+++ b/label_studio/utils/misc.py
@@ -235,7 +235,7 @@ def get_config_templates(config):
     template_dir = config.get('templates_dir', 'examples')
     for i, path in enumerate(iter_config_templates(template_dir)):
         # open and check xml
-        with open(path) as f:
+        with open(path, encoding='utf-8') as f:
             code = f.read()
         try:
             objectify.fromstring(code)


### PR DESCRIPTION
Hello, I encountered UnicodeDecodeError caused by a [configuration example in repository](https://github.com/heartexlabs/label-studio/blob/bf71ea49478f6a84560880a621f5181abc8e85c4/label_studio/examples/ts_rel_text/config.xml#L33). 
For arbitrary configuration files, I added encoding type into project configuration opener, and also modified several test codes.
I don't know if it's appropriate to send PR into `0.9.1.post2`. If I should send PR into other branch, please notice me. 
Please take a look. 😄

resolve #642 