### PR TITLE
Google Cloud Logging handler

### DIFF
--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -8,6 +8,7 @@ boto==2.49.0
 boto3==1.16.28
 botocore==1.19.28
 google-cloud-storage==1.28.1
+google-cloud-logging==2.6.0
 Django==3.1.13
 django_annoying==0.10.6
 django_debug_toolbar==3.2.1

--- a/label_studio/core/settings/base.py
+++ b/label_studio/core/settings/base.py
@@ -13,6 +13,9 @@ import os
 import re
 import logging
 
+import google.cloud.logging
+from google.auth.exceptions import GoogleAuthError
+
 # for printing messages before main logging config applied
 if not logging.getLogger().hasHandlers():
     logging.basicConfig(level=logging.DEBUG, format='%(message)s')
@@ -120,6 +123,20 @@ LOGGING = {
         'level': get_env('LOG_LEVEL', 'WARNING'),
     }
 }
+
+if get_env('GOOGLE_LOGGING_ENABLED', False):
+    try:
+        client = google.cloud.logging.Client()
+        client.setup_logging()
+
+        LOGGING['handlers']['google_cloud_logging'] = {
+            'level': get_env('LOG_LEVEL', 'WARNING'),
+            'class': 'google.cloud.logging.handlers.CloudLoggingHandler',
+            'client': client
+        }
+        LOGGING['root']['handlers'].append('google_cloud_logging')
+    except GoogleAuthError as e:
+        logger.exception('Google Cloud Logging handler could not be setup.')
 
 INSTALLED_APPS = [
     'django.contrib.admin',

--- a/label_studio/core/settings/base.py
+++ b/label_studio/core/settings/base.py
@@ -13,9 +13,6 @@ import os
 import re
 import logging
 
-import google.cloud.logging
-from google.auth.exceptions import GoogleAuthError
-
 # for printing messages before main logging config applied
 if not logging.getLogger().hasHandlers():
     logging.basicConfig(level=logging.DEBUG, format='%(message)s')
@@ -126,6 +123,9 @@ LOGGING = {
 
 if get_env('GOOGLE_LOGGING_ENABLED', False):
     try:
+        import google.cloud.logging
+        from google.auth.exceptions import GoogleAuthError
+
         client = google.cloud.logging.Client()
         client.setup_logging()
 


### PR DESCRIPTION
# Problem
When running label-studio on Google Cloud Run, the logs don't get formatted properly with the correct severity.

# Solution
Solution is to set up the `google.cloud.logging.Client` in `LOGGING` configs if `GOOGLE_LOGGING_ENABLED` env var is enabled.

# Testing
Tested enabling and disabling GOOGLE_LOGGING_ENABLED.
Running label-studio locally:
```
python label_studio/manage.py runserver
```
Building docker image locally:
```
docker build .
```
Building and deploying it remotely on Google Cloud Build and Google Cloud Run:
```
gcloud builds submit --tag gcr.io/maystra-poc/label-studio
gcloud run services describe label-studio --region us-central1
```