### PR TITLE
docs: Removed ENT tag from Release Notes info section

### DIFF
--- a/docs/source/guide/release_notes.md
+++ b/docs/source/guide/release_notes.md
@@ -9,7 +9,6 @@ meta_description: Discover what's new and improved, and review bug fixes, in the
 ---
 
 !!! info 
-    <i class='ent'></i> 
     The release notes for Label Studio Community Edition is available on the <a href="https://github.com/heartexlabs/label-studio/releases"> Label Studio GitHub repository</a>.
 
 ## Label Studio Enterprise 2.2


### PR DESCRIPTION
[DEV-3495]

[DEV-3495]: https://heartex.atlassian.net/browse/DEV-3495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ