### PR TITLE
fix: Remove extra slash for file url

### DIFF
--- a/label_studio/data_import/models.py
+++ b/label_studio/data_import/models.py
@@ -44,7 +44,7 @@ class FileUpload(models.Model):
         if settings.HOSTNAME and settings.CLOUD_FILE_STORAGE_ENABLED:
             return settings.HOSTNAME + self.file.url
         elif settings.FORCE_SCRIPT_NAME:
-            return settings.FORCE_SCRIPT_NAME.rstrip('/') + '/' + self.file.url
+            return settings.FORCE_SCRIPT_NAME + '/' + self.file.url.lstrip('/')
         else:
             return self.file.url
 

--- a/label_studio/data_import/models.py
+++ b/label_studio/data_import/models.py
@@ -44,7 +44,7 @@ class FileUpload(models.Model):
         if settings.HOSTNAME and settings.CLOUD_FILE_STORAGE_ENABLED:
             return settings.HOSTNAME + self.file.url
         elif settings.FORCE_SCRIPT_NAME:
-            return settings.FORCE_SCRIPT_NAME + '/' + self.file.url
+            return settings.FORCE_SCRIPT_NAME.rstrip('/') + '/' + self.file.url
         else:
             return self.file.url
 


### PR DESCRIPTION
This is the issue: https://github.com/heartexlabs/label-studio-frontend/issues/733

----

I am using label-studio with the `--host` parameter like this:

```
$ label-studio --host https://openbayes.com/jobs/abc/proxy/8080
```

Every thing works good until I import some images for ocr task. It seems that the generated urls in frontend have more than one `/` between the prefix and the upload path:

<img width="2529" alt="image" src="https://user-images.githubusercontent.com/661860/177247049-4a1967b6-f75c-41d2-a9bb-b4ebff45ccb3.png">

If I mannully remove the extra `/` in the 

```
/jobs/open-tutorials/jobs/proxy/8080 ---->//<---- data/upload/1/df0703be-AAMU4003561_45R1__011_0741_181125_224515_01_Manual_1.jpg
```

the url can access successfully.