### PR TITLE
[fix] Fixed the port flag for checking mysql availability

### DIFF
--- a/deploy/docker-entrypoint.d/20-wait-for-db.sh
+++ b/deploy/docker-entrypoint.d/20-wait-for-db.sh
@@ -10,7 +10,7 @@ if [ -n "${POSTGRE_HOST:-}" ]; then
   echo >&3 "=> Postgres is up."
 elif [ -n "${MYSQL_HOST:-}" ]; then
   echo >&3 "=> Waiting for MySQL..."
-  while ! mysqladmin ping -h"$MYSQL_HOST" -p"${MYSQL_PORT:-3306}" --silent; do
+  while ! mysqladmin ping -h"$MYSQL_HOST" -P"${MYSQL_PORT:-3306}" --silent; do
       echo >&3 "==> MySQL is unavailable - sleeping..."
       sleep 1
   done


### PR DESCRIPTION
While doing the initial deployment using MySQL database, the script checks if the MYSQL HOST can be pinged. The flag for passing port is uppercase `P` whereas the script was using lowercase `p` which is for entering password. 