### PR TITLE
docs: broken install instructions for docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ Docker Compose script provides production-ready stack consisting of the followin
 - [Nginx](https://www.nginx.com/) - proxy web server used to load various static data, including uploaded audio, images, etc.
 - [PostgreSQL](https://www.postgresql.org/) - production-ready database that replaces less performant SQLite3.
 
-Before the first startup **you must** assign the data folder to the correct user, to do so you can run this command.
+- If you are running this on Linux before the first startup **you must** assign the data folder to the correct user,
+  to do so you can run this command.
+
 ```bash
 chown -R 1001:0 mydata
 ```
@@ -72,6 +74,9 @@ To start using the app from `http://localhost:8080` run this command:
 ```bash
 docker-compose up
 ```
+
+If you have created certificates for tls  you have to place them in the [nginx/certs](./deploy/nginx/certs) folder
+the server will then be available at port 8086 instead.
 
 **this compose file + Nginx config allows **you and everyone else** to access this application from all 
 devices within the network, make sure that your router is configured properly.**

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ docker-compose up
 ```
 
 If you have created certificates for tls  you have to place them in the [nginx/certs](./deploy/nginx/certs) folder
-the server will then be available at port 8086 instead.
+the server will then be available on port 8086 instead.
 
-**this compose file + Nginx config allows **you and everyone else** to access this application from all 
-devices within the network, make sure that your router is configured properly.**
+This compose file + Nginx config allows **you and everyone else** to access this application from all 
+devices within the network, **make sure that your network is configured properly.**
 
 ### Install locally with pip
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Run Label Studio in a Docker container and access it at `http://localhost:8080`.
 
 ```bash
 docker pull heartexlabs/label-studio:latest
+chown -R 1001:0 $(pwd)/mydata
 docker run -it -p 8080:8080 -v $(pwd)/mydata:/label-studio/data heartexlabs/label-studio:latest
 ```
 You can find all the generated assets, including SQLite3 database storage `label_studio.sqlite3` and uploaded files, in the `./mydata` directory.
@@ -62,10 +63,18 @@ Docker Compose script provides production-ready stack consisting of the followin
 - [Nginx](https://www.nginx.com/) - proxy web server used to load various static data, including uploaded audio, images, etc.
 - [PostgreSQL](https://www.postgresql.org/) - production-ready database that replaces less performant SQLite3.
 
-To start using the app from `http://localhost` run this command:
+Before the first startup **you must** assign the data folder to the correct user, to do so you can run this command.
+```bash
+chown -R 1001:0 mydata
+```
+
+To start using the app from `http://localhost:8080` run this command:
 ```bash
 docker-compose up
 ```
+
+**this compose file + Nginx config allows **you and everyone else** to access this application from all 
+devices within the network, make sure that your router is configured properly.**
 
 ### Install locally with pip
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,15 +11,15 @@ services:
       - app
     environment:
       - LABEL_STUDIO_HOST=${LABEL_STUDIO_HOST:-}
-#   Optional: Specify SSL termination certificate & key
-#   Just drop your cert.pem and cert.key into folder 'deploy/nginx/certs'
-#      - NGINX_SSL_CERT=/certs/cert.pem
-#      - NGINX_SSL_CERT_KEY=/certs/cert.key
+    #   Optional: Specify SSL termination certificate & key
+    #   Just drop your cert.pem and cert.key into folder 'deploy/nginx/certs'
+    #      - NGINX_SSL_CERT=/certs/cert.pem
+    #      - NGINX_SSL_CERT_KEY=/certs/cert.key
     volumes:
       - ./mydata:/label-studio/data:rw
       - ./deploy/nginx/certs:/certs:ro
-#   Optional: Override nginx default conf
-#      - ./deploy/nginx/default.conf:/label-studio/deploy/nginx/default.conf
+    #   Optional: Override nginx default conf
+    #      - ./deploy/nginx/default.conf:/label-studio/deploy/nginx/default.conf
     command: nginx
 
   app:
@@ -31,6 +31,8 @@ services:
       - "8000"
     depends_on:
       - db
+    user: 1001:0
+
     environment:
       - DJANGO_DB=default
       - POSTGRE_NAME=postgres
@@ -40,7 +42,7 @@ services:
       - POSTGRE_HOST=db
       - LABEL_STUDIO_HOST=${LABEL_STUDIO_HOST:-}
       - JSON_LOG=1
-#      - LOG_LEVEL=DEBUG
+    #      - LOG_LEVEL=DEBUG
     volumes:
       - ./mydata:/label-studio/data:rw
     command: label-studio-uwsgi
@@ -52,10 +54,10 @@ services:
     # Optional: Enable TLS on PostgreSQL
     # Just drop your server.crt and server.key into folder 'deploy/pgsql/certs'
     # NOTE: Both files must have permissions u=rw (0600) or less
-#    command: >
-#      -c ssl=on
-#      -c ssl_cert_file=/var/lib/postgresql/certs/server.crt
-#      -c ssl_key_file=/var/lib/postgresql/certs/server.key
+    #    command: >
+    #      -c ssl=on
+    #      -c ssl_cert_file=/var/lib/postgresql/certs/server.crt
+    #      -c ssl_key_file=/var/lib/postgresql/certs/server.key
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
@@ -63,4 +65,5 @@ services:
       - ./deploy/pgsql/certs:/var/lib/postgresql/certs:ro
 
 volumes:
-  static: {}
+  static: { }
+

--- a/mydata/.gitkeep
+++ b/mydata/.gitkeep
@@ -1,0 +1,3 @@
+This file exists to ensure that the folder is created with the group and permission of the cloning user
+re own this folder with `sudo chown -R 1001:0 mydata`.
+


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)


#### Change has impacts in these area(s)

- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [ ] Frontend



### Describe the reason for change

Default instructions to run the docker compose stack are deprecated since 1.7, this pr addresses that.
e.g. https://github.com/heartexlabs/label-studio/issues/3766

#### What does this fix?
* list required commands for docker compose deploy on linux
* explicitly adds the user and group to the compose file
* creates a gitkeep for the mydata folder to prevent it being owned by root due to compose behaviour
  - this results in the folder being owned by the user, which cloned the repo
* fixes missing broken port in docker compose run example

#### What is the new behavior?
install instructions are no longer broken ( only tested on windows and linux=


#### What is the current behavior?
install instructions broken on linux ( see https://github.com/heartexlabs/label-studio/issues/3766)



#### What libraries were added/updated?
No changes to the dependencies were made



#### Does this change affect performance?
no

#### Does this change affect security?
it adds a note regarding a potentially unintended availability


#### What alternative approaches were there?




#### What feature flags were used to cover this change?
None


### Does this PR introduce a breaking change?

- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?

does not apply?
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Docs for new users
