### PR TITLE
Dev 1187: Add drafts to export JSON

### DIFF
--- a/docs/source/guide/export.md
+++ b/docs/source/guide/export.md
@@ -257,7 +257,8 @@ Review the full list of JSON properties in the [API documentation](api.html).
 | result.to_name | Name of the object tag that provided the region to be labeled. See [object tags](/tags). |
 | result.type | Type of tag used to annotate the task. |
 | result.value | Tag-specific value that includes details of the result of labeling the task. The value structure depends on the tag for the label. [Explore each tag](/tags) for more details. |
-| predictions | Array of machine learning predictions. Follows the same format as the completions array, with one additional parameter. |
+| drafts | Array of draft annotations. Follows the same format as the annotations array. Included only for tasks exported as a snapshot [from the UI](#Export-snapshots-using-the-UI) or [using the API](#Export-snapshots-using-the-API).
+| predictions | Array of machine learning predictions. Follows the same format as the annotations array, with one additional parameter. |
 | predictions.score | The overall score of the result, based on the probabilistic output, confidence level, or other. | 
 
 <!-- md image_units.md -->

--- a/docs/source/guide/tasks.md
+++ b/docs/source/guide/tasks.md
@@ -131,9 +131,10 @@ You can add other, optional keys to the JSON file.
 
 | JSON key | Description |
 | --- | --- | 
-| id | Optional. Integer to use as the task ID. |
 | annotations | Optional. List of annotations exported from Label Studio. [Label Studio's annotation format](export.html#Raw-JSON-format-of-completed-tasks) allows you to import annotation results in order to use them in subsequent labeling tasks. |
 | predictions | Optional. List of model prediction results, where each result is saved using [Label Studio's prediction format](export.html#Raw-JSON-format-of-completed-tasks). Import predictions for automatic task pre-labeling and active learning. See [Import predicted labels into Label Studio](predictions.html) |
+
+See [Relevant JSON property descriptions](export.html#Relevant-JSON-property-descriptions) in the export documentation for more details about the JSON format of exported tasks.
 
 ### Example JSON format
 


### PR DESCRIPTION
* Add description for drafts array to export JSON, which only appears when using "snapshot" functionality
* Remove ID from list of things that you can add to JSON when importing tasks, since you can't.