### PR TITLE
fix: DEV-1947: Fixed tabs randomly mixed after label stream

### DIFF
--- a/label_studio/data_manager/api.py
+++ b/label_studio/data_manager/api.py
@@ -122,7 +122,7 @@ class ViewAPI(viewsets.ModelViewSet):
         return Response(status=204)
 
     def get_queryset(self):
-        return View.objects.filter(project__organization=self.request.user.active_organization)
+        return View.objects.filter(project__organization=self.request.user.active_organization).order_by('id')
 
 
 class TaskPagination(PageNumberPagination):

--- a/label_studio/tests/data_manager/test_views_api.py
+++ b/label_studio/tests/data_manager/test_views_api.py
@@ -49,7 +49,9 @@ def test_views_api(business_client, project_id):
 
     # reset
     response = business_client.delete(
-        f"/api/dm/views/reset", data=json.dumps(dict(project=project_id)), content_type='application/json'
+        f"/api/dm/views/reset",
+        data=json.dumps(dict(project=project_id)),
+        content_type="application/json",
     )
 
     assert response.status_code == 204, response.content
@@ -60,16 +62,28 @@ def test_views_api(business_client, project_id):
 def test_views_api_filter_project(business_client):
     # create project
     response = business_client.post(
-        "/api/projects/", data=json.dumps(dict(title="test_project1")), content_type="application/json"
+        "/api/projects/",
+        data=json.dumps(dict(title="test_project1")),
+        content_type="application/json",
     )
     project1_id = response.json()["id"]
-    business_client.post("/api/dm/views/", data=json.dumps(dict(project=project1_id)), content_type="application/json")
+    business_client.post(
+        "/api/dm/views/",
+        data=json.dumps(dict(project=project1_id)),
+        content_type="application/json",
+    )
 
     response = business_client.post(
-        "/api/projects/", data=json.dumps(dict(title="test_project2")), content_type="application/json"
+        "/api/projects/",
+        data=json.dumps(dict(title="test_project2")),
+        content_type="application/json",
     )
     project2_id = response.json()["id"]
-    business_client.post("/api/dm/views/", data=json.dumps(dict(project=project2_id)), content_type="application/json")
+    business_client.post(
+        "/api/dm/views/",
+        data=json.dumps(dict(project=project2_id)),
+        content_type="application/json",
+    )
 
     # list all
     response = business_client.get("/api/dm/views/")
@@ -83,7 +97,9 @@ def test_views_api_filter_project(business_client):
 
     # filtered reset
     response = business_client.delete(
-        f"/api/dm/views/reset/", data=json.dumps(dict(project=project1_id)), content_type="application/json"
+        f"/api/dm/views/reset/",
+        data=json.dumps(dict(project=project1_id)),
+        content_type="application/json",
     )
     assert response.status_code == 204, response.content
 
@@ -172,6 +188,7 @@ def test_views_api_filters(business_client, project_id):
 
     assert response.status_code == 200, response.content
     assert response.json()["data"] == updated_payload["data"]
+
 
 def test_views_ordered_by_id(business_client, project_id):
     views = [{"view_data": 1}, {"view_data": 2}, {"view_data": 3}]


### PR DESCRIPTION
## Description of the proposed changes

Tabs are being randomly mixed after label stream. It's not guaranteed that backend will always return in the expected order. 

These changes add an ASC ID ordering in the view class to avoid this issue.

## Jira Ticket

https://heartex.atlassian.net/browse/DEV-1947
