### PR TITLE
Small doc fixes

### DIFF
--- a/docs/source/guide/FAQ.md
+++ b/docs/source/guide/FAQ.md
@@ -72,6 +72,7 @@ The most common mistake while resource loading is <b>CORS</b> (Cross-Origin Reso
        }
   }
   ```
+
 - If you use Amazon S3 with Label Studio, see [Troubleshoot CORS and access problems](storage.html#Troubleshoot-CORS-and-access-problems).
 - If you use Google Cloud Storage with Label Studio, see [Troubleshoot CORS and access problems](storage.html#Troubleshoot-CORS-and-access-problems).
 - If you serve your data from an HTTP server created like follows: `python -m http.server 8081 -d`, run the following from the command line:

--- a/docs/source/guide/api.md
+++ b/docs/source/guide/api.md
@@ -40,13 +40,13 @@ To perform most tasks with the Label Studio API, you must specify the project ID
 
 ### Create and set up a project
 
-Create a project and set up the labeling interface in Label Studio using the API. See the [Create new project API endpoint documentation](/api#operation/projects_create).
+Create a project and set up the labeling interface in Label Studio using the API. See the [Create new project API endpoint documentation](/api#operation/api_projects_create).
 
-If you want to make sure the configuration for your labeling interface is valid before submitting it using the API, you can use the [validate label config](/api#operation/projects_validate_create) API endpoint.
+If you want to make sure the configuration for your labeling interface is valid before submitting it using the API, you can use the [validate label config](/api#operation/api_projects_validate_create) API endpoint.
 
 ### Import tasks using the API
 
-To import tasks using the API, make sure you know the project ID that you want to add tasks to. See additional examples and parameter descriptions in the [import data endpoint documentation](/api#operation/projects_import_create)
+To import tasks using the API, make sure you know the project ID that you want to add tasks to. See additional examples and parameter descriptions in the [import data endpoint documentation](/api#operation/api_projects_import_create)
 
 ### Retrieve tasks
 Retrieve a paginated list of tasks for a specific project. If you want, you can also retrieve tasks and annotations using this API endpoint, as an alternative to exporting annotations. See details and parameters in the [list project tasks endpoint documentation](/api#operation/api_projects_tasks_list).
@@ -59,7 +59,7 @@ Choose your selected format from the response and then call the export endpoint.
 
 ### API endpoint reference for older Label Studio versions
 
-These API endpoints were introduced in Label Studio version 0.8.1 and are only valid until version 0.9.1. Use the [API documentation](/api) linked inside Label Studio and for guidance when working with version 1.0.0. 
+These API endpoints were introduced in Label Studio version 0.8.1 and are only valid until version 0.9.1. Use the [API documentation](/api), also linked inside Label Studio, for guidance when working with version 1.0.0. 
 
 ### Set up project configuration
 

--- a/docs/source/guide/api.md
+++ b/docs/source/guide/api.md
@@ -49,13 +49,13 @@ If you want to make sure the configuration for your labeling interface is valid 
 To import tasks using the API, make sure you know the project ID that you want to add tasks to. See additional examples and parameter descriptions in the [import data endpoint documentation](/api#operation/projects_import_create)
 
 ### Retrieve tasks
-Retrieve a paginated list of tasks for a specific project. If you want, you can also retrieve tasks and annotations using this API endpoint, as an alternative to exporting annotations. See details and parameters in the [list project tasks endpoint documentation](/api#operation/projects_tasks_list).
+Retrieve a paginated list of tasks for a specific project. If you want, you can also retrieve tasks and annotations using this API endpoint, as an alternative to exporting annotations. See details and parameters in the [list project tasks endpoint documentation](/api#operation/api_projects_tasks_list).
 
 ### Export annotations
 
 To export annotations, first see [which formats are available to export for your project](/api#operation/api_projects_export_formats_read). 
 
-Choose your selected format from the response and then call the export endpoint. See the [export annotations](/api#operation/projects_export_list) endpoint documentation for more details.
+Choose your selected format from the response and then call the export endpoint. See the [export annotations](/api#operation/api_projects_export_read) endpoint documentation for more details.
 
 ### API endpoint reference for older Label Studio versions
 

--- a/docs/source/guide/quality.md
+++ b/docs/source/guide/quality.md
@@ -10,7 +10,7 @@ meta_description: Review the annotations produced by annotators in your Label St
 
 > Beta documentation: Label Studio Enterprise v2.0.0 is currently in Beta. As a result, this documentation might not reflect the current functionality of the product.
 
-After multiple labelers have annotated tasks, review their output to validate the quality of the results. You can also perform this task after a model has predicted labels for tasks in your dataset. 
+After multiple labelers have annotated tasks, review their output to validate the quality of the results. You can also perform this task after a model has predicted labels for tasks in your dataset. To configure the settings for reviewing annotations, see [Set up review settings for your project](setup_project.html#Set-up-review-settings-for-your-project).
 
 <div class="enterprise"><p>
 The annotation review workflow is only available in Label Studio Enterprise Edition. If you're using Label Studio Community Edition, see <a href="label_studio_compare.html">Label Studio Features</a> to learn more.
@@ -27,7 +27,7 @@ After you [assign reviewers to tasks](#Assign-reviewers-to-tasks), they can revi
 1. Reviewers can click **Review Annotations** for a specific project, then click **Review All Tasks** on the Data Manager to start reviewing tasks. Administrators and project managers can click **Explore All Reviews** from the Data Manager or **Explore Review** from the Dashboard to review tasks.
 2. Review the first task and annotation. By default, you view the tasks in numeric order. If you want to change the order that you review tasks, see [Choose what to review](#Choose-what-to-review). You can see the annotator and their annotation. 
 - If the annotation is correct, click **Accept**.
-- If the annotation is mostly correct, you can correct it by selecting a different option, changing which region is selected, moving the bounding box, or whichever makes sense for the type of label you're reviewing. After correcting the annotation, click **Fix & Accept**. 
+- If the annotation is mostly correct, you can correct it by selecting a different option, changing the selected region, moving the bounding box, or whichever makes sense for the type of label you're reviewing. After correcting the annotation, click **Fix & Accept**. 
 - If the annotation is completely incorrect, or you don't want to attempt to correct it at all, click **Reject** to reject the annotation. To place a rejected task back in the Label Stream for annotation, you must delete the annotation. Rejecting an annotation does not return it to annotators to re-label.
 After you complete a review, the next task appears for your review.
 3. Continue reviewing annotated tasks until you've reviewed all annotated tasks. Click **Data Manager** to return to the list of tasks for the project.
@@ -60,7 +60,7 @@ If you don't see an annotator's activity reflected on the dashboard, make sure t
 
 The dataset progress displays the number of tasks considered to be fully annotated for the project. If the project requires a minimum annotation per task of more than one, some tasks might not appear as "annotated" because they are not yet fully annotated by the project standards.
 
-You can review how many tasks are left to be completed by annotators, how many tasks have been skipped, and how many tasks have been reviewed.
+You can review how many tasks remain to be completed by annotators, how many tasks have been skipped, and how many tasks have been reviewed.
 
 ### Review label distribution
 For specific labels, you can see in a donut chart how many labels of each type were applied to the tasks. Use this chart to identify possible problems with your dataset distribution, if some labels are overrepresented in an annotated dataset compared with others. 

--- a/docs/source/guide/setup_project.md
+++ b/docs/source/guide/setup_project.md
@@ -124,18 +124,18 @@ In Label Studio Community Edition, you can set up task sampling from the command
    Your changes save automatically. 
 
 ### <i class='ent'></i> Define the matching function for annotation statistics
-Annotation statistics such as annotator consensus are calculated using a matching score. If you want the matching score to calculate matches by requiring exact matching choices, choose that option in the annotation settings.
+Annotation statistics such as annotator consensus are calculated using a matching score. If you want the matching score to calculate matches by requiring exact matching choices, choose that option in the annotation settings. For more about matching scores and functions in Label Studio Enterprise, see [Annotation statistics](stats.html).
 
 1. Within a project on the Label Studio UI, click **Settings**.
 2. Click **Annotation Settings**.
 3. Under **Matching Function**, select **Exact matching choices**.
-4. For some types of labeling, you can also select a specific matching function. For more about matching functions in Label Studio Enterprise, see [Annotation statistics](stats.html).
+4. For some types of labeling, you can also select a specific matching function. 
 
 Your changes save automatically. 
 
 ## <i class='ent'></i> Set up review settings for your project
 
-Set up review settings to guide reviewers when they review annotated tasks.
+Set up review settings to guide reviewers when they review annotated tasks. For more about reviewing annotations, see [Review annotations in Label Studio](quality.html)
 
 <div class="enterprise"><p>
 Review settings and the review stream are only available in Label Studio Enterprise Edition. If you're using Label Studio Community Edition, see <a href="label_studio_compare.html">Label Studio Features</a> to learn more.

--- a/docs/source/guide/setup_project.md
+++ b/docs/source/guide/setup_project.md
@@ -56,7 +56,7 @@ In the project settings, you can add instructions and choose whether to show the
 
 1. Within a project on the Label Studio UI, click **Settings**.
 2. Click **Instructions**, or in Label Studio Enterprise, click **Annotation Settings**. 
-3. Type instructions and choose whether to show the instructions to annotators before labeling. 
+3. Type instructions and choose whether to show the instructions to annotators before labeling. If you want to provide additional details or links for reference, instructions support HTML markup.
 4. Click **Save**. <br/>Click the project name to return to the data manager view. 
 
 Annotators can view instructions at any time when labeling by clicking the (i) button from the labeling interface.
@@ -147,7 +147,7 @@ In the project settings, you can add instructions and choose whether to show the
 
 1. Within a project on the Label Studio UI, click **Settings**.
 2. Click **Review Settings**. 
-3. Type instructions and choose whether to show the instructions to reviewers before reviewing annotated tasks. 
+3. Type instructions and choose whether to show the instructions to reviewers before reviewing annotated tasks. If you want to provide additional details or links for reference, instructions support HTML markup.
 4. Click **Save**. <br/>Click **Data Manager** to return to the data manager view. 
 
 ### Set reviewing options

--- a/docs/source/guide/start.md
+++ b/docs/source/guide/start.md
@@ -24,7 +24,7 @@ Some available commands for Label Studio provide information or start the Label 
 | `label-studio` | Start the Label Studio server. |
 | `label-studio -h` `label-studio --help` | Display available command line arguments. |
 | `label-studio init <project_name> <optional_arguments>` | Initialize a specific project in Label Studio. |
-| `label-studio start <project_name> --init <optional_arguments>` | Start the Label Studio server and initiliaze a specific project. |
+| `label-studio start <project_name> --init <optional_arguments>` | Start the Label Studio server and initialize a specific project. |
 | `label-studio reset_password` | Reset the password for a specific Label Studio username. See [Create user accounts for Label Studio](signup.html). |
 | `label-studio shell` | Get access to a shell for Label Studio to manipulate data directly. See documentation for the Django [shell-plus command](https://django-extensions.readthedocs.io/en/latest/shell_plus.html). |
 | `label-studio version` | Show the version of Label Studio and then terminates.

--- a/docs/source/guide/tasks.md
+++ b/docs/source/guide/tasks.md
@@ -245,6 +245,8 @@ Use that script to do the following:
    The script collects the links to the files provided by that HTTP server and saves them to a `files.txt` file with one URL per line. 
 3. Import the file with URLs into Label Studio using the Label Studio UI. 
 
+> Note: You must keep the web server running while you perform your data labeling so that the URLs remain accessible to Label Studio.
+
 If your labeling configuration supports HyperText or multiple data types, use the Label Studio JSON format to specify the local file locations instead of a `txt` file. See [an example of this format](storage.html#Tasks-with-local-storage-file-references).
 
 If you serve your data from an HTTP server created like follows: `python -m http.server 8081 -d`, you might need to set up CORS for that server so that Label Studio can access the data files successfully. If needed, run the following from the command line:


### PR DESCRIPTION
Fixing broken links to API docs
Improving small things in local storage that were confusing
Added info about markup in instructions
Added cross-links to help information findability