### PR TITLE
Fixing duplicate key simple in ApiProvider

### DIFF
--- a/label_studio/frontend/src/providers/ApiProvider.js
+++ b/label_studio/frontend/src/providers/ApiProvider.js
@@ -41,7 +41,6 @@ const handleError = async (response, showModal = true) => {
 
     modal({
       allowClose: !isShutdown,
-      simple: true,
       body: isShutdown ? (
         <ErrorWrapper
           possum={false}


### PR DESCRIPTION
This is a minor fix, but the file modal sets the key `simple` twice.