### PR TITLE
[fix] docs jumping to wrong anchor at the load (DEV-1258)

### DIFF
--- a/docs/themes/htx/source/js/common.js
+++ b/docs/themes/htx/source/js/common.js
@@ -7,7 +7,7 @@
     initSubHeaders();
   }
 
-  initLocationHashFuzzyMatching();
+  window.addEventListener('DOMContentLoaded', initLocationHashFuzzyMatching);
   initPreviewButtons();
 
   function parseRawHash(hash) {


### PR DESCRIPTION
`initLocationHashFuzzyMatching` should be running after the page loads