### PR TITLE
Escape multiline description/instructions in tpl

### DIFF
--- a/label_studio/projects/templates/projects/settings.html
+++ b/label_studio/projects/templates/projects/settings.html
@@ -7,9 +7,9 @@
 
 {% block frontend_settings %}
   {
-    project: "{{project.title}}",
+    project: "{{project.title|escapejs}}",
     projectId: {{project.pk}},
-    projectDescription: "{{project.description}}",
-    projectInstruction: "{{project.expert_instruction}}",
+    projectDescription: "{{project.description|escapejs}}",
+    projectInstruction: "{{project.expert_instruction|escapejs}}",
   }
 {% endblock %}


### PR DESCRIPTION
Project title/description/instructions are used in django templates to non-react pages. Escape them for safety