### PR TITLE
Update webhook event reference to include number fields

### DIFF
--- a/docs/source/guide/webhook_reference.md
+++ b/docs/source/guide/webhook_reference.md
@@ -16,10 +16,10 @@ Webhooks sent from Label Studio include the following:
 | action | Details the action that the event represents. |
 | project | Included only for task and annotation events. Details about the project. |
 | task_number | Total number of tasks in the project. |
-| finished_task_number | Total number of annotated or skipped tasks in the project. |
+| finished_task_number | Total number of annotated tasks in the project. |
 | total_predictions_number | Total number of predictions for the project. |
 | total_annotations_number | Total number of annotations, skipped tasks, and ground truth annotations in the project. Can be different from the total number of annotated tasks. |
-| num_tasks_with_annotations | Total number of tasks with annotations in the project. |
+| num_tasks_with_annotations | Total number of tasks with annotations in the project. Does not count skipped and ground truth annotations. |
 | useful_annotation_number | Total number of annotations in the project. Excludes skipped and ground truth annotations.  |
 | ground_truth_number | Total number of annotations marked as ground truth annotations in the project. |
 | skipped_annotations_number | Total number of skipped or cancelled annotations in the project. |

--- a/docs/source/guide/webhook_reference.md
+++ b/docs/source/guide/webhook_reference.md
@@ -15,6 +15,14 @@ Webhooks sent from Label Studio include the following:
 | --- | --- |
 | action | Details the action that the event represents. |
 | project | Included only for task and annotation events. Details about the project. |
+| task_number | Total number of tasks in the project. |
+| finished_task_number | Total number of annotated or skipped tasks in the project. |
+| total_predictions_number | Total number of predictions for the project. |
+| total_annotations_number | Total number of annotations, skipped tasks, and ground truth annotations in the project. Can be different from the total number of annotated tasks. |
+| num_tasks_with_annotations | Total number of tasks with annotations in the project. |
+| useful_annotation_number | Total number of annotations in the project. Excludes skipped and ground truth annotations.  |
+| ground_truth_number | Total number of annotations marked as ground truth annotations in the project. |
+| skipped_annotations_number | Total number of skipped or cancelled annotations in the project. |
 
 The HTTP POST payloads that Label Studio sends to the configured webhook URLs include the headers that you set up when you [configure the webhook](webhooks.html).
 

--- a/label_studio/projects/serializers.py
+++ b/label_studio/projects/serializers.py
@@ -28,7 +28,8 @@ class ProjectSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
                                                               'skipped_annotations_number and ground_truth_number.')
     total_predictions_number = serializers.IntegerField(default=None, read_only=True,
                                                     help_text='Total predictions number in project including '
-                                                              'skipped_annotations_number and ground_truth_numberuseful_annotation_number.')
+                                                              'skipped_annotations_number, ground_truth_number, and '
+                                                              'useful_annotation_number.')
     useful_annotation_number = serializers.IntegerField(default=None, read_only=True,
                                                      help_text='Useful annotation number in project not including '
                                                                'skipped_annotations_number and ground_truth_number. '


### PR DESCRIPTION
All webhook event payloads include total number of tasks, total annotated tasks, total annotations, and more. Updated the table in the event reference (not the examples) to include names and descriptions. 