### PR TITLE
docs: Fix Requirements to Install and upgrade Label Studio page

### DIFF
--- a/docs/source/guide/install_requirements.md
+++ b/docs/source/guide/install_requirements.md
@@ -5,20 +5,19 @@ tier: opensource
 section: "Install"
 order: 103
 meta_title: Requirements to Install and Upgrade
-meta_description: "Label Studio documentation: Requirements to install and upgrade Label Studio." 
+meta_description: "Label Studio documentation: Requirements to install and upgrade Label Studio."
 ---
 
 <!-- md deploy.md -->
-
 
 ## Install prerequisite
 
 Install Label Studio in a clean Python environment. Heartex highly recommends using a virtual environment (venv or conda) to reduce the likelihood of package conflicts or missing packages.
 
-
 ## Install with pip
 
 To install Label Studio with pip and a virtual environment, you need Python version 3.8 or later. Run the following:
+
 ```bash
 python3 -m venv env
 source env/bin/activate
@@ -26,56 +25,68 @@ python -m pip install label-studio
 ```
 
 To install Label Studio with pip, you need Python version 3.8 or later. Run the following:
+
 ```bash
 pip install label-studio
 ```
 
-After you install Label Studio, start the server with the following command: 
+After you install Label Studio, start the server with the following command:
+
 ```bash
 label-studio
 ```
-The default web browser opens automatically at [http://localhost:8080](http://localhost:8080) with Label Studio. See [start Label Studio](start.html) for more options when starting Label Studio.
 
+The default web browser opens automatically at [http://localhost:8080](http://localhost:8080) with Label Studio. See [start Label Studio](start.html) for more options when starting Label Studio.
 
 ## Install with Docker
 
 Label Studio is also available as a Docker container. Make sure you have [Docker](https://www.docker.com/) installed on your machine.
 
-### Install with Docker on *nix
+### Install with Docker on \*nix
+
 To install and start Label Studio at [http://localhost:8080](http://localhost:8080), storing all labeling data in `./my_project` directory, run the following:
+
 ```bash
 docker run -it -p 8080:8080 -v $(pwd)/mydata:/label-studio/data heartexlabs/label-studio:latest
 ```
 
 !!! attention "important"
-    As this is a non-root container, the mounted files and directories must have the proper permissions for the `UID 1001`.
+As this is a non-root container, the mounted files and directories must have the proper permissions for the `UID 1001`.
 
 ### Install with Docker on Windows
+
 Or for Windows, you have to modify the volumes paths set by `-v` option.
 
 #### Override the default Docker install
+
 You can override the default Docker install by appending new arguments.
 
 In Windows Command Line (cmd):
+
 ```bash
 docker run -it -p 8080:8080 -v %cd%/mydata:/label-studio/data heartexlabs/label-studio:latest label-studio --log-level DEBUG
 ```
 
 In PowerShell:
+
 ```bash
 docker run -it -p 8080:8080 -v ${PWD}/mydata:/label-studio/data heartexlabs/label-studio:latest label-studio --log-level DEBUG
 ```
 
 ### Build a local image with Docker
+
 If you want to build a local image, run:
+
 ```bash
 docker build -t heartexlabs/label-studio:latest .
 ```
 
 ### Run with Docker Compose
+
 Use Docker Compose to serve Label Studio at `http://localhost:8080`. You must use Docker Compose version 1.25.0 or higher.
 
 Start Label Studio:
+
 ```bash
 docker-compose up -d
 ```
@@ -83,28 +94,32 @@ docker-compose up -d
 This starts Label Studio with a PostgreSQL database backend. You can also use a PostgreSQL database without Docker Compose. See [Set up database storage](storedata.html).
 
 ### Install Label Studio without internet access
+
 Download label-studio docker image (host with internet access and docker):
-```bash 
+
+```bash
 docker pull heartexlabs/label-studio:latest
 ```
 
-Export it as a tar archive: 
+Export it as a tar archive:
+
 ```bash
 docker save heartexlabs/label-studio:latest | gzip > label_studio_latest.tar.gz
 ```
 
 Transfer it to another VM:
+
 ```bash
 scp label_studio_latest.tar.gz <ANOTHER_HOST>:/tmp
 ```
 
-SSH into <ANOTHER_HOST> and import the archive:
+SSH into `<ANOTHER_HOST>` and import the archive:
+
 ```bash
 docker image import /tmp/label_studio_latest.tar.gz
 ```
 
 Follow steps from [Install and Upgrade to run LS](install.html#Install-with-Docker).
-
 
 ## Install on Ubuntu
 
@@ -140,24 +155,22 @@ conda activate label-studio
 pip install label-studio
 ```
 
-
 ## Upgrade Label Studio
 
-To upgrade to the latest version of Label Studio, reinstall or upgrade using pip. 
-
+To upgrade to the latest version of Label Studio, reinstall or upgrade using pip.
 
 ```bash
 pip install --upgrade label-studio
 ```
 
-Migration scripts run when you upgrade to version 1.0.0 from version 0.9.1 or earlier. 
+Migration scripts run when you upgrade to version 1.0.0 from version 0.9.1 or earlier.
 
 To make sure an existing project gets migrated, when you [start Label Studio](start.html), run the following command:
 
 ```bash
-label-studio start path/to/old/project 
+label-studio start path/to/old/project
 ```
 
-The most important change to be aware of is changes to rename "completions" to "annotations". See the [updated JSON format for completed tasks](export.html#Raw_JSON_format_of_completed_tasks). 
+The most important change to be aware of is changes to rename "completions" to "annotations". See the [updated JSON format for completed tasks](export.html#Raw_JSON_format_of_completed_tasks).
 
-If you customized the Label Studio Frontend, see the [Frontend reference guide](frontend_reference.html) for required updates to maintain compatibility with version 1.0.0.  
+If you customized the Label Studio Frontend, see the [Frontend reference guide](frontend_reference.html) for required updates to maintain compatibility with version 1.0.0.


### PR DESCRIPTION
Put the code snippet into backticks

### Test plan

1. This page should work fine now: https://deploy-preview-4501--label-studio-docs-new-theme.netlify.app/guide/install_requirements