### PR TITLE
Changed service account email to None as the default service account was resulting in an invalid argument

### DIFF
--- a/label_studio/io_storages/gcs/models.py
+++ b/label_studio/io_storages/gcs/models.py
@@ -147,7 +147,7 @@ class GCSImportStorage(ImportStorage, GCSStorageMixin):
         expires_at_ms = datetime.now() + timedelta(minutes=self.presign_ttl)
         # This next line is the trick!
         signing_credentials = compute_engine.IDTokenCredentials(auth_request, "",
-                                                                service_account_email=credentials.service_account_email)
+                                                                service_account_email=None)
         signed_url = signed_blob_path.generate_signed_url(expires_at_ms, credentials=signing_credentials, version="v4")
         return signed_url
 


### PR DESCRIPTION
While trying to connect with the GCS bucket, I was able to successfully read the number of objects in the bucket, however, the data was not loading from the bucket. Following is the stack trace. 

> [2021-04-14 12:05:06,472] [core.utils.common::custom_exception_handler::85] [ERROR] 4c589210-8293-4c0e-a05f-4750defe5a9a Error calling the IAM signBytes API: b'{n  "error": {n    "code": 400,n    "message": "Request contains an invalid argument.",n    "status": "INVALID_ARGUMENT"n  }\\n}n'Traceback (most recent call last):File "/home/lordzuko/miniconda3/envs/label-studio/lib/python3.8/site-packages/rest_framework/views.py", line 506, in dispatchresponse = handler(request, *args, **kwargs)File "/home/lordzuko/miniconda3/envs/label-studio/lib/python3.8/site-packages/label_studio/data_manager/api.py", line 133, in tasksreturn self.get_paginated_response(serializer.data)File "/home/lordzuko/miniconda3/envs/label-studio/lib/python3.8/site-packages/rest_framework/serializers.py", line 745, in dataret = super().dataFile "/home/lordzuko/miniconda3/envs/label-studio/lib/python3.8/site-packages/rest_framework/serializers.py", line 246, in dataself._data = self.to_representation(self.instance)File "/home/lordzuko/miniconda3/envs/label-studio/lib/python3.8/site-packages/rest_framework/serializers.py", line 663, in to_representationreturn [File "/home/lordzuko/miniconda3/envs/label-studio/lib/python3.8/site-packages/rest_framework/serializers.py", line 664, in <listcomp>self.child.to_representation(item) for item in iterableFile "/home/lordzuko/miniconda3/envs/label-studio/lib/python3.8/site-packages/label_studio/tasks/serializers.py", line 149, in to_representationinstance.data = instance.resolve_uri(instance.data, proxy=self.context.get('proxy', False))File "/home/lordzuko/miniconda3/envs/label-studio/lib/python3.8/site-packages/label_studio/tasks/models.py", line 135, in resolve_urireturn storage.resolve_task_data_uri(task_data)File "/home/lordzuko/miniconda3/envs/label-studio/lib/python3.8/site-packages/label_studio/io_storages/base_models.py", line 61, in resolve_task_data_uriresolved_uri = self.resolve_uri(data)File "/home/lordzuko/miniconda3/envs/label-studio/lib/python3.8/site-packages/label_studio/io_storages/gcs/models.py", line 159, in resolve_uriresolved_uri = self.resolve_gs(uri)File "/home/lordzuko/miniconda3/envs/label-studio/lib/python3.8/site-packages/label_studio/io_storages/gcs/models.py", line 103, in resolve_gsreturn self.python_cloud_function_get_signed_url(bucket_name, key)File "/home/lordzuko/miniconda3/envs/label-studio/lib/python3.8/site-packages/label_studio/io_storages/gcs/models.py", line 151, in python_cloud_function_get_signed_urlsigned_url = signed_blob_path.generate_signed_url(expires_at_ms, credentials=signing_credentials, version="v4")File "/home/lordzuko/miniconda3/envs/label-studio/lib/python3.8/site-packages/google/cloud/storage/blob.py", line 551, in generate_signed_urlreturn helper(File "/home/lordzuko/miniconda3/envs/label-studio/lib/python3.8/site-packages/google/cloud/storage/_signing.py", line 622, in generate_signed_url_v4signature_bytes = credentials.sign_bytes(string_to_sign.encode("ascii"))File "/home/lordzuko/miniconda3/envs/label-studio/lib/python3.8/site-packages/google/auth/compute_engine/credentials.py", line 404, in sign_bytesreturn self._signer.sign(message)File "/home/lordzuko/miniconda3/envs/label-studio/lib/python3.8/site-packages/google/auth/iam.py", line 99, in signresponse = self._make_signing_request(message)File "/home/lordzuko/miniconda3/envs/label-studio/lib/python3.8/site-packages/google/auth/iam.py", line 81, in _make_signing_requestraise exceptions.TransportError(google.auth.exceptions.TransportError: Error calling the IAM signBytes API: b'{n  "error": {n    "code": 400,n    "message": "Request contains an invalid argument.",n    "status": "INVALID_ARGUMENT"n  }\\n}n'



Post switching to the default value to `None`, fixed the issue and I was able to successfully load images from the GCS bucket and save annotations to the GCS bucket.

Please let me know if there are more details I have to add to this Pull request.