### PR TITLE
Using get_bool_env to check for flag in core.settings

### DIFF
--- a/label_studio/core/settings/base.py
+++ b/label_studio/core/settings/base.py
@@ -123,7 +123,8 @@ LOGGING = {
     }
 }
 
-if get_env('GOOGLE_LOGGING_ENABLED', False):
+if get_bool_env('GOOGLE_LOGGING_ENABLED', False):
+    logging.info('Google Cloud Logging handler is enabled.')
     try:
         import google.cloud.logging
         from google.auth.exceptions import GoogleAuthError


### PR DESCRIPTION
# Problem
On https://github.com/heartexlabs/label-studio/pull/1369 I introduced a flag in settings to enable/disable google logging. It should have been using get_bool_env instead of get_env.

# Solution
This PR fixes it as well as adds a logging line to help debugging if the handler is enabled or not.