### PR TITLE
fix: Typos identified by codespell

### DIFF
--- a/docs/source/blog/6-costly-data-labeling-mistakes-and-how-to-avoid-them.md
+++ b/docs/source/blog/6-costly-data-labeling-mistakes-and-how-to-avoid-them.md
@@ -91,7 +91,7 @@ Label Studio also has the capability to show labels dynamically as a task input,
 
 ## 5. Annotator Bias
 
-Biased models result from having too many annotators who represent a single, homogenous point of view. Since that group’s point of view is centered during the annotation process, the algorithm itself starts to center that point of view. This leaves marginalized groups and their interests out of algorithms ranging from [search results](https://www.bloomberg.com/news/articles/2021-10-19/google-quietly-tweaks-image-search-for-racially-diverse-results#xj4y7vzkg) to [recommendations](https://venturebeat.com/ai/researchers-find-evidence-of-bias-in-recommender-systems/).  
+Biased models result from having too many annotators who represent a single, homogeneous point of view. Since that group’s point of view is centered during the annotation process, the algorithm itself starts to center that point of view. This leaves marginalized groups and their interests out of algorithms ranging from [search results](https://www.bloomberg.com/news/articles/2021-10-19/google-quietly-tweaks-image-search-for-racially-diverse-results#xj4y7vzkg) to [recommendations](https://venturebeat.com/ai/researchers-find-evidence-of-bias-in-recommender-systems/).  
 
 There are less insidious forms of annotator bias, too. If you’re working with annotators who speak British English, they’ll call a bag of potato chips “Crisps.” Your American English speakers will label the same data “Chips.” Meanwhile, your British English speakers will reserve the “Chips” label for fries. That inconsistency will reflect in the algorithm itself, which will arbitrarily mix American and British English into its predictions. 
  

--- a/docs/source/blog/Automate-your-ML-pipeline-with-Label-Studio-and-Amazon-SageMaker.md
+++ b/docs/source/blog/Automate-your-ML-pipeline-with-Label-Studio-and-Amazon-SageMaker.md
@@ -396,7 +396,7 @@ AWS_GATEWAY_LAMBDA_RESOURCE_ID=$(aws apigateway create-resource \
 --parent-id "$GATEWAY_ROOT_ID" \
 --path-part LcWebHook | jq -r .id)
 ```
-6. Update the API Gateway with the resource ID for AWS Lambda. By default this example does not use authorization for the HTTP request, but you might want to secure your API Gatway configuration. See [Set up method request authorization](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-method-settings-method-request.html#setup-method-request-authorization) in the Amazon API Gateway documentation. From the command line, run the following:
+6. Update the API Gateway with the resource ID for AWS Lambda. By default this example does not use authorization for the HTTP request, but you might want to secure your API Gateway configuration. See [Set up method request authorization](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-method-settings-method-request.html#setup-method-request-authorization) in the Amazon API Gateway documentation. From the command line, run the following:
 ```bash
 aws apigateway put-method \
 --rest-api-id "$GATEWAY_ID" \

--- a/docs/source/blog/Improve-OCR-quality-with-Tesseract-and-Label-Studio.md
+++ b/docs/source/blog/Improve-OCR-quality-with-Tesseract-and-Label-Studio.md
@@ -210,7 +210,7 @@ After you set up your project and import the results from Tesseract, start label
 
 1. Click **Label all Tasks** and start correcting the recognized text regions. 
 2. Locate a region in the sidebar and click to update the text.
-   <img src="/images/ocr-blog/OCR-correct-single-region.gif" alt="Gif of updating the recognized text for a region to match teh text on the image in the Label Studio UI." class="gif-border" width="800px" height="500px"/>
+   <img src="/images/ocr-blog/OCR-correct-single-region.gif" alt="Gif of updating the recognized text for a region to match the text on the image in the Label Studio UI." class="gif-border" width="800px" height="500px"/>
 3. Click a label to identify the region as Text, a Product Name, or a Price.
 3. If needed, add additional regions.
    <img src="/images/ocr-blog/OCR-add-and-label-new-regions.gif" alt="Gif of adding new regions to the image and transcribing and labeling the text in the Label Studio UI." class="gif-border" width="800px" height="511px" />

--- a/docs/source/blog/release-050.md
+++ b/docs/source/blog/release-050.md
@@ -39,7 +39,7 @@ NER got an update, nested entities representation is more apparent now, and it's
 
 ### Image Segmentation
 
-Initial implementation of the image segmentation using masks. You get two controls, brush with configurable size, and eraser. The output format is RLE implemented by [rle-pack](https://www.npmjs.com/package/@thi.ng/rle-pack) library.
+Initial implementation of the image segmentation using masks. You get two controls, brush with configurable size, and eraser. The output format is RLE implemented by [rle-pack](https://www.npmjs.com/package/%40thi.ng/rle-pack) library.
 
 There is a [new template](/templates/image_segmentation.html) available that provides more information about the setup.
 

--- a/docs/source/guide/frontend.md
+++ b/docs/source/guide/frontend.md
@@ -108,7 +108,7 @@ labelStudio.on("labelStudioLoad", (LS) => {
 });
 
 labelStudio.on("submitAnnotation", (LS, annotation) => {
-  // Retrive an annotation in JSON format
+  // Retrieve an annotation in JSON format
   console.log(annotation.serializeAnnotation())
 });
 ```

--- a/docs/source/tags/number.md
+++ b/docs/source/tags/number.md
@@ -19,7 +19,7 @@ Use with the following data types: audio, image, HTML, paragraphs, text, time se
 | [min] | <code>number</code> |  | Minimum number value |
 | [max] | <code>number</code> |  | Maximum number value |
 | [step] | <code>number</code> | <code>1</code> | Step for value increment/decrement |
-| [defaultValue] | <code>number</code> |  | Default number value; will be added automaticaly to result for required fields |
+| [defaultValue] | <code>number</code> |  | Default number value; will be added automatically to result for required fields |
 | [hotkey] | <code>string</code> |  | Hotkey for increasing number value |
 | [required] | <code>boolean</code> | <code>false</code> | Whether to require number validation |
 | [requiredMessage] | <code>string</code> |  | Message to show if validation fails |

--- a/docs/source/templates/intent_classification.md
+++ b/docs/source/templates/intent_classification.md
@@ -61,7 +61,7 @@ Use the [Choices](/tags/choices.html) control tag to classify the intent for eac
     <Choice value="Unsatisfied" />
   </Choices>
 ```
-Because of the `perRegion="true"` argument, each choice applies to a different segment labeled as a segment. The `required="true"` argument ensures that each labeled audio segment has a choice selected before the annotation can be submited.
+Because of the `perRegion="true"` argument, each choice applies to a different segment labeled as a segment. The `required="true"` argument ensures that each labeled audio segment has a choice selected before the annotation can be submitted.
 
 ## Related tags
 

--- a/docs/source/templates/inventory_tracking.md
+++ b/docs/source/templates/inventory_tracking.md
@@ -26,7 +26,7 @@ Inventory Tracking system allows you to label exact products by given brand name
 </View>
 ```
 
-Let's get trough configuration. `View` is used only for layout purposes. The main thing here is the `value` in `PolygonLabels`, it allows us to load labels dynamically for every task from related array in task data, one `Label` per item. Every parameter from such item in data will be present as parameter in generated `Label` tag.
+Let's get through configuration. `View` is used only for layout purposes. The main thing here is the `value` in `PolygonLabels`, it allows us to load labels dynamically for every task from related array in task data, one `Label` per item. Every parameter from such item in data will be present as parameter in generated `Label` tag.
 
 Also there is new `html` parameter for `Label` tag which allows to display rich content as label. This content should be html-escaped:
 - `<` &rarr; `&lt;`

--- a/docs/source/templates/multi-page-document-annotation.md
+++ b/docs/source/templates/multi-page-document-annotation.md
@@ -73,7 +73,7 @@ The simplest way to work with multi-page document annotation is to go in [projec
       <Choice value="Eukarya">
         <Choice value="Human"/>
         <Choice value="Oppossum"/>
-        <Choice value="Extraterrestial"/>
+        <Choice value="Extraterrestrial"/>
       </Choices>
   </Taxonomy>
   </Repeater>

--- a/docs/source/templates/taxonomy.md
+++ b/docs/source/templates/taxonomy.md
@@ -27,7 +27,7 @@ Perform classification tasks within the context of a defined taxonomy or hierarc
     <Choice value="Eukarya">
       <Choice value="Human" />
       <Choice value="Oppossum" />
-      <Choice value="Extraterrestial" />
+      <Choice value="Extraterrestrial" />
     </Choice>
   </Taxonomy>
 </View>
@@ -52,7 +52,7 @@ Use the [Choice](/tags/choice.html) control tag within the Taxonomy tag to speci
     <Choice value="Eukarya">
       <Choice value="Human" />
       <Choice value="Oppossum" />
-      <Choice value="Extraterrestial" />
+      <Choice value="Extraterrestrial" />
     </Choice>
 ```
 Nest choices under a specific [Choice](/tags/choice.html) tag to create layers in the taxonomy.

--- a/label_studio/annotation_templates/natural-language-processing/taxonomy/config.xml
+++ b/label_studio/annotation_templates/natural-language-processing/taxonomy/config.xml
@@ -6,7 +6,7 @@
     <Choice value="Eukarya">
       <Choice value="Human" />
       <Choice value="Oppossum" />
-      <Choice value="Extraterrestial" />
+      <Choice value="Extraterrestrial" />
     </Choice>
   </Taxonomy>
 </View>

--- a/label_studio/core/feature_flags/README.md
+++ b/label_studio/core/feature_flags/README.md
@@ -70,4 +70,4 @@ Feature flags JSON object is available on frontend via
 window.APP_SETTINGS.feature_flags
 ```
 
-To make use flags with LD client, [populate it with bootstap values](https://docs.launchdarkly.com/sdk/features/bootstrapping#javascript)
+To make use flags with LD client, [populate it with bootstrap values](https://docs.launchdarkly.com/sdk/features/bootstrapping#javascript)

--- a/label_studio/core/settings/base.py
+++ b/label_studio/core/settings/base.py
@@ -541,7 +541,7 @@ FEATURE_FLAGS_FROM_FILE = get_bool_env('FEATURE_FLAGS_FROM_FILE', False)
 FEATURE_FLAGS_FILE = get_env('FEATURE_FLAGS_FILE', 'feature_flags.json')
 # or if file is not set, default is using offline mode
 FEATURE_FLAGS_OFFLINE = get_bool_env('FEATURE_FLAGS_OFFLINE', True)
-# default value for feature flags (if not overrided by environment or client)
+# default value for feature flags (if not overridden by environment or client)
 FEATURE_FLAGS_DEFAULT_VALUE = False
 
 # Strip harmful content from SVG files by default

--- a/label_studio/core/storage.py
+++ b/label_studio/core/storage.py
@@ -94,7 +94,7 @@ class AlternativeGoogleCloudStorageBase(GoogleCloudStorage):
     def url(self, name):
         """
         Return public url or a signed url for the Blob.
-        This DOES NOT check for existance of Blob - that makes codes too slow
+        This DOES NOT check for existence of Blob - that makes codes too slow
         for many use cases.
         Overridden to force the use of the IAM signBlob API.
         See https://github.com/googleapis/python-storage/blob/519074112775c19742522158f612b467cf590219/google/cloud/storage/_signing.py#L628  # NOQA

--- a/label_studio/core/utils/common.py
+++ b/label_studio/core/utils/common.py
@@ -505,7 +505,7 @@ def collect_versions(force=False):
 
 
 def get_organization_from_request(request):
-    """Helper for backward compatability with org_pk in session """
+    """Helper for backward compatibility with org_pk in session """
     # TODO remove session logic in next release
     user = request.user
     if user and user.is_authenticated:

--- a/label_studio/frontend/README.md
+++ b/label_studio/frontend/README.md
@@ -94,7 +94,7 @@ MyLayout.title = "My Page Set";
 MyLayout.path = "/some_root"
 ```
 
-Notice the `props` argument and `props.children`. This is the default React way of passing content to the component. It will work fo every component you create. In this case `children` would be a content of a single page you create depending on current route.
+Notice the `props` argument and `props.children`. This is the default React way of passing content to the component. It will work for every component you create. In this case `children` would be a content of a single page you create depending on current route.
 
 Layout can also be extended with `title` and `path`.
 

--- a/label_studio/io_storages/redis/models.py
+++ b/label_studio/io_storages/redis/models.py
@@ -51,7 +51,7 @@ class RedisStorageMixin(models.Model):
             # This should never happen, but better to check than to accidentally
             # overwrite an existing database by choosing a wrong default:
             raise ValueError(
-                "Please explicitely pass a redis db id to prevent accidentally overwriting existing database!")
+                "Please explicitly pass a redis db id to prevent accidentally overwriting existing database!")
 
         # Since tasks are always text, we use StrictRedis with utf-8 decoding.
         r = redis.StrictRedis(db=db, charset="utf-8", decode_responses=True, **redis_config)

--- a/label_studio/projects/api.py
+++ b/label_studio/projects/api.py
@@ -52,7 +52,7 @@ _result_schema = openapi.Schema(
     title='Labeling result',
     description='Labeling result (choices, labels, bounding boxes, etc.)',
     type=openapi.TYPE_OBJECT,
-    properies={
+    properties={
         'from_name': openapi.Schema(
             title='from_name',
             description='The name of the labeling tag from the project config',

--- a/label_studio/projects/migrations/0001_squashed_0065_auto_20210223_2014.py
+++ b/label_studio/projects/migrations/0001_squashed_0065_auto_20210223_2014.py
@@ -292,7 +292,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='project',
             name='title',
-            field=models.CharField(help_text='Project name, lenth is from 3 to 50 chars', max_length=50, validators=[django.core.validators.MinLengthValidator(3), django.core.validators.MaxLengthValidator(50)], verbose_name='name'),
+            field=models.CharField(help_text='Project name, length is from 3 to 50 chars', max_length=50, validators=[django.core.validators.MinLengthValidator(3), django.core.validators.MaxLengthValidator(50)], verbose_name='name'),
         ),
         migrations.AddField(
             model_name='project',

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -365,7 +365,7 @@ class Project(ProjectMixin, models.Model):
         if maximum_annotations_changed and (not overlap_cohort_percentage_changed or self.maximum_annotations == 1):
             tasks_with_overlap = self.tasks.filter(overlap__gt=1)
             if tasks_with_overlap.exists():
-                # if there is a part with overlaped tasks, affect only them
+                # if there is a part with overlapped tasks, affect only them
                 tasks_with_overlap.update(overlap=self.maximum_annotations)
             elif self.overlap_cohort_percentage < 100:
                 self._rearrange_overlap_cohort()

--- a/label_studio/server.py
+++ b/label_studio/server.py
@@ -353,7 +353,7 @@ def main():
             migrated = False
             project_path = pathlib.Path(input_args.project_name)
             if project_path.exists():
-                print('Project directory from previous verion of label-studio found')
+                print('Project directory from previous version of label-studio found')
                 print('Start migrating..')
                 config_path = project_path / 'config.json'
                 config = _get_config(config_path)

--- a/label_studio/tasks/models.py
+++ b/label_studio/tasks/models.py
@@ -645,7 +645,7 @@ def update_all_task_states_after_deleting_task(sender, instance, **kwargs):
 
 @receiver(pre_delete, sender=Task)
 def remove_data_columns(sender, instance, **kwargs):
-    """Reduce data column counters afer removing task"""
+    """Reduce data column counters after removing task"""
     instance.decrease_project_summary_counters()
 
 

--- a/label_studio/tests/test_invites.py
+++ b/label_studio/tests/test_invites.py
@@ -56,7 +56,7 @@ def test_reset_token_not_valid(business_client, client, settings):
 def test_token_get_not_post_shows_form(business_client, client, settings):
     settings.DISABLE_SIGNUP_WITHOUT_LINK = True
 
-    # cant bypass post
+    # can't bypass post
     response = business_client.get('/api/invite')
     invite_url = response.json()['invite_url']
     response = client.get(f'{invite_url}&email=test_user@example.com&password=test_password')

--- a/label_studio/tests/test_predictions.py
+++ b/label_studio/tests/test_predictions.py
@@ -750,7 +750,7 @@ def test_interactive_annotating_failing(business_client, configured_project):
 
     assert 'errors' in result
 
-    # BAD ML RESPONCE
+    # BAD ML RESPONSE
     with requests_mock.Mocker(real_http=True) as m:
         m.register_uri('POST', f'{ml_backend.url}/predict', json={'kebab': [[['eat']]]}, status_code=200)
 

--- a/label_studio/tests/test_project_validation.py
+++ b/label_studio/tests/test_project_validation.py
@@ -91,7 +91,7 @@ from django.urls import reverse
         <Choice value="Politics" />
       </View>
       <View style="margin-right: 4em">
-        <Header size="4" value="Speach Type" />
+        <Header size="4" value="Speech Type" />
         <Choice value="Legible" />
         <Choice value="Slurred" />
       </View>

--- a/label_studio/webhooks/utils.py
+++ b/label_studio/webhooks/utils.py
@@ -111,11 +111,11 @@ def api_webhook(action):
     def decorator(func):
         @wraps(func)
         def wrap(self, request, *args, **kwargs):
-            responce = func(self, request, *args, **kwargs)
+            response = func(self, request, *args, **kwargs)
 
             action_meta = WebhookAction.ACTIONS[action]
             many = action_meta['many']
-            instance = action_meta['model'].objects.get(id=responce.data.get('id'))
+            instance = action_meta['model'].objects.get(id=response.data.get('id'))
             if many:
                 instance = [instance]
             project = None
@@ -127,7 +127,7 @@ def api_webhook(action):
                 action,
                 instance,
             )
-            return responce
+            return response
 
         return wrap
 
@@ -163,10 +163,10 @@ def api_webhook_for_delete(action):
             if many:
                 obj = [obj]
 
-            responce = func(self, request, *args, **kwargs)
+            response = func(self, request, *args, **kwargs)
 
             emit_webhooks_for_instance(request.user.active_organization, project, action, obj)
-            return responce
+            return response
 
         return wrap
 


### PR DESCRIPTION
an extract from https://github.com/heartexlabs/label-studio/pull/3515 

Minor note that commit 93aa0d9b8a697f4ece6f1d46036f8976d7aafaf7 would no longer be `datalad rerun`-able since codespell configuration is no longer present in the PR.  I didn't bother rewriting commit message there though.

I also left out one commit which was not a typo fix but a workaround for `codespell`.