### PR TITLE
Share static volume between label-studio and nginx containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - LABEL_STUDIO_HOST=${LABEL_STUDIO_HOST:-""}
     volumes:
       - ./mydata:/label-studio/data:rw
+      - static:/label-studio/label_studio:rw
     command: [ "./deploy/wait-for-postgres.sh", "db", "bash", "/label-studio/deploy/start_label_studio.sh" ]
 
   db:


### PR DESCRIPTION
At least in my usage, static asset files were invisible to nginx when using docker-compose. This led to 404 GET errors and the label-studio frontend not loading. Made it so the label-studio container shares the static directory with the nginx container.