### PR TITLE
Fix updating project summary on task/annotation updates

### DIFF
--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -731,6 +731,8 @@ class ProjectSummary(models.Model):
                 for label in self._get_labels(result):
                     labels[from_name][label] = labels[from_name].get(label, 0) + 1
 
+        logger.debug(f'summary.created_annotations = {created_annotations}')
+        logger.debug(f'summary.created_labels = {labels}')
         self.created_annotations = created_annotations
         self.created_labels = labels
         self.save()
@@ -754,14 +756,15 @@ class ProjectSummary(models.Model):
                 if from_name not in labels:
                     continue
                 for label in self._get_labels(result):
+                    label = str(label)
                     if label in labels[from_name]:
                         labels[from_name][label] -= 1
                         if labels[from_name][label] == 0:
                             labels[from_name].pop(label)
                 if not labels[from_name]:
                     labels.pop(from_name)
-
+        logger.debug(f'summary.created_annotations = {created_annotations}')
+        logger.debug(f'summary.created_labels = {labels}')
         self.created_annotations = created_annotations
         self.created_labels = labels
         self.save()
-

--- a/label_studio/tasks/api.py
+++ b/label_studio/tasks/api.py
@@ -153,12 +153,10 @@ class AnnotationAPI(RequestDebugLogMixin, generics.RetrieveUpdateDestroyAPIView)
 
     def update(self, request, *args, **kwargs):
         # save user history with annotator_id, time & annotation result
-        update_id = self.request.user.id
         annotation_id = self.kwargs['pk']
         annotation = get_object_with_check_and_log(request, Annotation, pk=annotation_id)
-        task = annotation.task
 
-        task.save()  # refresh task metrics
+        annotation.task.save()  # refresh task metrics
 
         return super(AnnotationAPI, self).update(request, *args, **kwargs)
 

--- a/label_studio/tasks/models.py
+++ b/label_studio/tasks/models.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.db import models, connection
 from django.db.models import Q, F, When, Count, Case, Subquery, OuterRef, Value
 from django.db.models.functions import Coalesce
-from django.db.models.signals import post_delete, post_save, pre_delete
+from django.db.models.signals import post_delete, pre_save, post_save, pre_delete
 from django.db.utils import ProgrammingError, OperationalError
 from django.utils.translation import gettext_lazy as _
 from django.db.models import JSONField
@@ -224,6 +224,16 @@ class Task(TaskMixin, models.Model):
         # annotator annotation
         return self.annotations.first()
 
+    def increase_project_summary_counters(self):
+        if hasattr(self.project, 'summary'):
+            summary = self.project.summary
+            summary.update_data_columns([self])
+
+    def decrease_project_summary_counters(self):
+        if hasattr(self.project, 'summary'):
+            summary = self.project.summary
+            summary.remove_data_columns([self])
+
     class Meta:
         db_table = 'task'
         ordering = ['-updated_at']
@@ -302,6 +312,18 @@ class Annotation(AnnotationMixin, models.Model):
 
     def has_permission(self, user):
         return self.task.project.has_permission(user)
+
+    def increase_project_summary_counters(self):
+        if hasattr(self.task.project, 'summary'):
+            logger.debug(f'Increase project.summary counters from {self}')
+            summary = self.task.project.summary
+            summary.update_created_annotations_and_labels([self])
+
+    def decrease_project_summary_counters(self):
+        if hasattr(self.task.project, 'summary'):
+            logger.debug(f'Decrease project.summary counters from {self}')
+            summary = self.task.project.summary
+            summary.remove_created_annotations_and_labels([self])
 
 
 class TaskLock(models.Model):
@@ -384,45 +406,61 @@ def release_task_lock_before_delete(sender, instance, **kwargs):
     if instance is not None:
         instance.release_lock()
 
+# =========== PROJECT SUMMARY UPDATES ===========
+
 
 @receiver(pre_delete, sender=Task)
 def remove_data_columns(sender, instance, **kwargs):
     """Reduce data column counters afer removing task"""
-    task = instance
-    if hasattr(task.project, 'summary'):
-        summary = task.project.summary
-        summary.remove_data_columns([task])
+    instance.decrease_project_summary_counters()
+
+
+@receiver(pre_save, sender=Task)
+def delete_project_summary_data_columns_before_updating_task(sender, instance, **kwargs):
+    """Before updating task fields - ensure previous info removed from project.summary"""
+    try:
+        old_task = sender.objects.get(id=instance.id)
+    except Task.DoesNotExist:
+        # task just created - do nothing
+        return
+    old_task.decrease_project_summary_counters()
 
 
 @receiver(post_save, sender=Task)
 def update_project_summary_data_columns(sender, instance, created, update_fields, **kwargs):
-    """Update task counters in project summary"""
-    if hasattr(instance.project, 'summary') and (created or (update_fields and 'data' in update_fields)):
-        summary = instance.project.summary
-        summary.update_data_columns([instance])
+    """Update task counters in project summary in case when new task has been created"""
+    instance.decrease_project_summary_counters()
+
+
+@receiver(pre_save, sender=Annotation)
+def delete_project_summary_annotations_before_updating_annotation(sender, instance, **kwargs):
+    """Before updating annotation fields - ensure previous info removed from project.summary"""
+    try:
+        old_annotation = sender.objects.get(id=instance.id)
+    except Annotation.DoesNotExist:
+        # annotation just created - do nothing
+        return
+    old_annotation.decrease_project_summary_counters()
 
 
 @receiver(post_save, sender=Annotation)
 def update_project_summary_annotations_and_is_labeled(sender, instance, created, **kwargs):
     """Update annotation counters in project summary"""
-    if hasattr(instance.task.project, 'summary'):
-        summary = instance.task.project.summary
-        summary.update_created_annotations_and_labels([instance])
+    instance.increase_project_summary_counters()
 
-    # If new annotation created, update task.is_labeled state
     if created:
+        # If new annotation created, update task.is_labeled state
         logger.debug(f'Update task stats for task={instance.task}')
         instance.task.update_is_labeled()
         instance.task.save(update_fields=['is_labeled'])
 
 
 @receiver(pre_delete, sender=Annotation)
-def remove_project_summary_annotations_and_is_labeled(sender, instance, **kwargs):
+def remove_project_summary_annotations(sender, instance, **kwargs):
     """Remove annotation counters in project summary followed by deleting an annotation"""
-    if hasattr(instance.task.project, 'summary'):
-        logger.debug(f'Remove created annotations and labels for {instance.task}')
-        summary = instance.task.project.summary
-        summary.remove_created_annotations_and_labels([instance])
+    instance.decrease_project_summary_counters()
+
+# =========== END OF PROJECT SUMMARY UPDATES ===========
 
 
 @receiver(post_delete, sender=Annotation)

--- a/label_studio/tests/test_suites/config_validation.yml
+++ b/label_studio/tests/test_suites/config_validation.yml
@@ -163,3 +163,178 @@
             </Labels>
           </View>'
         status_code: 200
+
+
+- update_annotation_twice_should_not_invalidate_after_removing:
+    - /api/projects:
+        method: POST
+        data:
+          label_config: '
+          <View>
+            <Text name="text" value="$text"/>
+            <Choices name="label" toName="text">
+              <Choice value="1"/>
+              <Choice value="2"/>
+            </Choices>
+          </View>
+          '
+        status_code: 201
+        response:
+          id: '{pk}'
+
+    - /api/projects/{pk}/import:
+        method: POST
+        content_type: application/json
+        data:
+          - text: Example task sentence
+        status_code: 201
+
+    - /api/projects/{pk}/next:
+        method: GET
+        status_code: 200
+        response:
+          id: '{task_id}'
+
+    - /api/tasks/{task_id}/annotations:
+        method: POST
+        content_type: application/json
+        data:
+          result:
+            - from_name: label
+              to_name: text
+              type: choices
+              value:
+                choices:
+                  - 1
+        status_code: 201
+        response:
+          id: '{annotation_id}'
+
+    # Then update annotation again
+    - /api/annotations/{annotation_id}:
+        method: PATCH
+        content_type: application/json
+        data:
+          result:
+            - from_name: label
+              to_name: text
+              type: choices
+              value:
+                choices:
+                  - 1
+        status_code: 200
+
+    # ... and delete this annotation
+    - /api/annotations/{annotation_id}:
+        method: DELETE
+        content_type: application/json
+        status_code: 204
+
+    # Now try to remove "1" label from config - it should work fine
+    - /api/projects/{pk}:
+        method: PATCH
+        content_type: application/json
+        data:
+          # Trying to remove "1" label from labeling config results to failure
+          label_config: '
+          <View>
+            <Text name="text" value="$text"/>
+            <Choices name="label" toName="text">
+              <Choice value="2"/>
+              <Choice value="3"/>
+            </Choices>
+          </View>'
+        status_code: 200
+
+
+- update_annotation_twice_should_not_invalidate_after_removing_but_changing_result_values:
+    - /api/projects:
+        method: POST
+        data:
+          label_config: '
+          <View>
+            <Text name="text" value="$text"/>
+            <Choices name="label" toName="text">
+              <Choice value="1"/>
+              <Choice value="2"/>
+            </Choices>
+          </View>
+          '
+        status_code: 201
+        response:
+          id: '{pk}'
+
+    - /api/projects/{pk}/import:
+        method: POST
+        content_type: application/json
+        data:
+          - text: Example task sentence
+        status_code: 201
+
+    - /api/projects/{pk}/next:
+        method: GET
+        status_code: 200
+        response:
+          id: '{task_id}'
+
+    - /api/tasks/{task_id}/annotations:
+        method: POST
+        content_type: application/json
+        data:
+          result:
+            - from_name: label
+              to_name: text
+              type: choices
+              value:
+                choices:
+                  - 1
+        status_code: 201
+        response:
+          id: '{annotation_id}'
+
+    # Then update annotation again
+    - /api/annotations/{annotation_id}:
+        method: PATCH
+        content_type: application/json
+        data:
+          result:
+            - from_name: label
+              to_name: text
+              type: choices
+              value:
+                choices:
+                  # here we change result value that should be reflected in label config invalidation
+                  - 2
+        status_code: 200
+
+    # Now try to remove "1" label from config - it should work fine
+    - /api/projects/{pk}:
+        method: PATCH
+        content_type: application/json
+        data:
+          # Trying to remove "2" label from labeling config results to failure
+          label_config: '
+          <View>
+            <Text name="text" value="$text"/>
+            <Choices name="label" toName="text">
+              <Choice value="1"/>
+              <Choice value="3"/>
+            </Choices>
+          </View>'
+        status_code: 400
+
+    # Now try to remove "1" label from config - it should work fine, since we have "2" label in a dataset
+    - /api/projects/{pk}:
+        method: PATCH
+        content_type: application/json
+        data:
+          # Trying to remove "1" label from labeling config
+          label_config: '
+          <View>
+            <Text name="text" value="$text"/>
+            <Choices name="label" toName="text">
+              <Choice value="2"/>
+              <Choice value="3"/>
+            </Choices>
+          </View>'
+        status_code: 200


### PR DESCRIPTION
This PR fixes label config invalidation errors when tasks/annotations are removed after being updated twice