### PR TITLE
Configure .gitattributes to handle line endings on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Ensure shell script uses LF.
+Dockerfile  eol=lf
+*.sh        eol=lf


### PR DESCRIPTION
Workaround for known issue in docker-win: https://github.com/docker/for-win/issues/1340

Fixes: https://label-studio.slack.com/archives/CQ8LYPPJS/p1626704725265900