### PR TITLE
docs: LSDV-4714: Fix Quick Start link

### DIFF
--- a/docs/themes/v2/layout/partials/footer.ejs
+++ b/docs/themes/v2/layout/partials/footer.ejs
@@ -195,7 +195,7 @@
         </nav>
         <% if(!isEnterpriseTheme) { %>
           <div class="FooterCTA">
-            <a class="Button Secondary FooterCTAButton" href="https://labelstud.io/guide/"><span class="Heading XXSmall ButtonText astro-EXBSDJPD">Quick Start</span></a>
+            <a class="Button Secondary FooterCTAButton" href="/guide/get_started.html#Quick-start"><span class="Heading XXSmall ButtonText astro-EXBSDJPD">Quick Start</span></a>
             <svg class="FooterCTASquares" width="201" height="201" viewBox="0 0 201 201" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
               <rect x="0.504975" y="100.505" width="49.9901" height="49.9901" stroke="#505263" stroke-width="1.00995"></rect>
               <rect x="50.505" y="150.505" width="49.9901" height="49.9901" stroke="#505263" stroke-width="1.00995"></rect>

--- a/docs/themes/v2/layout/partials/header.ejs
+++ b/docs/themes/v2/layout/partials/header.ejs
@@ -107,7 +107,7 @@
           </button>
           <ul>
             <li>
-              <a href="/guide/index.html#Quick-start">Quickstart</a>
+              <a href="/guide/get_started.html#Quick-start">Quickstart</a>
             </li>
             <li>
               <a href="/guide/install_enterprise.html">Install</a>
@@ -159,6 +159,14 @@
             <li>
               <a href="/videos/">Videos</a>
             </li>
+            <li class="headerSeparator">
+              <a href="/community/">
+                Community
+              </a>
+            </li>
+            <li>
+              <a href="/academic/">Academic Program</a>
+            </li>
           </ul>
         </li>
         <li>
@@ -173,7 +181,7 @@
           </button>
           <ul>
             <li>
-              <a href="/guide/index.html#Quick-start">Quickstart</a>
+              <a href="/guide/get_started.html#Quick-start">Quickstart</a>
             </li>
             <li>
               <a href="/guide/install.html">Install</a>
@@ -196,9 +204,7 @@
           </ul>
         </li>
         <li>
-          <a href="/community/">
-            Community
-          </a>
+          <a href="/integrations">Integrations</a>
         </li>
         <li>
           <a href="https://heartex.com/free-trial" target="_blank" rel="noopener noreferrer">Try Cloud</a>
@@ -210,7 +216,7 @@
           </a>
         </li>
         <li>
-          <%- partial("component/button", { url: "https://labelstud.io/guide/index.html#Quick-start", label: "Quick start", }) %>
+          <%- partial("component/button", { url: "/guide/get_started.html#Quick-start", label: "Quick start", }) %>
         </li>
         <% } %>
     </ul>


### PR DESCRIPTION
Quick start is now under the overview page, so the link needs to be updated.

Also match header content as on https://labelstud.io/

### Test plan
https://deploy-preview-3805--label-studio-docs-new-theme.netlify.app/
