### PR TITLE
Fix link Markdown and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Install Label Studio locally, or deploy it in a cloud instance. Also you can try
 - [Deploy in a cloud instance](#deploy-in-a-cloud-instance)
 
 ### Install locally with Docker
-Official Label Studio docker imageis is (here)[https://hub.docker.com/r/heartexlabs/label-studio] and it can be downloaded with `docker pull`. 
+Official Label Studio docker imageis is [here](https://hub.docker.com/r/heartexlabs/label-studio) and it can be downloaded with `docker pull`. 
 Run Label Studio in a Docker container and access it at `http://localhost:8080`.
 
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Install Label Studio locally, or deploy it in a cloud instance. Also you can try
 - [Deploy in a cloud instance](#deploy-in-a-cloud-instance)
 
 ### Install locally with Docker
-Official Label Studio docker imageis is [here](https://hub.docker.com/r/heartexlabs/label-studio) and it can be downloaded with `docker pull`. 
+Official Label Studio docker image is [here](https://hub.docker.com/r/heartexlabs/label-studio) and it can be downloaded with `docker pull`. 
 Run Label Studio in a Docker container and access it at `http://localhost:8080`.
 
 


### PR DESCRIPTION
The Markdown for the Docker Hub link in `README.md` was using inverted syntax so it wasn't rendering properly.