### PR TITLE
Update docs based on feedback

### DIFF
--- a/docs/source/guide/install.md
+++ b/docs/source/guide/install.md
@@ -75,6 +75,8 @@ Start Label Studio:
 docker-compose up -d
 ```
 
+This starts Label Studio with a PostgreSQL database backend. 
+
 ## Install from source
 
 If you want to use nightly builds or extend the functionality, consider downloading the source code using Git and running Label Studio locally:
@@ -110,6 +112,12 @@ pip install --upgrade label-studio
 ```
 
 Migration scripts run when you upgrade to version 1.0.0 from version 0.9.1 or earlier. 
+
+To make sure an existing project gets migrated, when you [start Label Studio](start.html), run the following command:
+
+```bash
+label-studio start path/to/old/project 
+```
 
 The most important change to be aware of is changes to rename "completions" to "annotations". See the [updated JSON format for completed tasks](export.html#Raw_JSON_format_of_completed_tasks). 
 

--- a/docs/source/guide/install.md
+++ b/docs/source/guide/install.md
@@ -117,12 +117,12 @@ If you customized the Label Studio Frontend, see the [Frontend reference guide](
 
 
 
-## Database
+## Database storage
+Label Studio uses a database to store project data and configuration information. 
 
 ### SQLite database
 
-Label Studio uses SQLite by default. You don't need to configure anything. Label Studio stores all data in a single file in the specified directory of the admin user. 
-
+Label Studio uses SQLite by default. You don't need to configure anything. Label Studio stores all data in a single file in the specified directory of the admin user. After you [start Label Studio](start.html), the directory used is printed in the terminal. 
 
 ### PostgreSQL database
 

--- a/docs/source/guide/labeling.md
+++ b/docs/source/guide/labeling.md
@@ -46,8 +46,7 @@ You can create relations between two results with both directions and labels. To
 3. Select the second region for the annotation to complete the relation.
 
 <br>
-<img src="/images/screens/relation.png">
-<!--relations look a little bit different now, update this-->
+<img src="../images/relation.png">
 
 After you relate two annotation regions, you can modify the relation in the **Relations** section of the **Results** sidebar. 
 - To change the direction of the relation, click the direction button between the two related regions.

--- a/docs/source/guide/predictions.md
+++ b/docs/source/guide/predictions.md
@@ -1,5 +1,5 @@
 ---
-title: Import predicted labels into Label Studio
+title: Import pre-annotated data into Label Studio
 type: guide
 order: 301
 ---

--- a/docs/source/guide/signup.md
+++ b/docs/source/guide/signup.md
@@ -6,6 +6,7 @@ order: 103
 
 Sign up and create an account for Label Studio to start labeling data and setting up projects. 
 
+Everyone with an account in Label Studio has access to the same functionality. 
 
 ## Create an account
 

--- a/docs/source/guide/start.md
+++ b/docs/source/guide/start.md
@@ -10,12 +10,11 @@ After you install Label Studio, start the server to start using it.
 label-studio start
 ```
 
-By default, Label Studio starts with a SQLite database to store labeling tasks and annotations. You can specify different source and target storage for labeling tasks and annotations using Label Studio UI or the API. See [Sync data from cloud or database storage](storage.html) for more.
+By default, Label Studio starts with a SQLite database to store labeling tasks and annotations. You can specify different source and target storage for labeling tasks and annotations using Label Studio UI or the API. See [Database storage](install.html#Database-storage) for more.
 
 ## Labeling performance 
 
-The SQLite database works well for projects with tens of thousands of labeling tasks. If you want to annotate millions of tasks or anticipate a lot of concurrent users, use a PostgreSQL database. See [Install and upgrade Label Studio
-](install.html#PostgreSQL-database) for more.  
+The SQLite database works well for projects with tens of thousands of labeling tasks. If you want to annotate millions of tasks or anticipate a lot of concurrent users, use a PostgreSQL database. See [Install and upgrade Label Studio](install.html#PostgreSQL-database) for more.  
 
 For example, if you import data while labeling is being performed, labeling tasks can take more than 10 seconds to load and annotations can take more than 10 seconds to perform. If you want to label more than 100,000 tasks with 5 or more concurrent users, consider using PostgreSQL or another database with Label Studio. 
 
@@ -25,7 +24,7 @@ You can specify project config, machine learning backend and other options using
 
 * The Label Studio web server always uses the `0.0.0.0` address to start. If you need to change it to `localhost`, set `--internal-host` from console arguments to `localhost` and the web server starts at `localhost`.
 
-* You can use `--port` or `PORT` environment var to set port for Label Studio web server. 
+* You can use the `--port` or `PORT` environment var to set port for Label Studio web server. 
 
 ## Run Label Studio with an external domain name
 

--- a/docs/source/guide/storage.md
+++ b/docs/source/guide/storage.md
@@ -11,7 +11,7 @@ Set up the following cloud and other storage systems with Label Studio:
 - [Google Cloud Storage](#Google-Cloud-Storage)
 - [Microsoft Azure Blob storage](#Microsoft-Azure-Blob-storage)
 - [Redis database](#Redis-database)
-- [Local storage](#Local-storage)
+<!--- [Local storage](#Local-storage)-->
 
 Each source and target storage setup is project-specific. You can connect multiple buckets as source or target storage for a project. 
 
@@ -283,6 +283,7 @@ Run the following command to launch Label Studio, configure the connection to yo
 label-studio start my_project --init --db redis 
 ```
 
+<!--
 ## Local storage
 If you have local files that you want to add to Label Studio from a specific directory, you can set up a specific local directory as source or target storage. 
 
@@ -307,6 +308,6 @@ You can specify additional parameters from the Label Studio UI.
 | prefix | Specify an internal folder or container | empty | 
 | regex | Specify a regular expression to filter directory objects. Use ".*" to collect all objects. | Skips all directory objects. |
 | use_blob_urls | If true, treat every directory object as a source file. Use for resources like JPG, MP3, or similar file types. If false, directory objects are interpreted as tasks in Label Studio JSON format with one object per task. | false |
-
+-->
 
 

--- a/docs/source/guide/storage.md
+++ b/docs/source/guide/storage.md
@@ -1,5 +1,5 @@
 ---
-title: Sync data from cloud or redis
+title: Sync data from cloud or Redis storage
 type: guide
 order: 302
 ---
@@ -11,11 +11,10 @@ Set up the following cloud and other storage systems with Label Studio:
 - [Google Cloud Storage](#Google-Cloud-Storage)
 - [Microsoft Azure Blob storage](#Microsoft-Azure-Blob-storage)
 - [Redis database](#Redis-database)
-- [PostgreSQL database](#PostgreSQL-database)
 
 Each source and target storage setup is project-specific. You can connect multiple buckets as source or target storage for a project. 
 
-The connection to both source and target storage buckets is synced, so you can see new tasks after uploading them to the bucket without restarting Label Studio. 
+If you upload new data to a connected cloud storage bucket, sync the storage connection to add the new labeling tasks to Label Studio without restarting. 
 
 > Note: Choose your target storage carefully. When you start the labeling project, it must be empty or contain annotations that match previously created or imported tasks from source storage. Tasks are synced with annotations based on internal IDs, so if you accidentally connect to target storage with existing annotations with the same IDs, the connection might fail with undefined behavior.  
 

--- a/docs/source/guide/storage.md
+++ b/docs/source/guide/storage.md
@@ -11,6 +11,7 @@ Set up the following cloud and other storage systems with Label Studio:
 - [Google Cloud Storage](#Google-Cloud-Storage)
 - [Microsoft Azure Blob storage](#Microsoft-Azure-Blob-storage)
 - [Redis database](#Redis-database)
+- [Local storage](#Local-storage)
 
 Each source and target storage setup is project-specific. You can connect multiple buckets as source or target storage for a project. 
 
@@ -139,7 +140,7 @@ For Label Studio versions earlier than 1.0.0, you can use command line arguments
 label-studio start my_project --init --source gcs --source-path my-gcs-bucket
 ```
 
-#### Write completions to a bucket
+#### Write annotations to a bucket
 
 ```bash
 label-studio start my_project --init --target gcs-completions --source-path my-gcs-bucket
@@ -216,7 +217,7 @@ For Label Studio versions earlier than 1.0.0, you can use command line arguments
 label-studio start my_project --init --source azure-blob --source-path my-az-container-name
 ```
 
-#### Write completions to an Azure storage container
+#### Write annotations to an Azure storage container
 
 ```bash
 label-studio start my_project --init --target azure-blob --source-path my-az-container-name
@@ -239,7 +240,7 @@ You can also skip or leave the `"data_key"` parameter empty and Label Studio aut
 
 ## Redis database
 
-You can also store your tasks and completions in a [Redis database](https://redis.io/). You must store the tasks and completions in different databases. 
+You can also store your tasks and annotations in a [Redis database](https://redis.io/). You must store the tasks and annotations in different databases. 
 
 You might want to use a Redis database if you find that relying on a file-based cloud storage connection is slow for your datasets. 
 
@@ -281,3 +282,31 @@ Run the following command to launch Label Studio, configure the connection to yo
 ```bash
 label-studio start my_project --init --db redis 
 ```
+
+## Local storage
+If you have local files that you want to add to Label Studio from a specific directory, you can set up a specific local directory as source or target storage. 
+
+### Set up connection in the Label Studio UI
+In the Label Studio UI, do the following to set up the connection:
+
+1. Open Label Studio in your web browser.
+2. For a specific project, open **Settings > Cloud Storage**.
+3. Click **Add Source Storage**.  
+4. In the dialog box that appears, select **Local Files** as the storage type.
+5. Specify the name of the local directory.
+6. (Optional) Adjust the remaining parameters. See [Optional parameters](#Optional-parameters-5) on this page for more details.
+7. Click **Add Storage**.
+8. Repeat these steps for **Target Storage** to sync completed data annotations to a local directory.
+
+### Optional parameters
+
+You can specify additional parameters from the Label Studio UI.
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| prefix | Specify an internal folder or container | empty | 
+| regex | Specify a regular expression to filter directory objects. Use ".*" to collect all objects. | Skips all directory objects. |
+| use_blob_urls | If true, treat every directory object as a source file. Use for resources like JPG, MP3, or similar file types. If false, directory objects are interpreted as tasks in Label Studio JSON format with one object per task. | false |
+
+
+

--- a/docs/source/guide/tasks.md
+++ b/docs/source/guide/tasks.md
@@ -28,7 +28,9 @@ If you don't see a supported data or file type that you want to import, reach ou
 
 ## How to format your data to import it
 
-Label Studio treats different file types different ways. If you want to import multiple types of data to label at the same time, for example, images with captions or audio recordings with transcripts, you must use the [basic Label Studio JSON format](#Basic-Label-Studio-JSON-format). 
+Label Studio treats different file types different ways. 
+
+If you want to import multiple types of data to label at the same time, for example, images with captions or audio recordings with transcripts, you must use the [basic Label Studio JSON format](#Basic-Label-Studio-JSON-format). 
 
 You can also use a CSV file or a JSON list of tasks to point to URLs with the data, rather than directly importing the data if you need to import thousands of files.
 

--- a/docs/source/guide/tasks.md
+++ b/docs/source/guide/tasks.md
@@ -9,7 +9,7 @@ Get data into Label Studio by importing files, referencing URLs, or syncing with
 - If your data is stored in a cloud storage bucket, see [Sync data from cloud or database storage](storage.html).
 - If your data is stored in a Redis database, see [Sync data from cloud or database storage](storage.html).
 - If your data is stored at internet-accessible URLs, in files, or directories, [import it from the Label Studio UI](#Import-data-from-the-Label-Studio-UI).
-- If your data contains predictions or pre-annotations, see [Import predicted labels into Label Studio](predictions.html).
+- If your data contains predictions or pre-annotations, see [Import pre-annotated data into Label Studio](predictions.html).
 
 ## Types of data you can import into Label Studio
 


### PR DESCRIPTION
Slack feedback and some cleanup of links and such. 
* Adding intro sentence and fixing links to point to PostgreSQL section in install docs
* Fixing an updated screenshot ref
* Added info about accounts in response to slack questions
* Fixed docs bug about how to sync cloud storage (manual, not auto)
* Updated migration guidance with more info
* Fixed a couple mentions of completions that I'd missed somehow