### PR TITLE
fix: Sync storage with annotations when was_cancelled is not defined

### DIFF
--- a/label_studio/io_storages/base_models.py
+++ b/label_studio/io_storages/base_models.py
@@ -125,7 +125,7 @@ class ImportStorage(Storage):
                     raise ValueError(
                         'If you use "annotations" field in the task, ' 'you must put "data" field in the task too'
                     )
-                cancelled_annotations = len([a for a in annotations if a['was_cancelled']])
+                cancelled_annotations = len([a for a in annotations if a.get('was_cancelled', False)])
 
             if 'data' in data and isinstance(data['data'], dict):
                 data = data['data']


### PR DESCRIPTION
Per request here: https://github.com/heartexlabs/label-studio/issues/2852

Bug when importing an annotated json file from azure storage. Using sample from https://labelstud.io/guide/tasks.html#Example-JSON-format