### PR TITLE
fix: LSDV-4719: improve performance of project annotations

### DIFF
--- a/label_studio/projects/functions/__init__.py
+++ b/label_studio/projects/functions/__init__.py
@@ -1,7 +1,7 @@
 from django.db.models import Count, Q, OuterRef
 
 from core.utils.db import SQCount
-from tasks.models import Annotation, Task
+from tasks.models import Annotation, Task, Prediction
 from core.feature_flags import flag_set
 
 
@@ -22,8 +22,8 @@ def annotate_finished_task_number(queryset):
 
 
 def annotate_total_predictions_number(queryset):
-    return queryset.annotate(total_predictions_number=Count('tasks__predictions', distinct=True))
-
+    predictions = Prediction.objects.filter(task__project=OuterRef('id')).values('id')
+    return queryset.annotate(total_predictions_number=SQCount(predictions))
 
 def annotate_total_annotations_number(queryset):
     if flag_set('fflag_fix_back_LSDV_961_project_list_09022023_short', user='auto'):

--- a/label_studio/projects/functions/__init__.py
+++ b/label_studio/projects/functions/__init__.py
@@ -22,8 +22,12 @@ def annotate_finished_task_number(queryset):
 
 
 def annotate_total_predictions_number(queryset):
-    predictions = Prediction.objects.filter(task__project=OuterRef('id')).values('id')
-    return queryset.annotate(total_predictions_number=SQCount(predictions))
+    if flag_set("fflag_fix_back_lsdv_4719_improve_performance_of_project_annotations", user='auto'):
+        predictions = Prediction.objects.filter(task__project=OuterRef('id')).values('id')
+        return queryset.annotate(total_predictions_number=SQCount(predictions))
+    else:
+        return queryset.annotate(total_predictions_number=Count('tasks__predictions', distinct=True))
+
 
 def annotate_total_annotations_number(queryset):
     if flag_set('fflag_fix_back_LSDV_961_project_list_09022023_short', user='auto'):


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [x] Backend (API)
- [ ] Frontend


### Describe the reason for change
For very large projects, the projects list(and detail) endpoints can take nearly 10 seconds to load due to inefficient queries.


#### What does this fix?
Most of the queries making up the project endpoint were analyzed and the 2 worst queries were greatly improved.  The worst query is in the related [LSE PR](https://github.com/heartexlabs/label-studio-enterprise/pull/4292).  

#### Does this change affect performance?
In this PR `annotate_total_predictions_number` execution time was cut in half by about 2.  

### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Projects
