### PR TITLE
docs: Fix broken tag pages

### DIFF
--- a/docs/source/tags/choices.md
+++ b/docs/source/tags/choices.md
@@ -8,7 +8,7 @@ meta_description: Customize Label Studio with multiple choice labels for machine
 
 The `Choices` tag is used to create a group of choices, with radio buttons or checkboxes. It can be used for single or multi-class classification. Also, it is used for advanced classification tasks where annotators can choose one or multiple answers.
 
-Choices can have dynamic value to load labels from task. This task data should contain a list of options to create underlying <Choice>s. All the parameters from options will be transferred to corresponding tags.
+Choices can have dynamic value to load labels from task. This task data should contain a list of options to create underlying `<Choice>`s. All the parameters from options will be transferred to corresponding tags.
 
 The `Choices` tag can be used with any data types.
 

--- a/docs/source/tags/labels.md
+++ b/docs/source/tags/labels.md
@@ -8,7 +8,7 @@ meta_description: Customize Label Studio by using the Labels tag to provide a se
 
 The `Labels` tag provides a set of labels for labeling regions in tasks for machine learning and data science projects. Use the `Labels` tag to create a set of labels that can be assigned to identified region and specify the values of labels to assign to regions.
 
-All types of Labels can have dynamic value to load labels from task. This task data should contain a list of options to create underlying <Label>s. All the parameters from options will be transferred to corresponding tags.
+All types of Labels can have dynamic value to load labels from task. This task data should contain a list of options to create underlying `<Label>`s. All the parameters from options will be transferred to corresponding tags.
 
 The Labels tag can be used with audio and text data types. Other data types have type-specific Labels tags.
 

--- a/docs/source/tags/style.md
+++ b/docs/source/tags/style.md
@@ -12,7 +12,7 @@ The `Style` tag is used in combination with the View tag to apply custom CSS pro
 
 | Param | Type | Description |
 | --- | --- | --- |
-| .<className> | <code>string</code> | Reference the className specified in the View tag to apply to a section of the labeling configuration. |
+| .`<className>` | <code>string</code> | Reference the className specified in the View tag to apply to a section of the labeling configuration. |
 | [CSS property] | <code>string</code> | CSS property and value to apply. |
 
 ### Example


### PR DESCRIPTION
Need to make sure we backtick any HTML-like tag so the rendered doesn’t interpret it as HTML

### Test plan

https://deploy-preview-3785--label-studio-docs-new-theme.netlify.app/tags/choices.html should look good 