### PR TITLE
fix: DEV-3212: Add validation to avoid users import local files using URL

### DIFF
--- a/label_studio/data_import/uploader.py
+++ b/label_studio/data_import/uploader.py
@@ -174,6 +174,10 @@ def load_tasks(request, project):
         else:
             if settings.SSRF_PROTECTION_ENABLED and url_is_local(url):
                 raise ImportFromLocalIPError
+
+            if url.strip().startswith('file://'):
+                raise ValidationError('"url" is not valid')
+
             data_keys, found_formats, tasks, file_upload_ids = tasks_from_url(
                 file_upload_ids, project, request, url
             )

--- a/label_studio/tests/data_import/test_uploader.py
+++ b/label_studio/tests/data_import/test_uploader.py
@@ -1,0 +1,39 @@
+import pytest
+
+from rest_framework.exceptions import ValidationError
+
+from data_import.uploader import load_tasks
+
+pytestmark = pytest.mark.django_db
+
+
+class MockedRequest:
+    FILES = ()
+
+    def __init__(self, url):
+        self.url = url
+
+    @property
+    def content_type(self):
+        return "application/x-www-form-urlencoded"
+
+    @property
+    def data(self):
+        return {"url": self.url}
+
+
+class TestUploader:
+    @pytest.fixture
+    def project(self, configured_project):
+        return configured_project
+
+    class TestLoadTasks:
+
+        @pytest.mark.parametrize("url", ("file:///etc/passwd", " file://etc/kernel "))
+        def test_raises_for_local_files(self, url, project):
+            request = MockedRequest(url=url)
+
+            with pytest.raises(ValidationError) as e:
+                load_tasks(request, project)
+
+            assert '"url" is not valid' in str(e.value)

--- a/label_studio/tests/data_import/test_uploader.py
+++ b/label_studio/tests/data_import/test_uploader.py
@@ -28,7 +28,6 @@ class TestUploader:
         return configured_project
 
     class TestLoadTasks:
-
         @pytest.mark.parametrize("url", ("file:///etc/passwd", " file://etc/kernel "))
         def test_raises_for_local_files(self, url, project):
             request = MockedRequest(url=url)


### PR DESCRIPTION
## Description of the proposed changes

LS users are able to use data import functionality to access local files on the running system, including environment variables, etc. This is achieved by using `file://` url schema (ie. `file:///etc/passwd`).

Submitting a URL like this will cause Label Studio to fetch the local file and add it to the project, which can then be accessed in the `/data/uploads` folder.


## Jira Ticket

https://heartex.atlassian.net/browse/DEV-3212
