### PR TITLE
fix: LSDV-4711: Presigned proxy redirect should not cache

### DIFF
--- a/label_studio/data_import/api.py
+++ b/label_studio/data_import/api.py
@@ -562,6 +562,14 @@ class PresignStorageData(APIView):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         # Proxy to presigned url
-        return HttpResponseRedirect(redirect_to=url, status=status.HTTP_303_SEE_OTHER)
+        response = HttpResponseRedirect(redirect_to=url, status=status.HTTP_303_SEE_OTHER)
+
+        # NOTE: Temporary workaround:
+        # For some reason even though this is using a 303 which should never cache
+        # it at the moment will cache the redirect when running the python server directly.
+        # This is not an issue when running behind nginx and a more comprehensive solution to this will be coming.
+        response.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
+
+        return response
 
 

--- a/label_studio/tasks/models.py
+++ b/label_studio/tasks/models.py
@@ -282,8 +282,7 @@ class Task(TaskMixin, models.Model):
                 if storage:
                     try:
                         proxy_task = None
-                        if flag_set('fflag_fix_all_lsdv_4711_cors_errors_accessing_task_data_short',
-                                    self.project.organization.created_by):
+                        if flag_set('fflag_fix_all_lsdv_4711_cors_errors_accessing_task_data_short', user='auto'):
                             proxy_task = self
 
                         resolved_uri = storage.resolve_uri(task_data[field], proxy_task)


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [X] Backend (API)
- [ ] Frontend



### Describe the reason for change
When testing locally with the python server directly, and the CORS fixes from #3991 it seems to cache a 303 redirect, which shouldn't be happening. So for now we will add a header to ensure the browser doesn't cache the redirects, until we have a more comprehensive solution ready.


### Which logical domain(s) does this change affect?
Presigned URLS

