### PR TITLE
DOCS: DEV-1511 — Add more playground template enhancements

### DIFF
--- a/docs/source/templates/image_captioning.md
+++ b/docs/source/templates/image_captioning.md
@@ -48,26 +48,19 @@ Use the `placeholder` argument to provide placeholder text to the annotator, whi
 
 ## Enhance this template
 
+You can enhance this template in many ways.
+
 ### Add a sticky header so that you can always view the caption
 
+If you want to always view the annotation options on the labeling interface, even if you need to scroll around on the image or data being labeled, you can use styling with the [View](/tags/view.html) tag to specify the position.
 
-
+In this case, wrap the caption element in styled [View](/tags/view.html) tags:
 ```xml
-<View>
-  <View style="padding: 0 1em; margin: 1em 0; background: #f1f1f1; position: sticky; top: 0; border-radius: 3px">
-    <Labels name="label" toName="text" showInline="true">
-      <Label value="Person" />
-      <Label value="Organization" />
-    </Labels>
-  </View>
-
-  <View>
-    <Text name="text" value="$text" />
-  </View>
-</View>
-
+ <View style="padding: 0 1em; margin: 1em 0; background: #f1f1f1; position: sticky; top: 0; border-radius: 3px">
+  <TextArea name="caption" toName="image" placeholder="Enter description here..." rows="5" maxSubmissions="1"/>
+ </View>
 ```
-
+The `position: sticky; top: 0;` CSS sets the [TextArea](/tags/textarea.html) to be fixed at the top of the screen after the annotator scrolls down when viewing the task. The other styling options visually differentiate the section of the interface containing the text box from the rest of the interface.
 
 ## Related tags
 

--- a/docs/source/templates/image_captioning.md
+++ b/docs/source/templates/image_captioning.md
@@ -46,6 +46,29 @@ Use the [TextArea](/tags/textarea.html) control tag to provide a 5 row text box 
 ```
 Use the `placeholder` argument to provide placeholder text to the annotator, which can provide an example or further instructions. 
 
+## Enhance this template
+
+### Add a sticky header so that you can always view the caption
+
+
+
+```xml
+<View>
+  <View style="padding: 0 1em; margin: 1em 0; background: #f1f1f1; position: sticky; top: 0; border-radius: 3px">
+    <Labels name="label" toName="text" showInline="true">
+      <Label value="Person" />
+      <Label value="Organization" />
+    </Labels>
+  </View>
+
+  <View>
+    <Text name="text" value="$text" />
+  </View>
+</View>
+
+```
+
+
 ## Related tags
 
 - [Image](/tags/image.html)

--- a/docs/source/templates/image_classification.md
+++ b/docs/source/templates/image_classification.md
@@ -48,6 +48,28 @@ Use the [Choices](/tags/choices.html) control tag to display the choices availab
 ```
 You can modify the values of the [Choice](/tags/choice.html) tag to provide different classification options. Review the available arguments for the Choices tag for customization options. 
 
+## Enhance this template
+
+### Add a sticky left column
+
+```xml
+<View style="display: flex;">
+  <View style="padding: 0em 1em; background: #f1f1f1; margin-right: 1em; border-radius: 3px">
+    <View style="position: sticky; top: 0">
+      <Labels name="label" toName="text">
+        <Label value="Person" />
+        <Label value="Organization" />
+      </Labels>
+    </View>
+  </View>
+
+  <View>
+    <Text name="text" value="$text" />
+  </View>
+</View>
+
+```
+
 ## Related tags
 
 - [Image](/tags/image.html)

--- a/docs/source/templates/image_classification.md
+++ b/docs/source/templates/image_classification.md
@@ -50,21 +50,26 @@ You can modify the values of the [Choice](/tags/choice.html) tag to provide diff
 
 ## Enhance this template
 
+You can enhance this template in many ways.
+
 ### Add a sticky left column
+
+If you want the classification choices to appear to the left of the image, you can add styling to the [View](/tags/view.html) tag. 
 
 ```xml
 <View style="display: flex;">
   <View style="padding: 0em 1em; background: #f1f1f1; margin-right: 1em; border-radius: 3px">
     <View style="position: sticky; top: 0">
-      <Labels name="label" toName="text">
-        <Label value="Person" />
-        <Label value="Organization" />
-      </Labels>
+    <Choices name="choice" toName="image">
+        <Choice value="Adult content"/>
+        <Choice value="Weapons" />
+        <Choice value="Violence" />
+    </Choices>
     </View>
   </View>
-
+    
   <View>
-    <Text name="text" value="$text" />
+    <Image name="image" value="$image"/>
   </View>
 </View>
 

--- a/docs/source/templates/named_entity.md
+++ b/docs/source/templates/named_entity.md
@@ -126,22 +126,17 @@ The `visibleWhen` parameter with the View tag means that when a specific region 
 
 ### Filter a long list of labels
 
+If you want to filter a long list of labels, add the [Filter](/tags/filter.html) tag to your labeling configuration. For example, to filter the named entity recognition labels, add the following:
 ```xml
-<View style="display: flex;">
-  <View style="width: 350px; padding-right: 1em; height: 400px; overflow-y: auto">
-    <Filter name="fl" toName="ner" hotkey="shift+f" minlength="1" />
-    <Labels name="ner" toName="text" showInline="false">
-      <Label value="Person" />
-      <Label value="Organization" />
-    </Labels>
-  </View>
-
-  <View style="height: 400px; overflow: auto">
-    <Text name="text" value="$text" />
-  </View>
-</View>
+<Filter name="filter" toName="label" hotkey="shift+f" minlength="1" />
+<Labels name="label" toName="text" showInline="false">
+    <Label value="PER" background="red"/>
+    <Label value="ORG" background="darkorange"/>
+    <Label value="LOC" background="orange"/>
+    <Label value="MISC" background="green"/>
+</Labels>
 ```
-
+The `toName` parameter on the Filter tag references the `name` parameter for the [Labels](/tags/labels.html) tag. You can also specify a `hotkey` to use for the filter text box, and set the `minlength` parameter to specify the minimum number of characters typed into the filter before the list of labels is filtered. 
 
 
 ## Related tags

--- a/docs/source/templates/named_entity.md
+++ b/docs/source/templates/named_entity.md
@@ -124,6 +124,26 @@ You can also combine the [View](/tags/view.html) tag and the `perRegion` paramet
 ```
 The `visibleWhen` parameter with the View tag means that when a specific region is selected, the Header appears, prompting the annotator to supply a rating that applies to that region.
 
+### Filter a long list of labels
+
+```xml
+<View style="display: flex;">
+  <View style="width: 350px; padding-right: 1em; height: 400px; overflow-y: auto">
+    <Filter name="fl" toName="ner" hotkey="shift+f" minlength="1" />
+    <Labels name="ner" toName="text" showInline="false">
+      <Label value="Person" />
+      <Label value="Organization" />
+    </Labels>
+  </View>
+
+  <View style="height: 400px; overflow: auto">
+    <Text name="text" value="$text" />
+  </View>
+</View>
+```
+
+
+
 ## Related tags
 
 - [View](/tags/view.html)

--- a/docs/source/templates/sentiment_analysis.md
+++ b/docs/source/templates/sentiment_analysis.md
@@ -55,11 +55,13 @@ Use the [Choices](/tags/choices.html) control tag to provide the classification 
 
 ## Enhance this template
 
-### Multi-classification
+You can enhance this template in many ways.
+
+### Perform multi-classification
 
 You can use styling to visually separate different classification options to provide annotators a multi-classification task for text.
 
-For example, wrap the individual choice options for a single [Choices](/tags/choices.html) control tag in [View](/tags/view.html) tags that adjust the styling, and add [Header](/tags/header.html) tags to each section to visually separate the choices on the interface, while still storing all choices with the text sample in the annotations:
+For example, wrap the individual choice options for a single [Choices](/tags/choices.html) control tag in [View](/tags/view.html) tags that adjust the styling:
 ```xml
   <Choices name="sentiment" toName="text" choice="multiple">
     <View style="display: flex; justify-content: space-between">
@@ -78,22 +80,36 @@ For example, wrap the individual choice options for a single [Choices](/tags/cho
     </View>
   </Choices>
 ```
+Add [Header](/tags/header.html) tags to each section to visually separate the choices on the interface, while still storing all choices with the text sample in the annotations.
 
 ### Combine multiple types of labeling in three columns
 
+You can also perform other types of labeling in addition to text classification as part of one labeling task. In this example, you can create a three column view on the labeling interface, with the text sample to annotate in the center column and classification choices and named entity recognition labels in the other columns. Because tags in a labeling configuration are rendered in order, the order of the elements specifies which column each content appears within.
+
+Start by adding styling to the [View](/tags/view.html) tag for the labeling configuration to flex the display:
 ```xml
 <View style="display: flex;">
-  <View style="width: 150px; padding: 0 1em; margin-right: 0.5em; background: #f1f1f1; border-radius: 3px">
+```
+
+Then use styling with a new [View](/tags/view.html) tag to create a column for the named entity recognition labels:
+```xml
+  <View style="width: 150px; padding: 0 1em; margin-right: 0.5em; background: #f1f1f1; border-radius: 3px">    
     <Labels name="label" toName="text">
       <Label value="Person" />
       <Label value="Organization" />
     </Labels>
   </View>
+```
 
+Specify the [Text](/tags/text.html) object tag in another set of [View](/tags/view.html) tags to place it in the center column. 
+```xml
   <View>
     <Text name="text" value="$text" />
   </View>
+```
 
+Then create a third column with a [View](/tags/view.html) tag to display the available [Choices](/tags/choices.html) for classification, including a [Header](/tags/header.html) to provide guidance to annotators:
+```xml
   <View style="padding: 0 1em; margin-left: 0.5em; background: #f1f1f1; border-radius: 3px">
     <Choices name="importance" toName="text">
       <Header value="Text Importance" />
@@ -102,8 +118,11 @@ For example, wrap the individual choice options for a single [Choices](/tags/cho
       <Choice value="Low" />
     </Choices>
   </View>
-</View>
+```
 
+Don't forget to close the original [View](/tags/view.html) tag:
+```xml
+</View>
 ```
 
 ## Related tags
@@ -113,4 +132,7 @@ For example, wrap the individual choice options for a single [Choices](/tags/cho
 - [View](/tags/view.html)
 - [Header](/tags/header.html)
 
-
+## Related templates
+- [Named Entity Recognition](named_entity.html)
+- [Image Classification](image_classification.html)
+- [Slot Filling and Intent Classification](slot_filling.html)

--- a/docs/source/templates/sentiment_analysis.md
+++ b/docs/source/templates/sentiment_analysis.md
@@ -79,6 +79,33 @@ For example, wrap the individual choice options for a single [Choices](/tags/cho
   </Choices>
 ```
 
+### Combine multiple types of labeling in three columns
+
+```xml
+<View style="display: flex;">
+  <View style="width: 150px; padding: 0 1em; margin-right: 0.5em; background: #f1f1f1; border-radius: 3px">
+    <Labels name="label" toName="text">
+      <Label value="Person" />
+      <Label value="Organization" />
+    </Labels>
+  </View>
+
+  <View>
+    <Text name="text" value="$text" />
+  </View>
+
+  <View style="padding: 0 1em; margin-left: 0.5em; background: #f1f1f1; border-radius: 3px">
+    <Choices name="importance" toName="text">
+      <Header value="Text Importance" />
+      <Choice value="High" />
+      <Choice value="Medium" />
+      <Choice value="Low" />
+    </Choices>
+  </View>
+</View>
+
+```
+
 ## Related tags
 - [Text](/tags/text.html)
 - [Choices](/tags/choices.html)

--- a/docs/source/templates/text_summarization.md
+++ b/docs/source/templates/text_summarization.md
@@ -50,6 +50,25 @@ Use the [TextArea](/tags/textarea.html) control tag to provide a text box with a
             required="true" />
 ```
 
+### Long text with scrollbar
+
+```xml
+<View style="display: flex;">
+  <View style="padding: 0em 1em; background: #f1f1f1; margin-right: 1em; border-radius: 3px">
+    <View style="position: sticky; top: 0">
+      <Labels name="label" toName="text">
+        <Label value="Person" />
+        <Label value="Organization" />
+      </Labels>
+    </View>
+  </View>
+
+  <View style="height: 300px; overflow: auto;">
+    <Text name="text" value="$longText" />
+  </View>
+</View>
+```
+
 ## Related tags
 
 - [Header](/tags/header.html)

--- a/docs/source/templates/text_summarization.md
+++ b/docs/source/templates/text_summarization.md
@@ -50,22 +50,31 @@ Use the [TextArea](/tags/textarea.html) control tag to provide a text box with a
             required="true" />
 ```
 
-### Long text with scrollbar
 
+<!-- no header here because another PR has another enhancement-->
+
+### Display long text samples with a scrollbar
+
+If you want to change how Label Studio displays long text samples on the labeling interface, you can use the [View](/tags/view.html) tags to wrap labeling tags with CSS styling. 
+
+For example, you can constrain the text sample to a specific height, making it easier to keep the text summary that annotators provide visible.
 ```xml
-<View style="display: flex;">
-  <View style="padding: 0em 1em; background: #f1f1f1; margin-right: 1em; border-radius: 3px">
-    <View style="position: sticky; top: 0">
-      <Labels name="label" toName="text">
-        <Label value="Person" />
-        <Label value="Organization" />
-      </Labels>
-    </View>
-  </View>
+<View style="height: 300px; overflow: auto;">
+    <Text name="text" value="$longText" />
+</View>
+```
 
+In this case, the entire labeling configuration looks like the following:
+```xml
+<View>
+  <Header value="Please read the text" />
   <View style="height: 300px; overflow: auto;">
     <Text name="text" value="$longText" />
   </View>
+  <Header value="Provide one sentence summary" />
+  <TextArea name="answer" toName="text" 
+            showSubmitButton="true" maxSubmissions="1" editable="true" 
+            required="true" />
 </View>
 ```
 


### PR DESCRIPTION
- Add sticky header example to image caption template
- Add sticky left column example to image classification template 
- Add filter example to NER template
- Add three column labeling to text classification template and fix up multi-classification example
- Add scrollbar with long text example to text summarization template
- Add related templates to text classification template