### PR TITLE
feat: DEV-3145: Add command for export project in Opensource

### DIFF
--- a/docs/source/guide/export.md
+++ b/docs/source/guide/export.md
@@ -44,7 +44,11 @@ Use the following command to export data and annotations.
 
 ```shell
 label-studio export <project-id> <export-format> --path=<output-path>
+```
 
+To enable logs: 
+```shell
+DEBUG=1 LOG_LEVEL=DEBUG label-studio export <project-id> <export-format> --path=<output-path>
 ```
 
 ### <i class='ent'></i> Export snapshots using the UI

--- a/docs/source/guide/export.md
+++ b/docs/source/guide/export.md
@@ -36,7 +36,7 @@ Use the following steps to export data and annotations from the Label Studio UI.
 
 ### Export timeout in Community Edition
 
-If the export times out, see how to [export snapshots using the SDK](https://labelstud.io/sdk/project.html#label_studio_sdk.project.Project.export_snapshot_create) or [API](#Export-snapshots-using-the-API). You can also use a [console command](#Export-using-console-command) to export your project (see more below). 
+If the export times out, see how to [export snapshots using the SDK](https://labelstud.io/sdk/project.html#label_studio_sdk.project.Project.export_snapshot_create) or [API](#Export-snapshots-using-the-API). You can also use a [console command](#Export-using-console-command) to export your project. For more information, see the following section.
 
 ### Export using console command
 

--- a/docs/source/guide/export.md
+++ b/docs/source/guide/export.md
@@ -36,7 +36,16 @@ Use the following steps to export data and annotations from the Label Studio UI.
 
 ### Export timeout in Community Edition
 
-If the export times out, see how to [export snapshots using the SDK](https://labelstud.io/sdk/project.html#label_studio_sdk.project.Project.export_snapshot_create) or [API](#Export-snapshots-using-the-API).
+If the export times out, see how to [export snapshots using the SDK](https://labelstud.io/sdk/project.html#label_studio_sdk.project.Project.export_snapshot_create) or [API](#Export-snapshots-using-the-API). You can also use a [console command](#Export-using-console-command) to export your project (see more below). 
+
+### Export using console command
+
+Use the following command to export data and annotations.
+
+```shell
+label-studio export <project-id> <export-format> --path=<output-path>
+
+```
 
 ### <i class='ent'></i> Export snapshots using the UI
 

--- a/label_studio/core/argparser.py
+++ b/label_studio/core/argparser.py
@@ -136,9 +136,15 @@ def parse_input_args(input_args):
 
     # export_project sub-command parser
     export_project = subparsers.add_parser('export', help='Export project in a specific format', parents=[root_parser])
-    export_project.add_argument('project_id', help='ID of the project')
-    export_project.add_argument('export_format', help='Export format')
-    export_project.add_argument('--path', help='Path to place the exported project', required=False, default=EXPORT_DIR)
+    export_project.add_argument('project_id', help='Project ID')
+    export_project.add_argument('export_format', help='Export format (JSON, JSON_MIN, CSV, etc)')
+    export_project.add_argument('--export-path', help='Export file path or directory', default=EXPORT_DIR)
+    default_params = '{"annotations__completed_by": {"only_id": null}, "interpolate_key_frames": true}'
+    export_project.add_argument(
+        '--export-serializer-context',
+        help=f"Export serializer context, default value: '{default_params}'",
+        default=default_params
+    )
 
     args = parser.parse_args(input_args)
 

--- a/label_studio/core/argparser.py
+++ b/label_studio/core/argparser.py
@@ -133,6 +133,11 @@ def parse_input_args(input_args):
         '--from-scratch', dest='from_scratch', default=False, action='store_true', help='Recalculate from scratch'
     )
 
+    # export_project sub-command parser
+    export_project = subparsers.add_parser('export', help='Export project in a specific format', parents=[root_parser])
+    export_project.add_argument('project_id', help='ID of the project')
+    export_project.add_argument('export_format', help='File format')
+
     args = parser.parse_args(input_args)
 
     if not hasattr(args, 'label_config'):

--- a/label_studio/core/argparser.py
+++ b/label_studio/core/argparser.py
@@ -3,6 +3,8 @@
 import os
 import json
 
+from django.conf import settings
+
 from .utils.io import find_file
 
 
@@ -136,7 +138,8 @@ def parse_input_args(input_args):
     # export_project sub-command parser
     export_project = subparsers.add_parser('export', help='Export project in a specific format', parents=[root_parser])
     export_project.add_argument('project_id', help='ID of the project')
-    export_project.add_argument('export_format', help='File format')
+    export_project.add_argument('export_format', help='Export format')
+    export_project.add_argument('--path', help='Path to place the exported project', required=False, default=settings.EXPORT_DIR)
 
     args = parser.parse_args(input_args)
 

--- a/label_studio/core/argparser.py
+++ b/label_studio/core/argparser.py
@@ -3,8 +3,7 @@
 import os
 import json
 
-from django.conf import settings
-
+from .settings.base import EXPORT_DIR
 from .utils.io import find_file
 
 
@@ -139,7 +138,7 @@ def parse_input_args(input_args):
     export_project = subparsers.add_parser('export', help='Export project in a specific format', parents=[root_parser])
     export_project.add_argument('project_id', help='ID of the project')
     export_project.add_argument('export_format', help='Export format')
-    export_project.add_argument('--path', help='Path to place the exported project', required=False, default=settings.EXPORT_DIR)
+    export_project.add_argument('--path', help='Path to place the exported project', required=False, default=EXPORT_DIR)
 
     args = parser.parse_args(input_args)
 

--- a/label_studio/data_export/mixins.py
+++ b/label_studio/data_export/mixins.py
@@ -115,7 +115,8 @@ class ExportMixin:
         q = reduce(lambda x, y: x | y, q_list)
         return queryset.filter(q)
 
-    def _get_export_serializer_option(self, serialization_options):
+    @staticmethod
+    def _get_export_serializer_option(serialization_options):
         options = {'expand': []}
         if isinstance(serialization_options, dict):
             if (

--- a/label_studio/server.py
+++ b/label_studio/server.py
@@ -308,8 +308,10 @@ def main():
 
     if input_args.command == 'export':
         from tasks.functions import export_project
-        filename = export_project(input_args.project_id, input_args.export_format)
-        
+        filename = export_project(
+            input_args.project_id, input_args.export_format, input_args.path
+        )
+
         print(f'Project exported successfully: {filename}')
         return
 

--- a/label_studio/server.py
+++ b/label_studio/server.py
@@ -306,6 +306,13 @@ def main():
         calculate_stats_all_orgs(input_args.from_scratch, redis=True)
         return
 
+    if input_args.command == 'export':
+        from tasks.functions import export_project
+        filename = export_project(input_args.project_id, input_args.export_format)
+        
+        print(f'Project exported successfully: {filename}')
+        return
+
     # print version
     if input_args.command == 'version' or input_args.version:
         from label_studio import __version__

--- a/label_studio/server.py
+++ b/label_studio/server.py
@@ -311,10 +311,11 @@ def main():
 
         try:
             filename = export_project(
-                input_args.project_id, input_args.export_format, input_args.path
+                input_args.project_id, input_args.export_format, input_args.export_path,
+                serializer_context=input_args.export_serializer_context
             )
         except Exception as e:
-            logger.error(f'Failed to export project: {e}')
+            logger.exception(f'Failed to export project: {e}')
         else:
             logger.info(f'Project exported successfully: {filename}')
 

--- a/label_studio/server.py
+++ b/label_studio/server.py
@@ -308,11 +308,16 @@ def main():
 
     if input_args.command == 'export':
         from tasks.functions import export_project
-        filename = export_project(
-            input_args.project_id, input_args.export_format, input_args.path
-        )
 
-        print(f'Project exported successfully: {filename}')
+        try:
+            filename = export_project(
+                input_args.project_id, input_args.export_format, input_args.path
+            )
+        except Exception as e:
+            logger.error(f'Failed to export project: {e}')
+        else:
+            logger.info(f'Project exported successfully: {filename}')
+
         return
 
     # print version

--- a/label_studio/tasks/functions.py
+++ b/label_studio/tasks/functions.py
@@ -70,7 +70,7 @@ def redis_job_for_calculation(org, from_scratch):
             f"processed {str(task_count)} tasks"
         )
 
-def export_project(project_id, format):
+def export_project(project_id, format, path):
     logger = logging.getLogger(__name__)
 
     try:
@@ -102,7 +102,7 @@ def export_project(project_id, format):
         project, tasks, format, settings.CONVERTER_DOWNLOAD_RESOURCES, {}
     )
 
-    filepath = os.path.join(settings.EXPORT_DIR, filename)
+    filepath = os.path.join(path, filename)
 
     with open(filepath, "wb") as file:
         file.write(export_stream.read())

--- a/label_studio/tasks/functions.py
+++ b/label_studio/tasks/functions.py
@@ -92,10 +92,9 @@ def export_project(project_id, format, path):
     tasks = []
     for _task_ids in batch(task_ids, 1000):
         tasks += ExportDataSerializer(
-            _task_ids,
-            many=True,
-            expand=["drafts"],
-            context={"interpolate_key_frames": settings.INTERPOLATE_KEY_FRAMES},
+            _task_ids, 
+            many=True, 
+            context={"interpolate_key_frames": settings.INTERPOLATE_KEY_FRAMES}
         ).data
 
     export_stream, _, filename = DataExport.generate_export_file(

--- a/label_studio/tasks/functions.py
+++ b/label_studio/tasks/functions.py
@@ -75,11 +75,7 @@ def redis_job_for_calculation(org, from_scratch):
 def export_project(project_id, export_format, path):
     logger = logging.getLogger(__name__)
 
-    try:
-        project = Project.objects.get(id=project_id)
-    except Project.DoesNotExist:
-        logger.error(f"Project with id {project_id} does not exist.")
-        return
+    project = Project.objects.get(id=project_id)
 
     export_format = export_format.upper()
     supported_formats = [s['name'] for s in DataExport.get_export_formats(project)]

--- a/label_studio/tasks/functions.py
+++ b/label_studio/tasks/functions.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import logging
+import json
 
 from django.conf import settings
 
@@ -12,6 +13,7 @@ from data_export.serializers import ExportDataSerializer
 from organizations.models import Organization
 from projects.models import Project
 from tasks.models import Task
+from data_export.mixins import ExportMixin
 
 
 def calculate_stats_all_orgs(from_scratch, redis):
@@ -72,7 +74,7 @@ def redis_job_for_calculation(org, from_scratch):
         )
 
 
-def export_project(project_id, export_format, path):
+def export_project(project_id, export_format, path, serializer_context=None):
     logger = logging.getLogger(__name__)
 
     project = Project.objects.get(id=project_id)
@@ -87,29 +89,32 @@ def export_project(project_id, export_format, path):
         .prefetch_related("annotations", "predictions")
     )
 
-    logger.debug(
-        f"Start exporting project <{project.title}> ({project.id}) with task count {task_ids.count()}."
-    )
+    logger.debug(f"Start exporting project <{project.title}> ({project.id}) with task count {task_ids.count()}.")
 
+    # serializer context
+    if isinstance(serializer_context, str):
+        serializer_context = json.loads(serializer_context)
+    serializer_options = ExportMixin._get_export_serializer_option(serializer_context)
+
+    # export cycle
     tasks = []
     for _task_ids in batch(task_ids, 1000):
         tasks += ExportDataSerializer(
-            _task_ids, 
-            many=True, 
-            context={"interpolate_key_frames": settings.INTERPOLATE_KEY_FRAMES}
+            _task_ids,
+            many=True,
+            **serializer_options
         ).data
 
+    # convert to output format
     export_stream, _, filename = DataExport.generate_export_file(
         project, tasks, export_format, settings.CONVERTER_DOWNLOAD_RESOURCES, {}
     )
 
-    filepath = os.path.join(path, filename)
-
+    # write to file
+    filepath = os.path.join(path, filename) if os.path.isdir(path) else path
     with open(filepath, "wb") as file:
         file.write(export_stream.read())
 
-    logger.debug(
-        f"End exporting project <{project.title}> ({project.id}) in {export_format} format."
-    )
+    logger.debug(f"End exporting project <{project.title}> ({project.id}) in {export_format} format.")
 
     return filepath

--- a/label_studio/tests/tasks/test_functions.py
+++ b/label_studio/tests/tasks/test_functions.py
@@ -30,7 +30,7 @@ class TestExportProject:
         ).data
 
         with mocker.patch("builtins.open"):
-            filepath = export_project(project.id, "JSON")
+            filepath = export_project(project.id, "JSON", settings.EXPORT_DIR)
 
         assert filepath == settings.EXPORT_DIR + "/project.json"
 
@@ -40,6 +40,6 @@ class TestExportProject:
 
     def test_project_does_not_exist(self, mocker, generate_export_file):
         with mocker.patch("builtins.open"):
-            export_project(1, "JSON")
+            export_project(1, "JSON", settings.EXPORT_DIR)
 
         generate_export_file.assert_not_called()

--- a/label_studio/tests/tasks/test_functions.py
+++ b/label_studio/tests/tasks/test_functions.py
@@ -40,6 +40,7 @@ class TestExportProject:
 
     def test_project_does_not_exist(self, mocker, generate_export_file):
         with mocker.patch("builtins.open"):
-            export_project(1, "JSON", settings.EXPORT_DIR)
+            with pytest.raises(Exception):
+                export_project(1, "JSON", settings.EXPORT_DIR)
 
         generate_export_file.assert_not_called()

--- a/label_studio/tests/tasks/test_functions.py
+++ b/label_studio/tests/tasks/test_functions.py
@@ -1,0 +1,45 @@
+import io
+import pytest
+
+from django.conf import settings
+
+from data_export.serializers import ExportDataSerializer
+from tasks.functions import export_project
+
+pytestmark = pytest.mark.django_db
+
+
+class TestExportProject:
+    @pytest.fixture
+    def generate_export_file(self, mocker):
+        return mocker.patch(
+            "tasks.functions.DataExport.generate_export_file",
+            return_value=(io.BytesIO(b"stream"), "application/json", "project.json"),
+        )
+
+    @pytest.fixture
+    def project(self, configured_project):
+        return configured_project
+
+    def test_export_project(self, mocker, generate_export_file, project):
+        data = ExportDataSerializer(
+            project.tasks.all(),
+            many=True,
+            expand=["drafts"],
+            context={"interpolate_key_frames": settings.INTERPOLATE_KEY_FRAMES},
+        ).data
+
+        with mocker.patch("builtins.open"):
+            filepath = export_project(project.id, "JSON")
+
+        assert filepath == settings.EXPORT_DIR + "/project.json"
+
+        generate_export_file.assert_called_once_with(
+            project, data, "JSON", settings.CONVERTER_DOWNLOAD_RESOURCES, {}
+        )
+
+    def test_project_does_not_exist(self, mocker, generate_export_file):
+        with mocker.patch("builtins.open"):
+            export_project(1, "JSON")
+
+        generate_export_file.assert_not_called()

--- a/label_studio/tests/tasks/test_functions.py
+++ b/label_studio/tests/tasks/test_functions.py
@@ -1,4 +1,5 @@
 import io
+import os
 import pytest
 
 from django.conf import settings
@@ -31,7 +32,7 @@ class TestExportProject:
         with mocker.patch("builtins.open"):
             filepath = export_project(project.id, "JSON", settings.EXPORT_DIR)
 
-        assert filepath == settings.EXPORT_DIR + "/project.json"
+        assert filepath == os.path.join(settings.EXPORT_DIR, "project.json")
 
         generate_export_file.assert_called_once_with(
             project, data, "JSON", settings.CONVERTER_DOWNLOAD_RESOURCES, {}

--- a/label_studio/tests/tasks/test_functions.py
+++ b/label_studio/tests/tasks/test_functions.py
@@ -25,7 +25,6 @@ class TestExportProject:
         data = ExportDataSerializer(
             project.tasks.all(),
             many=True,
-            expand=["drafts"],
             context={"interpolate_key_frames": settings.INTERPOLATE_KEY_FRAMES},
         ).data
 


### PR DESCRIPTION
## Description of the proposed changes

These changes add a new command to export a Label Studio project in a specific format.

`label-studio export <project-id> <export-format>`

- The file generated will be saved inside `settings.EXPORT_DIR` folder.
- All the project tasks will be included in the process.
- Default values will be used to flags like `INTERPOLATE_KEY_FRAMES` and `CONVERTER_DOWNLOAD_RESOURCES` defined in the settings file.


## Jira Ticket

https://heartex.atlassian.net/browse/DEV-3145
