### PR TITLE
Fix wrong file path being checked when trying to sync images from local storage subfolders

### DIFF
--- a/label_studio/io_storages/localfiles/models.py
+++ b/label_studio/io_storages/localfiles/models.py
@@ -40,10 +40,10 @@ class LocalFilesImportStorage(ImportStorage, LocalFilesMixin):
                 if regex and not regex.match(key):
                     logger.debug(key + ' is skipped by regex filter')
                     continue
-                yield file.name
+                yield str(file)
 
     def get_data(self, key):
-        path = Path(self.path) / key
+        path = Path(key)
         if self.use_blob_urls:
             # include self-hosted links pointed to local resources via /data/filename?d=<path/to/local/dir>
             document_root = Path(get_env('LOCAL_FILES_DOCUMENT_ROOT', default='/'))


### PR DESCRIPTION
When syncing a local storage with subfolders, the server will try to import the images in these folders as if they were at the root of the storage, and thus will fail to retrieve them.

This PR fixes this issue by simply yielding the full path to the images as keys instead of just their names (don't know if there's any better way to do it but this works and doesn't seem to break anything else). 