### PR TITLE
Specify DB name in initialization script

### DIFF
--- a/deploy/docker-entrypoint.d/10-wait-for-postgres.sh
+++ b/deploy/docker-entrypoint.d/10-wait-for-postgres.sh
@@ -3,7 +3,7 @@ set -e
 
 if [ -n "${POSTGRE_HOST:-}" ]; then
   echo >&3 "=> Waiting for postgres..."
-  until PGPASSWORD=$POSTGRE_PASSWORD psql -h "$POSTGRE_HOST" -p $POSTGRE_PORT -U "$POSTGRE_USER" -c '\q'; do
+  until PGPASSWORD=$POSTGRE_PASSWORD psql -h "$POSTGRE_HOST" -p $POSTGRE_PORT -U "$POSTGRE_USER" -d "${POSTGRE_NAME:=root}" -c '\q'; do
     echo >&3 "==> Postgres is unavailable - sleeping..."
     sleep 1
   done


### PR DESCRIPTION
If the DB name is not `root`, then we cannot to the DB.
Add the bash substitution arg to `POSTGRE_NAME` so we can set the name of the DB using env. vars