### PR TITLE
fix: Codespell configuration and github action workflow

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,8 @@
+[codespell]
+skip = *.css*,*.yml,*.map,*.js,package-lock.json,*.ai,.venv,.git,build,*.egg-info,*.lock
+# aks - unfortunately, not case sensitive yet as promised
+#    see https://github.com/codespell-project/codespell/issues/2375
+# ist - from german
+# respone - response one, popular among examples along with resptwo, respthree
+# classe - spanish(?) example
+ignore-words-list = aks,postgressql,filterin,ser,ist,respone,classe

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,17 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [develop,master]
+  pull_request:
+    branches: [develop,master]
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: codespell-project/actions-codespell@master

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -13,5 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: codespell-project/actions-codespell@master
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v1

--- a/docs/source/guide/webhook_reference.md
+++ b/docs/source/guide/webhook_reference.md
@@ -61,7 +61,7 @@ The webhook payload includes the name of the action and some additional task dat
         {
             "id": 21,
             "data": {
-                "ner": "Opossums like to be aloft \n\n\n\n\n\nin trees."
+                "ner": "Opossums like to be aloft \n\n\n\n\n\n in trees."
             },
             "meta": {},
             "created_at": "2021-08-17T13:51:02.590839Z",


### PR DESCRIPTION
Please check the diff carefully, but interestingly it also feels to provide a "bug fix"  in https://github.com/heartexlabs/label-studio/compare/develop...yarikoptic:label-studio:enh-codespell?expand=1#diff-de230f8c6422148eba24cf335d041aa51a20c329de9c1953ae201a5d1b2cc84f for "properties" typo fix?