### PR TITLE
Adding .env,.envrc,tags to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ venv/
 .venv
 .vscode
 .autoenv
+.env
+.envrc
 # web/static
 
 deploy/license.txt
@@ -44,6 +46,7 @@ archive
 *.idea/*
 .vscode/*
 pyrightconfig.json
+tags
 tags.temp
 mydatabase
 label_studio.sqlite3


### PR DESCRIPTION
# Problem
1. tags file (created when running ctags) shouldn't be added to the repo.
2. autoenv and direnv private hidden env files shouldn't be added to commits.

# Solution
Adding these files to be ignored in .gitignore
