### PR TITLE
docs: Fix Style and Image docs, fix CSS ref link

### DIFF
--- a/docs/source/tags/image.md
+++ b/docs/source/tags/image.md
@@ -26,43 +26,43 @@ When you annotate image regions with this tag, the annotations are saved as perc
 | [zoomBy] | <code>float</code> | <code>1.1</code> | Scale factor |
 | [grid] | <code>boolean</code> | <code>false</code> | Whether to show a grid |
 | [gridSize] | <code>number</code> | <code>30</code> | Specify size of the grid |
-| [gridColor] | <code>string</code> | <code>&quot;\&quot;#EEEEF4\&quot;&quot;</code> | Color of the grid in hex, opacity is 0.15 |
+| [gridColor] | <code>string</code> | <code>&quot;#EEEEF4&quot;</code> | Color of the grid in hex, opacity is 0.15 |
 | [zoomControl] | <code>boolean</code> | <code>false</code> | Show zoom controls in toolbar |
 | [brightnessControl] | <code>boolean</code> | <code>false</code> | Show brightness control in toolbar |
 | [contrastControl] | <code>boolean</code> | <code>false</code> | Show contrast control in toolbar |
 | [rotateControl] | <code>boolean</code> | <code>false</code> | Show rotate control in toolbar |
 | [crosshair] | <code>boolean</code> | <code>false</code> | Show crosshair cursor |
-| [horizontalAlignment] | <code>string</code> | <code>&quot;\&quot;left\&quot;&quot;</code> | Where to align image horizontally. Can be one of "left", "center" or "right" |
-| [verticalAlignment] | <code>string</code> | <code>&quot;\&quot;top\&quot;&quot;</code> | Where to align image vertically. Can be one of "top", "center" or "bottom" |
-| [defaultZoom] | <code>string</code> | <code>&quot;\&quot;fit\&quot;&quot;</code> | Specify the initial zoom of the image within the viewport while preserving it’s ratio. Can be one of "auto", "original" or "fit" |
+| [horizontalAlignment] | <code>string</code> | <code>&quot;left&quot;</code> | Where to align image horizontally. Can be one of "left", "center" or "right" |
+| [verticalAlignment] | <code>string</code> | <code>&quot;top&quot;</code> | Where to align image vertically. Can be one of "top", "center" or "bottom" |
+| [defaultZoom] | <code>string</code> | <code>&quot;fit&quot;</code> | Specify the initial zoom of the image within the viewport while preserving it’s ratio. Can be one of "auto", "original" or "fit" |
 | [valuelist] | <code>string</code> |  | References a variable that holds a list of image URLs |
-| [crossOrigin] | <code>string</code> | <code>&quot;\&quot;none\&quot;&quot;</code> | Configures CORS cross domain behavior for this image, either "none", "anonymous", or "use-credentials", similar to [DOM `img` crossOrigin property](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/crossOrigin). |
+| [crossOrigin] | <code>string</code> | <code>&quot;none&quot;</code> | Configures CORS cross domain behavior for this image, either "none", "anonymous", or "use-credentials", similar to [DOM `img` crossOrigin property](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/crossOrigin). |
 
 ### Example
-<!--Labeling configuration to display an image on the labeling interface-->
+
+Labeling configuration to display an image on the labeling interface
+
+```html
 <View>
   <!-- Retrieve the image url from the url field in JSON or column in CSV -->
   <Image name="image" value="$url" rotateControl="true" zoomControl="true"></Image>
 </View>
- * @example
-<!--Labeling configuration to perform multi-image segmentation-->
+```
+### Example
 
-Config:
-```xml
+Labeling configuration to perform multi-image segmentation
+
+```html
 <View>
   <!-- Retrieve the image url from the url field in JSON or column in CSV -->
   <Image name="image" valueList="$images" rotateControl="true" zoomControl="true"></Image>
 </View>
-```
-
-Data:
-```json
-{
+<!-- {
   "data": {
     "images": [
       "https://images.unsplash.com/photo-1556740734-7f3a7d7f0f9c?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1950&q=80",
       "https://images.unsplash.com/photo-1556740734-7f3a7d7f0f9c?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1950&q=80",
     ]
   }
-}
+} -->
 ```

--- a/docs/source/tags/style.md
+++ b/docs/source/tags/style.md
@@ -6,13 +6,13 @@ meta_title: Style Tag to use CSS Styles
 meta_description: Customize Label Studio with CSS styles to modify the labeling interface for machine learning and data science projects.
 ---
 
-The `Style` tag is used in combination with the View tag to apply custom CSS properties to the labeling interface. See the [CSS Reference](https://www.w3schools.com/cssref/default.asp) on the W3Schools page for a full list of available properties that you can reference. You can also adjust default Label Studio CSS classes. Use the browser developer tools to inspect the element on the UI and locate the class name, then specify that class name in the `Style` tag.
+The `Style` tag is used in combination with the View tag to apply custom CSS properties to the labeling interface. See the [CSS Reference](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference) on the MDN page for a full list of available properties that you can reference. You can also adjust default Label Studio CSS classes. Use the browser developer tools to inspect the element on the UI and locate the class name, then specify that class name in the `Style` tag.
 
 ### Parameters
 
 | Param | Type | Description |
 | --- | --- | --- |
-| .<className> | <code>string</code> | Reference the className specified in the View tag to apply to a section of the labeling configuration. |
+| `.<className>` | <code>string</code> | Reference the className specified in the View tag to apply to a section of the labeling configuration. |
 | [CSS property] | <code>string</code> | CSS property and value to apply. |
 
 ### Example


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



### Describe the reason for change
Docs are broken because of wrong format:
- `<>` should be escaped
- examples should contain xml directly, all comments go into `<!-- -->` html comments




### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)
