### PR TITLE
feat: DEV-239: Added support to import jsonl files via API

### DIFF
--- a/label_studio/data_import/models.py
+++ b/label_studio/data_import/models.py
@@ -96,8 +96,24 @@ class FileUpload(models.Model):
             tasks = json.loads(raw_data.decode('utf8'))
         if isinstance(tasks, dict):
             tasks = [tasks]
+        
+        return self.normalize_json_tasks(tasks)
+
+    def read_tasks_list_from_jsonl(self):
+        logger.debug('Read tasks list from JSONL file {}'.format(self.file.name))
+
+        raw_data = self.content
+        json_objects = raw_data.split("\n")
+
+        tasks = (json.loads(value) for value in json_objects if value)
+
+        return self.normalize_json_tasks(tasks)
+
+    def normalize_json_tasks(self, tasks):
+        """Normalize tasks to be within data structure."""
+    
         tasks_formatted = []
-        for i, task in enumerate(tasks):
+        for task in tasks:
             if not task.get('data'):
                 task = {'data': task}
             if not isinstance(task['data'], dict):
@@ -136,6 +152,8 @@ class FileUpload(models.Model):
                 tasks = self.read_tasks_list_from_txt()
             elif file_format == '.json':
                 tasks = self.read_tasks_list_from_json()
+            elif file_format =='.jsonl':
+                tasks = self.read_tasks_list_from_jsonl()
 
             # otherwise - only one object tag should be presented in label config
             elif not self.project.one_object_in_label_config:

--- a/label_studio/tests/data_import/test_api.py
+++ b/label_studio/tests/data_import/test_api.py
@@ -1,0 +1,32 @@
+import pytest
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+
+pytestmark = pytest.mark.django_db
+
+
+class TestImportAPI:
+    @pytest.fixture
+    def url(self, configured_project):
+        return reverse(
+            "data_import:api-projects:project-import", args=[configured_project.id]
+        )
+
+    def test_import_accepts_jsonl(self, url, business_client):
+        data = (
+            b'{"id":100,"annotations":[],"file_upload":"d123c1f3-bb1f75c8cb.json","drafts":[],"predictions":[100],"data":{},"meta":{}, "meta_info": "info", "text":"Dog", "updated_by":1,"comment_authors":[]}\n'
+            b'{"id":120,"annotations":[],"file_upload":"d456c1f3-bb1f75c8cb.json","drafts":[],"predictions":[120],"data":{},"meta":{}, "meta_info": "info", "text":"Dog", "updated_by":2,"comment_authors":[]}\n'
+        )
+
+        file = SimpleUploadedFile("file.jsonl", data, content_type="application/json")
+        payload = {"tasks.jsonl": file}
+
+        response = business_client.post(url, payload, format="multipart")
+        assert response.status_code == 201, response.content
+
+        data = response.data
+        assert data["task_count"] == 2
+        assert data["annotation_count"] == 0
+        assert data["prediction_count"] == 0
+        assert data["found_formats"] == {".jsonl": 1}

--- a/label_studio/tests/data_import/test_models.py
+++ b/label_studio/tests/data_import/test_models.py
@@ -1,0 +1,62 @@
+import pytest
+
+from django.core.files.base import ContentFile
+
+from data_import.models import FileUpload
+
+pytestmark = pytest.mark.django_db
+
+
+class TestFileUpload:
+    @pytest.fixture
+    def jsonl_file(self, configured_project):
+        return FileUpload.objects.create(
+            user=configured_project.created_by,
+            project=configured_project,
+            file=ContentFile(
+                '{"id":100,"annotations":[],"file_upload":"d123c1f3-bb1f75c8cb.json","drafts":[],"predictions":[100],"data":{},"meta":{}, "updated_by":1,"comment_authors":[]}\n'
+                '{"id":120,"annotations":[],"file_upload":"d456c1f3-bb1f75c8cb.json","drafts":[],"predictions":[120],"data":{},"meta":{}, "updated_by":2,"comment_authors":[]}\n',
+                name="data.jsonl",
+            ),
+        )
+
+    def test_read_tasks_calls_jsonl_reader(self, mocker, jsonl_file):
+        mocked_read_jsonl = mocker.patch(
+            "data_import.models.FileUpload.read_tasks_list_from_jsonl"
+        )
+
+        jsonl_file.read_tasks()
+        mocked_read_jsonl.assert_called_once()
+
+    def test_read_tasks_list_from_jsonl(self, jsonl_file):
+        tasks = jsonl_file.read_tasks_list_from_jsonl()
+
+        assert len(tasks) == 2
+        assert tasks == [
+            {
+                "data": {
+                    "id": 100,
+                    "annotations": [],
+                    "file_upload": "d123c1f3-bb1f75c8cb.json",
+                    "drafts": [],
+                    "predictions": [100],
+                    "data": {},
+                    "meta": {},
+                    "updated_by": 1,
+                    "comment_authors": [],
+                }
+            },
+            {
+                "data": {
+                    "id": 120,
+                    "annotations": [],
+                    "file_upload": "d456c1f3-bb1f75c8cb.json",
+                    "drafts": [],
+                    "predictions": [120],
+                    "data": {},
+                    "meta": {},
+                    "updated_by": 2,
+                    "comment_authors": [],
+                }
+            },
+        ]


### PR DESCRIPTION
## Description of the proposed changes

These changes allow users to import tasks using jsonl files via API

## Jira Ticket

https://heartex.atlassian.net/browse/DEV-239
