### PR TITLE
fix: LSDV-5289: Decrease lockiness of task update code

### DIFF
--- a/label_studio/projects/mixins.py
+++ b/label_studio/projects/mixins.py
@@ -25,7 +25,7 @@ class ProjectMixin:
         # get only id from queryset to decrease data size in job
         if not (isinstance(tasks_queryset, set) or isinstance(tasks_queryset, list)):
             tasks_queryset = set(tasks_queryset.values_list('id', flat=True))
-        start_job_async_or_sync(self._update_tasks_counters_and_is_labeled, tasks_queryset, from_scratch=from_scratch)
+        start_job_async_or_sync(self._update_tasks_counters_and_is_labeled, list(tasks_queryset), from_scratch=from_scratch)
 
     def update_tasks_counters_and_task_states(self, tasks_queryset, maximum_annotations_changed,
                                             overlap_cohort_percentage_changed, tasks_number_changed, from_scratch=True):


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [ ] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Backend (Database)
- [ ] Backend (API)
- [ ] Frontend



### Describe the reason for change
_(link to issue, supportive screenshots etc.)_



#### What does this fix?
_(if this is a bug fix)_

Lengthy deadlocks (1+hr) from this code have caused some tasks on rqworker to hang for more than an hour. We theorize this is because the existing implementation updates all task counts in a loop wrapped in `transaction.atomic()`, then updates the same tasks' `is_labeled` fields in another bulk update loop, also wrapped in a different `transaction.atomic()`.

In addition to each loop wrapped in `atomic` resulting in a lock on each row that it updates that lasts for the duration of the entire loop, the atomicity guarantee we really want (and which the present implementation does not provide) is that if a task's counts are updated, that task's `is_labeled` field is updated; a failure in the latter step should result in a rollback of the former.

This new implementation should hold locks for much less time (since, after each batch of rows has had its counts updated and `is_labeled` values updated, it can be fully released from all locks), and also give us the atomicity guarantee that we're seeking.

#### What is the new behavior?
_(if this is a breaking or feature change)_



#### What is the current behavior?
_(if this is a breaking or feature change)_



#### What libraries were added/updated?
_(list all with version changes)_



#### Does this change affect performance?
Yes. This is expected to reduce database deadlocks originating from rq_worker updating tasks' counts and `is_labeled` fields.



#### Does this change affect security?
_(if so describe the impacts positive or negative)_



#### What alternative approaches were there?
_(briefly list any if applicable)_



#### What feature flags were used to cover this change?
_(briefly list any if applicable)_



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [ ] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
_(for bug fixes/features, be as precise as possible. ex. Authentication, Annotation History, Review Stream etc.)_

