### PR TITLE
fix: LSDV-3074: Ignore feature flag file in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,5 @@ docker-compose.override.yml
 .bash_history
 
 # if you want to include feature flags - use 
-# git add -f feature_flags.json
+# git add -f label_studio/feature_flags.json
 label_studio/feature_flags.json

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ docker-compose.override.yml
 .python_history
 .viminfo
 .bash_history
+
+# if you want to include feature flags - use 
+# git add -f feature_flags.json
+label_studio/feature_flags.json


### PR DESCRIPTION
If you want to include feature_flags.json, use 
```
git add -f feature_flags.json
```