### PR TITLE
Fix docker-compose startup (#1004)

### DIFF
--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -5,8 +5,8 @@ set -e
 # if wait-for-postgres script is specified, we sleep in the loop until Postgre is up
 if [[ "$1" = "./deploy/wait-for-postgres.sh" ]]; then
     # ./deploy/wait-for-postgres.sh db
-    $1 $2
-    shift 2
+    $1
+    shift 1
 fi
 
 echo "=> Do database migrations..."

--- a/deploy/wait-for-postgres.sh
+++ b/deploy/wait-for-postgres.sh
@@ -3,7 +3,6 @@
 
 set -e
 
-cmd="$@"
 
 until PGPASSWORD=$POSTGRE_PASSWORD psql -h "$POSTGRE_HOST" -p $POSTGRE_PORT -U "$POSTGRE_USER" -c '\q'; do
   >&2 echo "Postgres is unavailable - sleeping"
@@ -11,4 +10,3 @@ until PGPASSWORD=$POSTGRE_PASSWORD psql -h "$POSTGRE_HOST" -p $POSTGRE_PORT -U "
 done
 
 >&2 echo "Postgres is up - executing command"
-exec $cmd


### PR DESCRIPTION
Issue with docker-compose at startup.
app container is not starting label-studio: `wait-for-postgres.sh`, after checking the postgres service, executes `bash`, this prevents `docker-entrypoint.sh` from executing the rest of the commands that should start label-studio app.
