### PR TITLE
Expand bash variable in quotes to avoid expansion errors

### DIFF
--- a/scripts/serve_local_files.sh
+++ b/scripts/serve_local_files.sh
@@ -27,5 +27,5 @@ reset=`tput sgr0`
 echo "${green}File list stored in '${OUTPUT_FILE}'. Now import it directly from Label Studio UI${reset}"
 
 echo "Running web server on the port ${PORT}"
-cd $INPUT_DIR
+cd "$INPUT_DIR"
 python3 -m http.server $PORT


### PR DESCRIPTION
if there is a space in `INPUT_DIR`, then `$INPUT_DIR` will expand to two strings, giving an error in the CD command. Wrapping the expansion in quotes fixes this.