### PR TITLE
Add pre-annotation troubleshooting 

### DIFF
--- a/docs/source/guide/FAQ.md
+++ b/docs/source/guide/FAQ.md
@@ -93,5 +93,11 @@ If you find that after annotating audio data, the visible audio wave doesn't mat
 ffmpeg -y -i audio.mp3 -ar 8k -ac 1 audio.wav
 ```
 
+## Predictions aren't visible to annotators  
 
+See [Troubleshoot pre-annotations](predictions.html#Troubleshoot-pre-annotations) to investigate possible reasons why predictions don't show up.
+
+## Can't label PDF data
+
+Label Studio does not support labeling PDF files directly. However, you can convert files to HTML using your PDF viewer or another tool and label the PDF as part of the HTML. See an example labeling configuration in the [Label Studio playground](/playground/?config=%3CView%3E%3Cbr%3E%20%20%3CHyperText%20name%3D%22pdf%22%20value%3D%22%24pdf%22%2F%3E%3Cbr%3E%3Cbr%3E%20%20%3CHeader%20value%3D%22Rate%20this%20article%22%2F%3E%3Cbr%3E%20%20%3CRating%20name%3D%22rating%22%20toName%3D%22pdf%22%20maxRating%3D%2210%22%20icon%3D%22star%22%20size%3D%22medium%22%20%2F%3E%3Cbr%3E%3Cbr%3E%20%20%3CChoices%20name%3D%22choices%22%20choice%3D%22single-radio%22%20toName%3D%22pdf%22%20showInline%3D%22true%22%3E%3Cbr%3E%20%20%20%20%3CChoice%20value%3D%22Important%20article%22%2F%3E%3Cbr%3E%20%20%20%20%3CChoice%20value%3D%22Yellow%20press%22%2F%3E%3Cbr%3E%20%20%3C%2FChoices%3E%3Cbr%3E%3C%2FView%3E%3Cbr%3E).
 

--- a/docs/source/guide/predictions.md
+++ b/docs/source/guide/predictions.md
@@ -649,7 +649,7 @@ If annotators can't see predictions or if you encounter unexpected behavior afte
 In the **Settings > Machine Learning** section for your project, make sure that the following settings are configured:
 - Enable **Show predictions to annotators in the Label Stream and Quick View**
 - Select the relevant **Model Version** in the drop-down. If there is no drop-down menu visible, there might not be a model version listed for the pre-annotations, or there might be another issue happening. 
-- Disable the option to **Reveal pre-annotations interactively**, unless you're using [interactive pre-annotations](ml.html#Get-interactive-preannotations).
+- Disable the option to **Reveal pre-annotations interactively**, which requires manual action from annotators to display pre-annotated regions. 
 
 ### Check the configuration values of your labeling configuration and tasks
 The `from_name` of the pre-annotation task JSON must match the value of the name in the `<Labels name="label" toName="text">` portion of the labeling configuration. The `to_name` must match the `toName` value. 

--- a/docs/source/guide/predictions.md
+++ b/docs/source/guide/predictions.md
@@ -649,7 +649,7 @@ If annotators can't see predictions or if you encounter unexpected behavior afte
 In the **Settings > Machine Learning** section for your project, make sure that the following settings are configured:
 - Enable **Show predictions to annotators in the Label Stream and Quick View**
 - Select the relevant **Model Version** in the drop-down. If there is no drop-down menu visible, there might not be a model version listed for the pre-annotations, or there might be another issue happening. 
-- Disable the option to **Reveal pre-annotations interactively**, which requires manual action from annotators to display pre-annotated regions. 
+- <i class='ent'></i> Disable the option to **Reveal pre-annotations interactively**, which requires manual action from annotators to display pre-annotated regions. (Label Studio Enterprise only)  
 
 ### Check the configuration values of your labeling configuration and tasks
 The `from_name` of the pre-annotation task JSON must match the value of the name in the `<Labels name="label" toName="text">` portion of the labeling configuration. The `to_name` must match the `toName` value. 

--- a/docs/source/guide/predictions.md
+++ b/docs/source/guide/predictions.md
@@ -642,7 +642,14 @@ For more assistance, review this [example code creating a Label Studio task with
 
 
 ## Troubleshoot pre-annotations
-If you encounter unexpected behavior after you import pre-annotations into Label Studio, review this guidance to resolve the issues.
+
+If annotators can't see predictions or if you encounter unexpected behavior after you import pre-annotations into Label Studio, review this guidance to resolve the issues.
+
+### Make sure the predictions are visible to annotators
+In the **Settings > Machine Learning** section for your project, make sure that the following settings are configured:
+- Enable **Show predictions to annotators in the Label Stream and Quick View**
+- Select the relevant **Model Version** in the drop-down. If there is no drop-down menu visible, there might not be a model version listed for the pre-annotations, or there might be another issue happening. 
+- Disable the option to **Reveal pre-annotations interactively**, unless you're using [interactive pre-annotations](ml.html#Get-interactive-preannotations).
 
 ### Check the configuration values of your labeling configuration and tasks
 The `from_name` of the pre-annotation task JSON must match the value of the name in the `<Labels name="label" toName="text">` portion of the labeling configuration. The `to_name` must match the `toName` value. 


### PR DESCRIPTION
Add notes in troubleshooting spots about what to do if pre-annotations aren't visible to annotators, since we've had a number of questions about this lately.