### PR TITLE
fix: DEV-3337: add storage_filename to filters (contains and exact) 

### DIFF
--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -33,6 +33,7 @@ django-extensions==3.1.0
 django-rest-swagger==2.2.0
 django-user-agents==0.4.0
 django-ranged-fileresponse>=0.1.2
+django-queryable-properties==1.8.3
 drf_dynamic_fields==0.3.0
 djangorestframework==3.13.1
 drf-flex-fields==0.9.5

--- a/label_studio/core/utils/check_field.py
+++ b/label_studio/core/utils/check_field.py
@@ -1,0 +1,31 @@
+from django.db import models
+from django.core.exceptions import FieldDoesNotExist
+
+
+def check_model_field_exist(model: models.Model, fieldname: str) -> bool:
+    """
+    Checking for model field existing.
+    if you use hasattr(), model field and property return same result.
+    This function help to feel the difference.
+    :param model: class of model for checking
+    :param fieldname: name of filed for checking
+    :return: True if filed exist
+    """
+    try:
+        model._meta.get_field(fieldname)
+        return True
+    except FieldDoesNotExist:
+        return False
+
+
+def is_field_property(model: models.Model, fieldname: str) -> bool:
+    """
+    Checking is callable parameter a property
+    :param model: class of model for checking
+    :param fieldname: name of filed for checking
+    :return: True if parameter is property
+    """
+    if hasattr(model, fieldname):
+        return not check_model_field_exist(model, fieldname)
+    else:
+        raise FieldDoesNotExist


### PR DESCRIPTION
Above all, thank you for label-studio. I would like to point out that I am pushing to opensource project first time. So please, don't be too harsh if i do something wrong.

There is issue [#3337](https://github.com/heartexlabs/label-studio/issues/3337) about the inability to filter by storage_name. I added ability to filtering by storage_filename. I've used [django-queryable-properties](https://github.com/W1ldPo1nter/django-queryable-properties) library. So, now we can use any properties for filters. I have only implemented a few filters: icontains and exact. Because there are some trouble with __isnull filter and regex. 
