### PR TITLE
Docs: DEV-1717 — Enhance time series templates

### DIFF
--- a/docs/source/templates/activity_recognition.md
+++ b/docs/source/templates/activity_recognition.md
@@ -12,9 +12,7 @@ meta_description: Template for labeling human activity recognition in a time ser
 
 If you want to perform time series classification for human activity recognition, use this template to classify different activities across several time series channels.
 
-## Template Preview
-
-Interactively preview this labeling template:
+## Interactive Template Preview
 
 <div id="main-preview"></div>
 
@@ -22,7 +20,6 @@ Interactively preview this labeling template:
 
 ```html
 <View>
-    <!-- Control tag for region labels, use to label the time series channels with the type of activity -->
     <TimeSeriesLabels name="label" toName="ts">
         <Label value="Run" background="red"/>
         <Label value="Walk" background="green"/>
@@ -30,9 +27,7 @@ Interactively preview this labeling template:
         <Label value="Swim" background="#f6a"/>
         <Label value="Ride" background="#351"/>
     </TimeSeriesLabels>
-
-    <!-- Object tag for time series data source, use to manage the display 
-    of the time series data in the labeling interface -->
+    
     <TimeSeries name="ts" valueType="url" value="$timeseriesUrl"
                 sep=","
                 timeColumn="time"
@@ -54,6 +49,47 @@ Interactively preview this labeling template:
     </TimeSeries>
 </View>
 ```
+
+## About the labeling configuration
+
+All labeling configurations must be wrapped in [View](/tags/view.html) tags.
+
+Use the [TimeSeriesLabels](/tags/timeserieslabels.html) control tag to provide a list of labels that annotators can apply to regions on the time series graph:
+```xml
+    <TimeSeriesLabels name="label" toName="ts">
+        <Label value="Run" background="red"/>
+        <Label value="Walk" background="green"/>
+        <Label value="Fly" background="blue"/>
+        <Label value="Swim" background="#f6a"/>
+        <Label value="Ride" background="#351"/>
+    </TimeSeriesLabels>
+```
+
+Use the [TimeSeries](/tags/timeseries.html) object tag to specify the time series data source. The `valueType="url"` parameter specifies that the time series data is available as a URL, rather than a file, and the `value="$csv"` parameter specifies that the URL is stored in a data key called `timeseriesUrl`. The `sep=","` parameter specifies that a comma is the data separator, as is standard for a CSV-formatted file. The time parameters specify which column contains the time data, the format of the time data in the file, and how to display the time data on the labeling interface. 
+```xml
+    <TimeSeries name="ts" valueType="url" value="$timeseriesUrl"
+                sep=","
+                timeColumn="time"
+                timeFormat="%Y-%m-%d %H:%M:%S.%f"
+                timeDisplayFormat="%Y-%m-%d"
+                overviewChannels="velocity">
+
+        <Channel column="velocity"
+                 units="miles/h"
+                 displayFormat=",.1f"
+                 strokeColor="#1f77b4"
+                 legend="Velocity"/>
+
+        <Channel column="acceleration"
+                 units="miles/h^2"
+                 displayFormat=",.1f"
+                 strokeColor="#ff7f0e"
+                 legend="Acceleration"/>
+    </TimeSeries>
+```
+The `overviewChannels` parameter in the [TimeSeries](/tags/timeseries.html) tag specifies the column in the time series data to display on the time series graph as a channel. 
+
+You can then use the Channel tag and its parameters to provide details about each channel, such as the column name, the units of the data, the `displayFormat` of the channel data using d3 format, the `strokeColor` to use when highlighting the channel, and the name of the channel as it should appear in the labeling interface legend. 
 
 ## Related tags
 

--- a/docs/source/templates/change_point_detection.md
+++ b/docs/source/templates/change_point_detection.md
@@ -12,9 +12,7 @@ meta_description: Template for labeling change point detection in time series da
 
 If you need to find sudden changes in time series data, use this template to perform change point detection. Label the change on relevant time series channels. 
 
-## Template Preview
-
-Interactively preview this labeling template:
+## Interactive Template Preview
 
 <div id="main-preview"></div>
 
@@ -22,13 +20,10 @@ Interactively preview this labeling template:
 
 ```html
 <View>
-    <!-- Control tag for region labels, use to highlight the change -->
     <TimeSeriesLabels name="label" toName="ts">
         <Label value="Change" background="red" />
     </TimeSeriesLabels>
-
-    <!-- Object tag for time series data source, use to specify the 
-    location and format of the time series data -->
+    
     <TimeSeries name="ts" valueType="url" value="$csv"
                 sep=","
                 timeColumn="time"
@@ -44,6 +39,34 @@ Interactively preview this labeling template:
     </TimeSeries>
 </View>
 ```
+
+## About the labeling configuration
+
+All labeling configurations must be wrapped in [View](/tags/view.html) tags.
+
+Use the [TimeSeriesLabels](/tags/timeserieslabels.html) control tag to allow annotators to label the region indicating change on the time series graph:
+```xml
+    <TimeSeriesLabels name="label" toName="ts">
+        <Label value="Change" background="red" />
+    </TimeSeriesLabels>
+```
+
+Use the [TimeSeries](/tags/timeseries.html) object tag to specify the time series data source. The `valueType="url"` parameter specifies that the time series data is available as a URL, rather than a file, and the `value="$csv"` parameter specifies that the URL is stored in a data key called `csv`. The `sep=","` parameter specifies that a comma is the data separator, as is standard for a CSV-formatted file. The time parameters specify which column contains the time data, the format of the time data in the file, and how to display the time data on the labeling interface. 
+```xml
+ <TimeSeries name="ts" valueType="url" value="$csv"
+                sep=","
+                timeColumn="time"
+                timeFormat="%Y-%m-%d %H:%M:%S.%f"
+                timeDisplayFormat="%Y-%m-%d"
+                overviewChannels="velocity">
+        <Channel column="velocity"
+                 units="miles/h"
+                 displayFormat=",.1f"
+                 strokeColor="#1f77b4"
+                 legend="Velocity"/>
+    </TimeSeries>
+```
+The `overviewChannels` parameter in the [TimeSeries](/tags/timeseries.html) tag specifies the column in the time series data to display on the time series graph as a channel. You can then use the Channel tag and its parameters to provide details about the data, such as the units of the data, the `displayFormat` of the channel data using d3 format, the `strokeColor` to use when highlighting the channel, and the name of the channel as it should appear in the labeling interface legend. 
 
 ## Related tags
 

--- a/docs/source/templates/outliers_anomaly_detection.md
+++ b/docs/source/templates/outliers_anomaly_detection.md
@@ -12,9 +12,7 @@ meta_description: Template for detecting outliers and anomallies in time series 
 
 If you want to train a machine learning model to detect outliers and anomalies in time series data, use this template to label suspicious regions and classify those regions of the time series channels as outliers or anomalies.
 
-## Template Preview
-
-Interactively preview this labeling template:
+## Interactive Template Preview
 
 <div id="main-preview"></div>
 
@@ -23,7 +21,6 @@ Interactively preview this labeling template:
 ```html
 <View>
 
-    <!-- Object tag to specify the time series data source -->
     <TimeSeries name="ts" valueType="url" value="$csv"
                 sep=","
                 timeColumn="time"
@@ -37,18 +34,52 @@ Interactively preview this labeling template:
                  strokeColor="#1f77b4"
                  legend="Velocity"/>
     </TimeSeries>
-    <!-- Control tag to specify the labels to apply to regions -->
     <TimeSeriesLabels name="label" toName="ts">
         <Label value="Region" background="red" />
     </TimeSeriesLabels>
-    <!--Use the Choices control tag to classify whether each specific
-    region is an Outlier or an Anomaly in the time series data.-->
   <Choices name="region_type" toName="ts"
         perRegion="true" required="true">
       <Choice value="Outlier"/>
       <Choice value="Anomaly"/>
   </Choices>
 </View>
+```
+
+## About the labeling configuration
+
+All labeling configurations must be wrapped in [View](/tags/view.html) tags.
+
+Use the [TimeSeries](/tags/timeseries.html) object tag to specify the time series data source. The `valueType="url"` parameter specifies that the time series data is available as a URL, rather than a file, and the `value="$csv"` parameter specifies that the URL is stored in a data key called `csv`. The `sep=","` parameter specifies that a comma is the data separator, as is standard for a CSV-formatted file. The time parameters specify which column contains the time data, the format of the time data in the file, and how to display the time data on the labeling interface. 
+```xml
+ <TimeSeries name="ts" valueType="url" value="$csv"
+                sep=","
+                timeColumn="time"
+                timeFormat="%Y-%m-%d %H:%M:%S.%f"
+                timeDisplayFormat="%Y-%m-%d"
+                overviewChannels="velocity">
+        <Channel column="velocity"
+                 units="miles/h"
+                 displayFormat=",.1f"
+                 strokeColor="#1f77b4"
+                 legend="Velocity"/>
+    </TimeSeries>
+```
+The `overviewChannels` parameter in the [TimeSeries](/tags/timeseries.html) tag specifies the column in the time series data to display on the time series graph as a channel. You can then use the Channel tag and its parameters to provide details about the data, such as the units of the data, the `displayFormat` of the channel data using d3 format, the `strokeColor` to use when highlighting the channel, and the name of the channel as it should appear in the labeling interface legend. 
+
+Use the [TimeSeriesLabels](/tags/timeserieslabels.html) control tag to specify the labels to apply to regions in the time series graph:
+```xml
+<TimeSeriesLabels name="label" toName="ts">
+        <Label value="Region" background="red" />
+</TimeSeriesLabels>
+```
+
+Use the [Choices](/tags/choices.html) control tag to classify whether each specific region is an Outlier or an Anomaly in the time series data:
+```xml
+<Choices name="region_type" toName="ts"
+        perRegion="true" required="true">
+      <Choice value="Outlier"/>
+      <Choice value="Anomaly"/>
+</Choices>
 ```
 
 ## Related tags

--- a/docs/source/templates/signal_quality.md
+++ b/docs/source/templates/signal_quality.md
@@ -12,41 +12,25 @@ meta_description: Template to classify signal quality in a time series with Labe
 
 Identify regions on a time series and rate and classify the quality of the signal. 
 
-## Template Preview
-
-Interactively preview this labeling template:
+## Interactive Template Preview
 
 <div id="main-preview"></div>
 
 ## Labeling Configuration
 
 ```html
-
-   
 <View>
-    <!-- If no region of the time series data is selected, 
-    this section is visible on the labeling interface -->
     <View visibleWhen="no-region-selected"
           style="height:120px">
-
-        <!-- Use the TimeSeriesLabels control tag to label 
-         specific regions on the time series data. -->
         <TimeSeriesLabels name="label" toName="ts">
             <Label value="Region" background="#5b5"/>
         </TimeSeriesLabels>
     </View>
-
-    <!-- When a region is selected on the labeling interface,
-     this section of labeling options is visible to annotators-->
+    
     <View visibleWhen="region-selected" style="height:120px">
-
-        <!-- Use the Rating control tag to prompt annotators
-         to select a 10 star scale rating for the selected region-->
         <Rating name="rating" toName="ts"
                 maxRating="10" icon="star"
                 perRegion="true"/>
-        <!-- Use the Choices control tag to prompt annotators
-         to select a choice for the selected region-->
         <Choices name="choices" toName="ts"
                  showInline="true" required="true"
                  perRegion="true">
@@ -55,9 +39,6 @@ Interactively preview this labeling template:
             <Choice value="Poor"/>
         </Choices>
     </View>
-
-    <!-- Use the TimeSeries object tag and the Channel tag to 
-     display the TimeSeries data and channels to the annotators. -->
     <TimeSeries name="ts" valueType="url" value="$csv"
                 sep="," timeColumn="time">
         <Channel column="signal_1"
@@ -66,6 +47,60 @@ Interactively preview this labeling template:
                  strokeColor="#f70" legend="Signal 2"/>
     </TimeSeries>
 </View>
+```
+
+## About the labeling configuration
+
+All labeling configurations must be wrapped in [View](/tags/view.html) tags.
+
+Use the `visibleWhen` parameter with the [View](/tags/view.html) tag to create a section of the labeling configuration that is only visible when no region is selected:
+```xml
+<View visibleWhen="no-region-selected"
+          style="height:120px">
+``` 
+
+When that section of the labeling interface is visible, annotators can use the [TimeSeriesLabels](/tags/timeserieslabels.html) control tag to label specific regions on the time series data:
+```xml
+        <TimeSeriesLabels name="label" toName="ts">
+            <Label value="Region" background="#5b5"/>
+        </TimeSeriesLabels>
+    </View>
+```
+
+Use the `visibleWhen` parameter with a different [View](/tags/view.html) tag to create a section of the labeling interface that is visible only when a region is selected:
+```xml
+<View visibleWhen="region-selected" style="height:120px">
+```
+
+When that section of the labeling interface is visible, annotators can use the [Rating](/tags/rating.html) control tag to select a 10 star rating for the selected region:
+```xml
+<Rating name="rating" toName="ts"
+                maxRating="10" icon="star"
+                perRegion="true"/>
+```
+The `perRegion="true"` parameter means that this rating only applies to the selected region.
+
+Still within that region-specific section of the labeling interface, annotators can use the [Choices](/tags/choices.html) control tag to select a choice for the selected region:
+```xml
+        <Choices name="choices" toName="ts"
+                 showInline="true" required="true"
+                 perRegion="true">
+            <Choice value="Good"/>
+            <Choice value="Medium"/>
+            <Choice value="Poor"/>
+        </Choices>
+    </View>
+```
+
+Use the [TimeSeries](/tags/timeseries.html) object tag and the Channel tag to display the TimeSeries data and channels to the annotators:
+```xml
+    <TimeSeries name="ts" valueType="url" value="$csv"
+                sep="," timeColumn="time">
+        <Channel column="signal_1"
+                 strokeColor="#17b" legend="Signal 1"/>
+        <Channel column="signal_2"
+                 strokeColor="#f70" legend="Signal 2"/>
+    </TimeSeries>
 ```
 
 ## Related tags

--- a/docs/source/templates/time_series.md
+++ b/docs/source/templates/time_series.md
@@ -155,8 +155,7 @@ All tasks in Label Studio are stored in JSON and this is the native format for L
 
 ## Output format example
 
-
-Users make annotations while labeling a task. One annotation is represented by a JSON structure and each annotation has a `result` field that looks like the following example:
+Annotators add labels to time series tasks. Label Studio represents each completed annotation with a JSON structure. Each annotation has a `result` field that looks like the following example for time series labeling projects:
 
 ```json
 {
@@ -197,16 +196,19 @@ Users make annotations while labeling a task. One annotation is represented by a
 
 ## Enhance this template
 
+If you want to enhance this template, you can make a number of changes to the tag configurations. 
+
 ### Multiple time series in one project
 
-If you want to use multiple time series files in one project, you must make your CSV files available as URLs and create an input JSON with tasks pointing to those CSVs. For example:
+If you want to use multiple time series datasets in one project, you must make your CSV files available as URLs and import a JSON-formatted file with tasks that reference those CSV files. 
+
+For example, for a task that can reference two sets of time series data:
 
 ```json
 [ { "data": { "csv_file1": "http://example.com/path/file1.csv", "csv_file2": "http://example.com/path/file2.csv" } } ]
 ```
 
-The accompanying labeling configuration is as follows:
-
+You could then set up the following labeling configuration to reference each CSV file and be able to label them both on the same labeling interface:
 ```html
 <View>
   <Header value="First time series" />
@@ -226,8 +228,8 @@ The accompanying labeling configuration is as follows:
   </TimeSeries>
 </View>
 ```
-
+The `value` parameter in the [TimeSeries](/tags/timeseries.html) tag is used to refer to the JSON key with the CSV file URL. 
 
 ### Video & audio sync with time series
 
-It's possible to synchronize TimeSeries with video and audio in Label Studio. Right now you can do it using HyperText tag with HTML objects `<audio src="path">`/`<video src="path">` and TimeSeries together. We have some solutions for this in testing. [Contact us](https://slack.labelstudio.heartex.com/?source=template-timeseries) in Slack to learn more.
+It's possible to synchronize TimeSeries with video and audio in Label Studio. Right now you can do this using the [HyperText](/tags/hypertext.html) tag with HTML objects `<audio src="path">`/`<video src="path">` and TimeSeries together. [Contact us](https://slack.labelstudio.heartex.com/?source=template-timeseries) in Slack to learn more about this experimental functionality.

--- a/docs/source/templates/time_series.md
+++ b/docs/source/templates/time_series.md
@@ -12,9 +12,7 @@ meta_description: Template for labeling multivariate and simple time series data
 
 Label any type of time series data using this generic template.
 
-## Template Preview
-
-Interactively preview this labeling template:
+## Interactive Template Preview
 
 <div id="main-preview"></div>
 
@@ -26,19 +24,38 @@ Example project configuration for multivariate time series labeling:
   
 ```html
 <View>
-    <!--Use the TimeSeriesLabels control tag to highlight
-    and label specific spans of a time series graph-->
   <TimeSeriesLabels name="label" toName="ts">
     <Label value="Run"/>
     <Label value="Walk"/>
   </TimeSeriesLabels> 
-    <!--Use the TimeSeries object tag to display time series data and channels-->
   <TimeSeries name="ts" valueType="url" value="$csv_url" timeColumn="time">
     <Channel column="sensorone" />
     <Channel column="sensortwo" />
   </TimeSeries>
 </View>
 ```
+
+## About the labeling configuration
+
+All labeling configurations must be wrapped in [View](/tags/view.html) tags.
+
+Use the [TimeSeriesLabels](/tags/timeserieslabels.html) control tag to highlight and label specific spans of a time series graph:
+```xml
+<TimeSeriesLabels name="label" toName="ts">
+    <Label value="Run"/>
+    <Label value="Walk"/>
+</TimeSeriesLabels> 
+```
+The tag is linked to the [TimeSeries](/tags/timeseries.html) object tag with a `toName` parameter.
+
+Use the [TimeSeries](/tags/timeseries.html) object tag to display time series data and channels:
+```xml
+<TimeSeries name="ts" valueType="url" value="$csv_url" timeColumn="time">
+    <Channel column="sensorone" />
+    <Channel column="sensortwo" />
+</TimeSeries>
+```
+The `valueType="url"` parameter means that Label Studio expects links to CSV files in JSON-formatted tasks. The `timeColumn` parameter specifies the column in your dataset to use as the X-axis for time. If you don't specify a `timeColumn`, Label Studio uses incremental integer values as the X-axis: `0, 1, 2, ...`.
 
 ### Input data
 Example CSV file input for the labeling configuration looks as follows:
@@ -49,15 +66,6 @@ time,sensorone,sensortwo
 1,20,30
 2,30,40
 ```
-
-### Template notes
-
-`<TimeSeriesLabels>` is linked with `<TimeSeries>` with a toName field.
-  
-`<TimeSeries>` has an attribute `valueType="url"`, which means that Label Studio expects links to CSV files in JSON-formatted tasks.
-
-Specify `timeColumn` in `TimeSeries` to use a specific column from your dataset as the X-axis. If you skip it, then Label Studio uses incremental integer values `0, 1, 2, ...` as the X-axis.
-
 
 ## Related tags
 - [TimeSeriesLabels](/tags/timeserieslabels.html)

--- a/docs/source/templates/time_series.md
+++ b/docs/source/templates/time_series.md
@@ -16,7 +16,7 @@ Label any type of time series data using this generic template.
 
 <div id="main-preview"></div>
 
-<!--Need to fix this preview because it previews all of the configs on this page oh no-->
+<!--Need to fix this preview because it previews all the configs on this page oh no-->
   
 ## Labeling Configuration
   
@@ -80,11 +80,9 @@ Label Studio supports several input types for time series:
 - TSV with or without a header
 - JSON
 
-### CSV
+### CSV Example
 
-CSV files are the most common way to upload time series data.
-
-For example, if you have a CSV file with 3 columns:
+For example, for a CSV file with 3 columns:
 
 ```csv
 time,sensorone,sensortwo
@@ -93,32 +91,28 @@ time,sensorone,sensortwo
 0.2,1.64,5.85
  ```
 
-Your `<TimeSeries>` tag must have an attribute `valueType="url"` to inform Label Studio to open the value in the task as a URL referencing a CSV file:
-
-```html
-<View>
-  <TimeSeries name="ts" valueType="url" value="$csv_url" sep="," timeColumn="time">
-    <Channel column="sensorone" />
-  </TimeSeries>
-</View> 
-```
-
-Example `file.json` to upload:
-
+Then, create a JSON file that references a URL for the CSV file to upload to Label Studio:
 ```json
 [ { "data": { "csv_url": "http://example.com/path/to/file.csv" } } ]
 ```
 
-### TSV 
-
-For TSV you need to configure a separator using the `sep` attribute on the `TimeSeries` tag. TSV format is very similar to CSV but the separator is a tab (`\t`) instead of a comma. The functionality is the same as CSV.
-
+Because the JSON file references a URL, and the URL is specified in a field called `csv_url`, set up the TimeSeries object tag like follows in your labeling configuration:
 ```html
-<View>
-  <TimeSeries name="ts" valueType="url" value="$csv_url" sep="\t" timeColumn="time">
+<TimeSeries name="ts" valueType="url" value="$csv_url" sep="," timeColumn="time">
+    <Channel column="sensorone" />
+</TimeSeries>
+```
+In this case, the `<TimeSeries>` tag has the `valueType="url"` attribute because the CSV file is referenced as a URL. See [How to import your data](/guide/tasks.html#How-to-import-your-data).
+
+### TSV Example
+
+If you're uploading a tab-separated file, use the `sep` attribute on the `TimeSeries` tag to specify tab separation.
+
+For example, set up the TimeSeries object tag like follows in your labeling configuration:
+```html
+<TimeSeries name="ts" valueType="url" value="$csv_url" sep="\t" timeColumn="time">
     <Channel column="0"/>
-  </TimeSeries>
-</View> 
+</TimeSeries>
 ```
 
 ### Headless CSV & TSV
@@ -201,7 +195,7 @@ Users make annotations while labeling a task. One annotation is represented by a
 }
 ```
 
-## Special cases
+## Enhance this template
 
 ### Multiple time series in one project
 

--- a/docs/source/templates/time_series_forecasting.md
+++ b/docs/source/templates/time_series_forecasting.md
@@ -12,9 +12,7 @@ meta_description: Template for preparing time series data for forecasting use ca
 
 To train a machine learning model to perform forecasting on time series data, create a dataset using this template. This template prompts annotators to highlight predictable region spans in the time series channels and label them as "Regions", then identify the trend forecast for a specific region. 
 
-## Template Preview
-
-Interactively preview this labeling template:
+## Interactive Template Preview
 
 <div id="main-preview"></div>
 
@@ -22,10 +20,7 @@ Interactively preview this labeling template:
 
 ```html
 <View>
-    <!--Use the Header tag to provide instructions to annotators-->
     <Header value="Select predictable region spans in time series:"/>
-    <!--Use the TimeSeriesLabels control tag to provide a way to label
-    specific regions on the time series graph-->
     <TimeSeriesLabels name="predictable" toName="stock">
         <Label value="Regions" background="red" />
     </TimeSeriesLabels>
@@ -52,6 +47,47 @@ Interactively preview this labeling template:
         <Choice value="Steady"/>
     </Choices>
 </View>
+```
+
+## About the labeling configuration
+
+All labeling configurations must be wrapped in [View](/tags/view.html) tags.
+
+You can add a [header](/tags/header.html) to provide instructions to the annotator:
+```xml
+<Header value="Select predictable region spans in time series:"/>
+```
+
+Use the [TimeSeriesLabels](/tags/timeserieslabels.html) control tag to provide a way to label specific regions on the time series graph:
+```xml
+<TimeSeriesLabels name="predictable" toName="stock">
+        <Label value="Regions" background="red" />
+</TimeSeriesLabels>
+```
+
+Use the [TimeSeries](/tags/timeseries.html) object tag to display time series data. The `valueType="url"` parameter specifies that the time series data is available as a URL, rather than a file, and the `value="$csv"` parameter specifies that the URL is stored in a data key called `csv`. The `sep=","` parameter specifies that a comma is the data separator, as is standard for a CSV-formatted file. The time parameters specify which column contains the time data, the format of the time data in the file, and how to display the time data on the labeling interface. 
+```xml
+    <TimeSeries name="stock" valueType="url" value="$csv"
+                sep=","
+                timeColumn="time"
+                timeFormat="%Y-%m-%d %H:%M:%S.%f"
+                timeDisplayFormat="%Y-%m-%d"
+                overviewChannels="value">
+        <Channel column="value"
+                 displayFormat=",.1f"
+                 strokeColor="#1f77b4"
+                 legend="Stock Value"/>
+    </TimeSeries>
+```
+Use the Channel tag to specify the name and display format, using d3 format, of the time series channel. You can use the `legend` parameter to specify the value to use for describing the channel.
+
+Use the Choices control tag to prompt annotators to choose the trend for the overall time series graph:
+```xml
+    <Choices name="trend_forecast" toName="stock">
+        <Choice value="Up"/>
+        <Choice value="Down"/>
+        <Choice value="Steady"/>
+    </Choices>
 ```
 
 ## Related tags


### PR DESCRIPTION
* Streamline interactive template presentation
* Add details about all labeling configs
* Streamline input format examples for generic time series
* Add "enhance this template" section to generic time series to restructure other examples