### PR TITLE
FIX: S3 Import issue causing nested jsons

### DIFF
--- a/label_studio/io_storages/base_models.py
+++ b/label_studio/io_storages/base_models.py
@@ -93,7 +93,6 @@ class ImportStorage(Storage):
                 if 'data' not in data:
                     raise ValueError('If you use "predictions" field in the task, '
                                      'you must put "data" field in the task too')
-                data = data['data']
 
             # annotations
             annotations = data.get('annotations', [])
@@ -101,6 +100,8 @@ class ImportStorage(Storage):
                 if 'data' not in data:
                     raise ValueError('If you use "annotations" field in the task, '
                                      'you must put "data" field in the task too')
+
+            if 'data' in data and isinstance(data['data'], dict):
                 data = data['data']
 
             with transaction.atomic():


### PR DESCRIPTION
```Fix: JSONs which were present in S3 tasks were not being parsed correctly. They were getting created as nested JSONs where the entire data went into the data field. Also there would have been bugs, had `predictions` or `annotations` field been found in the json field. ```