### PR TITLE
quickstart start ml backend instruction fix

### DIFF
--- a/docs/source/guide/ml.md
+++ b/docs/source/guide/ml.md
@@ -68,8 +68,7 @@ Follow these steps to set up an example text classifier ML backend with Label St
    
 3. Start the ML backend server.
    ```bash
-   label-studio start my_ml_backend --init \ 
-     --ml-backends http://localhost:9090
+   label-studio-ml start my_ml_backend
    ```
    
 4. Start Label Studio. Create a project and import text data. 


### PR DESCRIPTION
The Quickstart step 3 says to "Start the ML backend server", but the current command is for starting label-studio with a new project and attaching an existing, already running backend. With the current command, the later step 6 fails as there is no running backend at http://localhost:9090.

```
label-studio start my_ml_backend --init \ 
     --ml-backends http://localhost:9090
```

The updated command will start the label-studio-\*ml\* backend server (i.e. http://localhost:9090).
```
label-studio-ml start my_ml_backend
```

Then in step 6, the link to `http://localhost:9090` will be valid.
