### PR TITLE
Fixed the two times predict call issue for single task prediction

### DIFF
--- a/label_studio/ml/models.py
+++ b/label_studio/ml/models.py
@@ -180,7 +180,7 @@ class MLBackend(models.Model):
             return
 
         # ML Backend doesn't support batch of tasks, do it one by one
-        elif len(responses) == 1:
+        elif len(responses) == 1 and len(tasks) != 1:
             logger.warning(
                 f"'ML backend '{self.title}' doesn't support batch processing of tasks, "
                 f"switched to one-by-one task retrieval"


### PR DESCRIPTION
Tickets: 
- https://github.com/heartexlabs/label-studio-ml-backend/issues/64
- #1755 