### PR TITLE
fix: DEV-1906: launchdarkly to switch to file if cannot connect to redis

### DIFF
--- a/label_studio/core/feature_flags/base.py
+++ b/label_studio/core/feature_flags/base.py
@@ -38,7 +38,7 @@ elif settings.FEATURE_FLAGS_OFFLINE:
     client = ldclient.get()
 else:
     # Production usage
-    if hasattr(settings, 'REDIS_LOCATION'):
+    try:
         logger.debug(f'Set LaunchDarkly config with Redis feature store at {settings.REDIS_LOCATION}')
         store = Redis.new_feature_store(
             url=settings.REDIS_LOCATION,
@@ -49,7 +49,7 @@ else:
             feature_store=store,
             http=HTTPConfig(connect_timeout=5)
         ))
-    else:
+    except:
         logger.debug('Set LaunchDarkly config without Redis...')
         ldclient.set_config(Config(settings.FEATURE_FLAGS_API_KEY, http=HTTPConfig(connect_timeout=5)))
     client = ldclient.get()

--- a/label_studio/core/utils/request.py
+++ b/label_studio/core/utils/request.py
@@ -1,0 +1,7 @@
+def serialize_request(request):
+    try:
+        data = {key: value for key, value in request.META.items() if isinstance(value, (str, bool, int, float))}
+        data[request.method] = getattr(request, request.method)
+        return data
+    except:
+        return {}


### PR DESCRIPTION
 - Fix launchdarkly to switch to file if cannot connect to redis
 - Add request serializer for debugging