### PR TITLE
patch: ALS broken data manager fix [patch for 2.2.12dev-41]

### DIFF
--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -32,6 +32,7 @@ django-rest-swagger==2.2.0
 django-user-agents==0.4.0
 django-ranged-fileresponse>=0.1.2
 drf_dynamic_fields==0.3.0
+djangorestframework==3.13.1
 drf-flex-fields==0.9.5
 drf_yasg==1.20.0
 drf-generators==0.3.0

--- a/label_studio/organizations/api.py
+++ b/label_studio/organizations/api.py
@@ -104,14 +104,15 @@ class OrganizationMemberListAPI(generics.ListAPIView):
 
     def get_queryset(self):
         org = generics.get_object_or_404(self.request.user.organizations, pk=self.kwargs[self.lookup_field])
-        if flag_set('fix-backend-dev-3134-exclude-deactivated-users', self.request.user):
+        if flag_set('fix_backend_dev_3134_exclude_deactivated_users', self.request.user):
             serializer = OrganizationsParamsSerializer(data=self.request.GET)
             serializer.is_valid(raise_exception=True)
             active = serializer.validated_data.get('active')
-            contributed_to_projects = serializer.validated_data.get('contributed_to_projects')
-            if active or not contributed_to_projects:
-                # return only active users (exclude DISABLED and NOT_ACTIVATED)
+            
+            # return only active users (exclude DISABLED and NOT_ACTIVATED)
+            if active:
                 return org.active_members.order_by('user__username')
+            
             # organization page to show all members
             return org.members.order_by('user__username')
         else:

--- a/label_studio/organizations/serializers.py
+++ b/label_studio/organizations/serializers.py
@@ -36,13 +36,15 @@ class UserSerializerWithProjects(UserSerializer):
         if not self.context.get('contributed_to_projects', False):
             return None
 
-        return user.created_projects.values('id', 'title')
+        return user.created_projects.filter(organization=user.active_organization).values('id', 'title')
 
     def get_contributed_to_projects(self, user):
         if not self.context.get('contributed_to_projects', False):
             return None
 
-        projects = user.annotations.values('task__project__id', 'task__project__title')
+        projects = user.annotations\
+            .filter(task__project__organization=user.active_organization)\
+            .values('task__project__id', 'task__project__title')
         contributed_to = [(json.dumps({'id': p['task__project__id'], 'title': p['task__project__title']}), 0)
                           for p in projects]
         contributed_to = OrderedDict(contributed_to)  # remove duplicates without ordering losing


### PR DESCRIPTION
fix: DEV-3239, DEV-3465: Data manager is broken if annotator is deactivated. Projects, displayed on user's organization page, include other organizations