### PR TITLE
fix: #3649: display number of projects list per page

### DIFF
--- a/label_studio/frontend/src/pages/Projects/Projects.js
+++ b/label_studio/frontend/src/pages/Projects/Projects.js
@@ -67,7 +67,7 @@ export const ProjectsPage = () => {
 
     if (isFF(FF_DEV_2575) && data?.results?.length) {
       const additionalData = await api.callApi("projects", {
-        params: { ids: data?.results?.map(({ id }) => id).join(',') },
+        params: { ids: data?.results?.map(({ id }) => id).join(','), page_size: pageSize },
         signal: abortController.controller.current.signal,
         errorFilter: (e) => e.error.includes('aborted'), 
       });


### PR DESCRIPTION
Fix bug described in #3649 Incorrect display projects per page after selecting a number greater than 30.

After fix, the projects are displayed correctly.

#### What does this fix?
Added page_size parameter in:
https://github.com/heartexlabs/label-studio/blob/9308125b3633997d2546a26a7855804c850cc32a/label_studio/frontend/src/pages/Projects/Projects.js#L70
Changed to:
```
params: { ids: data?.results?.map(({ id }) => id).join(','), page_size: pageSize },
```

### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### Which logical domain(s) does this change affect?
Front-end: Projects

