### PR TITLE
Docs: DEV-1511 — Enhance relevant templates with playground templates

### DIFF
--- a/docs/source/templates/audio_regions.md
+++ b/docs/source/templates/audio_regions.md
@@ -57,12 +57,6 @@ Use the [AudioPlus](/tags/audioplus.html) object tag to specify the location of 
 <AudioPlus name="audio" value="$url"></AudioPlus>
 ```
 
-## Enhance this template
-
-### Audio regions example
-
-
-
 ## Related tags
 
 - [AudioPlus](/tags/audioplus.html)

--- a/docs/source/templates/audio_regions.md
+++ b/docs/source/templates/audio_regions.md
@@ -57,6 +57,12 @@ Use the [AudioPlus](/tags/audioplus.html) object tag to specify the location of 
 <AudioPlus name="audio" value="$url"></AudioPlus>
 ```
 
+## Enhance this template
+
+### Audio regions example
+
+
+
 ## Related tags
 
 - [AudioPlus](/tags/audioplus.html)

--- a/docs/source/templates/automatic_speech_recognition_segments.md
+++ b/docs/source/templates/automatic_speech_recognition_segments.md
@@ -56,6 +56,24 @@ Use the [TextArea](/tags/textarea.html) control tag to prompt annotators to prov
 ```
 The `editable="true"` argument specifies that the transcript can be edited, and `required="true"` sets the transcript as a required field for the annotator. Without a transcript provided for each segment of the audio clip (set by the `perRegion="true"` argument), the annotation can't be submitted.
 
+## Enhance this template
+
+### Add context to specific audio segments
+
+If you want to prompt annotators to add context to specific audio segments, such as by selecting the accent or assumed gender of the speakers in a given audio clip, you can add the following to your labeling configuration:
+```xml
+    <View visibleWhen="region-selected">
+      <Header value="Select the assumed gender of the speaker:" />
+      <Choices name="gender" toName="audio"
+               perRegion="true" required="true">
+        <Choice value="Man" />
+        <Choice value="Woman" />
+      </Choices>
+    </View>
+```
+The `visibleWhen` parameter for the [View](/tags/view.html) tag means that the choice is only visible when a specific audio segment is selected. The [Header](/tags/header.html) tag provides instructions to the annotator. The [Choices](/tags/choices.html) tag includes the `perRegion` parameter to apply the selected choice only to the selected audio segment. 
+
+
 ## Related tags
 
 - [AudioPlus](/tags/audioplus.html)

--- a/docs/source/templates/image_bbox.md
+++ b/docs/source/templates/image_bbox.md
@@ -45,6 +45,10 @@ Use the [RectangleLabels](/tags/rectanglelabels.html) control tag to add labels 
   </RectangleLabels>
 ```
 
+## Enhance this template
+
+### Image bboxes
+
 ## Related tags
 
 - [Image](/tags/image.html)

--- a/docs/source/templates/image_bbox.md
+++ b/docs/source/templates/image_bbox.md
@@ -47,7 +47,30 @@ Use the [RectangleLabels](/tags/rectanglelabels.html) control tag to add labels 
 
 ## Enhance this template
 
-### Image bboxes
+### Add descriptions to detected objects
+
+If you want to add further context to object detection tasks with bounding boxes, you can add some **per-region** conditional labeling parameters to your labeling configuration. 
+
+For example, to prompt annotators to add descriptions to detected objects, you can add the following to your labeling configuration:
+```xml
+  <View visibleWhen="region-selected">
+    <Header value="Describe object" />
+    <TextArea name="answer" toName="image" editable="true"
+              perRegion="true" required="true" />
+    <Choices name="choices" toName="image"
+             perRegion="true">
+      <Choice value="Correct"/>
+      <Choice value="Broken"/>
+    </Choices>
+  </View>
+```
+The `visibleWhen` parameter of the [View](/tags/view.html) tag hides the description prompt from annotators until a bounding box is selected. 
+
+After the annotator selects a bounding box, the [Header](/tags/header.html) appears and provides instructions to annotators.
+
+The [TextArea](/tags/textarea.html) control tag displays an editable text box that applies to the selected bounding box, specified with the `perRegion="true"` parameter. You can also add a `placeholder` parameter to provide suggested text to annotators. 
+
+In addition, you can prompt annotators to provide additional feedback about the content of the bounding box, such as the status of the item in the box, using the [Choices](/tags/choices.html) tag with the `perRegion` parameter.
 
 ## Related tags
 

--- a/docs/source/templates/named_entity.md
+++ b/docs/source/templates/named_entity.md
@@ -30,7 +30,6 @@ If you want to perform named entity recognition (NER) on a sample of text, use t
 </View>
 ```
 
-
 ## About the labeling configuration
 
 All labeling configurations must be wrapped in [View](/tags/view.html) tags.
@@ -92,6 +91,38 @@ The [Text](/tags/text.html) object tag specifies the text to label:
 ```
 
 Then you can close the two remaining View tags.
+
+### Enforce word alignment
+
+If you want to allow annotations of only full words and enforce word alignment in labeling tasks, you can use the `granularity` parameter on the [Text](/tags/text.html) object tag to make sure that all highlighted spans in a NER task are complete words.
+
+For example, adjust your Text tag like follows:
+```xml
+<Text name="text" value="$text" granularity="word" />
+```
+
+### Add context to specific NER spans
+
+If you want to add context to specific NER spans, you can set up conditional **per-region labeling** with your NER template.
+
+
+For example, prompt annotators to choose the relevance of every text span in the text sample is:
+```xml
+<Choices name="relevance" toName="text" perRegion="true">
+    <Choice value="Relevant" />
+    <Choice value="Non Relevant" />
+</Choices>
+```
+The `perRegion` parameter means that these choice options apply for each text span region. 
+
+You can also combine the [View](/tags/view.html) tag and the `perRegion` parameter of the [Rating](/tags/rating.html) control tag to prompt annotators to rate their confidence in the accuracy of each individual text span region:
+```xml
+<View visibleWhen="region-selected">
+    <Header value="Your confidence" />
+</View>
+<Rating name="confidence" toName="text" perRegion="true" />
+```
+The `visibleWhen` parameter with the View tag means that when a specific region is selected, the Header appears, prompting the annotator to supply a rating that applies to that region.
 
 ## Related tags
 

--- a/docs/source/templates/sentiment_analysis.md
+++ b/docs/source/templates/sentiment_analysis.md
@@ -57,8 +57,33 @@ Use the [Choices](/tags/choices.html) control tag to provide the classification 
 
 ### Multi-classification
 
+You can use styling to visually separate different classification options to provide annotators a multi-classification task for text.
+
+For example, wrap the individual choice options for a single [Choices](/tags/choices.html) control tag in [View](/tags/view.html) tags that adjust the styling, and add [Header](/tags/header.html) tags to each section to visually separate the choices on the interface, while still storing all choices with the text sample in the annotations:
+```xml
+  <Choices name="sentiment" toName="text" choice="multiple">
+    <View style="display: flex; justify-content: space-between">
+      <View style="width: 50%">
+        <Header value="Select Topics" />
+        <Choice value="Politics"/>
+    	<Choice value="Business"/>
+    	<Choice value="Sport"/>
+      </View>
+      <View>
+        <Header value="Select Moods" />
+        <Choice value="Cheerful"/>
+    	<Choice value="Melancholy"/>
+    	<Choice value="Romantic"/>
+      </View>
+    </View>
+  </Choices>
+```
+
 ## Related tags
 - [Text](/tags/text.html)
 - [Choices](/tags/choices.html)
+- [Choice](/tags/choice.html)
+- [View](/tags/view.html)
+- [Header](/tags/header.html)
 
 

--- a/docs/source/templates/sentiment_analysis.md
+++ b/docs/source/templates/sentiment_analysis.md
@@ -36,6 +36,10 @@ Interactively preview this labeling template:
 </View>
 ```
 
+## Enhance this template
+
+### Multi-classification
+
 ## Related tags
 - [Text](/tags/text.html)
 - [Choices](/tags/choices.html)


### PR DESCRIPTION
Enhanced the following templates with the corresponding templates from playground:
- Text Classification / Sentiment Analysis with Text > Multi Classification 
- Named Entity Recognition with Text > Word Alignment and Per Region > Text spans labeling 
- Automatic Speech Recognition with Segments with Per Region > Audio Regions Example
- Object Detection with bboxes with Per Region > Image bboxes labeling

Chose to describe the specific parts of the templates that were different rather than posting entirely new labeling configs that were largely the same but slightly different. Instead, focused on just the parts that were different and explained those.

More updates to come!