### PR TITLE
Include <Relation> tag as label

### DIFF
--- a/label_studio/core/label_config.py
+++ b/label_studio/core/label_config.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 _DATA_EXAMPLES = None
-_LABEL_TAGS = {'Label', 'Choice'}
+_LABEL_TAGS = {'Label', 'Choice', 'Relation'}
 SINGLE_VALUED_TAGS = {
     'choices': str,
     'rating': int,


### PR DESCRIPTION
There is a bug in <Relations> and <Relation> tag parsing. When parsed as label_config parameter of LabelStudioMLBase, relation tags were ignored.

Take the default relation extraction template as an example. 
```
        <View>
          <Relations name="rel_label" toName="text">
            <Relation value="org:founded_by"/>
            <Relation value="org:founded"/>
          </Relations>
          <Labels name="label" toName="text">
            <Label value="Organization" background="orange"/>
            <Label value="Person" background="green"/>
            <Label value="Datetime" background="blue"/>
          </Labels>
          <Text name="text" value="$text"/>
        </View>
```
The above xml template will be parsed by parse_config util function as following json. \
```
        {
            "label": {
                "type": "Labels",
                "to_name": [
                    "text"
                ],
                "inputs": [{
                    "type": "Text",
                    "value": "text"
                }],
                "labels": [
                    "Organization",
                    "Person",
                    "Datetime"
                ],
                "labels_attrs": {...}
            }
        }
```