### PR TITLE
docs: LSDV-4718: Fix incorrect naming of the mounted directory

### DIFF
--- a/docs/source/guide/install.md
+++ b/docs/source/guide/install.md
@@ -57,7 +57,7 @@ The default web browser opens automatically at [http://localhost:8080](http://lo
 Label Studio is also available as a Docker container. Make sure you have [Docker](https://www.docker.com/) installed on your machine.
 
 ### Install with Docker on *nix
-To install and start Label Studio at [http://localhost:8080](http://localhost:8080), storing all labeling data in `./my_project` directory, run the following:
+To install and start Label Studio at [http://localhost:8080](http://localhost:8080), storing all labeling data in `./mydata` directory, run the following:
 ```bash
 docker run -it -p 8080:8080 -v $(pwd)/mydata:/label-studio/data heartexlabs/label-studio:latest
 ```


### PR DESCRIPTION
In the install documentation about running docker, the naming about the mounted folder is inconsistent. As the mount-path is  named `mydata` I guess the folder should by named accordingly also in the sentence above.