### PR TITLE
Docs: DEV-1511 — Hide template galleries from the TOC

### DIFF
--- a/docs/source/templates/gallery_asr.html
+++ b/docs/source/templates/gallery_asr.html
@@ -1,10 +1,9 @@
 ---
 title: Template Gallery - Audio/Speech Processing
-type: templates
-order: 1002
 meta_title: Gallery of Audio/Speech Processing Labeling Templates
 meta_description: Gallery of templates available to perform data labeling and annotation tasks with Label Studio for your machine learning model and data science projects.
 ---
+<!--removing type and order to hide from the TOC-->
 
 <link rel="stylesheet" href="/tutorials/styles.css">
 

--- a/docs/source/templates/gallery_asr.html
+++ b/docs/source/templates/gallery_asr.html
@@ -16,7 +16,6 @@ meta_description: Gallery of templates available to perform data labeling and an
   @media screen and (min-width: 900px) {
     .content {
       margin-top: 1em;
-      margin-left: 290px !important;
     }
   }
 </style>

--- a/docs/source/templates/gallery_conversational_ai.html
+++ b/docs/source/templates/gallery_conversational_ai.html
@@ -17,7 +17,6 @@ meta_description: Gallery of templates available to perform data labeling and an
   @media screen and (min-width: 900px) {
     .content {
       margin-top: 1em;
-      margin-left: 290px !important;
     }
   }
 </style>

--- a/docs/source/templates/gallery_conversational_ai.html
+++ b/docs/source/templates/gallery_conversational_ai.html
@@ -1,10 +1,10 @@
 ---
 title: Template Gallery - Conversational AI
-type: templates
-order: 1003
 meta_title: Gallery of Conversational AI Labeling Templates
 meta_description: Gallery of templates available to perform data labeling and annotation tasks with Label Studio for your machine learning model and data science projects.
 ---
+<!--removing type and order to hide from the TOC-->
+
 
 <link rel="stylesheet" href="/tutorials/styles.css">
 

--- a/docs/source/templates/gallery_cv.html
+++ b/docs/source/templates/gallery_cv.html
@@ -17,7 +17,6 @@ meta_description: Gallery of templates available to perform data labeling and an
   @media screen and (min-width: 900px) {
     .content {
       margin-top: 1em;
-      margin-left: 290px !important;
     }
   }
 </style>

--- a/docs/source/templates/gallery_cv.html
+++ b/docs/source/templates/gallery_cv.html
@@ -1,10 +1,10 @@
 ---
 title: Template Gallery - Computer Vision
-type: templates
-order: 1000
 meta_title: Gallery of Computer Vision Labeling Templates
 meta_description: Gallery of templates available to perform data labeling and annotation tasks with Label Studio for your machine learning model and data science projects.
 ---
+<!--removing type and order to hide from the TOC-->
+
 
 <link rel="stylesheet" href="/tutorials/styles.css">
 

--- a/docs/source/templates/gallery_data_parsing.html
+++ b/docs/source/templates/gallery_data_parsing.html
@@ -17,7 +17,6 @@ meta_description: Gallery of templates available to perform data labeling and an
   @media screen and (min-width: 900px) {
     .content {
       margin-top: 1em;
-      margin-left: 290px !important;
     }
   }
 </style>

--- a/docs/source/templates/gallery_data_parsing.html
+++ b/docs/source/templates/gallery_data_parsing.html
@@ -1,10 +1,10 @@
 ---
 title: Template Gallery - Structured Data Parsing
-type: templates
-order: 1005
 meta_title: Gallery of Structured Data Parsing Labeling Templates
 meta_description: Gallery of templates available to perform data labeling and annotation tasks with Label Studio for your machine learning model and data science projects.
 ---
+<!--removing type and order to hide from the TOC-->
+
 
 <link rel="stylesheet" href="/tutorials/styles.css">
 

--- a/docs/source/templates/gallery_nlp.html
+++ b/docs/source/templates/gallery_nlp.html
@@ -17,7 +17,6 @@ meta_description: Gallery of nlp templates available to perform data labeling an
   @media screen and (min-width: 900px) {
     .content {
       margin-top: 1em;
-      margin-left: 290px !important;
     }
   }
 </style>

--- a/docs/source/templates/gallery_nlp.html
+++ b/docs/source/templates/gallery_nlp.html
@@ -1,10 +1,10 @@
 ---
 title: Template Gallery - Natural Language Processing
-type: templates
-order: 1001
 meta_title: Gallery of Natural Language Processing Labeling Templates
 meta_description: Gallery of nlp templates available to perform data labeling and annotation tasks with Label Studio for your machine learning model and data science projects.
 ---
+<!--removing type and order to hide from the TOC-->
+
 
 <link rel="stylesheet" href="/tutorials/styles.css">
 

--- a/docs/source/templates/gallery_rns.html
+++ b/docs/source/templates/gallery_rns.html
@@ -1,10 +1,9 @@
 ---
 title: Template Gallery - Ranking & Scoring
-type: templates
-order: 1004
 meta_title: Gallery of Ranking & Scoring Labeling Templates
 meta_description: Gallery of templates available to perform data labeling and annotation tasks with Label Studio for your machine learning model and data science projects.
 ---
+<!--removing type and order to hide from the TOC-->
 
 <link rel="stylesheet" href="/tutorials/styles.css">
 

--- a/docs/source/templates/gallery_rns.html
+++ b/docs/source/templates/gallery_rns.html
@@ -16,7 +16,6 @@ meta_description: Gallery of templates available to perform data labeling and an
   @media screen and (min-width: 900px) {
     .content {
       margin-top: 1em;
-      margin-left: 290px !important;
     }
   }
 </style>

--- a/docs/source/templates/gallery_timeseries.html
+++ b/docs/source/templates/gallery_timeseries.html
@@ -1,10 +1,9 @@
 ---
 title: Template Gallery - Time Series Analysis
-type: templates
-order: 1006
 meta_title: Gallery of Time Series Analysis Labeling Templates
 meta_description: Gallery of templates available to perform data labeling and annotation tasks with Label Studio for your machine learning model and data science projects.
 ---
+<!--removing type and order to hide from the TOC-->
 
 <link rel="stylesheet" href="/tutorials/styles.css">
 

--- a/docs/source/templates/gallery_timeseries.html
+++ b/docs/source/templates/gallery_timeseries.html
@@ -16,7 +16,6 @@ meta_description: Gallery of templates available to perform data labeling and an
   @media screen and (min-width: 900px) {
     .content {
       margin-top: 1em;
-      margin-left: 290px !important;
     }
   }
 </style>

--- a/docs/source/templates/gallery_videos.html
+++ b/docs/source/templates/gallery_videos.html
@@ -1,10 +1,9 @@
 ---
 title: Template Gallery - Videos
-type: templates
-order: 1007
 meta_title: Gallery of Video Labeling Templates
 meta_description: Gallery of templates available to perform data labeling and annotation tasks with Label Studio for your machine learning model and data science projects.
 ---
+<!--removing type and order to hide from the TOC-->
 
 <link rel="stylesheet" href="/tutorials/styles.css">
 

--- a/docs/source/templates/gallery_videos.html
+++ b/docs/source/templates/gallery_videos.html
@@ -16,7 +16,6 @@ meta_description: Gallery of templates available to perform data labeling and an
   @media screen and (min-width: 900px) {
     .content {
       margin-top: 1em;
-      margin-left: 290px !important;
     }
   }
 </style>

--- a/docs/themes/htx/layout/partials/toc.ejs
+++ b/docs/themes/htx/layout/partials/toc.ejs
@@ -91,10 +91,6 @@
           <li><h4>Videos</h4></li>
         <% } %>
 
-        <% if (fileName === 'gallery_cv') { %>
-          <li><h4>Template Galleries</h4></li>
-        <% } %>
-
       <% } %>
     <li>
       <a href="<%- url_for(p.path) %>" class="sidebar-link<%- page.title === p.title ? ' current' : '' %><%- p.is_new ? ' new' : '' %>">


### PR DESCRIPTION
Hide the template galleries from the TOC to provide a more consistent experience. 

This does prevent the TOC from appearing at all on sub-gallery pages, so the gallery pages look like this:
<img width="1440" alt="Screen Shot 2022-03-07 at 11 24 04 AM" src="https://user-images.githubusercontent.com/11081412/157104017-357ae680-3ab4-4fb0-b26e-83fc92a5b352.png">

If this format is okay, please merge this PR. If this workaround is worse than the current state, then close this PR without merging.
