### PR TITLE
fix: LSDV-5036: Issue with cloud storage url causing errors and improperly created urls (#4143)

### DIFF
--- a/label_studio/data_export/api.py
+++ b/label_studio/data_export/api.py
@@ -466,7 +466,7 @@ class ExportDownloadAPI(generics.RetrieveAPIView):
             if isinstance(file.storage, FileSystemStorage):
                 url = file.storage.url(file.name)
             else:
-                url = file.storage.url(file.name, storage_url=True, http_method=request.method)
+                url = file.storage.url(file.name, storage_url=True)
             protocol = urlparse(url).scheme
 
             # Let NGINX handle it

--- a/label_studio/data_import/api.py
+++ b/label_studio/data_import/api.py
@@ -482,11 +482,8 @@ class DownloadStorageData(APIView):
     """ Check auth for nginx auth_request
     """
     swagger_schema = None
-    http_method_names = ['get', 'head']
+    http_method_names = ['get']
     permission_classes = (IsAuthenticated, )
-
-    def head(self, request, *args, **kwargs):
-        return self.get(request, *args, **kwargs)
 
     def get(self, request, *args, **kwargs):
         """ Get export files list
@@ -504,7 +501,7 @@ class DownloadStorageData(APIView):
             file_upload = FileUpload.objects.filter(file=filepath).last()
 
             if file_upload is not None and file_upload.has_permission(request.user):
-                url = file_upload.file.storage.url(file_upload.file.name, storage_url=True, http_method=request.method)
+                url = file_upload.file.storage.url(file_upload.file.name, storage_url=True)
         elif filepath.startswith(settings.AVATAR_PATH):
             user = User.objects.filter(avatar=filepath).first()
             if user is not None and request.user.active_organization.has_user(user):


### PR DESCRIPTION
* fix: LSDV-5036: Issue with cloud storage url causing errors and improperly created urls

* remove head support from DownloadStorageData as it is not required
