### PR TITLE
fix: DEV-1525: update label-studio-converter with conll, pillow & nltk version bumps. Remove python 3.6 from tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,10 +22,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 3.6
           - 3.7
           - 3.8
           - 3.9
+          - 3.10
 
     env:
       DJANGO_SETTINGS_MODULE: core.settings.label_studio
@@ -216,10 +216,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 3.6
           - 3.7
           - 3.8
           - 3.9
+          - 3.10
 
     env:
       DJANGO_SETTINGS_MODULE: core.settings.label_studio

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,6 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
-          - '3.10'
 
     env:
       DJANGO_SETTINGS_MODULE: core.settings.label_studio
@@ -219,7 +218,6 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
-          - '3.10'
 
     env:
       DJANGO_SETTINGS_MODULE: core.settings.label_studio

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Install OS dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install virtualenv libsasl2-dev python-dev libldap2-dev libssl-dev
+          sudo apt-get install virtualenv libsasl2-dev python-dev libldap2-dev libssl-dev libxml2-dev libxslt-dev python-dev
 
       - uses: actions/cache@v2.1.7
         name: Configure pip cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
-          - 3.10
+          - '3.10'
 
     env:
       DJANGO_SETTINGS_MODULE: core.settings.label_studio
@@ -219,7 +219,7 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
-          - 3.10
+          - '3.10'
 
     env:
       DJANGO_SETTINGS_MODULE: core.settings.label_studio

--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -57,5 +57,5 @@ redis>=3.5.0
 sentry-sdk>=1.1.0
 launchdarkly-server-sdk==7.3.0
 
-label-studio-converter==0.0.37
+label-studio-converter==0.0.38
 label-studio-tools==0.0.0.dev11


### PR DESCRIPTION
…k version bumps