### PR TITLE
Fixes PORT variable's argument index

### DIFF
--- a/scripts/serve_local_files.sh
+++ b/scripts/serve_local_files.sh
@@ -1,7 +1,7 @@
 INPUT_DIR=$1
 WILDCARD=${2}
 OUTPUT_FILE=${3:-"files.txt"}
-PORT=${3:-8081}
+PORT=${4:-8081}
 
 FIND_CMD="find ${INPUT_DIR} -type f"
 if [ -z "$WILDCARD" ]; then


### PR DESCRIPTION
Currently, the `OUTPUT_FILE` and `PORT` variables are assigned from the same command argument `$3`. Since, `PORT` is declared after `OUTPUT_FILE `, I believe it was intended for `PORT` to get its value from the 4th argument `$4`.