### PR TITLE
fix: Issue 3220 Update Django version for CVEs

### DIFF
--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -21,7 +21,7 @@ google-resumable-media==0.5.1
 googleapis-common-protos==1.52.0
 grpc-google-iam-v1==0.12.3
 
-Django==3.2.14
+Django==3.2.16
 django_annoying==0.10.6
 django_debug_toolbar==3.2.1
 django_filter==2.4.0


### PR DESCRIPTION
## What is this?

Fixes issue https://github.com/heartexlabs/label-studio/issues/3220 by bumping to `Django==3.2.16` that fixed two CVEs related to Django.

I followed [what was done here when it was last updated to `3.2.14`](https://github.com/heartexlabs/label-studio/pull/2706)

## Dev notes

I only have a Mac so I tested locally with `sqlite` and one of the tests (see below) failed for the `develop` base branch when I pulled from the most recent -- yet I don't see a failed build on GitHub 🤔. All other tests passed.

Therefor I'm not sure if my test setup was correct. I tried following both `README` to install and then copied how GItHub workflow script setup the testing env to no avail. This may not be an issue though.

```
FAILED tests/test_api.py::test_creating_activating_new_ml_backend[201-http://my.super.ai-4] - assert 5 == 4
```

