### PR TITLE
[fix] Project config code view overflow

### DIFF
--- a/label_studio/frontend/src/pages/CreateProject/Config/Config.styl
+++ b/label_studio/frontend/src/pages/CreateProject/Config/Config.styl
@@ -204,6 +204,7 @@ styled_scroll()
   margin-left: auto;
 }
 .wizard .configure__code
+  overflow: hidden
   textarea
   :global(.react-codemirror2)
     flex: 1


### PR DESCRIPTION
Fixes overflow on the code view for a project config when it has long lines. Without this fix, using arrow keys to move the cursor in the code view won't properly scroll horiztonally.

Before fix:

<img width="593" alt="Screen Shot" src="https://user-images.githubusercontent.com/5820654/138766074-86f3bee0-2f7e-4afe-95f8-9fd6edc470f1.png">

After fix:

<img width="592" alt="Screen Shot" src="https://user-images.githubusercontent.com/5820654/138766112-5d0ddfff-bd79-4d3e-a13e-2029f536808b.png">
