### PR TITLE
fixing link typos

### DIFF
--- a/docs/source/guide/frontend_reference.md
+++ b/docs/source/guide/frontend_reference.md
@@ -15,7 +15,7 @@ LSF version 1.0.0 is not compatible with earlier versions of Label Studio. If yo
 | onUpdateCompletion | onUpdateAnnotation |
 | onDeleteCompletion | onDeleteAnnotation | 
 
-If you rely on specific formatting of Label Studio completed tasks, [Label Studio's annotation format](/guide/export.html#Raw-JSON-format-of-completed-tasks) has also been updated. 
+If you rely on specific formatting of Label Studio completed tasks, [Label Studio's annotation format](export.html#Raw-JSON-format-of-completed-tasks) has also been updated. 
 
 ## Implement the Label Studio Frontend
 
@@ -133,13 +133,13 @@ Default: `null`
 
 Type data: `array`
 
-Array of annotations. See the [annotation documentation](/guide/export.html#Raw-JSON-format-of-completed-tasks) for more information.
+Array of annotations. See the [annotation documentation](export.html#Raw-JSON-format-of-completed-tasks) for more information.
 
 #### predictions
 
 Type data: `array`
 
-Array of predictions. Similar structure as completions or annotations. See the [annotation documentation](/guide/export.html#Raw-JSON-format-of-completed-tasks) and [guidance for importing predicted labels](predictions.html) for more information.
+Array of predictions. Similar structure as completions or annotations. See the [annotation documentation](export.html#Raw-JSON-format-of-completed-tasks) and [guidance for importing predicted labels](predictions.html) for more information.
 
 ### user
 

--- a/docs/source/guide/index.md
+++ b/docs/source/guide/index.md
@@ -59,8 +59,8 @@ When you upload data to Label Studio, each item in the dataset becomes a labelin
 | Relation | A defined relationship between two labeled regions. 
 | Pre-labeling | What machine learning models perform in Label Studio or separate from Label Studio. The result of predicting labels for items in a dataset are predicted labels, or pre-labels. |
 | Annotations | The output of a labeling task. Previously called "completions". |
-| Templates | Example labeling configurations that you can use to specify the type of labeling that you're performing with your dataset. See [all available templates](/templates.html) |
-| Tags | Configuration options to customize the labeling interface. See [more about tags](/tags.html). |
+| Templates | Example labeling configurations that you can use to specify the type of labeling that you're performing with your dataset. See [all available templates](/templates) |
+| Tags | Configuration options to customize the labeling interface. See [more about tags](/tags). |
 
 
 ## Components and architecture

--- a/docs/source/guide/install.md
+++ b/docs/source/guide/install.md
@@ -6,7 +6,7 @@ order: 200
 
 Install Label Studio on premises or in the cloud. Choose the install method that works best for your environment:
 - [Install with pip](#Install-with-pip)
-- [Install with Docker](#Install-with-docker)
+- [Install with Docker](#Install-with-Docker)
 - [Install from source](#Install-from-source)
 - [Install with Anaconda](#Install-with-Anaconda)
 - [Install for local development](#Install-for-local-development)

--- a/docs/source/guide/ml.md
+++ b/docs/source/guide/ml.md
@@ -122,7 +122,7 @@ The process of creating annotated training data for supervised machine learning 
 Depending on score types you can select a sampling strategy: 
 * prediction-score-min (min is the best score) 
  
-See more about active learning sampling in [Set up task sampling for your project](guide/start.html#Set-up-task-sampling-for-your-project). 
+See more about active learning sampling in [Set up task sampling for your project](start.html#Set-up-task-sampling-for-your-project). 
 
 ## Troubleshooting
 
@@ -147,7 +147,7 @@ If you can't resolve them by yourself, <a href="https://join.slack.com/t/label-s
 
 ### My predictions are wrong or I can't see the model prediction results on the labeling page
 
-Most likely, the format of the predictions you're trying to view are incorrect. The ML backend predictions format follows the same structure as [predictions in imported preannotations](/guide/tasks.html#Import-predicted-labels-into-Label-Studio).
+Most likely, the format of the predictions you're trying to view are incorrect. The ML backend predictions format follows the same structure as [predictions in imported preannotations](predictions.html).
 
 
 

--- a/docs/source/guide/setup.md
+++ b/docs/source/guide/setup.md
@@ -28,7 +28,7 @@ After you save a project, any other collaborator with access to the Label Studio
 
 Configure the labels and task type for annotators using the templates included with Label Studio or by defining your own combination of tags to set up the labeling interface for your project. 
 
-1. Select a template from the [available templates](https://labelstud.io/templates/) or customize one.
+1. Select a template from the [available templates](/templates) or customize one.
 2. Label Studio automatically selects the field to label based on your data. If needed, modify the selected field. 
 3. Add label names on new lines. 
 4. (Optional) Choose new colors for the labels by clicking the label name and choosing a new color using the color selector.
@@ -59,7 +59,7 @@ If you want to make changes to the labeling interface or perform a different typ
 
 ## Customize a template
 
-You can customize a [labeling config template](https://labelstud.io/templates/) or use a custom configuration that you create from scratch. If you create a custom configuration that might be useful to other Label Studio users, consider [contributing the configuration as a template](https://github.com/heartexlabs/label-studio/tree/master/label_studio/examples).
+You can customize a [labeling config template](/templates) or use a custom configuration that you create from scratch. If you create a custom configuration that might be useful to other Label Studio users, consider [contributing the configuration as a template](https://github.com/heartexlabs/label-studio/tree/master/label_studio/examples).
 
 The labeling configuration for a project is an XML file that contains three types of tags specific to Label Studio.
 
@@ -86,9 +86,9 @@ For example, to classify images that are referenced in your data as URLs (`$imag
 </View>
 ```
 
-This labeling config references the image resource in the [Image](https://labelstud.io/tags/image.html) object tag, and specifies the available labels to select in the [Choices](https://labelstud.io/tags/choices.html) control tag.
+This labeling config references the image resource in the [Image](/tags/image.html) object tag, and specifies the available labels to select in the [Choices](/tags/choices.html) control tag.
 
-If you want to customize this example, such as to allow labelers to select both Cat and Dog labels for a single image, modify the parameters used with the [Choices](https://labelstud.io/tags/choices.html) control tag:
+If you want to customize this example, such as to allow labelers to select both Cat and Dog labels for a single image, modify the parameters used with the [Choices](/tags/choices.html) control tag:
 
 ```html
 

--- a/docs/source/guide/start.md
+++ b/docs/source/guide/start.md
@@ -110,11 +110,11 @@ LABEL_STUDIO_HOST
 
 If you want, you can specify a different hostname for Label Studio, but you don't need to.
 
-To run Label Studio with Heroku and use PostgreSQL as the [database storage](install.html#Database_storage), specify the PostgreSQL environment variables required as part of the Heroku environment variable `DATABASE_URL`. For example, to specify a PostgreSQL database hosted on Amazon:
+To run Label Studio with Heroku and use PostgreSQL as the [database storage](storedata.html), specify the PostgreSQL environment variables required as part of the Heroku environment variable `DATABASE_URL`. For example, to specify a PostgreSQL database hosted on Amazon:
 ```
 DATABASE_URL = postgres://username:password@hostname.compute.amazonaws.com:5432/dbname
 ```
-Then you can specify the required environment variables for a PostgreSQL connection as config variables. See [Database storage](install.html#Database_storage).
+Then you can specify the required environment variables for a PostgreSQL connection as config variables. See [Database storage](storedata.html).
 
 <!--
 ## Run Label Studio on the cloud using a different cloud provider
@@ -158,6 +158,6 @@ The following table lists the available sampling options:
 | uniform | Tasks are sampled with equal probabilities. |
 | prediction-score-min | Tasks with the minimum average prediction score are shown to annotators. To use this option, you must also include predictions data in the task data that you import into Label Studio. |
 
-You can also use the API to set up sampling for a specific project. Send a PATCH request to the `/api/projects/<project_id>` endpoint to set sampling for the specified project. See the [API reference for projects](https://labelstud.io/api#operation/projects_partial_update). 
+You can also use the API to set up sampling for a specific project. Send a PATCH request to the `/api/projects/<project_id>` endpoint to set sampling for the specified project. See the [API reference for projects](/api#operation/projects_partial_update). 
 
 Individual annotators can also control the order in which they label tasks by adjusting the filtering and ordering of labeling tasks in the Label Studio UI. See [Set up your labeling project](setup.html).

--- a/docs/source/guide/tasks.md
+++ b/docs/source/guide/tasks.md
@@ -39,7 +39,7 @@ You can also use a CSV file or a JSON list of tasks to point to URLs with the da
 
 One way to import data into Label Studio is using a JSON-formatted list of tasks. The `data` key of the JSON file references each task as an entry in a JSON dictionary. If there is no `data` key, Label Studio interprets the entire JSON file as one task. 
 
-In the `data` JSON dictionary, use key-value pairs that correspond to the source key expected by the object tag in the [label config](/guide/setup.html#Customize-the-labeling-interface-for-your-project) that you set up for your dataset. 
+In the `data` JSON dictionary, use key-value pairs that correspond to the source key expected by the object tag in the [label config](setup.html#Customize-the-labeling-interface-for-your-project) that you set up for your dataset. 
 
 Depending on the type of object tag, Label Studio interprets field values differently:
 - `<Text value="$key">`: `value` is interpreted as plain text.
@@ -55,8 +55,8 @@ You can add other, optional keys to the JSON file.
 | JSON key | Description |
 | --- | --- | 
 | id | Optional. Integer to use as the task ID. |
-| annotations | Optional. List of annotations exported from Label Studio. [Label Studio's annotation format](/guide/export.html#Raw-JSON-format-of-completed-tasks) allows you to import annotation results in order to use them in subsequent labeling tasks. |
-| predictions | Optional. List of model prediction results, where each result is saved using [Label Studio's prediction format](/guide/export.html#Raw-JSON-format-of-completed-tasks). Import predictions for automatic task pre-labeling and active learning. See [Import predicted labels into Label Studio](/guide/predictions.html) |
+| annotations | Optional. List of annotations exported from Label Studio. [Label Studio's annotation format](export.html#Raw-JSON-format-of-completed-tasks) allows you to import annotation results in order to use them in subsequent labeling tasks. |
+| predictions | Optional. List of model prediction results, where each result is saved using [Label Studio's prediction format](export.html#Raw-JSON-format-of-completed-tasks). Import predictions for automatic task pre-labeling and active learning. See [Import predicted labels into Label Studio](predictions.html) |
 
 #### Example JSON format
 


### PR DESCRIPTION
fixing link syntax typos in ML doc