### PR TITLE
docs: remove whitespace from bibtex citation key

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Want to use **The Coolest Feature X** but Label Studio doesn't support it? Check
 ## Citation
 
 ```tex
-@misc{Label Studio,
+@misc{labelStudio,
   title={{Label Studio}: Data labeling software},
   url={https://github.com/heartexlabs/label-studio},
   note={Open source software available from https://github.com/heartexlabs/label-studio},


### PR DESCRIPTION
Whitespaces are not allowed in bibtex citation keys, see e.g.: https://tex.stackexchange.com/questions/224674/can-i-have-a-reference-with-spacing-using-bibtex-like-citeauthor-year