### PR TITLE
fix: LSDV-5348: More robust and uniform SSRF defenses

### DIFF
--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -52,6 +52,7 @@ pydantic>=1.7.3,<=1.11.0
 python_dateutil==2.8.1
 pytz ~=2022.1
 requests==2.31.0
+urllib3==1.26.16
 rq==1.10.1
 rules==2.2
 ujson>=3.0.0

--- a/label_studio/core/settings/base.py
+++ b/label_studio/core/settings/base.py
@@ -581,6 +581,9 @@ FEATURE_FLAGS_OFFLINE = get_bool_env('FEATURE_FLAGS_OFFLINE', True)
 # default value for feature flags (if not overridden by environment or client)
 FEATURE_FLAGS_DEFAULT_VALUE = False
 
+# Whether to send analytics telemetry data
+COLLECT_ANALYTICS = get_bool_env('collect_analytics', True)
+
 # Strip harmful content from SVG files by default
 SVG_SECURITY_CLEANUP = get_bool_env('SVG_SECURITY_CLEANUP', False)
 

--- a/label_studio/core/utils/contextlog.py
+++ b/label_studio/core/utils/contextlog.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 from .common import get_app_version, get_client_ip
 from .params import get_bool_env
 from .io import get_config_dir, find_file
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +42,7 @@ class ContextLog(object):
     _log_payloads = _load_log_payloads()
 
     def __init__(self):
-        self.collect_analytics = get_bool_env('collect_analytics', True)
+        self.collect_analytics = settings.COLLECT_ANALYTICS
         self.version = get_app_version()
         self.server_id = self._get_server_id()
 

--- a/label_studio/core/utils/exceptions.py
+++ b/label_studio/core/utils/exceptions.py
@@ -44,11 +44,6 @@ class LabelStudioXMLSyntaxErrorSentryIgnored(Exception):
     pass
 
 
-class ImportFromLocalIPError(LabelStudioAPIException):
-    default_detail = 'Importing from local IP is not allowed'
-    status_code = status.HTTP_403_FORBIDDEN
-
-
-class MLModelLocalIPError(LabelStudioAPIException):
-    default_detail = 'Adding models with local IP is not allowed'
+class InvalidUploadUrlError(LabelStudioAPIException):
+    default_detail = 'The provided URL was not valid. URLs must begin with http:// or https://, and cannot be local IPs.'
     status_code = status.HTTP_403_FORBIDDEN

--- a/label_studio/core/utils/io.py
+++ b/label_studio/core/utils/io.py
@@ -17,7 +17,8 @@ from tempfile import mkstemp, mkdtemp
 
 from django.conf import settings
 from appdirs import user_config_dir, user_data_dir, user_cache_dir
-from core.utils.exceptions import InvalidUploadUrlError
+
+from label_studio.core.utils.exceptions import InvalidUploadUrlError
 
 
 _DIR_APP_NAME = 'label-studio'

--- a/label_studio/core/utils/io.py
+++ b/label_studio/core/utils/io.py
@@ -18,7 +18,8 @@ from tempfile import mkstemp, mkdtemp
 from django.conf import settings
 from appdirs import user_config_dir, user_data_dir, user_cache_dir
 
-from label_studio.core.utils.exceptions import InvalidUploadUrlError
+# full path import results in unit test failures
+from .exceptions import InvalidUploadUrlError
 
 
 _DIR_APP_NAME = 'label-studio'

--- a/label_studio/core/utils/io.py
+++ b/label_studio/core/utils/io.py
@@ -11,11 +11,13 @@ import ujson as json
 import itertools
 import yaml
 
-from urllib.parse import urlparse
+from urllib3.util import parse_url
 from contextlib import contextmanager
 from tempfile import mkstemp, mkdtemp
 
+from django.conf import settings
 from appdirs import user_config_dir, user_data_dir, user_cache_dir
+from core.utils.exceptions import InvalidUploadUrlError
 
 
 _DIR_APP_NAME = 'label-studio'
@@ -167,26 +169,40 @@ class SerializableGenerator(list):
     def __iter__(self):
         return itertools.chain(self._head, *self[:1])
 
+def validate_upload_url(url, block_local_urls=True):
+    """Utility function for defending against SSRF attacks. Raises
+        - InvalidUploadUrlError if the url is not HTTP[S], or if block_local_urls is enabled
+          and the URL resolves to a local address.
+        - LabelStudioApiException if the hostname cannot be resolved
 
-def url_is_local(url):
-    domain = urlparse(url).hostname
+    :param url: Url to be checked for validity/safety,
+    :param block_local_urls: Whether urls that resolve to local/private networks should be allowed.
+    """
+
+    parsed_url = parse_url(url)
+
+    if parsed_url.scheme not in ('http', 'https'):
+        raise InvalidUploadUrlError
+
+    domain = parsed_url.host
     try:
         ip = socket.gethostbyname(domain)
     except socket.error:
         from core.utils.exceptions import LabelStudioAPIException
         raise LabelStudioAPIException(f"Can't resolve hostname {domain}")
-    else:
-        if ip in (
-            '0.0.0.0', # nosec
-        ):
-            return True
-        local_subnets = [
-            '127.0.0.0/8',
-            '10.0.0.0/8',
-            '172.16.0.0/12',
-            '192.168.0.0/16',
-        ]
-        for subnet in local_subnets:
-            if ipaddress.ip_address(ip) in ipaddress.ip_network(subnet):
-                return True
-        return False
+
+    if not block_local_urls:
+        return
+
+    if ip == '0.0.0.0':  # nosec
+        raise InvalidUploadUrlError
+    local_subnets = [
+        '127.0.0.0/8',
+        '10.0.0.0/8',
+        '172.16.0.0/12',
+        '192.168.0.0/16',
+    ]
+    for subnet in local_subnets:
+        if ipaddress.ip_address(ip) in ipaddress.ip_network(subnet):
+            raise InvalidUploadUrlError
+

--- a/label_studio/data_import/uploader.py
+++ b/label_studio/data_import/uploader.py
@@ -3,7 +3,6 @@
 import os
 import io
 import csv
-import ssl
 import requests
 import logging
 import mimetypes
@@ -16,13 +15,11 @@ except:
 from rest_framework.exceptions import ValidationError
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
-from urllib.request import urlopen
 
 from .models import FileUpload
-from core.utils.io import url_is_local
+from core.utils.io import validate_upload_url
 from core.utils.common import timeit
 from core.feature_flags import flag_set
-from core.utils.exceptions import ImportFromLocalIPError
 
 logger = logging.getLogger(__name__)
 csv.field_size_limit(131072 * 10)
@@ -133,30 +130,18 @@ def tasks_from_url(file_upload_ids, project, user, url, could_be_tasks_list):
     try:
         filename = url.rsplit('/', 1)[-1]
 
-        if flag_set('fflag_fix_back_lsdv_4568_import_csv_links_03032023_short'):
-            response = requests.get(
-                url, verify=False, headers={'Accept-Encoding': None}
-            )  # nosec
-            file_content = response.content
-            check_tasks_max_file_size(int(response.headers['content-length']))
-        else:
-            ctx = ssl.create_default_context()
-            ctx.check_hostname = False
-            ctx.verify_mode = ssl.CERT_NONE
-            with urlopen(url, context=ctx) as file:  # nosec
-                # check size
-                meta = file.info()
-                check_tasks_max_file_size(int(meta.get("Content-Length")))
-                file_content = file.read()
-                if isinstance(file_content, str):
-                    file_content = file_content.encode()
+        validate_upload_url(url, block_local_urls=settings.SSRF_PROTECTION_ENABLED)
+        # Reason for #nosec: url has been validated as SSRF safe by the
+        # validation check above.
+        response = requests.get(
+            url, verify=False, headers={'Accept-Encoding': None}
+        )  # nosec
+        file_content = response.content
+        check_tasks_max_file_size(int(response.headers['content-length']))
         file_upload = create_file_upload(
             user, project, SimpleUploadedFile(filename, file_content)
         )
-        if (
-            flag_set('fflag_fix_back_lsdv_4568_import_csv_links_03032023_short')
-            and file_upload.format_could_be_tasks_list
-        ):
+        if file_upload.format_could_be_tasks_list:
             could_be_tasks_list = True
         file_upload_ids.append(file_upload.id)
         tasks, found_formats, data_keys = FileUpload.load_tasks_from_uploaded_files(
@@ -216,12 +201,6 @@ def load_tasks_for_async_import(project_import, user):
 
         # download file using url and read tasks from it
         else:
-            if settings.SSRF_PROTECTION_ENABLED and url_is_local(url):
-                raise ImportFromLocalIPError
-
-            if url.strip().startswith('file://'):
-                raise ValidationError('"url" is not valid')
-
             could_be_tasks_list = False
             (
                 data_keys,
@@ -289,12 +268,6 @@ def load_tasks(request, project):
 
         # download file using url and read tasks from it
         else:
-            if settings.SSRF_PROTECTION_ENABLED and url_is_local(url):
-                raise ImportFromLocalIPError
-
-            if url.strip().startswith('file://'):
-                raise ValidationError('"url" is not valid')
-
             (
                 data_keys,
                 found_formats,

--- a/label_studio/feature_flags.json
+++ b/label_studio/feature_flags.json
@@ -3336,33 +3336,6 @@
       "version": 2,
       "deleted": false
     },
-    "fflag_fix_back_lsdv_4568_import_csv_links_03032023_short": {
-      "key": "fflag_fix_back_lsdv_4568_import_csv_links_03032023_short",
-      "on": true,
-      "prerequisites": [],
-      "targets": [],
-      "contextTargets": [],
-      "rules": [],
-      "fallthrough": {
-        "variation": 0
-      },
-      "offVariation": 1,
-      "variations": [
-        true,
-        false
-      ],
-      "clientSideAvailability": {
-        "usingMobileKey": false,
-        "usingEnvironmentId": false
-      },
-      "clientSide": false,
-      "salt": "4d6e875af4b3453a827a94db5eb8a88d",
-      "trackEvents": false,
-      "trackEventsFallthrough": false,
-      "debugEventsUntilDate": null,
-      "version": 3,
-      "deleted": false
-    },
     "fflag_fix_back_lsdv_4648_annotator_filter_29052023_short": {
       "key": "fflag_fix_back_lsdv_4648_annotator_filter_29052023_short",
       "on": false,

--- a/label_studio/ml/serializers.py
+++ b/label_studio/ml/serializers.py
@@ -3,14 +3,12 @@
 from django.conf import settings
 from rest_framework import serializers
 from ml.models import MLBackend
-from core.utils.io import url_is_local
-from core.utils.exceptions import MLModelLocalIPError
-
+from core.utils.io import validate_upload_url
 
 class MLBackendSerializer(serializers.ModelSerializer):
     def validate_url(self, value):
-        if settings.ML_BLOCK_LOCAL_IP and url_is_local(value):
-            raise MLModelLocalIPError
+        validate_upload_url(value, block_local_urls=settings.ML_BLOCK_LOCAL_IP)
+
         return value
 
     def validate(self, attrs):

--- a/label_studio/tests/data_import/test_uploader.py
+++ b/label_studio/tests/data_import/test_uploader.py
@@ -1,10 +1,11 @@
 import pytest
+from unittest import mock
 
 from django.conf import settings
 from rest_framework.exceptions import ValidationError
 
 from core.utils.exceptions import InvalidUploadUrlError
-from data_import.uploader import load_tasks, check_tasks_max_file_size
+from data_import.uploader import load_tasks, check_tasks_max_file_size, validate_upload_url
 
 pytestmark = pytest.mark.django_db
 
@@ -23,35 +24,38 @@ class MockedRequest:
     def data(self):
         return {"url": self.url}
 
+    @property
+    def user(self):
+        return None
+
 
 class TestUploader:
     @pytest.fixture
     def project(self, configured_project, settings):
-        settings.SSRF_PROTECTION_ENABLED = True
         return configured_project
 
     class TestLoadTasks:
-        @pytest.mark.parametrize("url", ("file:///etc/passwd", " file://etc/kernel "))
-        def test_raises_for_local_files(self, url, project):
+        @mock.patch('data_import.uploader.validate_upload_url', wraps=validate_upload_url)
+        @pytest.mark.parametrize("url", ("file:///etc/passwd", "ftp://example.org"))
+        def test_raises_for_unsafe_urls(self, validate_upload_url_mock, url, project):
             request = MockedRequest(url=url)
 
-            with pytest.raises(InvalidUploadUrlError) as e:
+            with pytest.raises(ValidationError) as e:
                 load_tasks(request, project)
+                assert 'The provided URL was not valid.' in e.value
 
-        @pytest.mark.parametrize("url", ("http://0.0.0.0", " https://0.0.0.0 "))
-        def test_raises_for_local_urls(self, url, project):
-            request = MockedRequest(url="http://0.0.0.0")
+            validate_upload_url_mock.assert_called_once_with(url, block_local_urls=False)
 
-            with pytest.raises(InvalidUploadUrlError) as e:
+        @mock.patch('data_import.uploader.validate_upload_url', wraps=validate_upload_url)
+        def test_raises_for_local_urls_with_ssrf_protection_enabled(self, validate_upload_url_mock, project, settings):
+            settings.SSRF_PROTECTION_ENABLED = True
+            request = MockedRequest(url='http://0.0.0.0')
+
+            with pytest.raises(ValidationError) as e:
                 load_tasks(request, project)
+                assert 'The provided URL was not valid.' in e.value
 
-        @pytest.mark.parametrize("url", ("ftp://example.org", "jdni://example.org"))
-        def test_raises_for_non_http_schemas(self, url, project):
-            request = MockedRequest(url="http://0.0.0.0")
-
-            with pytest.raises(InvalidUploadUrlError) as e:
-                load_tasks(request, project)
-
+            validate_upload_url_mock.assert_called_once_with('http://0.0.0.0', block_local_urls=True)
 
 
 class TestTasksFileChecks:

--- a/label_studio/tests/test_core.py
+++ b/label_studio/tests/test_core.py
@@ -4,6 +4,10 @@ import pytest
 import types
 from core.utils.common import int_from_request
 from core.utils.params import bool_from_request
+from core.utils.io import validate_upload_url
+from core.utils.exceptions import InvalidUploadUrlError
+from core.utils.exceptions import LabelStudioAPIException
+
 from rest_framework.exceptions import ValidationError
 
 
@@ -134,3 +138,51 @@ def test_start_browser():
 
     assert start_browser('http://localhost:8080', True) is None
     assert start_browser('http://localhost:8080', False) is None
+
+@pytest.mark.parametrize('url, block_local_urls, raises_exc', [
+    ('http://0.0.0.0', True, InvalidUploadUrlError),
+    ('http://0.0.0.0', False, None),
+    ('https://0.0.0.0', True, InvalidUploadUrlError),
+    ('https://0.0.0.0', False, None),
+    # Non-http[s] schemes
+    ('ftp://example.org', True, InvalidUploadUrlError),
+    ('ftp://example.org', False, InvalidUploadUrlError),
+    ('FILE:///etc/passwd', True, InvalidUploadUrlError),
+    ('file:///etc/passwd', False, InvalidUploadUrlError),
+    # Start and end of 127.0.0.0/8
+    ('https://127.0.0.0', True, InvalidUploadUrlError),
+    ('https://127.255.255.255', True, InvalidUploadUrlError),
+    # Start and end of 10.0.0.0/8
+    ('http://10.0.0.0', True, InvalidUploadUrlError),
+    ('https://10.255.255.255', True, InvalidUploadUrlError),
+    # Start and end of 172.16.0.0/12
+    ('https://172.16.0.0', True, InvalidUploadUrlError),
+    ('https://172.31.255.255', True, InvalidUploadUrlError),
+    # Start and end of 192.168.0.0/16
+    ('https://192.168.0.0', True, InvalidUploadUrlError),
+    ('https://192.168.255.255', True, InvalidUploadUrlError),
+    # Valid external IPs
+    ('https://4.4.4.4', True, None),
+    ('https://8.8.8.8', True, None),
+    ('http://8.8.8.8', False, None),
+    # Valid external websites
+    ('https://example.org', True, None),
+    ('http://example.org', False, None),
+    # Space prepended to otherwise valid external IP
+    (' http://8.8.8.8', False, InvalidUploadUrlError),
+    # Host that doesn't resolve
+    ('http://example', False, LabelStudioAPIException),
+    ('http://example', True, LabelStudioAPIException),
+    # localhost
+    ('http://localhost', True, InvalidUploadUrlError),
+    ('http://localhost', False, None),
+ ])
+@pytest.mark.django_db
+def test_core_validate_upload_url(url, block_local_urls, raises_exc):
+
+    if raises_exc is None:
+        assert validate_upload_url(url, block_local_urls=block_local_urls) is None
+        return
+
+    with pytest.raises(raises_exc) as e:
+        validate_upload_url(url, block_local_urls=block_local_urls)

--- a/label_studio/tests/utils.py
+++ b/label_studio/tests/utils.py
@@ -59,7 +59,7 @@ def import_from_url_mock(**kwargs):
             url='https://data.heartextest.net'
 
             with open('./tests/test_suites/samples/test_1.csv', 'rb') as f:
-                matcher = re.compile('data.heartextest.net/test_1.csv')
+                matcher = re.compile('data\.heartextest\.net/test_1\.csv')
 
                 m.get(matcher, body=f, headers={'Content-Length': '100'})
                 yield m

--- a/label_studio/tests/utils.py
+++ b/label_studio/tests/utils.py
@@ -54,14 +54,15 @@ def register_ml_backend_mock(m, url='http://localhost:9090', predictions=None, h
 
 @contextmanager
 def import_from_url_mock(**kwargs):
-    with requests_mock.Mocker(real_http=True) as m:
-        url='https://data.heartextest.net'
+    with mock.patch('data_import.uploader.validate_upload_url'):
+        with requests_mock.Mocker(real_http=True) as m:
+            url='https://data.heartextest.net'
 
-        with open('./tests/test_suites/samples/test_1.csv', 'rb') as f:
-            matcher = re.compile('data.heartextest.net/test_1.csv')
+            with open('./tests/test_suites/samples/test_1.csv', 'rb') as f:
+                matcher = re.compile('data.heartextest.net/test_1.csv')
 
-            m.get(matcher, body=f, headers={'Content-Length': '100'})
-            yield m
+                m.get(matcher, body=f, headers={'Content-Length': '100'})
+                yield m
 
 
 class _TestJob(object):


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [x] Backend (API)
- [ ] Frontend



### Describe the reason for change

While reviewing a CodeQL finding (https://github.com/heartexlabs/label-studio/security/code-scanning/586) which turned out to be a false positive, a few shortcomings in the SSRF defense code were identified:

- The previous `url_is_local` implementation would throw an exception in the UI when a URL value like `asdf` was passed. Note that it was only called when SSRF_PROTECTION_ENABLED is True.

![image](https://github.com/heartexlabs/label-studio/assets/3943358/f62461ce-c84d-4694-a59d-5cce733daed8)

After this change, the result is

![image](https://github.com/heartexlabs/label-studio/assets/3943358/9d62e286-4da4-4dcd-b857-80e8977b64f0)

- A separate check, outside of the `url_is_local` function, tested to see whether the URL began with "file://" in the uploader. This check would have been possible to bypass by using "FILE://" as the scheme, but luckily would have led to the above (unintentional) exception from `url_is_local` if SSRF protection was enabled via `settings.SSRF_PROTECTION_ENABLED`. Additionally, `requests.get`, which we have been using to fetch data since `fflag_fix_back_lsdv_4568_import_csv_links_03032023_short` was enabled, throws an exception for a `file://` scheme by default.
- The previous URL validation approach was inconsistent between the uploader code and the ML Backend Serializer, which had no separate check for any non-http[s] schemes. Now, we always allowlist only "http" and "https" schemes when accepting URLs from clients.
- `urllib.parse.urlparse` was previously used in the implementation of `url_is_local`; `requests` by contrast uses `urrlib3` to parse URLs. Per https://claroty.com/wp-content/uploads/2022/01/Exploiting-URL-Parsing-Confusion.pdf, to minimize risk of exploits stemming from parser inconsistencies, it's best to minimize the number of URL parsers used in any application.
- Testing for SSRF defenses was previously anemic; this PR adds extensive unit tests for the validator function.


#### What does this fix?
See screenshots above; this definitely fixes a low-level exception reaching the UI if SSRF_PROTECTION_ENABLED, and may also help protect LS against other exploits.


#### What is the new behavior?
_(if this is a breaking or feature change)_



#### What is the current behavior?
_(if this is a breaking or feature change)_



#### What libraries were added/updated?
`urllib3` was exact pinned to 1.26.16, which was the version `pip show` revealed was already installed in the LS app container.
This is because `urllib3.util.parse_url` is now imported in core/utils/io.py


#### Does this change affect performance?
_(if so describe the impacts positive or negative)_



#### Does this change affect security?
This change should make our SSRF defenses more robust, and adds testing.



#### What alternative approaches were there?
_(briefly list any if applicable)_



#### What feature flags were used to cover this change?

`fflag_fix_back_lsdv_4568_import_csv_links_03032023_short` was removed by this change. AFAIK this feature flag is enabled everywhere.


### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [ ] No
- [x] Not sure (briefly explain the situation below)

A feature flag has been removed.

### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [x] unit



### Which logical domain(s) does this change affect?
URL data uploader, ML Backend API

