### PR TITLE
Remove support for Python 3.6 from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ docker-compose up
 ### Install locally with pip
 
 ```bash
-# Requires Python >=3.6 <=3.9
+# Requires Python >=3.7 <=3.9
 pip install label-studio
 
 # Start the server at http://localhost:8080

--- a/docs/source/guide/install.md
+++ b/docs/source/guide/install.md
@@ -29,14 +29,14 @@ Install Label Studio in a clean Python environment. We highly recommend using a 
 
 ## Install with pip
 
-To install Label Studio with pip and a virtual environment, you need Python version 3.6 or later. Run the following:
+To install Label Studio with pip and a virtual environment, you need Python version 3.7 or later. Run the following:
 ```bash
 python3 -m venv env
 source env/bin/activate
 python -m pip install label-studio
 ```
 
-To install Label Studio with pip, you need Python version 3.6 or later. Run the following:
+To install Label Studio with pip, you need Python version 3.7 or later. Run the following:
 ```bash
 pip install label-studio
 ```


### PR DESCRIPTION
Pillow upgrade to 9.0.0 means Python 3.6 is no longer supported by Label Studio