### PR TITLE
Terraform files to deploy label-studio Google Cloud, cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,21 @@
+steps:
+  - id: "build image"
+    name: "gcr.io/cloud-builders/docker"
+    args:
+      [
+        "build",
+        "-t",
+        "gcr.io/${PROJECT_ID}/${_SERVICE_NAME}",
+        "${_SERVICE_FOLDER}",
+      ]
+
+  - id: "push image"
+    name: "gcr.io/cloud-builders/docker"
+    args: ["push", "gcr.io/${PROJECT_ID}/${_SERVICE_NAME}"]
+
+substitutions:
+  _SERVICE_FOLDER: .
+  _SERVICE_NAME: label-studio
+
+images:
+  - "gcr.io/${PROJECT_ID}/${_SERVICE_NAME}"

--- a/deploy/gcp/database.tf
+++ b/deploy/gcp/database.tf
@@ -1,0 +1,16 @@
+# The Cloud SQL postgres
+resource "google_sql_database_instance" "label-studio-postgres" {
+  name             = "label-studio-sql"
+  database_version = "POSTGRES_13"
+  region           = var.region
+
+  settings {
+    tier = var.database_tier
+  }
+}
+
+resource "google_sql_user" "users" {
+  name     = var.database_user
+  instance = google_sql_database_instance.label-studio-postgres.name
+  password = var.database_password
+}

--- a/deploy/gcp/main.tf
+++ b/deploy/gcp/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.80"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project
+}
+
+locals {
+  service_folder = "service"
+  service_name   = "label-studio"
+
+  deployment_name        = "label-studio"
+  label_studio_worker_sa = "serviceAccount:${google_service_account.label_studio_worker.email}"
+}

--- a/deploy/gcp/outputs.tf
+++ b/deploy/gcp/outputs.tf
@@ -1,0 +1,3 @@
+output "service_url" {
+  value = google_cloud_run_service.label-studio.status[0].url
+}

--- a/deploy/gcp/project.tf
+++ b/deploy/gcp/project.tf
@@ -1,0 +1,32 @@
+# Enable services
+resource "google_project_service" "run" {
+  service            = "run.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "iam" {
+  service            = "iam.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "cloudbuild" {
+  service            = "cloudbuild.googleapis.com"
+  disable_on_destroy = false
+}
+
+# Create a service account
+resource "google_service_account" "label_studio_worker" {
+  account_id   = "label-studio-worker"
+  display_name = "Label Studio SA"
+}
+
+# Set permissions
+resource "google_project_iam_binding" "service_permissions" {
+  for_each = toset([
+    "logging.logWriter", "cloudsql.client"
+  ])
+
+  role       = "roles/${each.key}"
+  members    = [local.label_studio_worker_sa]
+  depends_on = [google_service_account.label_studio_worker]
+}

--- a/deploy/gcp/service.tf
+++ b/deploy/gcp/service.tf
@@ -1,0 +1,98 @@
+# The Cloud Run service
+resource "google_cloud_run_service" "label-studio" {
+  name                       = local.service_name
+  location                   = var.region
+  autogenerate_revision_name = true
+
+  template {
+    spec {
+      service_account_name = google_service_account.label_studio_worker.email
+      containers {
+        image = "gcr.io/${var.project}/${local.service_name}"
+        env {
+          name  = "DEBUG"
+          value = "True"
+        }
+        env {
+          name  = "LOG_LEVEL"
+          value = "DEBUG"
+        }
+        env {
+          name  = "DJANGO_DB"
+          value = "default"
+        }
+        env {
+          name  = "POSTGRE_USER"
+          value = "postgres"
+        }
+        env {
+          name  = "POSTGRE_PASSWORD"
+          value = google_sql_user.users.password
+        }
+        env {
+          name  = "POSTGRE_NAME"
+          value = "postgres"
+        }
+        env {
+          name  = "POSTGRE_HOST"
+          value = "/cloudsql/${google_sql_database_instance.label-studio-postgres.connection_name}"
+        }
+        env {
+          name  = "POSTGRE_PORT"
+          value = "5432"
+        }
+        env {
+          name  = "GOOGLE_LOGGING_ENABLED"
+          value = "True"
+        }
+      }
+    }
+
+    metadata {
+      annotations = {
+        "autoscaling.knative.dev/maxScale"      = "1000"
+        "run.googleapis.com/cloudsql-instances" = google_sql_database_instance.label-studio-postgres.connection_name
+        "run.googleapis.com/client-name"        = "terraform"
+      }
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+
+  depends_on = [google_project_service.run, google_sql_database_instance.label-studio-postgres]
+}
+
+# Set service public
+data "google_iam_policy" "noauth" {
+  binding {
+    role = "roles/run.invoker"
+    members = [
+      "allUsers",
+    ]
+  }
+}
+
+resource "google_cloud_run_service_iam_policy" "noauth" {
+  location = google_cloud_run_service.label-studio.location
+  project  = google_cloud_run_service.label-studio.project
+  service  = google_cloud_run_service.label-studio.name
+
+  policy_data = data.google_iam_policy.noauth.policy_data
+  depends_on  = [google_cloud_run_service.label-studio]
+}
+
+resource "google_cloud_run_domain_mapping" "default" {
+  location = var.region
+  name     = var.domain_name
+
+  metadata {
+    namespace = var.project
+  }
+
+  spec {
+    route_name = google_cloud_run_service.label-studio.name
+  }
+}

--- a/deploy/gcp/variables.tf
+++ b/deploy/gcp/variables.tf
@@ -1,0 +1,31 @@
+variable "project" {
+  type        = string
+  description = "Google Cloud Platform Project ID"
+}
+
+variable "region" {
+  default = "us-central1"
+  type    = string
+}
+
+variable "database_user" {
+  default     = "postgres"
+  type        = string
+  description = "PostgresSQL user."
+}
+
+variable "database_password" {
+  type        = string
+  description = "PostgresSQL database user password."
+}
+
+variable "database_tier" {
+  default     = "db-f1-micro"
+  type        = string
+  description = "PostgresSQL database tier."
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Domain name where service will be served from."
+}

--- a/docs/source/guide/install.md
+++ b/docs/source/guide/install.md
@@ -3,7 +3,7 @@ title: Install and upgrade Label Studio
 type: guide
 order: 200
 meta_title: Install and Upgrade
-meta_description: Label Studio documentation for installing and upgrading Label Studio with Docker, pip, and anaconda to use for your machine learning and data science projects. 
+meta_description: Label Studio documentation for installing and upgrading Label Studio with Docker, pip, and anaconda to use for your machine learning and data science projects.
 ---
 
 Install Label Studio on premises or in the cloud. Choose the installation method that works best for your environment:
@@ -12,6 +12,7 @@ Install Label Studio on premises or in the cloud. Choose the installation method
 - [Install on Ubuntu](#Install-on-Ubuntu)
 - [Install from source](#Install-from-source)
 - [Install with Anaconda](#Install-with-Anaconda)
+- [Install on Google Cloud](#Install-on-Google-Cloud)
 - [Upgrade Label Studio](#Upgrade-Label-Studio)
 
 <!-- md deploy.md -->
@@ -22,7 +23,7 @@ Label Studio is tested with the latest version of Google Chrome and is expected 
 - Apple Safari
 - Mozilla Firefox
 
-If using other web browsers, or older versions of supported web browsers, unexpected behavior could occur. 
+If using other web browsers, or older versions of supported web browsers, unexpected behavior could occur.
 
 ## Install prerequisite
 Install Label Studio in a clean Python environment. We highly recommend using a virtual environment (venv or conda) to reduce the likelihood of package conflicts or missing packages.
@@ -41,7 +42,7 @@ To install Label Studio with pip, you need Python version 3.6 or later. Run the 
 pip install label-studio
 ```
 
-After you install Label Studio, start the server with the following command: 
+After you install Label Studio, start the server with the following command:
 ```bash
 label-studio
 ```
@@ -62,7 +63,7 @@ docker run -it -p 8080:8080 -v `pwd`/mydata:/label-studio/data heartexlabs/label
 Or for Windows, you have to modify the volumes paths set by `-v` option.
 
 #### Override the default Docker install
-You can override the default Docker install by appending new arguments: 
+You can override the default Docker install by appending new arguments:
 ```bash
 docker run -it -p 8080:8080 -v `pwd`/mydata:/label-studio/data heartexlabs/label-studio:latest label-studio --log-level DEBUG
 ```
@@ -117,21 +118,49 @@ conda activate label-studio
 pip install label-studio
 ```
 
+## Install on Google Cloud
+
+1. First login with `gcloud`
+```bash
+gcloud auth application-default login
+```
+
+2. You can use `direnv` to keep track of necessary env variables. Set up `.envrc` and don't forget to run `direnv allow`.
+```bash
+export PROJECT_ID=maystra-poc
+```
+
+3. Build the docker image and push it to Google Build with:
+```bash
+// Needs to be from the same directory as cloudbuild.yaml
+gcloud builds submit
+```
+
+4. Init terraform and apply changes
+```bash
+cd deploy/gcp
+terraform init
+terraform apply -var="database_password=<DB_PASSWORD>" \
+                -var="project=<PROJECT_ID>" \
+                -var="database_user=<DB_USER>" \
+                -var="domain_name=<DOMAIN_NAME>"
+```
+
 ## Troubleshoot installation
 
 You might see errors when installing Label Studio. Follow these steps to resolve them.
 
 ### Run the latest version of Label Studio
-Many bugs might be fixed in patch releases or maintenance releases. Make sure you're running the latest version of Label Studio by upgrading your installation before you start Label Studio. 
+Many bugs might be fixed in patch releases or maintenance releases. Make sure you're running the latest version of Label Studio by upgrading your installation before you start Label Studio.
 
 ### Errors about missing packages
 
 If you see errors about missing packages, install those packages and try to install Label Studio again. Make sure that you run Label Studio in a clean Python environment, such as a virtual environment.
 
-For Windows users the default installation might fail to build the `lxml` package. Consider manually installing it from [the unofficial Windows binaries](https://www.lfd.uci.edu/~gohlke/pythonlibs/#lxml). If you are running Windows 64-bit with Python 3.8 or later, run `pip install lxml‑4.5.0‑cp38‑cp38‑win_amd64.whl` to install it. 
+For Windows users the default installation might fail to build the `lxml` package. Consider manually installing it from [the unofficial Windows binaries](https://www.lfd.uci.edu/~gohlke/pythonlibs/#lxml). If you are running Windows 64-bit with Python 3.8 or later, run `pip install lxml‑4.5.0‑cp38‑cp38‑win_amd64.whl` to install it.
 
 
-### Errors from Label Studio 
+### Errors from Label Studio
 
 If you see any other errors during installation, try to rerun the installation.
 
@@ -141,21 +170,21 @@ pip install --ignore-installed label-studio
 
 
 ## Upgrade Label Studio
-To upgrade to the latest version of Label Studio, reinstall or upgrade using pip. 
+To upgrade to the latest version of Label Studio, reinstall or upgrade using pip.
 
 
 ```bash
 pip install --upgrade label-studio
 ```
 
-Migration scripts run when you upgrade to version 1.0.0 from version 0.9.1 or earlier. 
+Migration scripts run when you upgrade to version 1.0.0 from version 0.9.1 or earlier.
 
 To make sure an existing project gets migrated, when you [start Label Studio](start.html), run the following command:
 
 ```bash
-label-studio start path/to/old/project 
+label-studio start path/to/old/project
 ```
 
-The most important change to be aware of is changes to rename "completions" to "annotations". See the [updated JSON format for completed tasks](export.html#Raw_JSON_format_of_completed_tasks). 
+The most important change to be aware of is changes to rename "completions" to "annotations". See the [updated JSON format for completed tasks](export.html#Raw_JSON_format_of_completed_tasks).
 
-If you customized the Label Studio Frontend, see the [Frontend reference guide](frontend_reference.html) for required updates to maintain compatibility with version 1.0.0.  
+If you customized the Label Studio Frontend, see the [Frontend reference guide](frontend_reference.html) for required updates to maintain compatibility with version 1.0.0.

--- a/docs/source/guide/install.md
+++ b/docs/source/guide/install.md
@@ -120,23 +120,24 @@ pip install label-studio
 
 ## Install on Google Cloud
 
-1. First login with `gcloud`
+1. From the command line, log in with `gcloud`
 ```bash
 gcloud auth application-default login
 ```
 
-2. You can use `direnv` to keep track of necessary env variables. Set up `.envrc` and don't forget to run `direnv allow`.
+> You can keep track of necessary env variables with `direnv`. Set up `.envrc` and don't forget to run `direnv allow`.
 ```bash
-export PROJECT_ID=maystra-poc
+export PROJECT_ID=<your-project>
 ```
 
-3. Build the docker image and push it to Google Build with:
+3. Build the Docker image.
+4. Push the Docker image you built to Google Build using the following command:
 ```bash
 // Needs to be from the same directory as cloudbuild.yaml
 gcloud builds submit
 ```
 
-4. Init terraform and apply changes
+4. Initiate terraform and apply changes. From the command line, run the following:
 ```bash
 cd deploy/gcp
 terraform init


### PR DESCRIPTION
I set these up personally to deploy label-studio for my company. Thought I would send this upstream in case people need a quick way to get it on Google Cloud.

This commit does 2 things:

1. Introduces `cloudbuild.yaml`, which allows a quick docker image to be built on Google Cloud Build.
2. Adds terraform files to bootstrap label-studio on Google Run connected to a Postgres instance on Google SQL. Mapped with a proper service account as well as domain mapping.

I wanted to write up some docs on how people can use these files, but I wasn't sure where the maintainers would like it. Let me know and I can update this commit!

# Testing

1. First login with `gcloud`
```
gcloud auth application-default login
```

2. Using `direnv` to keep track of necessary env variables. Set up `.envrc` with:
```
export PROJECT_ID=maystra-poc
```

3. Build the docker image and push it to Google Build with:
```
// needs to be from the same directory as cloudbuild.yaml
gcloud builds submit
```

4. Init terraform and apply changes

```
cd deploy/gcp
terraform init
terraform apply -var="database_password=<DB_PASSWORD>" \
                           -var="project=<PROJECT_ID>" \
                           -var="database_user=<DB_USER>" \
                           -var="domain_name=<DOMAIN_NAME>"
```
