### PR TITLE
fix: LSDV-5222: custom weights reset following labeling interface changes

### DIFF
--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -590,11 +590,18 @@ class Project(ProjectMixin, models.Model):
         control_weights = {}
         exclude_control_types = ('Filter',)
 
-        def get_value(key, subkey=None):
-            value = self.control_weights.get(control_name, {}).get(key, {})
-            if subkey:
-                value = value.get(subkey)
-            return value if value is not None else 1.0
+        def get_label(label):
+            label_value = self.control_weights.get(control_name, {}).get('labels', {}).get(label)
+            return label_value if label_value is not None else 1.0
+
+        def get_overall(name):
+            weights = self.control_weights.get(name, None)
+            if not weights:
+                return 1.0
+            else:
+                weight = weights.get('overall', None)
+                return weight if weight is not None else 1.0
+
 
         for control_name in outputs:
             control_type = outputs[control_name]['type']
@@ -602,9 +609,9 @@ class Project(ProjectMixin, models.Model):
                 continue
 
             control_weights[control_name] = {
-                'overall': get_value('overall'),
+                'overall': get_overall(control_name),
                 'type': control_type,
-                'labels': {label: get_value('labels', label) for label in outputs[control_name].get('labels', [])},
+                'labels': {label: get_label(label) for label in outputs[control_name].get('labels', [])},
             }
         return control_weights
 

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -594,13 +594,13 @@ class Project(ProjectMixin, models.Model):
                 continue
 
             def get_label(label):
-                return self.control_weights.get(control_name, {}).get('labels', {}).get(label)
+                label_value = self.control_weights.get(control_name, {}).get('labels', {}).get(label)
+                return label_value if label_value is not None else 1.0
 
             control_weights[control_name] = {
                 'overall': self.control_weights.get(control_name, {}).get('overall') or 1.0,
                 'type': control_type,
-                'labels': {label: get_label(label) if get_label(label) is not None else 1.0 for label in
-                           outputs[control_name].get('labels', [])},
+                'labels': {label: get_label(label) for label in outputs[control_name].get('labels', [])},
             }
         return control_weights
 

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -588,19 +588,22 @@ class Project(ProjectMixin, models.Model):
         outputs = self.get_parsed_config(autosave_cache=False)
         control_weights = {}
         exclude_control_types = ('Filter',)
+
+        def get_value(key, subkey=None):
+            value = self.control_weights.get(control_name, {}).get(key, {})
+            if subkey:
+                value = value.get(subkey)
+            return value if value is not None else 1.0
+
         for control_name in outputs:
             control_type = outputs[control_name]['type']
             if control_type in exclude_control_types:
                 continue
 
-            def get_label(label):
-                label_value = self.control_weights.get(control_name, {}).get('labels', {}).get(label)
-                return label_value if label_value is not None else 1.0
-
             control_weights[control_name] = {
-                'overall': self.control_weights.get(control_name, {}).get('overall') or 1.0,
+                'overall': get_value('overall'),
                 'type': control_type,
-                'labels': {label: get_label(label) for label in outputs[control_name].get('labels', [])},
+                'labels': {label: get_value('labels', label) for label in outputs[control_name].get('labels', [])},
             }
         return control_weights
 

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -593,31 +593,13 @@ class Project(ProjectMixin, models.Model):
             if control_type in exclude_control_types:
                 continue
 
-            def get_label_id(label):
-                # Get label id from the 'labels_attrs' field, return None if 'id' is missing
-                return outputs[control_name]['labels_attrs'].get(label, {}).get('id')
-
-            def get_label_data(label):
-                # Check if id exists for this label
-                label_id = get_label_id(label)
-                if label_id is not None:
-                    # If id exists, try to fetch weight using id
-                    weight = self.control_weights.get(control_name, {}).get('labels', {}).get(label_id, {}).get(
-                        'weight')
-                else:
-                    # If id does not exist, fall back to using label name to fetch weight
-                    weight = self.control_weights.get(control_name, {}).get('labels', {}).get(label, 1.0)
-                    try:
-                        weight = weight['weight']
-                    except TypeError:  # in this case weight is already a float
-                        pass
-                # Return a dictionary with the label's name and its weight
-                return {'name': label, 'weight': weight if weight is not None else 1.0}
+            def get_label(label):
+                return self.control_weights.get(control_name, {}).get('labels', {}).get(label)
 
             control_weights[control_name] = {
                 'overall': self.control_weights.get(control_name, {}).get('overall') or 1.0,
                 'type': control_type,
-                'labels': {get_label_id(label) or label: get_label_data(label) for label in
+                'labels': {label: get_label(label) if get_label(label) is not None else 1.0 for label in
                            outputs[control_name].get('labels', [])},
             }
         return control_weights


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [x] Backend (API)
- [ ] Frontend

#### What does this fix?
When custom weight is set to zero and anything is changed in the labeling interface, the custom weight is reset to 1.0.  This is because a check in the code interprets zero as False.  


#### What is the new behavior?
The fix it to update the check to only interpret None as not set (0 will now qualify as being set and not trigger an update to the default).


### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Labeling Interface / Custom Weights
