### PR TITLE
fix: LSDV-5289: add FF to toggle long atomic transactions for perf/deadlocks reasons

### DIFF
--- a/label_studio/core/utils/common.py
+++ b/label_studio/core/utils/common.py
@@ -302,7 +302,7 @@ def db_is_not_sqlite() -> bool:
 
 @contextlib.contextmanager
 def conditional_atomic(
-        predicate: Callable[..., bool],
+        predicate: Callable[..., bool] = db_is_not_sqlite,
         predicate_args: Optional[Iterable[Any]] = None,
         predicate_kwargs: Optional[Mapping[str, Any]]) = None,
     ) -> Generator[None, None, None]:
@@ -310,6 +310,7 @@ def conditional_atomic(
 
     Params:
         predicate: function taking any combination of args and kwargs
+          defaults to `db_is_not_sqlite` for historical/compatibility reasons.
         predicate_args: optional array of positional args for the predicate
         predicate_kwargs: optional map of keyword args for the predicate
     """

--- a/label_studio/core/utils/common.py
+++ b/label_studio/core/utils/common.py
@@ -304,7 +304,7 @@ def db_is_not_sqlite() -> bool:
 def conditional_atomic(
         predicate: Callable[..., bool] = db_is_not_sqlite,
         predicate_args: Optional[Iterable[Any]] = None,
-        predicate_kwargs: Optional[Mapping[str, Any]]) = None,
+        predicate_kwargs: Optional[Mapping[str, Any]] = None,
     ) -> Generator[None, None, None]:
     """Use transaction if and only if the passed predicate function returns true
 

--- a/label_studio/core/utils/common.py
+++ b/label_studio/core/utils/common.py
@@ -2,6 +2,8 @@
 """
 from __future__ import unicode_literals
 
+from typing import Generator, Iterable, Mapping, Callable, Optional, Any
+
 import os
 import io
 import time
@@ -289,12 +291,32 @@ def start_browser(ls_url, no_browser):
     logger.info('Start browser at URL: ' + browser_url)
 
 
-@contextlib.contextmanager
-def conditional_atomic():
-    """Skip opening transaction for sqlite database backend
-    for performance improvement"""
+def db_is_not_sqlite() -> bool:
+    """
+    A common predicate for use with conditional_atomic.
 
-    if settings.DJANGO_DB != settings.DJANGO_DB_SQLITE:
+    Checks if the DB is NOT sqlite, because sqlite dbs are locked during any write.
+    """
+
+    return settings.DJANGO_DB != settings.DJANGO_DB_SQLITE
+
+@contextlib.contextmanager
+def conditional_atomic(
+        predicate: Callable[..., bool],
+        predicate_args: Optional[Iterable[Any]] = None,
+        predicate_kwargs: Optional[Mapping[str, Any]]) = None,
+    ) -> Generator[None, None, None]:
+    """Use transaction if and only if the passed predicate function returns true
+
+    Params:
+        predicate: function taking any combination of args and kwargs
+        predicate_args: optional array of positional args for the predicate
+        predicate_kwargs: optional map of keyword args for the predicate
+    """
+
+    should_use_transaction = predicate(*(predicate_args or []), **(predicate_kwargs or {}))
+
+    if should_use_transaction:
         with transaction.atomic():
             yield
     else:

--- a/label_studio/ml/models.py
+++ b/label_studio/ml/models.py
@@ -8,7 +8,7 @@ from django.dispatch import receiver
 from django.db.models.signals import post_save
 from django.conf import settings
 
-from core.utils.common import safe_float, conditional_atomic, load_func
+from core.utils.common import safe_float, conditional_atomic, load_func, db_is_not_sqlite
 
 from ml.api_connector import MLApi
 from projects.models import Project
@@ -216,7 +216,7 @@ class MLBackend(models.Model):
                     'model_version': ml_api_result.response.get('model_version', self.model_version),
                 }
             )
-        with conditional_atomic():
+        with conditional_atomic(predicate=db_is_not_sqlite):
             prediction_ser = PredictionSerializer(data=predictions, many=True)
             prediction_ser.is_valid(raise_exception=True)
             prediction_ser.save()
@@ -248,7 +248,7 @@ class MLBackend(models.Model):
         task_id = task_ser['id']
         r = prediction_response['result']
         score = prediction_response.get('score')
-        with conditional_atomic():
+        with conditional_atomic(predicate=db_is_not_sqlite):
             prediction = Prediction.objects.create(
                 result=r,
                 score=safe_float(score),

--- a/label_studio/projects/functions/next_task.py
+++ b/label_studio/projects/functions/next_task.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from core.feature_flags import flag_set
 import numpy as np
 
-from core.utils.common import conditional_atomic
+from core.utils.common import conditional_atomic, db_is_not_sqlite
 from tasks.models import Annotation, Task
 from projects.models import LabelStreamHistory
 from projects.functions.stream_history import add_stream_history
@@ -254,7 +254,7 @@ def get_task_from_qs_with_sampling(not_solved_tasks, user_solved_tasks_array, pr
 def get_next_task(user, prepared_tasks, project, dm_queue, assigned_flag=None):
     logger.debug(f'get_next_task called. user: {user}, project: {project}, dm_queue: {dm_queue}')
 
-    with conditional_atomic():
+    with conditional_atomic(predicate=db_is_not_sqlite):
         next_task = None
         use_task_lock = True
         queue_info = ''

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -874,7 +874,7 @@ class Project(ProjectMixin, models.Model):
                 queryset = make_queryset_from_iterable(task_ids_slice)
                 num_tasks_updated += self._update_tasks_counters(queryset, from_scratch)
                 bulk_update_stats_project_tasks(queryset, self)
-                page_idx += 1
+            page_idx += 1
         return num_tasks_updated
 
     def _update_tasks_counters_and_task_states(self, queryset, maximum_annotations_changed,

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -845,8 +845,8 @@ class Project(ProjectMixin, models.Model):
             objs.append(task)
         with conditional_atomic(
             predicate=flag_set,
-            predicate_args=['fflag_fix_back_lsdv_5289_run_bulk_updates_in_transactions_short']
-            predicate_kwargs={'user': self.organization.created_by}
+            predicate_args=['fflag_fix_back_lsdv_5289_run_bulk_updates_in_transactions_short'],
+            predicate_kwargs={'user': self.organization.created_by},
         ):
             bulk_update(objs, update_fields=['total_annotations', 'cancelled_annotations', 'total_predictions'], batch_size=settings.BATCH_SIZE)
         return len(objs)
@@ -865,8 +865,8 @@ class Project(ProjectMixin, models.Model):
         while (task_ids_slice := task_ids[page_idx * settings.BATCH_SIZE:(page_idx + 1) * settings.BATCH_SIZE]):
             with conditional_atomic(
                 predicate=flag_set,
-                predicate_args=['fflag_fix_back_lsdv_5289_run_bulk_updates_in_transactions_short']
-                predicate_kwargs={'user': organization_created_by}
+                predicate_args=['fflag_fix_back_lsdv_5289_run_bulk_updates_in_transactions_short'],
+                predicate_kwargs={'user': organization_created_by},
             ):
                 # If counters are updated, is_labeled must be updated as well. Hence, if either fails, we
                 # will roll back. NB: as part of LSDV-5289, we are considering eliminating this transaction

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -14,7 +14,13 @@ from annoying.fields import AutoOneToOneField
 from data_manager.managers import TaskQuerySet
 from projects.functions.utils import make_queryset_from_iterable
 from tasks.models import Task, Prediction, Annotation, AnnotationDraft, Q_task_finished_annotations, bulk_update_stats_project_tasks
-from core.utils.common import create_hash, get_attr_or_item, load_func, merge_labels_counters
+from core.utils.common import (
+    conditional_atomic,
+    create_hash,
+    get_attr_or_item,
+    load_func,
+    merge_labels_counters,
+)
 from core.utils.exceptions import LabelStudioValidationErrorSentryIgnored
 from core.label_config import (
     validate_label_config,

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -27,6 +27,7 @@ from core.label_config import (
     get_annotation_tuple, check_control_in_config_by_regex, check_toname_in_config_by_regex,
     get_original_fromname_by_regex, get_all_types,
 )
+from core.feature_flags import flag_set
 from core.bulk_update_utils import bulk_update
 from label_studio_tools.core.label_config import parse_config
 from projects.functions import (
@@ -842,8 +843,12 @@ class Project(ProjectMixin, models.Model):
             task.cancelled_annotations = task.new_cancelled_annotations
             task.total_predictions = task.new_total_predictions
             objs.append(task)
-
-        bulk_update(objs, update_fields=['total_annotations', 'cancelled_annotations', 'total_predictions'], batch_size=settings.BATCH_SIZE)
+        with conditional_atomic(
+            predicate=flag_set,
+            predicate_args=['fflag_fix_back_lsdv_5289_run_bulk_updates_in_transactions_short']
+            predicate_kwargs={'user': self.organization.created_by}
+        ):
+            bulk_update(objs, update_fields=['total_annotations', 'cancelled_annotations', 'total_predictions'], batch_size=settings.BATCH_SIZE)
         return len(objs)
 
     def _update_tasks_counters_and_is_labeled(self, task_ids, from_scratch=True):
@@ -855,12 +860,21 @@ class Project(ProjectMixin, models.Model):
         """
         num_tasks_updated = 0
         page_idx = 0
+        organization_created_by = self.organization.created_by}
 
         while (task_ids_slice := task_ids[page_idx * settings.BATCH_SIZE:(page_idx + 1) * settings.BATCH_SIZE]):
-            queryset = make_queryset_from_iterable(task_ids_slice)
-            num_tasks_updated += self._update_tasks_counters(queryset, from_scratch)
-            bulk_update_stats_project_tasks(queryset, self)
-            page_idx += 1
+            with conditional_atomic(
+                predicate=flag_set,
+                predicate_args=['fflag_fix_back_lsdv_5289_run_bulk_updates_in_transactions_short']
+                predicate_kwargs={'user': organization_created_by}
+            ):
+                # If counters are updated, is_labeled must be updated as well. Hence, if either fails, we
+                # will roll back. NB: as part of LSDV-5289, we are considering eliminating this transaction
+                # behavior for performance reasons (see conditional_atomic call above).
+                queryset = make_queryset_from_iterable(task_ids_slice)
+                num_tasks_updated += self._update_tasks_counters(queryset, from_scratch)
+                bulk_update_stats_project_tasks(queryset, self)
+                page_idx += 1
         return num_tasks_updated
 
     def _update_tasks_counters_and_task_states(self, queryset, maximum_annotations_changed,

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -860,7 +860,7 @@ class Project(ProjectMixin, models.Model):
         """
         num_tasks_updated = 0
         page_idx = 0
-        organization_created_by = self.organization.created_by}
+        organization_created_by = self.organization.created_by
 
         while (task_ids_slice := task_ids[page_idx * settings.BATCH_SIZE:(page_idx + 1) * settings.BATCH_SIZE]):
             with conditional_atomic(

--- a/label_studio/tasks/models.py
+++ b/label_studio/tasks/models.py
@@ -876,29 +876,28 @@ def bulk_update_stats_project_tasks(tasks, project=None):
     # get project if it's not in params
     if project is None:
         project = tasks[0].project
-    with transaction.atomic():
-        use_overlap = project._can_use_overlap()
-        maximum_annotations = project.maximum_annotations
-        # update filters if we can use overlap
-        if use_overlap:
-            # finished tasks
-            finished_tasks = tasks.filter(Q(total_annotations__gte=maximum_annotations) |
-                                          Q(total_annotations__gte=1, overlap=1))
-            ids = finished_tasks.values_list('id', flat=True)
-            tasks.filter(id__in=ids).update(is_labeled=True)
-            # unfinished tasks
-            tasks.exclude(id__in=ids).update(is_labeled=False)
-        else:
-            # update objects without saving if we can't use overlap
-            for task in tasks:
-                update_task_stats(task, save=False)
-            try:
-                # start update query batches
-                bulk_update(tasks, update_fields=['is_labeled'], batch_size=settings.BATCH_SIZE)
-            except OperationalError as exp:
-                logger.error("Operational error while updating tasks: {exc}", exc_info=True)
-                # try to update query batches one more time
-                start_job_async_or_sync(bulk_update, tasks, in_seconds=settings.BATCH_JOB_RETRY_TIMEOUT, update_fields=['is_labeled'], batch_size=settings.BATCH_SIZE)
+
+    use_overlap = project._can_use_overlap()
+    maximum_annotations = project.maximum_annotations
+    # update filters if we can use overlap
+    if use_overlap:
+        # finished tasks
+        finished_tasks = tasks.filter(Q(total_annotations__gte=maximum_annotations) |
+                                        Q(total_annotations__gte=1, overlap=1))
+        finished_tasks_ids = finished_tasks.values_list('id', flat=True)
+        tasks.update(is_labeled=Q(id__in=finished_tasks_ids))
+
+    else:
+        # update objects without saving if we can't use overlap
+        for task in tasks:
+            update_task_stats(task, save=False)
+        try:
+            # start update query batches
+            bulk_update(tasks, update_fields=['is_labeled'], batch_size=settings.BATCH_SIZE)
+        except OperationalError as exp:
+            logger.error("Operational error while updating tasks: {exc}", exc_info=True)
+            # try to update query batches one more time
+            start_job_async_or_sync(bulk_update, tasks, in_seconds=settings.BATCH_JOB_RETRY_TIMEOUT, update_fields=['is_labeled'], batch_size=settings.BATCH_SIZE)
 
 
 Q_finished_annotations = Q(was_cancelled=False) & Q(result__isnull=False)

--- a/label_studio/tasks/models.py
+++ b/label_studio/tasks/models.py
@@ -879,8 +879,8 @@ def bulk_update_stats_project_tasks(tasks, project=None):
 
     with conditional_atomic(
         predicate=flag_set,
-        predicate_args=['fflag_fix_back_lsdv_5289_run_bulk_updates_in_transactions_short']
-        predicate_kwargs={'user': project.organization.created_by}
+        predicate_args=['fflag_fix_back_lsdv_5289_run_bulk_updates_in_transactions_short'],
+        predicate_kwargs={'user': project.organization.created_by},
     ):
         use_overlap = project._can_use_overlap()
         maximum_annotations = project.maximum_annotations

--- a/label_studio/tasks/models.py
+++ b/label_studio/tasks/models.py
@@ -26,8 +26,13 @@ from rest_framework.exceptions import ValidationError
 
 from core.feature_flags import flag_set
 from core.redis import start_job_async_or_sync
-from core.utils.common import find_first_one_to_one_related_field_by_prefix, string_is_url, load_func, \
-    temporary_disconnect_list_signal
+from core.utils.common import (
+    conditional_atomic,
+    find_first_one_to_one_related_field_by_prefix,
+    load_func,
+    string_is_url,
+    temporary_disconnect_list_signal,
+)
 from core.utils.params import get_env
 from core.label_config import SINGLE_VALUED_TAGS
 from core.current_request import get_current_request

--- a/label_studio/tests/test_block_objects.py
+++ b/label_studio/tests/test_block_objects.py
@@ -6,9 +6,7 @@ from tasks.models import Task, Annotation, Prediction, bulk_update_stats_project
 
 
 @pytest.mark.django_db
-def test_export(
-        business_client, configured_project
-):
+def test_export(business_client, configured_project):
     task_query = Task.objects.filter(project=configured_project.id)
     task_query.update(is_labeled=True)
     t = threading.Thread(target=worker_change_stats, args=(task_query.values_list('id', flat=True),))
@@ -22,6 +20,6 @@ def test_export(
     assert Task.objects.filter(is_labeled=True).count() == 0
 
 
-def worker_change_stats(time_seconds, tasks):
+def worker_change_stats(tasks):
     tasks = Task.objects.filter(id__in=tasks)
     bulk_update_stats_project_tasks(tasks)


### PR DESCRIPTION
\### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [ ] Frontend



### Describe the reason for change
_(link to issue, supportive screenshots etc.)_

Bulk update calls in transactions are likely untenable for performance/deadlock reasons, and it's not clear we were getting much utility from the transactions in any case. Per https://www.postgresql.org/docs/15/explicit-locking.html#LOCKING-DEADLOCKS "it is a bad idea for applications to hold transactions open for long periods of time", and for example, `update_task_stats` will make one or more sql queries for each task under certain conditions, while every row updated by `_update_tasks_counters` is still held by a row-level lock.

#### What does this fix?
_(if this is a bug fix)_

Uses a feature flag (`fflag_fix_back_lsdv_5289_run_bulk_updates_in_transactions_short` - which defaults to on) to govern whether certain bulk updates will run inside transactions.

Also simplify a query and fix a broken test.

#### What is the new behavior?
_(if this is a breaking or feature change)_

Once `fflag_fix_back_lsdv_5289_run_bulk_updates_in_transactions_short` is set to false, under some conditions, bulk update loops will throw an exception and the changes will not be rolled back, as they previously were.

#### What is the current behavior?
_(if this is a breaking or feature change)_



#### What libraries were added/updated?
_(list all with version changes)_



#### Does this change affect performance?
_(if so describe the impacts positive or negative)_



#### Does this change affect security?
_(if so describe the impacts positive or negative)_



#### What alternative approaches were there?
_(briefly list any if applicable)_



#### What feature flags were used to cover this change?
_(briefly list any if applicable)_



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [ ] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
_(for bug fixes/features, be as precise as possible. ex. Authentication, Annotation History, Review Stream etc.)_

Database performance