### PR TITLE
Label-studio behind a proxy fails to reimport

### DIFF
--- a/label_studio/data_import/api.py
+++ b/label_studio/data_import/api.py
@@ -311,7 +311,7 @@ class ReImportAPI(ImportAPI):
                 'file_upload_ids': [],
                 'found_formats': {},
                 'data_columns': []
-            }, status=status.HTTP_204_NO_CONTENT)
+            }, status=status.HTTP_200_OK)
 
         tasks, found_formats, data_columns = FileUpload.load_tasks_from_uploaded_files(
             project, file_upload_ids,  files_as_tasks_list=files_as_tasks_list)


### PR DESCRIPTION
PR #1044 [1] introduces an early return for empty reimports.
However, it responds with `204`.

While that may seem a good choice, it is also wrong. According to the
specification [2][3], `204` should not have a body.

This is not a problem when trying to access label-studio from a browser.
The problem arises when using label-studio behind a proxy.

Since the reimport's response, *needs* to reach label-stuiod, in addition
to having a body, it should be a simple `200`.

Fixes #2451

[1] https://github.com/heartexlabs/label-studio/pull/1044
[2] https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
[3] https://restfulapi.net/http-status-204-no-content/