### PR TITLE
support subfolder for s3 when sync with prefix set.

### DIFF
--- a/label_studio/io_storages/s3/models.py
+++ b/label_studio/io_storages/s3/models.py
@@ -106,7 +106,7 @@ class S3ImportStorage(S3StorageMixin, ImportStorage):
     def iterkeys(self):
         client, bucket = self.get_client_and_bucket()
         if self.prefix:
-            bucket_iter = bucket.objects.filter(Prefix=self.prefix.rstrip('/') + '/', Delimiter='/').all()
+            bucket_iter = bucket.objects.filter(Prefix=self.prefix.rstrip('/') + '/').all()
         else:
             bucket_iter = bucket.objects.all()
         regex = re.compile(str(self.regex_filter)) if self.regex_filter else None


### PR DESCRIPTION
When setting a bucket prefix, only sync the files under the folder, not files under the sub folders.
This patch is to support syncing files under the sub folders.