### PR TITLE
chore: LSDV-5417: Mypy for label studio

### DIFF
--- a/deploy/requirements-test.txt
+++ b/deploy/requirements-test.txt
@@ -12,4 +12,20 @@ responses==0.13.0
 pytest-xdist~=2.5.0
 importlib-metadata==4.13.0;python_version < '3.8'
 psutil==5.9.4
-
+mypy==1.4.1
+django-stubs==4.2.3
+pyre-check==0.9.18
+lxml-stubs==0.4.0
+types-psutil==5.9.5.16
+types-mock==5.1.0.1
+types-bleach==6.0.0.4
+pandas-stubs==2.0.2.230605
+types-urllib3==1.26.25.14
+types-redis==4.6.0.3
+types-google-cloud-ndb==2.1.0.8
+types-colorama==0.4.15.12
+types-ujson==5.8.0.1
+types-setuptools==68.0.0.3
+types-requests==2.31.0.2
+types-jsonschema==4.17.0.10
+appdirs-stubs==0.1.0

--- a/deploy/requirements-test.txt
+++ b/deploy/requirements-test.txt
@@ -29,3 +29,4 @@ types-setuptools==68.0.0.3
 types-requests==2.31.0.2
 types-jsonschema==4.17.0.10
 appdirs-stubs==0.1.0
+djangorestframework-stubs[compatible-mypy]==3.14.2

--- a/label_studio/core/api_permissions.py
+++ b/label_studio/core/api_permissions.py
@@ -2,5 +2,5 @@ from rest_framework.permissions import BasePermission
 
 
 class HasObjectPermission(BasePermission):
-    def has_object_permission(self, request, view, obj):
+    def has_object_permission(self, request, view, obj):  # type: ignore[no-untyped-def]
         return obj.has_permission(request.user)

--- a/label_studio/core/argparser.py
+++ b/label_studio/core/argparser.py
@@ -7,7 +7,7 @@ from .settings.base import EXPORT_DIR
 from .utils.io import find_file
 
 
-def parse_input_args(input_args):
+def parse_input_args(input_args):  # type: ignore[no-untyped-def]
     """ Combine args with json config
 
     :return: config dict
@@ -15,13 +15,13 @@ def parse_input_args(input_args):
     import sys
     import argparse
 
-    def valid_filepath(filepath):
+    def valid_filepath(filepath):  # type: ignore[no-untyped-def]
         path = os.path.abspath(os.path.expanduser(filepath))
         if os.path.exists(path):
             return path
         raise FileNotFoundError(filepath)
 
-    def project_name(raw_name):
+    def project_name(raw_name):  # type: ignore[no-untyped-def]
         """ Remove trailing / and leading ./ from project name"""
         return os.path.normpath(raw_name)
 
@@ -37,7 +37,7 @@ def parse_input_args(input_args):
         '--data-dir', dest='data_dir', help='Directory for storing all application related data'
     )
     root_parser.add_argument('-d', '--debug', dest='debug', action='store_true', help='Debug mode', default=False)
-    default_config_path = find_file('default_config.json')
+    default_config_path = find_file('default_config.json')  # type: ignore[no-untyped-call]
     root_parser.add_argument(
         '-c', '--config', dest='config_path', type=valid_filepath, default=default_config_path, help='Server config'
     )

--- a/label_studio/core/bulk_update_utils.py
+++ b/label_studio/core/bulk_update_utils.py
@@ -11,15 +11,15 @@ from django.db import connections, models
 from django.db.models.sql import UpdateQuery
 
 
-def _get_db_type(field, connection):
+def _get_db_type(field, connection):  # type: ignore[no-untyped-def]
     if isinstance(field, (models.PositiveSmallIntegerField,
                           models.PositiveIntegerField)):
-        return field.db_type(connection).split(' ', 1)[0]
+        return field.db_type(connection).split(' ', 1)[0]  # type: ignore[union-attr]
 
     return field.db_type(connection)
 
 
-def _as_sql(obj, field, query, compiler, connection):
+def _as_sql(obj, field, query, compiler, connection):  # type: ignore[no-untyped-def]
     value = getattr(obj, field.attname)
 
     if hasattr(value, 'resolve_expression'):
@@ -37,7 +37,7 @@ def _as_sql(obj, field, query, compiler, connection):
     return value, placeholder
 
 
-def flatten(l, types=(list, float)):
+def flatten(l, types=(list, float)):  # type: ignore[no-untyped-def]
     """
     Flat nested list of lists into a single list.
     """
@@ -45,7 +45,7 @@ def flatten(l, types=(list, float)):
     return [item for sublist in l for item in sublist]
 
 
-def grouper(iterable, size):
+def grouper(iterable, size):  # type: ignore[no-untyped-def]
     # http://stackoverflow.com/a/8991553
     it = iter(iterable)
     while True:
@@ -55,7 +55,7 @@ def grouper(iterable, size):
         yield chunk
 
 
-def validate_fields(meta, fields):
+def validate_fields(meta, fields):  # type: ignore[no-untyped-def]
 
     fields = frozenset(fields)
     field_names = set()
@@ -76,12 +76,12 @@ def validate_fields(meta, fields):
         )
 
 
-def get_fields(update_fields, exclude_fields, meta, obj=None):
+def get_fields(update_fields, exclude_fields, meta, obj=None):  # type: ignore[no-untyped-def]
 
     deferred_fields = set()
 
     if update_fields is not None:
-        validate_fields(meta, update_fields)
+        validate_fields(meta, update_fields)  # type: ignore[no-untyped-call]
     elif obj:
         deferred_fields = obj.get_deferred_fields()
 
@@ -89,7 +89,7 @@ def get_fields(update_fields, exclude_fields, meta, obj=None):
         exclude_fields = set()
     else:
         exclude_fields = set(exclude_fields)
-        validate_fields(meta, exclude_fields)
+        validate_fields(meta, exclude_fields)  # type: ignore[no-untyped-call]
 
     exclude_fields |= deferred_fields
 
@@ -112,7 +112,7 @@ def get_fields(update_fields, exclude_fields, meta, obj=None):
     return fields
 
 
-def bulk_update(objs, meta=None, update_fields=None, exclude_fields=None,
+def bulk_update(objs, meta=None, update_fields=None, exclude_fields=None,  # type: ignore[no-untyped-def]
                 using='default', batch_size=None, pk_field='pk'):
     assert batch_size is None or batch_size > 0
 
@@ -124,11 +124,11 @@ def bulk_update(objs, meta=None, update_fields=None, exclude_fields=None,
     batch_size = batch_size or len(objs)
 
     if meta:
-        fields = get_fields(update_fields, exclude_fields, meta)
+        fields = get_fields(update_fields, exclude_fields, meta)  # type: ignore[no-untyped-call]
     else:
         meta = objs[0]._meta
         if update_fields is not None:
-            fields = get_fields(update_fields, exclude_fields, meta, objs[0])
+            fields = get_fields(update_fields, exclude_fields, meta, objs[0])  # type: ignore[no-untyped-call]
         else:
             fields = None
 
@@ -149,7 +149,7 @@ def bulk_update(objs, meta=None, update_fields=None, exclude_fields=None,
     case_template = "WHEN %s THEN {} "
 
     lenpks = 0
-    for objs_batch in grouper(objs, batch_size):
+    for objs_batch in grouper(objs, batch_size):  # type: ignore[no-untyped-call]
 
         pks = []
         parameters = defaultdict(list)
@@ -157,14 +157,14 @@ def bulk_update(objs, meta=None, update_fields=None, exclude_fields=None,
 
         for obj in objs_batch:
 
-            pk_value, _ = _as_sql(obj, pk_field, query, compiler, connection)
+            pk_value, _ = _as_sql(obj, pk_field, query, compiler, connection)  # type: ignore[no-untyped-call]
             pks.append(pk_value)
 
-            loaded_fields = fields or get_fields(update_fields, exclude_fields, meta, obj)
+            loaded_fields = fields or get_fields(update_fields, exclude_fields, meta, obj)  # type: ignore[no-untyped-call]
 
             for field in loaded_fields:
-                value, placeholder = _as_sql(obj, field, query, compiler, connection)
-                parameters[field].extend(flatten([pk_value, value], types=tuple))
+                value, placeholder = _as_sql(obj, field, query, compiler, connection)  # type: ignore[no-untyped-call]
+                parameters[field].extend(flatten([pk_value, value], types=tuple))  # type: ignore[no-untyped-call]
                 placeholders[field].append(placeholder)
 
         values = ', '.join(
@@ -172,13 +172,13 @@ def bulk_update(objs, meta=None, update_fields=None, exclude_fields=None,
                 column=field.column,
                 pk_column=pk_field.column,
                 cases=(case_template*len(placeholders[field])).format(*placeholders[field]),
-                type=_get_db_type(field, connection=connection),
+                type=_get_db_type(field, connection=connection),  # type: ignore[no-untyped-call]
             )
             for field in parameters.keys()
         )
 
-        parameters = flatten(parameters.values(), types=list)
-        parameters.extend(pks)
+        parameters = flatten(parameters.values(), types=list)  # type: ignore[no-untyped-call]
+        parameters.extend(pks)  # type: ignore[attr-defined]
 
         n_pks = len(pks)
         del pks

--- a/label_studio/core/context_processors.py
+++ b/label_studio/core/context_processors.py
@@ -2,20 +2,20 @@
 """
 from django.conf import settings as django_settings
 from core.utils.common import collect_versions
-from core.feature_flags import all_flags
+from core.feature_flags import all_flags  # type: ignore[attr-defined]
 
 
-def sentry_fe(request):
+def sentry_fe(request):  # type: ignore[no-untyped-def]
     # return the value you want as a dictionary, you may add multiple values in there
     return {
-        'SENTRY_FE': django_settings.SENTRY_FE
+        'SENTRY_FE': django_settings.SENTRY_FE  # type: ignore[misc]
     }
 
 
-def settings(request):
+def settings(request):  # type: ignore[no-untyped-def]
     """ Make available django settings on each template page
     """
-    versions = collect_versions()
+    versions = collect_versions()  # type: ignore[no-untyped-call]
 
     # django templates can't access names with hyphens
     versions['lsf'] = versions.get('label-studio-frontend', {})
@@ -32,7 +32,7 @@ def settings(request):
 
     feature_flags = {}
     if hasattr(request, 'user'):
-        feature_flags = all_flags(request.user)
+        feature_flags = all_flags(request.user)  # type: ignore[no-untyped-call]
 
     return {
         'settings': django_settings,

--- a/label_studio/core/current_request.py
+++ b/label_studio/core/current_request.py
@@ -7,18 +7,18 @@ from django.dispatch import receiver
 _thread_locals = local()
 
 
-def get_current_request():
+def get_current_request():  # type: ignore[no-untyped-def]
     """ returns the request object for this thread """
     result = getattr(_thread_locals, "request", None)
     return result
 
 
 class ThreadLocalMiddleware(CommonMiddleware):
-    def process_request(self, request):
+    def process_request(self, request):  # type: ignore[no-untyped-def]
         _thread_locals.request = request
 
 
 @receiver(request_finished)
-def clean_request(sender, **kwargs):
+def clean_request(sender, **kwargs):  # type: ignore[no-untyped-def]
     if hasattr(_thread_locals, 'request'):
         del _thread_locals.request

--- a/label_studio/core/decorators.py
+++ b/label_studio/core/decorators.py
@@ -1,7 +1,7 @@
-def permission_required(*permissions, fn=None):
+def permission_required(*permissions, fn=None):  # type: ignore[no-untyped-def]
 
-    def decorator(view):
-        def wrapped_view(self, request, *args, **kwargs):
+    def decorator(view):  # type: ignore[no-untyped-def]
+        def wrapped_view(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
 
             if callable(fn):
                 obj = fn(request, *args, **kwargs)

--- a/label_studio/core/feature_flags/base.py
+++ b/label_studio/core/feature_flags/base.py
@@ -22,12 +22,12 @@ else:
 logger = logging.getLogger(__name__)
 
 
-def get_feature_file_path():
+def get_feature_file_path():  # type: ignore[no-untyped-def]
     package_name = 'label_studio' if settings.VERSION_EDITION == 'Community' else 'label_studio_enterprise'
     if settings.FEATURE_FLAGS_FILE.startswith('/'):
         return settings.FEATURE_FLAGS_FILE
     else:
-        return find_node(package_name, settings.FEATURE_FLAGS_FILE, 'file')
+        return find_node(package_name, settings.FEATURE_FLAGS_FILE, 'file')  # type: ignore[no-untyped-call]
 
 
 if settings.FEATURE_FLAGS_FROM_FILE:
@@ -38,13 +38,13 @@ if settings.FEATURE_FLAGS_FROM_FILE:
             'FEATURE_FLAGS_FILE=my_flags.yml'
         )
 
-    feature_flags_file = get_feature_file_path()
+    feature_flags_file = get_feature_file_path()  # type: ignore[no-untyped-call]
 
     logger.info(f'Read flags from file {feature_flags_file}')
     data_source = Files.new_data_source(paths=[feature_flags_file])
     config = Config(
         sdk_key=settings.FEATURE_FLAGS_API_KEY or 'whatever',
-        update_processor_class=data_source,
+        update_processor_class=data_source,  # type: ignore[arg-type]
         send_events=False)
     ldclient.set_config(config)
     client = ldclient.get()
@@ -55,9 +55,9 @@ elif settings.FEATURE_FLAGS_OFFLINE:
 else:
     # Production usage
     if hasattr(settings, 'REDIS_LOCATION'):
-        logger.debug(f'Set LaunchDarkly config with Redis feature store at {settings.REDIS_LOCATION}')
+        logger.debug(f'Set LaunchDarkly config with Redis feature store at {settings.REDIS_LOCATION}')  # type: ignore[misc]
         store = Redis.new_feature_store(
-            url=settings.REDIS_LOCATION,
+            url=settings.REDIS_LOCATION,  # type: ignore[misc]
             prefix='feature-flags',
             caching=CacheConfig(expiration=30))
         ldclient.set_config(Config(
@@ -71,7 +71,7 @@ else:
     client = ldclient.get()
 
 
-def _get_user_repr(user):
+def _get_user_repr(user):  # type: ignore[no-untyped-def]
     """Turn user object into dict with required properties"""
     from users.serializers import UserSerializer
     if user.is_anonymous:
@@ -85,7 +85,7 @@ def _get_user_repr(user):
     return user_data
 
 
-def flag_set(feature_flag, user=None, override_system_default=None):
+def flag_set(feature_flag, user=None, override_system_default=None):  # type: ignore[no-untyped-def]
     """Use this method to check whether this flag is set ON to the current user, to split the logic on backend
     For example,
     ```
@@ -100,12 +100,12 @@ def flag_set(feature_flag, user=None, override_system_default=None):
         user = AnonymousUser
     elif user == 'auto':
         user = AnonymousUser
-        request = get_current_request()
+        request = get_current_request()  # type: ignore[no-untyped-call]
         if request and getattr(request, 'user', None) and request.user.is_authenticated:
             user = request.user
 
-    user_dict = _get_user_repr(user)
-    env_value = get_bool_env(feature_flag, default=None)
+    user_dict = _get_user_repr(user)  # type: ignore[no-untyped-call]
+    env_value = get_bool_env(feature_flag, default=None)  # type: ignore[no-untyped-call]
     if env_value is not None:
         return env_value
     if override_system_default is not None:
@@ -115,18 +115,18 @@ def flag_set(feature_flag, user=None, override_system_default=None):
     return client.variation(feature_flag, user_dict, system_default)
 
 
-def all_flags(user):
+def all_flags(user):  # type: ignore[no-untyped-def]
     """Return the output of this method in API response, to bootstrap client-side flags.
     More on https://docs.launchdarkly.com/sdk/features/bootstrapping#javascript
     """
-    user_dict = _get_user_repr(user)
+    user_dict = _get_user_repr(user)  # type: ignore[no-untyped-call]
     logger.debug(f'Resolve all flags state for user {user_dict}')
     state = client.all_flags_state(user_dict)
     flags = state.to_json_dict()
 
-    env_ff = get_all_env_with_prefix('ff_', is_bool=True)
-    env_fflag = get_all_env_with_prefix('fflag_', is_bool=True)
-    env_fflag2 = get_all_env_with_prefix('fflag-', is_bool=True)
+    env_ff = get_all_env_with_prefix('ff_', is_bool=True)  # type: ignore[no-untyped-call]
+    env_fflag = get_all_env_with_prefix('fflag_', is_bool=True)  # type: ignore[no-untyped-call]
+    env_fflag2 = get_all_env_with_prefix('fflag-', is_bool=True)  # type: ignore[no-untyped-call]
     env_ff.update(env_fflag)
     env_ff.update(env_fflag2)
 

--- a/label_studio/core/feature_flags/base.py
+++ b/label_studio/core/feature_flags/base.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import ldclient
 import logging
 
@@ -7,9 +9,15 @@ from ldclient.feature_store import CacheConfig
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from label_studio.core.utils.params import get_bool_env, get_all_env_with_prefix
-from label_studio.core.utils.io import find_node
-from label_studio.core.current_request import get_current_request
+
+if TYPE_CHECKING:
+    from core.utils.params import get_bool_env, get_all_env_with_prefix
+    from core.utils.io import find_node
+    from core.current_request import get_current_request
+else:
+    from label_studio.core.utils.params import get_bool_env, get_all_env_with_prefix
+    from label_studio.core.utils.io import find_node
+    from label_studio.core.current_request import get_current_request
 
 logger = logging.getLogger(__name__)
 

--- a/label_studio/core/filters.py
+++ b/label_studio/core/filters.py
@@ -1,8 +1,8 @@
-from django_filters import Filter
-from django_filters.constants import EMPTY_VALUES
+from django_filters import Filter  # type: ignore[import]
+from django_filters.constants import EMPTY_VALUES  # type: ignore[import]
 
-class ListFilter(Filter):
-    def filter(self, qs, value):
+class ListFilter(Filter):  # type: ignore[misc]
+    def filter(self, qs, value):  # type: ignore[no-untyped-def]
         if value in EMPTY_VALUES:
             return qs
         value_list = value.split(",")

--- a/label_studio/core/label_config.py
+++ b/label_studio/core/label_config.py
@@ -1,5 +1,7 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
+from typing import TYPE_CHECKING
+
 import logging
 import json
 import pandas as pd
@@ -14,10 +16,14 @@ from collections import OrderedDict
 import defusedxml.ElementTree as etree
 from collections import defaultdict
 from django.conf import settings
-from label_studio.core.utils.io import find_file
-from label_studio.core.utils.exceptions import (
-    LabelStudioValidationErrorSentryIgnored, LabelStudioXMLSyntaxErrorSentryIgnored
-)
+
+if TYPE_CHECKING:
+    from core.utils.io import find_file
+    from core.utils.exceptions import LabelStudioValidationErrorSentryIgnored
+else:
+    from label_studio.core.utils.io import find_file
+    from label_studio.core.utils.exceptions import LabelStudioValidationErrorSentryIgnored
+
 from label_studio_tools.core import label_config
 
 logger = logging.getLogger(__name__)

--- a/label_studio/core/management/commands/locked_migrate.py
+++ b/label_studio/core/management/commands/locked_migrate.py
@@ -11,7 +11,7 @@ DEFAULT_LOCK_ID = getattr(settings, "MIGRATE_LOCK_ID", 1000)
 class Command(MigrateCommand):
     help = "Run Django migrations safely, using a lock"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser):  # type: ignore[no-untyped-def]
         MigrateCommand.add_arguments(self, parser)
         parser.add_argument(
             "--migrate-lock-id",
@@ -20,7 +20,7 @@ class Command(MigrateCommand):
             help="The id of the advisory lock to use",
         )
 
-    def handle(self, *args, **options):
+    def handle(self, *args, **options):  # type: ignore[no-untyped-def]
         database = options["database"]
         if not options["skip_checks"]:
             self.check(databases=[database])

--- a/label_studio/core/management/commands/show_async_migrations.py
+++ b/label_studio/core/management/commands/show_async_migrations.py
@@ -10,10 +10,10 @@ logger = logging.getLogger(__name__)
 class Command(BaseCommand):
     help = 'Show async migrations'
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser):  # type: ignore[no-untyped-def]
         parser.add_argument('-o', '--organization', type=int, help='organization id', default=-1)
 
-    def handle(self, *args, **options):
+    def handle(self, *args, **options):  # type: ignore[no-untyped-def]
         org = options['organization']
         logger.debug(f"===> AsyncMigrationStatus for Organization {org if org > -1 else 'ALL'}")
         if org == -1:

--- a/label_studio/core/mixins.py
+++ b/label_studio/core/mixins.py
@@ -9,14 +9,14 @@ logger = logging.getLogger(__name__)
 
 
 class DummyModelMixin():
-    def has_permission(self, user):
+    def has_permission(self, user):  # type: ignore[no-untyped-def]
         return True
 
 
 class GetParentObjectMixin:
     parent_queryset = None
 
-    def get_parent_object(self):
+    def get_parent_object(self):  # type: ignore[no-untyped-def]
         """
         The same as get_object method from DRF, but for the parent object
         For example if you want to get project inside /api/projects/ID/tasks handler

--- a/label_studio/core/models.py
+++ b/label_studio/core/models.py
@@ -42,5 +42,5 @@ class AsyncMigrationStatus(models.Model):
     created_at = models.DateTimeField(_('created at'), auto_now_add=True, help_text='Creation time')
     updated_at = models.DateTimeField(_('updated at'), auto_now=True, help_text='Last updated time')
 
-    def __str__(self):
+    def __str__(self):  # type: ignore[no-untyped-def]
         return f'(id={self.id}) ' + self.name + (' at project ' + str(self.project) if self.project else '')

--- a/label_studio/core/old_ls_migration.py
+++ b/label_studio/core/old_ls_migration.py
@@ -21,7 +21,7 @@ from core.utils.params import get_env
 
 
 @contextlib.contextmanager
-def suppress_autotime(model, fields):
+def suppress_autotime(model, fields):  # type: ignore[no-untyped-def]
     """ allow to keep original created_at value for auto_now_add=True field
     """
     _original_values = {}
@@ -39,7 +39,7 @@ def suppress_autotime(model, fields):
                 field.auto_now_add = _original_values[field.name]['auto_now_add']
 
 
-def _migrate_tasks(project_path, project):
+def _migrate_tasks(project_path, project):  # type: ignore[no-untyped-def]
     """ Migrate tasks from json file to database objects"""
     tasks_path = project_path / 'tasks.json'
     with io.open(os.path.abspath(tasks_path), encoding='utf-8') as t:
@@ -64,7 +64,7 @@ def _migrate_tasks(project_path, project):
                             task_annotation.created_at = datetime.datetime.fromtimestamp(
                                 annotation['created_at'], tz=datetime.datetime.now().astimezone().tzinfo
                             )
-                            task_annotation.save()
+                            task_annotation.save()  # type: ignore[no-untyped-call]
 
             # migrate predictions
             predictions_data = task_data.get('predictions', [])
@@ -74,10 +74,10 @@ def _migrate_tasks(project_path, project):
                     task_prediction.created_at = datetime.datetime.fromtimestamp(
                         prediction['created_at'], tz=datetime.datetime.now().astimezone().tzinfo
                     )
-                    task_prediction.save()
+                    task_prediction.save()  # type: ignore[no-untyped-call]
 
 
-def _migrate_tabs(project_path, project):
+def _migrate_tabs(project_path, project):  # type: ignore[no-untyped-def]
     """Migrate tabs from tabs.json to Views table"""
     tabs_path = project_path / 'tabs.json'
     if tabs_path.exists():
@@ -105,7 +105,7 @@ def _migrate_tabs(project_path, project):
                                 }
                             )
                             filter_group.filters.add(view_filter)
-                hidden_columns = {'explore': [], 'labeling': []}
+                hidden_columns = {'explore': [], 'labeling': []}  # type: ignore[var-annotated]
                 hidden_columns_data = tab.pop('hiddenColumns', None)
 
                 # apply naming change to tabs internal data
@@ -122,7 +122,7 @@ def _migrate_tabs(project_path, project):
                 view.save()
 
 
-def _migrate_storages(project, config):
+def _migrate_storages(project, config):  # type: ignore[no-untyped-def]
     """Migrate source and target storages from config.json to database"""
 
     # source storages migration
@@ -209,19 +209,19 @@ def _migrate_storages(project, config):
             )
 
 
-def _migrate_ml_backends(project, config):
+def _migrate_ml_backends(project, config):  # type: ignore[no-untyped-def]
     """Migrate ml backend settings from config.json to database"""
     ml_backends = config.get('ml_backends', [])
     for ml_backend in ml_backends:
         MLBackend.objects.create(project=project, url=ml_backend.get('url'), title=ml_backend.get('name'))
 
 
-def _migrate_uploaded_files(project, project_path):
+def _migrate_uploaded_files(project, project_path):  # type: ignore[no-untyped-def]
     """Migrate files uploaded by user"""
     source_upload_path = project_path / 'upload'
     if not source_upload_path.exists():
         return
-    target_upload_path = pathlib.Path(get_env('LABEL_STUDIO_BASE_DATA_DIR', get_data_dir())) / 'upload'
+    target_upload_path = pathlib.Path(get_env('LABEL_STUDIO_BASE_DATA_DIR', get_data_dir())) / 'upload'  # type: ignore[no-untyped-call, no-untyped-call]
     if not target_upload_path.exists():
         os.makedirs(str(target_upload_path), exist_ok=True)
 
@@ -232,12 +232,12 @@ def _migrate_uploaded_files(project, project_path):
             FileUpload.objects.create(user=project.created_by, project=project, file=File(f, name=file_name))
 
 
-def migrate_existing_project(project_path, project, config):
+def migrate_existing_project(project_path, project, config):  # type: ignore[no-untyped-def]
     """Migration projects from previous version of Label Studio"""
 
-    _migrate_tasks(project_path, project)
-    _migrate_tabs(project_path, project)
-    _migrate_storages(project, config)
-    _migrate_ml_backends(project, config)
-    _migrate_uploaded_files(project, project_path)
+    _migrate_tasks(project_path, project)  # type: ignore[no-untyped-call]
+    _migrate_tabs(project_path, project)  # type: ignore[no-untyped-call]
+    _migrate_storages(project, config)  # type: ignore[no-untyped-call]
+    _migrate_ml_backends(project, config)  # type: ignore[no-untyped-call]
+    _migrate_uploaded_files(project, project_path)  # type: ignore[no-untyped-call]
 

--- a/label_studio/core/permissions.py
+++ b/label_studio/core/permissions.py
@@ -1,7 +1,7 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
 import logging
-import rules
+import rules  # type: ignore[import]
 
 from pydantic import BaseModel
 from typing import Optional
@@ -49,7 +49,7 @@ class ViewClassPermission(BaseModel):
     POST: Optional[str] = None
 
 
-def make_perm(name, pred, overwrite=False):
+def make_perm(name, pred, overwrite=False):  # type: ignore[no-untyped-def]
     if rules.perm_exists(name):
         if overwrite:
             rules.remove_perm(name)
@@ -59,4 +59,4 @@ def make_perm(name, pred, overwrite=False):
 
 
 for _, permission_name in all_permissions:
-    make_perm(permission_name, rules.is_authenticated)
+    make_perm(permission_name, rules.is_authenticated)  # type: ignore[no-untyped-call]

--- a/label_studio/core/redis.py
+++ b/label_studio/core/redis.py
@@ -6,12 +6,12 @@ from functools import partial
 import sys
 import redis
 import logging
-import django_rq
+import django_rq  # type: ignore[import]
 
 from django_rq import get_connection
-from rq.registry import StartedJobRegistry
-from rq.command import send_stop_job_command
-from rq.exceptions import InvalidJobOperation
+from rq.registry import StartedJobRegistry  # type: ignore[import]
+from rq.command import send_stop_job_command  # type: ignore[import]
+from rq.exceptions import InvalidJobOperation  # type: ignore[import]
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ except:
     _redis = None
 
 
-def redis_healthcheck():
+def redis_healthcheck():  # type: ignore[no-untyped-def]
     if not _redis:
         return False
     try:
@@ -43,41 +43,41 @@ def redis_healthcheck():
         return True
 
 
-def redis_connected():
-    return redis_healthcheck()
+def redis_connected():  # type: ignore[no-untyped-def]
+    return redis_healthcheck()  # type: ignore[no-untyped-call]
 
 
-def redis_get(key):
-    if not redis_healthcheck():
+def redis_get(key):  # type: ignore[no-untyped-def]
+    if not redis_healthcheck():  # type: ignore[no-untyped-call]
         return
     return _redis.get(key)
 
 
-def redis_hget(key1, key2):
-    if not redis_healthcheck():
+def redis_hget(key1, key2):  # type: ignore[no-untyped-def]
+    if not redis_healthcheck():  # type: ignore[no-untyped-call]
         return
     return _redis.hget(key1, key2)
 
 
-def redis_set(key, value, ttl=None):
-    if not redis_healthcheck():
+def redis_set(key, value, ttl=None):  # type: ignore[no-untyped-def]
+    if not redis_healthcheck():  # type: ignore[no-untyped-call]
         return
     return _redis.set(key, value, ex=ttl)
 
 
-def redis_hset(key1, key2, value):
-    if not redis_healthcheck():
+def redis_hset(key1, key2, value):  # type: ignore[no-untyped-def]
+    if not redis_healthcheck():  # type: ignore[no-untyped-call]
         return
     return _redis.hset(key1, key2, value)
 
 
-def redis_delete(key):
-    if not redis_healthcheck():
+def redis_delete(key):  # type: ignore[no-untyped-def]
+    if not redis_healthcheck():  # type: ignore[no-untyped-call]
         return
     return _redis.delete(key)
 
 
-def start_job_async_or_sync(job, *args, in_seconds=0, **kwargs):
+def start_job_async_or_sync(job, *args, in_seconds=0, **kwargs):  # type: ignore[no-untyped-def]
     """
     Start job async with redis or sync if redis is not connected
     :param job: Job function
@@ -87,7 +87,7 @@ def start_job_async_or_sync(job, *args, in_seconds=0, **kwargs):
     :return: Job or function result
     """
 
-    redis = redis_connected() and kwargs.get('redis', True)
+    redis = redis_connected() and kwargs.get('redis', True)  # type: ignore[no-untyped-call]
     queue_name = kwargs.get("queue_name", "default")
     if 'queue_name' in kwargs:
         del kwargs['queue_name']
@@ -121,7 +121,7 @@ def start_job_async_or_sync(job, *args, in_seconds=0, **kwargs):
             raise
 
 
-def is_job_in_queue(queue, func_name, meta):
+def is_job_in_queue(queue, func_name, meta):  # type: ignore[no-untyped-def]
     """
     Checks if func_name with kwargs[meta] is in queue (doesn't check workers)
     :param queue: queue object
@@ -130,12 +130,12 @@ def is_job_in_queue(queue, func_name, meta):
     :return: True if job in queue
     """
     # get all jobs from Queue
-    jobs = get_jobs_by_meta(queue, func_name, meta)
+    jobs = get_jobs_by_meta(queue, func_name, meta)  # type: ignore[no-untyped-call]
     # check if there is job with meta in list
     return any(jobs)
 
 
-def is_job_on_worker(job_id, queue_name):
+def is_job_on_worker(job_id, queue_name):  # type: ignore[no-untyped-def]
     """
     Checks if job id is on workers
     :param job_id: Job ID
@@ -147,7 +147,7 @@ def is_job_on_worker(job_id, queue_name):
     return job_id in ids
 
 
-def delete_job_by_id(queue, id):
+def delete_job_by_id(queue, id):  # type: ignore[no-untyped-def]
     """
     Delete job by id from queue
     @param queue: Queue on redis to delete from
@@ -173,7 +173,7 @@ def delete_job_by_id(queue, id):
             logger.debug(f"Redis job {id} was not found: {str(e)}")
 
 
-def get_jobs_by_meta(queue, func_name, meta):
+def get_jobs_by_meta(queue, func_name, meta):  # type: ignore[no-untyped-def]
     """
     Get jobs from queue by func_name and meta data
     :param queue: Queue on redis to check in

--- a/label_studio/core/settings/base.py
+++ b/label_studio/core/settings/base.py
@@ -9,13 +9,19 @@ https://docs.djangoproject.com/en/3.1/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.1/ref/settings/
 """
+from typing import TYPE_CHECKING
+
 import os
 import re
 import logging
 import json
 
 from datetime import timedelta
-from label_studio.core.utils.params import get_bool_env, get_env
+
+if TYPE_CHECKING:
+    from core.utils.params import get_bool_env, get_env
+else:
+    from label_studio.core.utils.params import get_bool_env, get_env
 
 formatter = 'standard'
 JSON_LOG = get_bool_env('JSON_LOG', False)
@@ -74,8 +80,12 @@ LOGGING = {
 if not logging.getLogger().hasHandlers():
     logging.basicConfig(level=logging.DEBUG, format='%(message)s')
 
-from label_studio.core.utils.io import get_data_dir
-from label_studio.core.utils.params import get_bool_env, get_env, get_env_list_int
+if TYPE_CHECKING:
+    from core.utils.io import get_data_dir
+    from core.utils.params import get_bool_env, get_env
+else:
+    from label_studio.core.utils.io import get_data_dir
+    from label_studio.core.utils.params import get_bool_env, get_env
 
 logger = logging.getLogger(__name__)
 SILENCED_SYSTEM_CHECKS = []

--- a/label_studio/core/settings/base.py
+++ b/label_studio/core/settings/base.py
@@ -24,7 +24,7 @@ else:
     from label_studio.core.utils.params import get_bool_env, get_env
 
 formatter = 'standard'
-JSON_LOG = get_bool_env('JSON_LOG', False)
+JSON_LOG = get_bool_env('JSON_LOG', False)  # type: ignore[no-untyped-call]
 if JSON_LOG:
     formatter = 'json'
 
@@ -91,7 +91,7 @@ logger = logging.getLogger(__name__)
 SILENCED_SYSTEM_CHECKS = []
 
 # Hostname is used for proper path generation to the resources, pages, etc
-HOSTNAME = get_env('HOST', '')
+HOSTNAME = get_env('HOST', '')  # type: ignore[no-untyped-call]
 if HOSTNAME:
     if not HOSTNAME.startswith('http://') and not HOSTNAME.startswith('https://'):
         logger.info(
@@ -108,7 +108,7 @@ if HOSTNAME:
             # http[s]://domain.com:8080/script_name => /script_name
             pattern = re.compile(r'^http[s]?:\/\/([^:\/\s]+(:\d*)?)(.*)?')
             match = pattern.match(HOSTNAME)
-            FORCE_SCRIPT_NAME = match.group(3)
+            FORCE_SCRIPT_NAME = match.group(3)  # type: ignore[union-attr]
             if FORCE_SCRIPT_NAME:
                 logger.info("=> Django URL prefix is set to: %s", FORCE_SCRIPT_NAME)
 
@@ -118,14 +118,14 @@ INTERNAL_PORT = '8080'
 SECRET_KEY = '$(fefwefwef13;LFK{P!)@#*!)kdsjfWF2l+i5e3t(8a1n'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = get_bool_env('DEBUG', True)
-DEBUG_MODAL_EXCEPTIONS = get_bool_env('DEBUG_MODAL_EXCEPTIONS', True)
+DEBUG = get_bool_env('DEBUG', True)  # type: ignore[no-untyped-call]
+DEBUG_MODAL_EXCEPTIONS = get_bool_env('DEBUG_MODAL_EXCEPTIONS', True)  # type: ignore[no-untyped-call]
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # Base path for media root and other uploaded files
-BASE_DATA_DIR = get_env('BASE_DATA_DIR', get_data_dir())
+BASE_DATA_DIR = get_env('BASE_DATA_DIR', get_data_dir())  # type: ignore[no-untyped-call, no-untyped-call]
 os.makedirs(BASE_DATA_DIR, exist_ok=True)
 logger.info('=> Database and media directory: %s', BASE_DATA_DIR)
 
@@ -136,23 +136,23 @@ DJANGO_DB_SQLITE = 'sqlite'
 DJANGO_DB_POSTGRESQL = 'postgresql'
 DJANGO_DB = 'default'
 DATABASE_NAME_DEFAULT = os.path.join(BASE_DATA_DIR, 'label_studio.sqlite3')
-DATABASE_NAME = get_env('DATABASE_NAME', DATABASE_NAME_DEFAULT)
+DATABASE_NAME = get_env('DATABASE_NAME', DATABASE_NAME_DEFAULT)  # type: ignore[no-untyped-call]
 DATABASES_ALL = {
     DJANGO_DB_POSTGRESQL: {
         'ENGINE': 'django.db.backends.postgresql',
-        'USER': get_env('POSTGRE_USER', 'postgres'),
-        'PASSWORD': get_env('POSTGRE_PASSWORD', 'postgres'),
-        'NAME': get_env('POSTGRE_NAME', 'postgres'),
-        'HOST': get_env('POSTGRE_HOST', 'localhost'),
-        'PORT': int(get_env('POSTGRE_PORT', '5432')),
+        'USER': get_env('POSTGRE_USER', 'postgres'),  # type: ignore[no-untyped-call]
+        'PASSWORD': get_env('POSTGRE_PASSWORD', 'postgres'),  # type: ignore[no-untyped-call]
+        'NAME': get_env('POSTGRE_NAME', 'postgres'),  # type: ignore[no-untyped-call]
+        'HOST': get_env('POSTGRE_HOST', 'localhost'),  # type: ignore[no-untyped-call]
+        'PORT': int(get_env('POSTGRE_PORT', '5432')),  # type: ignore[no-untyped-call]
     },
     DJANGO_DB_MYSQL: {
         'ENGINE': 'django.db.backends.mysql',
-        'USER': get_env('MYSQL_USER', 'root'),
-        'PASSWORD': get_env('MYSQL_PASSWORD', ''),
-        'NAME': get_env('MYSQL_NAME', 'labelstudio'),
-        'HOST': get_env('MYSQL_HOST', 'localhost'),
-        'PORT': int(get_env('MYSQL_PORT', '3306')),
+        'USER': get_env('MYSQL_USER', 'root'),  # type: ignore[no-untyped-call]
+        'PASSWORD': get_env('MYSQL_PASSWORD', ''),  # type: ignore[no-untyped-call]
+        'NAME': get_env('MYSQL_NAME', 'labelstudio'),  # type: ignore[no-untyped-call]
+        'HOST': get_env('MYSQL_HOST', 'localhost'),  # type: ignore[no-untyped-call]
+        'PORT': int(get_env('MYSQL_PORT', '3306')),  # type: ignore[no-untyped-call]
     },
     DJANGO_DB_SQLITE: {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -163,25 +163,25 @@ DATABASES_ALL = {
     },
 }
 DATABASES_ALL['default'] = DATABASES_ALL[DJANGO_DB_POSTGRESQL]
-DATABASES = {'default': DATABASES_ALL.get(get_env('DJANGO_DB', 'default'))}
+DATABASES = {'default': DATABASES_ALL.get(get_env('DJANGO_DB', 'default'))}  # type: ignore[no-untyped-call]
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
-if get_bool_env('GOOGLE_LOGGING_ENABLED', False):
+if get_bool_env('GOOGLE_LOGGING_ENABLED', False):  # type: ignore[no-untyped-call]
     logging.info('Google Cloud Logging handler is enabled.')
     try:
         import google.cloud.logging
-        from google.auth.exceptions import GoogleAuthError
+        from google.auth.exceptions import GoogleAuthError  # type: ignore[import]
 
-        client = google.cloud.logging.Client()
-        client.setup_logging()
+        client = google.cloud.logging.Client()  # type: ignore[no-untyped-call]
+        client.setup_logging()  # type: ignore[no-untyped-call]
 
-        LOGGING['handlers']['google_cloud_logging'] = {
-            'level': get_env('LOG_LEVEL', 'WARNING'),
+        LOGGING['handlers']['google_cloud_logging'] = {  # type: ignore[index]
+            'level': get_env('LOG_LEVEL', 'WARNING'),  # type: ignore[no-untyped-call]
             'class': 'google.cloud.logging.handlers.CloudLoggingHandler',
             'client': client,
         }
-        LOGGING['root']['handlers'].append('google_cloud_logging')
+        LOGGING['root']['handlers'].append('google_cloud_logging')  # type: ignore[index]
     except GoogleAuthError as e:
         logger.exception('Google Cloud Logging handler could not be setup.')
 
@@ -275,7 +275,7 @@ AUTH_USER_MODEL = 'users.User'
 AUTHENTICATION_BACKENDS = ['rules.permissions.ObjectPermissionBackend', 'django.contrib.auth.backends.ModelBackend', ]
 USE_USERNAME_FOR_LOGIN = False
 
-DISABLE_SIGNUP_WITHOUT_LINK = get_bool_env('DISABLE_SIGNUP_WITHOUT_LINK', False)
+DISABLE_SIGNUP_WITHOUT_LINK = get_bool_env('DISABLE_SIGNUP_WITHOUT_LINK', False)  # type: ignore[no-untyped-call]
 
 # Password validation:
 # https://docs.djangoproject.com/en/2.1/ref/settings/#auth-password-validators
@@ -355,13 +355,13 @@ SWAGGER_SETTINGS = {
 
 }
 
-SENTRY_DSN = get_env('SENTRY_DSN', None)
-SENTRY_RATE = float(get_env('SENTRY_RATE', 0.25))
-SENTRY_ENVIRONMENT = get_env('SENTRY_ENVIRONMENT', 'stage.opensource')
+SENTRY_DSN = get_env('SENTRY_DSN', None)  # type: ignore[no-untyped-call]
+SENTRY_RATE = float(get_env('SENTRY_RATE', 0.25))  # type: ignore[no-untyped-call]
+SENTRY_ENVIRONMENT = get_env('SENTRY_ENVIRONMENT', 'stage.opensource')  # type: ignore[no-untyped-call]
 SENTRY_REDIS_ENABLED = False
-FRONTEND_SENTRY_DSN = get_env('FRONTEND_SENTRY_DSN', None)
-FRONTEND_SENTRY_RATE = get_env('FRONTEND_SENTRY_RATE', 0.1)
-FRONTEND_SENTRY_ENVIRONMENT = get_env('FRONTEND_SENTRY_ENVIRONMENT', 'stage.opensource')
+FRONTEND_SENTRY_DSN = get_env('FRONTEND_SENTRY_DSN', None)  # type: ignore[no-untyped-call]
+FRONTEND_SENTRY_RATE = get_env('FRONTEND_SENTRY_RATE', 0.1)  # type: ignore[no-untyped-call]
+FRONTEND_SENTRY_ENVIRONMENT = get_env('FRONTEND_SENTRY_ENVIRONMENT', 'stage.opensource')  # type: ignore[no-untyped-call]
 
 ROOT_URLCONF = 'core.urls'
 WSGI_APPLICATION = 'core.wsgi.application'
@@ -391,21 +391,21 @@ STATICFILES_FINDERS = (
 STATICFILES_STORAGE = 'core.storage.SkipMissedManifestStaticFilesStorage'
 
 # Sessions and CSRF
-SESSION_COOKIE_SECURE = bool(int(get_env('SESSION_COOKIE_SECURE', False)))
-SESSION_COOKIE_SAMESITE = get_env('SESSION_COOKIE_SAMESITE', 'Lax')
+SESSION_COOKIE_SECURE = bool(int(get_env('SESSION_COOKIE_SECURE', False)))  # type: ignore[no-untyped-call]
+SESSION_COOKIE_SAMESITE = get_env('SESSION_COOKIE_SAMESITE', 'Lax')  # type: ignore[no-untyped-call]
 
-CSRF_COOKIE_SECURE = bool(int(get_env('CSRF_COOKIE_SECURE', SESSION_COOKIE_SECURE)))
-CSRF_COOKIE_HTTPONLY = bool(int(get_env('CSRF_COOKIE_HTTPONLY', SESSION_COOKIE_SECURE)))
-CSRF_COOKIE_SAMESITE = get_env('CSRF_COOKIE_SAMESITE', 'Lax')
+CSRF_COOKIE_SECURE = bool(int(get_env('CSRF_COOKIE_SECURE', SESSION_COOKIE_SECURE)))  # type: ignore[no-untyped-call]
+CSRF_COOKIE_HTTPONLY = bool(int(get_env('CSRF_COOKIE_HTTPONLY', SESSION_COOKIE_SECURE)))  # type: ignore[no-untyped-call]
+CSRF_COOKIE_SAMESITE = get_env('CSRF_COOKIE_SAMESITE', 'Lax')  # type: ignore[no-untyped-call]
 
 # Inactivity user sessions
-INACTIVITY_SESSION_TIMEOUT_ENABLED = bool(int(get_env('INACTIVITY_SESSION_TIMEOUT_ENABLED', True)))
+INACTIVITY_SESSION_TIMEOUT_ENABLED = bool(int(get_env('INACTIVITY_SESSION_TIMEOUT_ENABLED', True)))  # type: ignore[no-untyped-call]
 # The most time a login will last, regardless of activity
-MAX_SESSION_AGE = int(get_env('MAX_SESSION_AGE', timedelta(days=14).total_seconds()))
+MAX_SESSION_AGE = int(get_env('MAX_SESSION_AGE', timedelta(days=14).total_seconds()))  # type: ignore[no-untyped-call]
 # The most time that can elapse between activity with the server before the user is logged out
-MAX_TIME_BETWEEN_ACTIVITY = int(get_env('MAX_TIME_BETWEEN_ACTIVITY', timedelta(days=5).total_seconds()))
+MAX_TIME_BETWEEN_ACTIVITY = int(get_env('MAX_TIME_BETWEEN_ACTIVITY', timedelta(days=5).total_seconds()))  # type: ignore[no-untyped-call]
 
-SSRF_PROTECTION_ENABLED = get_bool_env('SSRF_PROTECTION_ENABLED', False)
+SSRF_PROTECTION_ENABLED = get_bool_env('SSRF_PROTECTION_ENABLED', False)  # type: ignore[no-untyped-call]
 
 # user media files
 MEDIA_ROOT = os.path.join(BASE_DATA_DIR, 'media')
@@ -455,29 +455,29 @@ DELAYED_EXPORT_DIR = 'export'
 os.makedirs(os.path.join(BASE_DATA_DIR, MEDIA_ROOT, DELAYED_EXPORT_DIR), exist_ok=True)
 
 # file / task size limits
-DATA_UPLOAD_MAX_MEMORY_SIZE = int(get_env('DATA_UPLOAD_MAX_MEMORY_SIZE', 250 * 1024 * 1024))
+DATA_UPLOAD_MAX_MEMORY_SIZE = int(get_env('DATA_UPLOAD_MAX_MEMORY_SIZE', 250 * 1024 * 1024))  # type: ignore[no-untyped-call]
 TASKS_MAX_NUMBER = 1000000
 TASKS_MAX_FILE_SIZE = DATA_UPLOAD_MAX_MEMORY_SIZE
 
-TASK_LOCK_TTL = int(get_env('TASK_LOCK_TTL', default=86400))
+TASK_LOCK_TTL = int(get_env('TASK_LOCK_TTL', default=86400))  # type: ignore[no-untyped-call]
 
-LABEL_STREAM_HISTORY_LIMIT = int(get_env('LABEL_STREAM_HISTORY_LIMIT', default=100))
+LABEL_STREAM_HISTORY_LIMIT = int(get_env('LABEL_STREAM_HISTORY_LIMIT', default=100))  # type: ignore[no-untyped-call]
 
-RANDOM_NEXT_TASK_SAMPLE_SIZE = int(get_env('RANDOM_NEXT_TASK_SAMPLE_SIZE', 50))
+RANDOM_NEXT_TASK_SAMPLE_SIZE = int(get_env('RANDOM_NEXT_TASK_SAMPLE_SIZE', 50))  # type: ignore[no-untyped-call]
 
-TASK_API_PAGE_SIZE_MAX = int(get_env('TASK_API_PAGE_SIZE_MAX', 0)) or None
+TASK_API_PAGE_SIZE_MAX = int(get_env('TASK_API_PAGE_SIZE_MAX', 0)) or None  # type: ignore[no-untyped-call]
 
 # Email backend
-FROM_EMAIL = get_env('FROM_EMAIL', 'Label Studio <hello@labelstud.io>')
-EMAIL_BACKEND = get_env('EMAIL_BACKEND', 'django.core.mail.backends.dummy.EmailBackend')
+FROM_EMAIL = get_env('FROM_EMAIL', 'Label Studio <hello@labelstud.io>')  # type: ignore[no-untyped-call]
+EMAIL_BACKEND = get_env('EMAIL_BACKEND', 'django.core.mail.backends.dummy.EmailBackend')  # type: ignore[no-untyped-call]
 
-ENABLE_LOCAL_FILES_STORAGE = get_bool_env('ENABLE_LOCAL_FILES_STORAGE', default=True)
-LOCAL_FILES_SERVING_ENABLED = get_bool_env('LOCAL_FILES_SERVING_ENABLED', default=False)
-LOCAL_FILES_DOCUMENT_ROOT = get_env('LOCAL_FILES_DOCUMENT_ROOT', default=os.path.abspath(os.sep))
+ENABLE_LOCAL_FILES_STORAGE = get_bool_env('ENABLE_LOCAL_FILES_STORAGE', default=True)  # type: ignore[no-untyped-call]
+LOCAL_FILES_SERVING_ENABLED = get_bool_env('LOCAL_FILES_SERVING_ENABLED', default=False)  # type: ignore[no-untyped-call]
+LOCAL_FILES_DOCUMENT_ROOT = get_env('LOCAL_FILES_DOCUMENT_ROOT', default=os.path.abspath(os.sep))  # type: ignore[no-untyped-call]
 
-SYNC_ON_TARGET_STORAGE_CREATION = get_bool_env('SYNC_ON_TARGET_STORAGE_CREATION', default=True)
+SYNC_ON_TARGET_STORAGE_CREATION = get_bool_env('SYNC_ON_TARGET_STORAGE_CREATION', default=True)  # type: ignore[no-untyped-call]
 
-ALLOW_IMPORT_TASKS_WITH_UNKNOWN_EMAILS = get_bool_env('ALLOW_IMPORT_TASKS_WITH_UNKNOWN_EMAILS', default=False)
+ALLOW_IMPORT_TASKS_WITH_UNKNOWN_EMAILS = get_bool_env('ALLOW_IMPORT_TASKS_WITH_UNKNOWN_EMAILS', default=False)  # type: ignore[no-untyped-call]
 
 """ React Libraries: do not forget to change this dir in /etc/nginx/nginx.conf """
 # EDITOR = label-studio-frontend repository
@@ -495,15 +495,15 @@ LOGIN_REDIRECT_URL = '/'
 LOGIN_URL = '/'
 MIN_GROUND_TRUTH = 10
 DATA_UNDEFINED_NAME = '$undefined$'
-LICENSE = {}
-VERSIONS = {}
+LICENSE = {}  # type: ignore[var-annotated]
+VERSIONS = {}  # type: ignore[var-annotated]
 VERSION_EDITION = 'Community'
 LATEST_VERSION_CHECK = True
 VERSIONS_CHECK_TIME = 0
-ALLOW_ORGANIZATION_WEBHOOKS = get_bool_env('ALLOW_ORGANIZATION_WEBHOOKS', False)
-CONVERTER_DOWNLOAD_RESOURCES = get_bool_env('CONVERTER_DOWNLOAD_RESOURCES', True)
-EXPERIMENTAL_FEATURES = get_bool_env('EXPERIMENTAL_FEATURES', False)
-USE_ENFORCE_CSRF_CHECKS = get_bool_env('USE_ENFORCE_CSRF_CHECKS', True)  # False is for tests
+ALLOW_ORGANIZATION_WEBHOOKS = get_bool_env('ALLOW_ORGANIZATION_WEBHOOKS', False)  # type: ignore[no-untyped-call]
+CONVERTER_DOWNLOAD_RESOURCES = get_bool_env('CONVERTER_DOWNLOAD_RESOURCES', True)  # type: ignore[no-untyped-call]
+EXPERIMENTAL_FEATURES = get_bool_env('EXPERIMENTAL_FEATURES', False)  # type: ignore[no-untyped-call]
+USE_ENFORCE_CSRF_CHECKS = get_bool_env('USE_ENFORCE_CSRF_CHECKS', True)    # type: ignore[no-untyped-call] # False is for tests
 CLOUD_FILE_STORAGE_ENABLED = False
 
 IO_STORAGES_IMPORT_LINK_NAMES = [
@@ -522,8 +522,8 @@ USER_SERIALIZER_UPDATE = 'users.serializers.BaseUserSerializerUpdate'
 TASK_SERIALIZER = 'tasks.serializers.BaseTaskSerializer'
 EXPORT_DATA_SERIALIZER = 'data_export.serializers.BaseExportDataSerializer'
 DATA_MANAGER_GET_ALL_COLUMNS = 'data_manager.functions.get_all_columns'
-DATA_MANAGER_ANNOTATIONS_MAP = {}
-DATA_MANAGER_ACTIONS = {}
+DATA_MANAGER_ANNOTATIONS_MAP = {}  # type: ignore[var-annotated]
+DATA_MANAGER_ACTIONS = {}  # type: ignore[var-annotated]
 DATA_MANAGER_CUSTOM_FILTER_EXPRESSIONS = 'data_manager.functions.custom_filter_expressions'
 DATA_MANAGER_PREPROCESS_FILTER = 'data_manager.functions.preprocess_filter'
 USER_LOGIN_FORM = 'users.forms.LoginForm'
@@ -540,15 +540,15 @@ INTERACTIVE_DATA_SERIALIZER = 'data_export.serializers.BaseExportDataSerializerF
 DELETE_TASKS_ANNOTATIONS_POSTPROCESS = None
 
 
-def project_delete(project):
+def project_delete(project):  # type: ignore[no-untyped-def]
     project.delete()
 
 
-def user_auth(user_model, email, password):
+def user_auth(user_model, email, password):  # type: ignore[no-untyped-def]
     return None
 
 
-def collect_versions_dummy(**kwargs):
+def collect_versions_dummy(**kwargs):  # type: ignore[no-untyped-def]
     return {}
 
 
@@ -556,7 +556,7 @@ PROJECT_DELETE = project_delete
 USER_AUTH = user_auth
 COLLECT_VERSIONS = collect_versions_dummy
 
-WEBHOOK_TIMEOUT = float(get_env('WEBHOOK_TIMEOUT', 1.0))
+WEBHOOK_TIMEOUT = float(get_env('WEBHOOK_TIMEOUT', 1.0))  # type: ignore[no-untyped-call]
 WEBHOOK_SERIALIZERS = {
     'project': 'webhooks.serializers_for_hooks.ProjectWebhookSerializer',
     'task': 'webhooks.serializers_for_hooks.TaskWebhookSerializer',
@@ -565,7 +565,7 @@ WEBHOOK_SERIALIZERS = {
     'label_link': 'labels_manager.serializers.LabelLinkSerializer',
 }
 
-EDITOR_KEYMAP = json.dumps(get_env("EDITOR_KEYMAP"))
+EDITOR_KEYMAP = json.dumps(get_env("EDITOR_KEYMAP"))  # type: ignore[no-untyped-call]
 
 # fix a problem with Windows mimetypes for JS and PNG
 import mimetypes
@@ -576,93 +576,93 @@ mimetypes.add_type("image/png", ".png", True)
 # fields name was used in DM api before
 REST_FLEX_FIELDS = {"FIELDS_PARAM": "include"}
 
-INTERPOLATE_KEY_FRAMES = get_env('INTERPOLATE_KEY_FRAMES', False)
+INTERPOLATE_KEY_FRAMES = get_env('INTERPOLATE_KEY_FRAMES', False)  # type: ignore[no-untyped-call]
 
 # Feature Flags
-FEATURE_FLAGS_API_KEY = get_env('FEATURE_FLAGS_API_KEY', default='any key')
+FEATURE_FLAGS_API_KEY = get_env('FEATURE_FLAGS_API_KEY', default='any key')  # type: ignore[no-untyped-call]
 
 # we may set feature flags from file
-FEATURE_FLAGS_FROM_FILE = get_bool_env('FEATURE_FLAGS_FROM_FILE', False)
-FEATURE_FLAGS_FILE = get_env('FEATURE_FLAGS_FILE', 'feature_flags.json')
+FEATURE_FLAGS_FROM_FILE = get_bool_env('FEATURE_FLAGS_FROM_FILE', False)  # type: ignore[no-untyped-call]
+FEATURE_FLAGS_FILE = get_env('FEATURE_FLAGS_FILE', 'feature_flags.json')  # type: ignore[no-untyped-call]
 # or if file is not set, default is using offline mode
-FEATURE_FLAGS_OFFLINE = get_bool_env('FEATURE_FLAGS_OFFLINE', True)
+FEATURE_FLAGS_OFFLINE = get_bool_env('FEATURE_FLAGS_OFFLINE', True)  # type: ignore[no-untyped-call]
 # default value for feature flags (if not overridden by environment or client)
 FEATURE_FLAGS_DEFAULT_VALUE = False
 
 # Whether to send analytics telemetry data
-COLLECT_ANALYTICS = get_bool_env('collect_analytics', True)
+COLLECT_ANALYTICS = get_bool_env('collect_analytics', True)  # type: ignore[no-untyped-call]
 
 # Strip harmful content from SVG files by default
-SVG_SECURITY_CLEANUP = get_bool_env('SVG_SECURITY_CLEANUP', False)
+SVG_SECURITY_CLEANUP = get_bool_env('SVG_SECURITY_CLEANUP', False)  # type: ignore[no-untyped-call]
 
-ML_BLOCK_LOCAL_IP = get_bool_env('ML_BLOCK_LOCAL_IP', False)
+ML_BLOCK_LOCAL_IP = get_bool_env('ML_BLOCK_LOCAL_IP', False)  # type: ignore[no-untyped-call]
 
-RQ_LONG_JOB_TIMEOUT = int(get_env('RQ_LONG_JOB_TIMEOUT', 36000))
+RQ_LONG_JOB_TIMEOUT = int(get_env('RQ_LONG_JOB_TIMEOUT', 36000))  # type: ignore[no-untyped-call]
 
-APP_WEBSERVER = get_env('APP_WEBSERVER', 'django')
+APP_WEBSERVER = get_env('APP_WEBSERVER', 'django')  # type: ignore[no-untyped-call]
 
-BATCH_JOB_RETRY_TIMEOUT = int(get_env('BATCH_JOB_RETRY_TIMEOUT', 60))
+BATCH_JOB_RETRY_TIMEOUT = int(get_env('BATCH_JOB_RETRY_TIMEOUT', 60))  # type: ignore[no-untyped-call]
 
-FUTURE_SAVE_TASK_TO_STORAGE = get_bool_env('FUTURE_SAVE_TASK_TO_STORAGE', default=False)
-FUTURE_SAVE_TASK_TO_STORAGE_JSON_EXT = get_bool_env('FUTURE_SAVE_TASK_TO_STORAGE_JSON_EXT', default=True)
-STORAGE_IN_PROGRESS_TIMER = get_env('STORAGE_IN_PROGRESS_TIMER', 5.0)
+FUTURE_SAVE_TASK_TO_STORAGE = get_bool_env('FUTURE_SAVE_TASK_TO_STORAGE', default=False)  # type: ignore[no-untyped-call]
+FUTURE_SAVE_TASK_TO_STORAGE_JSON_EXT = get_bool_env('FUTURE_SAVE_TASK_TO_STORAGE_JSON_EXT', default=True)  # type: ignore[no-untyped-call]
+STORAGE_IN_PROGRESS_TIMER = get_env('STORAGE_IN_PROGRESS_TIMER', 5.0)  # type: ignore[no-untyped-call]
 
-USE_NGINX_FOR_EXPORT_DOWNLOADS = get_bool_env('USE_NGINX_FOR_EXPORT_DOWNLOADS', False)
+USE_NGINX_FOR_EXPORT_DOWNLOADS = get_bool_env('USE_NGINX_FOR_EXPORT_DOWNLOADS', False)  # type: ignore[no-untyped-call]
 
-if get_env('MINIO_STORAGE_ENDPOINT') and not get_bool_env('MINIO_SKIP', False):
+if get_env('MINIO_STORAGE_ENDPOINT') and not get_bool_env('MINIO_SKIP', False):  # type: ignore[no-untyped-call, no-untyped-call]
     CLOUD_FILE_STORAGE_ENABLED = True
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
-    AWS_STORAGE_BUCKET_NAME = get_env('MINIO_STORAGE_BUCKET_NAME')
-    AWS_ACCESS_KEY_ID = get_env('MINIO_STORAGE_ACCESS_KEY')
-    AWS_SECRET_ACCESS_KEY = get_env('MINIO_STORAGE_SECRET_KEY')
-    AWS_S3_ENDPOINT_URL = get_env('MINIO_STORAGE_ENDPOINT')
+    AWS_STORAGE_BUCKET_NAME = get_env('MINIO_STORAGE_BUCKET_NAME')  # type: ignore[no-untyped-call]
+    AWS_ACCESS_KEY_ID = get_env('MINIO_STORAGE_ACCESS_KEY')  # type: ignore[no-untyped-call]
+    AWS_SECRET_ACCESS_KEY = get_env('MINIO_STORAGE_SECRET_KEY')  # type: ignore[no-untyped-call]
+    AWS_S3_ENDPOINT_URL = get_env('MINIO_STORAGE_ENDPOINT')  # type: ignore[no-untyped-call]
     AWS_QUERYSTRING_AUTH = False
     # make domain for FileUpload.file
     AWS_S3_SECURE_URLS = False
     AWS_S3_URL_PROTOCOL = 'http:' if HOSTNAME.startswith('http://') else 'https:'
     AWS_S3_CUSTOM_DOMAIN = HOSTNAME.replace('http://', '').replace('https://', '') + '/data'
 
-if get_env('STORAGE_TYPE') == "s3":
+if get_env('STORAGE_TYPE') == "s3":  # type: ignore[no-untyped-call]
     CLOUD_FILE_STORAGE_ENABLED = True
     DEFAULT_FILE_STORAGE = 'core.storage.CustomS3Boto3Storage'
-    if get_env('STORAGE_AWS_ACCESS_KEY_ID'):
-        AWS_ACCESS_KEY_ID = get_env('STORAGE_AWS_ACCESS_KEY_ID')
-    if get_env('STORAGE_AWS_SECRET_ACCESS_KEY'):
-        AWS_SECRET_ACCESS_KEY = get_env('STORAGE_AWS_SECRET_ACCESS_KEY')
-    AWS_STORAGE_BUCKET_NAME = get_env('STORAGE_AWS_BUCKET_NAME')
-    AWS_S3_REGION_NAME = get_env('STORAGE_AWS_REGION_NAME', None)
-    AWS_S3_ENDPOINT_URL = get_env('STORAGE_AWS_ENDPOINT_URL', None)
-    if get_env('STORAGE_AWS_OBJECT_PARAMETERS'):
-        AWS_S3_OBJECT_PARAMETERS = json.loads(get_env('STORAGE_AWS_OBJECT_PARAMETERS'))
-    AWS_QUERYSTRING_EXPIRE = int(get_env('STORAGE_AWS_X_AMZ_EXPIRES', '86400'))
-    AWS_LOCATION = get_env('STORAGE_AWS_FOLDER', default='')
-    AWS_S3_USE_SSL = get_bool_env('STORAGE_AWS_S3_USE_SSL', True)
-    AWS_S3_VERIFY = get_env('STORAGE_AWS_S3_VERIFY', None)
+    if get_env('STORAGE_AWS_ACCESS_KEY_ID'):  # type: ignore[no-untyped-call]
+        AWS_ACCESS_KEY_ID = get_env('STORAGE_AWS_ACCESS_KEY_ID')  # type: ignore[no-untyped-call]
+    if get_env('STORAGE_AWS_SECRET_ACCESS_KEY'):  # type: ignore[no-untyped-call]
+        AWS_SECRET_ACCESS_KEY = get_env('STORAGE_AWS_SECRET_ACCESS_KEY')  # type: ignore[no-untyped-call]
+    AWS_STORAGE_BUCKET_NAME = get_env('STORAGE_AWS_BUCKET_NAME')  # type: ignore[no-untyped-call]
+    AWS_S3_REGION_NAME = get_env('STORAGE_AWS_REGION_NAME', None)  # type: ignore[no-untyped-call]
+    AWS_S3_ENDPOINT_URL = get_env('STORAGE_AWS_ENDPOINT_URL', None)  # type: ignore[no-untyped-call]
+    if get_env('STORAGE_AWS_OBJECT_PARAMETERS'):  # type: ignore[no-untyped-call]
+        AWS_S3_OBJECT_PARAMETERS = json.loads(get_env('STORAGE_AWS_OBJECT_PARAMETERS'))  # type: ignore[no-untyped-call]
+    AWS_QUERYSTRING_EXPIRE = int(get_env('STORAGE_AWS_X_AMZ_EXPIRES', '86400'))  # type: ignore[no-untyped-call]
+    AWS_LOCATION = get_env('STORAGE_AWS_FOLDER', default='')  # type: ignore[no-untyped-call]
+    AWS_S3_USE_SSL = get_bool_env('STORAGE_AWS_S3_USE_SSL', True)  # type: ignore[no-untyped-call]
+    AWS_S3_VERIFY = get_env('STORAGE_AWS_S3_VERIFY', None)  # type: ignore[no-untyped-call]
     if AWS_S3_VERIFY == 'false' or AWS_S3_VERIFY == 'False' or AWS_S3_VERIFY == '0':
         AWS_S3_VERIFY = False
 
-if get_env('STORAGE_TYPE') == "azure":
+if get_env('STORAGE_TYPE') == "azure":  # type: ignore[no-untyped-call]
     CLOUD_FILE_STORAGE_ENABLED = True
     DEFAULT_FILE_STORAGE = 'core.storage.CustomAzureStorage'
-    AZURE_ACCOUNT_NAME = get_env('STORAGE_AZURE_ACCOUNT_NAME')
-    AZURE_ACCOUNT_KEY = get_env('STORAGE_AZURE_ACCOUNT_KEY')
-    AZURE_CONTAINER = get_env('STORAGE_AZURE_CONTAINER_NAME')
-    AZURE_URL_EXPIRATION_SECS = int(get_env('STORAGE_AZURE_URL_EXPIRATION_SECS', '86400'))
-    AZURE_LOCATION = get_env('STORAGE_AZURE_FOLDER', default='')
+    AZURE_ACCOUNT_NAME = get_env('STORAGE_AZURE_ACCOUNT_NAME')  # type: ignore[no-untyped-call]
+    AZURE_ACCOUNT_KEY = get_env('STORAGE_AZURE_ACCOUNT_KEY')  # type: ignore[no-untyped-call]
+    AZURE_CONTAINER = get_env('STORAGE_AZURE_CONTAINER_NAME')  # type: ignore[no-untyped-call]
+    AZURE_URL_EXPIRATION_SECS = int(get_env('STORAGE_AZURE_URL_EXPIRATION_SECS', '86400'))  # type: ignore[no-untyped-call]
+    AZURE_LOCATION = get_env('STORAGE_AZURE_FOLDER', default='')  # type: ignore[no-untyped-call]
 
-if get_env('STORAGE_TYPE') == "gcs":
+if get_env('STORAGE_TYPE') == "gcs":  # type: ignore[no-untyped-call]
     CLOUD_FILE_STORAGE_ENABLED = True
     # DEFAULT_FILE_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'
     DEFAULT_FILE_STORAGE = 'core.storage.AlternativeGoogleCloudStorage'
-    GS_PROJECT_ID = get_env('STORAGE_GCS_PROJECT_ID')
-    GS_BUCKET_NAME = get_env('STORAGE_GCS_BUCKET_NAME')
-    GS_EXPIRATION = timedelta(seconds=int(get_env('STORAGE_GCS_EXPIRATION_SECS', '86400')))
-    GS_LOCATION = get_env('STORAGE_GCS_FOLDER', default='')
-    GS_CUSTOM_ENDPOINT = get_env('STORAGE_GCS_ENDPOINT')
+    GS_PROJECT_ID = get_env('STORAGE_GCS_PROJECT_ID')  # type: ignore[no-untyped-call]
+    GS_BUCKET_NAME = get_env('STORAGE_GCS_BUCKET_NAME')  # type: ignore[no-untyped-call]
+    GS_EXPIRATION = timedelta(seconds=int(get_env('STORAGE_GCS_EXPIRATION_SECS', '86400')))  # type: ignore[no-untyped-call]
+    GS_LOCATION = get_env('STORAGE_GCS_FOLDER', default='')  # type: ignore[no-untyped-call]
+    GS_CUSTOM_ENDPOINT = get_env('STORAGE_GCS_ENDPOINT')  # type: ignore[no-untyped-call]
 
-CSRF_TRUSTED_ORIGINS = get_env('CSRF_TRUSTED_ORIGINS', [])
+CSRF_TRUSTED_ORIGINS = get_env('CSRF_TRUSTED_ORIGINS', [])  # type: ignore[no-untyped-call]
 if CSRF_TRUSTED_ORIGINS:
     CSRF_TRUSTED_ORIGINS = CSRF_TRUSTED_ORIGINS.split(",")
 
 REAL_HOSTNAME = os.getenv('HOSTNAME')  # we have to use getenv, because we don't use LABEL_STUDIO_ prefix
-GCS_CLOUD_STORAGE_FORCE_DEFAULT_CREDENTIALS = get_bool_env('GCS_CLOUD_STORAGE_FORCE_DEFAULT_CREDENTIALS', False)
+GCS_CLOUD_STORAGE_FORCE_DEFAULT_CREDENTIALS = get_bool_env('GCS_CLOUD_STORAGE_FORCE_DEFAULT_CREDENTIALS', False)  # type: ignore[no-untyped-call]

--- a/label_studio/core/settings/label_studio.py
+++ b/label_studio/core/settings/label_studio.py
@@ -1,5 +1,7 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
+from typing import TYPE_CHECKING
+
 import os
 import pathlib
 
@@ -40,13 +42,14 @@ FRONTEND_SENTRY_ENVIRONMENT = get_env('FRONTEND_SENTRY_ENVIRONMENT', 'opensource
 
 EDITOR_KEYMAP = json.dumps(get_env("EDITOR_KEYMAP"))
 
-from label_studio import __version__
-from label_studio.core.utils import sentry
-sentry.init_sentry(release_name='label-studio', release_version=__version__)
+if not TYPE_CHECKING:
+    from label_studio import __version__
+    from label_studio.core.utils import sentry
+    sentry.init_sentry(release_name='label-studio', release_version=__version__)
 
-# we should do it after sentry init
-from label_studio.core.utils.common import collect_versions
-versions = collect_versions()
+    # we should do it after sentry init
+    from label_studio.core.utils.common import collect_versions
+    versions = collect_versions()
 
 # in Label Studio Community version, feature flags are always ON
 FEATURE_FLAGS_DEFAULT_VALUE = True

--- a/label_studio/core/settings/label_studio.py
+++ b/label_studio/core/settings/label_studio.py
@@ -7,7 +7,7 @@ import pathlib
 
 from core.settings.base import *
 
-DJANGO_DB = get_env('DJANGO_DB', DJANGO_DB_SQLITE)
+DJANGO_DB = get_env('DJANGO_DB', DJANGO_DB_SQLITE)  # type: ignore[name-defined]
 DATABASES = {'default': DATABASES_ALL[DJANGO_DB]}
 
 MIDDLEWARE.append('organizations.middleware.DummyGetSessionMiddleware')
@@ -17,30 +17,30 @@ if INACTIVITY_SESSION_TIMEOUT_ENABLED:
 
 ADD_DEFAULT_ML_BACKENDS = False
 
-LOGGING['root']['level'] = get_env('LOG_LEVEL', 'WARNING')
+LOGGING['root']['level'] = get_env('LOG_LEVEL', 'WARNING')  # type: ignore[name-defined, index]
 
-DEBUG = get_bool_env('DEBUG', False)
+DEBUG = get_bool_env('DEBUG', False)  # type: ignore[name-defined]
 
-DEBUG_PROPAGATE_EXCEPTIONS = get_bool_env('DEBUG_PROPAGATE_EXCEPTIONS', False)
+DEBUG_PROPAGATE_EXCEPTIONS = get_bool_env('DEBUG_PROPAGATE_EXCEPTIONS', False)  # type: ignore[name-defined]
 
-SESSION_COOKIE_SECURE = get_bool_env('SESSION_COOKIE_SECURE', False)
+SESSION_COOKIE_SECURE = get_bool_env('SESSION_COOKIE_SECURE', False)  # type: ignore[name-defined]
 
 SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 
 RQ_QUEUES = {}
 
-SENTRY_DSN = get_env(
+SENTRY_DSN = get_env(  # type: ignore[name-defined]
     'SENTRY_DSN',
     'https://68b045ab408a4d32a910d339be8591a4@o227124.ingest.sentry.io/5820521'
 )
-SENTRY_ENVIRONMENT = get_env('SENTRY_ENVIRONMENT', 'opensource')
+SENTRY_ENVIRONMENT = get_env('SENTRY_ENVIRONMENT', 'opensource')  # type: ignore[name-defined]
 
-FRONTEND_SENTRY_DSN = get_env(
+FRONTEND_SENTRY_DSN = get_env(  # type: ignore[name-defined]
     'FRONTEND_SENTRY_DSN',
     'https://5f51920ff82a4675a495870244869c6b@o227124.ingest.sentry.io/5838868')
-FRONTEND_SENTRY_ENVIRONMENT = get_env('FRONTEND_SENTRY_ENVIRONMENT', 'opensource')
+FRONTEND_SENTRY_ENVIRONMENT = get_env('FRONTEND_SENTRY_ENVIRONMENT', 'opensource')  # type: ignore[name-defined]
 
-EDITOR_KEYMAP = json.dumps(get_env("EDITOR_KEYMAP"))
+EDITOR_KEYMAP = json.dumps(get_env("EDITOR_KEYMAP"))  # type: ignore[name-defined, name-defined]
 
 if not TYPE_CHECKING:
     from label_studio import __version__
@@ -54,15 +54,15 @@ if not TYPE_CHECKING:
 # in Label Studio Community version, feature flags are always ON
 FEATURE_FLAGS_DEFAULT_VALUE = True
 # or if file is not set, default is using offline mode
-FEATURE_FLAGS_OFFLINE = get_bool_env('FEATURE_FLAGS_OFFLINE', True)
+FEATURE_FLAGS_OFFLINE = get_bool_env('FEATURE_FLAGS_OFFLINE', True)  # type: ignore[name-defined]
 
 from core.utils.io import find_file
-FEATURE_FLAGS_FILE = get_env('FEATURE_FLAGS_FILE', 'feature_flags.json')
+FEATURE_FLAGS_FILE = get_env('FEATURE_FLAGS_FILE', 'feature_flags.json')  # type: ignore[name-defined]
 FEATURE_FLAGS_FROM_FILE = True
 try:
     from core.utils.io import find_node
-    find_node('label_studio', FEATURE_FLAGS_FILE, 'file')
+    find_node('label_studio', FEATURE_FLAGS_FILE, 'file')  # type: ignore[no-untyped-call]
 except IOError:
     FEATURE_FLAGS_FROM_FILE = False
 
-STORAGE_PERSISTENCE = get_bool_env('STORAGE_PERSISTENCE', True)
+STORAGE_PERSISTENCE = get_bool_env('STORAGE_PERSISTENCE', True)  # type: ignore[name-defined]

--- a/label_studio/core/templatetags/filters.py
+++ b/label_studio/core/templatetags/filters.py
@@ -12,7 +12,7 @@ register = template.Library()
 
 
 @register.filter
-def initials(val, jn=""):
+def initials(val, jn=""):  # type: ignore[no-untyped-def]
     """ Given a string return its initials join by $jn
     """
     res = []
@@ -30,62 +30,62 @@ def initials(val, jn=""):
         
 
 @register.filter
-def get_at_index(l, index):
+def get_at_index(l, index):  # type: ignore[no-untyped-def]
     return l[index]
 
 
 @register.filter
-def get_item(dictionary, key):
+def get_item(dictionary, key):  # type: ignore[no-untyped-def]
     return dictionary.get(key, None)
 
 
 @register.filter
-def json_dumps_ensure_ascii(dictionary):
+def json_dumps_ensure_ascii(dictionary):  # type: ignore[no-untyped-def]
     return json.dumps(dictionary, ensure_ascii=False)
 
 
 @register.filter
-def json_escape_quote(data):
+def json_escape_quote(data):  # type: ignore[no-untyped-def]
     data_str = json.dumps(data, ensure_ascii=False)
     return data_str.replace("'", "\\'")
 
 
 @register.filter
-def escape_lt_gt(s):
+def escape_lt_gt(s):  # type: ignore[no-untyped-def]
     return s.replace('<', '&lt;').replace('>', '&gt;')
 
 
 @register.filter
-def datetime2str(d):
+def datetime2str(d):  # type: ignore[no-untyped-def]
     if isinstance(d, str):
         return d
     return d.strftime('%Y-%m-%d %H:%M:%S')
 
 
 @register.filter
-def start_zero_padding(number):
+def start_zero_padding(number):  # type: ignore[no-untyped-def]
     return '%5.5i' % number
 
 
 @register.filter
-def collaborator_id_in_url(id_, url):
+def collaborator_id_in_url(id_, url):  # type: ignore[no-untyped-def]
     return ('collaborator_id=' + str(id_)) in url
 
 
 @register.filter
-def date_for_license(date):
+def date_for_license(date):  # type: ignore[no-untyped-def]
     if isinstance(date, str):
         date = datetime.strptime(date, '%Y-%m-%d')
     return date.strftime("%d %b %Y %H:%M")
 
 
 @register.filter
-def current_date(some):
+def current_date(some):  # type: ignore[no-untyped-def]
     return datetime.now()
 
 
 @register.filter
-def is_current_date_greater_than(date):
+def is_current_date_greater_than(date):  # type: ignore[no-untyped-def]
     if date is None:
         return False
     if isinstance(date, str):
@@ -94,12 +94,12 @@ def is_current_date_greater_than(date):
 
 
 @register.filter
-def multiply(value, arg):
+def multiply(value, arg):  # type: ignore[no-untyped-def]
     return value * arg
 
 
 @register.simple_tag
-def custom_autocomplete(key=''):
+def custom_autocomplete(key=''):  # type: ignore[no-untyped-def]
     if settings.LICENSE.get('disable_autocomplete', False):
         if key == 'password':
             return format_html('autocomplete="new-password"')
@@ -109,7 +109,7 @@ def custom_autocomplete(key=''):
 
 
 @register.simple_tag(takes_context=True)
-def var_exists(context, name):
+def var_exists(context, name):  # type: ignore[no-untyped-def]
     dicts = context.dicts  # array of dicts
     if dicts:
         for d in dicts:

--- a/label_studio/core/urls.py
+++ b/label_studio/core/urls.py
@@ -22,8 +22,8 @@ from django.contrib import admin
 from django.urls import path, re_path
 from django.views.generic.base import RedirectView
 
-from drf_yasg import openapi
-from drf_yasg.views import get_schema_view
+from drf_yasg import openapi  # type: ignore[import]
+from drf_yasg.views import get_schema_view  # type: ignore[import]
 from rest_framework.permissions import AllowAny
 
 from core import views
@@ -32,7 +32,7 @@ from core.utils.common import collect_versions
 
 handler500 = 'core.views.custom_500'
 
-versions = collect_versions()
+versions = collect_versions()  # type: ignore[no-untyped-call]
 schema_view = get_schema_view(
     openapi.Info(
         title="Label Studio API",
@@ -46,13 +46,13 @@ schema_view = get_schema_view(
 
 urlpatterns = [
     re_path(r'^$', views.main, name='main'),
-    re_path(r'^sw\.js$', views.static_file_with_host_resolver('static/js/sw.js', content_type='text/javascript')),
-    re_path(r'^sw-fallback\.js$', views.static_file_with_host_resolver('static/js/sw-fallback.js', content_type='text/javascript')),
+    re_path(r'^sw\.js$', views.static_file_with_host_resolver('static/js/sw.js', content_type='text/javascript')),  # type: ignore[no-untyped-call]
+    re_path(r'^sw-fallback\.js$', views.static_file_with_host_resolver('static/js/sw-fallback.js', content_type='text/javascript')),  # type: ignore[no-untyped-call]
     re_path(r'^favicon\.ico$', RedirectView.as_view(url='/static/images/favicon.ico', permanent=True)),
     re_path(r'^label-studio-frontend/(?P<path>.*)$', serve, kwargs={'document_root': settings.EDITOR_ROOT, 'show_indexes': True}),
     re_path(r'^dm/(?P<path>.*)$', serve, kwargs={'document_root': settings.DM_ROOT, 'show_indexes': True}),
     re_path(r'^react-app/(?P<path>.*)$', serve, kwargs={'document_root': settings.REACT_APP_ROOT, 'show_indexes': True}),
-    re_path(r'^static/fonts/roboto/roboto.css$', views.static_file_with_host_resolver('static/fonts/roboto/roboto.css', content_type='text/css')),
+    re_path(r'^static/fonts/roboto/roboto.css$', views.static_file_with_host_resolver('static/fonts/roboto/roboto.css', content_type='text/css')),  # type: ignore[no-untyped-call]
     re_path(r'^static/(?P<path>.*)$', serve, kwargs={'document_root': settings.STATIC_ROOT, 'show_indexes': True}),
 
     re_path(r'^', include('organizations.urls')),
@@ -93,7 +93,7 @@ urlpatterns = [
 
 if settings.DEBUG:
     try:
-        import debug_toolbar
+        import debug_toolbar  # type: ignore[import]
         urlpatterns = [path('__debug__/', include(debug_toolbar.urls))] + urlpatterns
     except ImportError:
         pass

--- a/label_studio/core/utils/db.py
+++ b/label_studio/core/utils/db.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 import logging
 
-from core.feature_flags import flag_set
+from core.feature_flags import flag_set  # type: ignore[attr-defined]
 from django.db import models
 from django.db.models import Subquery
 
@@ -16,7 +16,7 @@ class SQCount(Subquery):
     output_field = models.IntegerField()
 
 
-def fast_first(queryset):
+def fast_first(queryset):  # type: ignore[no-untyped-def]
     """Replacement for queryset.first() when you don't need ordering,
     queryset.first() works slowly in some cases
     """
@@ -30,7 +30,7 @@ def should_run_bulk_update_in_transaction(organization_created_by_user: "User") 
     """Check flag for the given user, log result and user id to info for debugging
     purposes"""
 
-    bulk_update_should_run_in_transaction = flag_set(
+    bulk_update_should_run_in_transaction = flag_set(  # type: ignore[no-untyped-call]
         "fflag_fix_back_lsdv_5289_run_bulk_updates_in_transactions_short",
         user=organization_created_by_user,
         override_system_default=True,
@@ -40,4 +40,4 @@ def should_run_bulk_update_in_transaction(organization_created_by_user: "User") 
         f"[deadlocks debugging] {bulk_update_should_run_in_transaction=} {organization_created_by_user.id=}"
     )
 
-    return bulk_update_should_run_in_transaction
+    return bulk_update_should_run_in_transaction  # type: ignore[no-any-return]

--- a/label_studio/core/utils/exceptions.py
+++ b/label_studio/core/utils/exceptions.py
@@ -24,7 +24,7 @@ class LabelStudioDatabaseLockedException(LabelStudioAPIException):
 
 
 class ProjectExistException(LabelStudioAPIException):
-    status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
+    status_code = status.HTTP_422_UNPROCESSABLE_ENTITY  # type: ignore[assignment]
     default_detail = 'Project with the same title already exists'
 
 
@@ -46,4 +46,4 @@ class LabelStudioXMLSyntaxErrorSentryIgnored(Exception):
 
 class InvalidUploadUrlError(LabelStudioAPIException):
     default_detail = 'The provided URL was not valid. URLs must begin with http:// or https://, and cannot be local IPs.'
-    status_code = status.HTTP_403_FORBIDDEN
+    status_code = status.HTTP_403_FORBIDDEN  # type: ignore[assignment]

--- a/label_studio/core/utils/formatter.py
+++ b/label_studio/core/utils/formatter.py
@@ -1,5 +1,5 @@
 from typing import TYPE_CHECKING
-from pythonjsonlogger import jsonlogger
+from pythonjsonlogger import jsonlogger  # type: ignore[import]
 
 if TYPE_CHECKING:
     from core.current_request import get_current_request
@@ -7,11 +7,11 @@ else:
     from label_studio.core.current_request import get_current_request
 
 
-class CustomJsonFormatter(jsonlogger.JsonFormatter):
-    def add_fields(self, log_record, record, message_dict):
+class CustomJsonFormatter(jsonlogger.JsonFormatter):  # type: ignore[misc]
+    def add_fields(self, log_record, record, message_dict):  # type: ignore[no-untyped-def]
         super(CustomJsonFormatter, self).add_fields(log_record, record, message_dict)
         request_id = None
-        request = get_current_request()
+        request = get_current_request()  # type: ignore[no-untyped-call]
         if request and 'X-Request-ID' in request.headers:
             request_id = request.headers['X-Request-ID']
         log_record['request_id'] = request_id

--- a/label_studio/core/utils/formatter.py
+++ b/label_studio/core/utils/formatter.py
@@ -1,5 +1,10 @@
+from typing import TYPE_CHECKING
 from pythonjsonlogger import jsonlogger
-from label_studio.core.current_request import get_current_request
+
+if TYPE_CHECKING:
+    from core.current_request import get_current_request
+else:
+    from label_studio.core.current_request import get_current_request
 
 
 class CustomJsonFormatter(jsonlogger.JsonFormatter):

--- a/label_studio/core/utils/io.py
+++ b/label_studio/core/utils/io.py
@@ -25,11 +25,11 @@ from .exceptions import InvalidUploadUrlError
 _DIR_APP_NAME = 'label-studio'
 
 
-def good_path(path):
+def good_path(path):  # type: ignore[no-untyped-def]
     return os.path.abspath(os.path.expanduser(path))
 
 
-def find_node(package_name, node_path, node_type):
+def find_node(package_name, node_path, node_type):  # type: ignore[no-untyped-def]
     assert node_type in ('dir', 'file', 'any')
     basedir = pkg_resources.resource_filename(package_name, '')
     node_path = os.path.join(*node_path.split('/'))  # linux to windows compatibility
@@ -55,29 +55,29 @@ def find_node(package_name, node_path, node_type):
         )
 
 
-def find_file(file):
-    return find_node('label_studio', file, 'file')
+def find_file(file):  # type: ignore[no-untyped-def]
+    return find_node('label_studio', file, 'file')  # type: ignore[no-untyped-call]
 
 
-def find_dir(directory):
-    return find_node('label_studio', directory, 'dir')
+def find_dir(directory):  # type: ignore[no-untyped-def]
+    return find_node('label_studio', directory, 'dir')  # type: ignore[no-untyped-call]
 
 
 @contextmanager
-def get_temp_file():
+def get_temp_file():  # type: ignore[no-untyped-def]
     fd, path = mkstemp()
     yield path
     os.close(fd)
 
 
 @contextmanager
-def get_temp_dir():
+def get_temp_dir():  # type: ignore[no-untyped-def]
     dirpath = mkdtemp()
     yield dirpath
     shutil.rmtree(dirpath)
 
 
-def get_config_dir():
+def get_config_dir():  # type: ignore[no-untyped-def]
     config_dir = user_config_dir(appname=_DIR_APP_NAME)
     try:
         os.makedirs(config_dir, exist_ok=True)
@@ -86,31 +86,31 @@ def get_config_dir():
     return config_dir
 
 
-def get_data_dir():
+def get_data_dir():  # type: ignore[no-untyped-def]
     data_dir = user_data_dir(appname=_DIR_APP_NAME)
     os.makedirs(data_dir, exist_ok=True)
     return data_dir
 
 
-def get_cache_dir():
+def get_cache_dir():  # type: ignore[no-untyped-def]
     cache_dir = user_cache_dir(appname=_DIR_APP_NAME)
     os.makedirs(cache_dir, exist_ok=True)
     return cache_dir
 
 
-def delete_dir_content(dirpath):
+def delete_dir_content(dirpath):  # type: ignore[no-untyped-def]
     for f in glob.glob(dirpath + '/*'):
-        remove_file_or_dir(f)
+        remove_file_or_dir(f)  # type: ignore[no-untyped-call]
 
 
-def remove_file_or_dir(path):
+def remove_file_or_dir(path):  # type: ignore[no-untyped-def]
     if os.path.isfile(path):
         os.remove(path)
     elif os.path.isdir(path):
         shutil.rmtree(path)
 
 
-def get_all_files_from_dir(d):
+def get_all_files_from_dir(d):  # type: ignore[no-untyped-def]
     out = []
     for name in os.listdir(d):
         filepath = os.path.join(d, name)
@@ -119,14 +119,14 @@ def get_all_files_from_dir(d):
     return out
 
 
-def iter_files(root_dir, ext):
+def iter_files(root_dir, ext):  # type: ignore[no-untyped-def]
     for root, _, files in os.walk(root_dir):
         for f in files:
             if f.lower().endswith(ext):
                 yield os.path.join(root, f)
 
 
-def json_load(file, int_keys=False):
+def json_load(file, int_keys=False):  # type: ignore[no-untyped-def]
     with io.open(file, encoding='utf8') as f:
         data = json.load(f)
         if int_keys:
@@ -135,20 +135,20 @@ def json_load(file, int_keys=False):
             return data
 
 
-def read_yaml(filepath):
+def read_yaml(filepath):  # type: ignore[no-untyped-def]
     if not os.path.exists(filepath):
-        filepath = find_file(filepath)
+        filepath = find_file(filepath)  # type: ignore[no-untyped-call]
     with io.open(filepath, encoding='utf-8') as f:
         data = yaml.load(f, Loader=yaml.FullLoader)  # nosec
     return data
 
 
-def read_bytes_stream(filepath):
+def read_bytes_stream(filepath):  # type: ignore[no-untyped-def]
     with open(filepath, mode='rb') as f:
         return io.BytesIO(f.read())
 
 
-def get_all_dirs_from_dir(d):
+def get_all_dirs_from_dir(d):  # type: ignore[no-untyped-def]
     out = []
     for name in os.listdir(d):
         filepath = os.path.join(d, name)
@@ -157,21 +157,21 @@ def get_all_dirs_from_dir(d):
     return out
 
 
-class SerializableGenerator(list):
+class SerializableGenerator(list):  # type: ignore[type-arg]
     """Generator that is serializable by JSON"""
 
-    def __init__(self, iterable):
+    def __init__(self, iterable):  # type: ignore[no-untyped-def]
         tmp_body = iter(iterable)
         try:
             self._head = iter([next(tmp_body)])
             self.append(tmp_body)
         except StopIteration:
-            self._head = []
+            self._head = []  # type: ignore[assignment]
 
-    def __iter__(self):
+    def __iter__(self):  # type: ignore[no-untyped-def]
         return itertools.chain(self._head, *self[:1])
 
-def validate_upload_url(url, block_local_urls=True):
+def validate_upload_url(url, block_local_urls=True):  # type: ignore[no-untyped-def]
     """Utility function for defending against SSRF attacks. Raises
         - InvalidUploadUrlError if the url is not HTTP[S], or if block_local_urls is enabled
           and the URL resolves to a local address.
@@ -188,7 +188,7 @@ def validate_upload_url(url, block_local_urls=True):
 
     domain = parsed_url.host
     try:
-        ip = socket.gethostbyname(domain)
+        ip = socket.gethostbyname(domain)  # type: ignore[arg-type]
     except socket.error:
         from core.utils.exceptions import LabelStudioAPIException
         raise LabelStudioAPIException(f"Can't resolve hostname {domain}")

--- a/label_studio/core/utils/params.py
+++ b/label_studio/core/utils/params.py
@@ -2,7 +2,7 @@ import os
 from rest_framework.exceptions import ValidationError
 
 
-def cast_bool_from_str(value):
+def cast_bool_from_str(value):  # type: ignore[no-untyped-def]
     if isinstance(value, str):
         if value.lower() in ['true', 'yes', 'on', '1']:
             value = True
@@ -14,7 +14,7 @@ def cast_bool_from_str(value):
     return value
 
 
-def bool_from_request(params, key, default):
+def bool_from_request(params, key, default):  # type: ignore[no-untyped-def]
     """ Get boolean value from request GET, POST, etc
 
     :param params: dict POST, GET, etc
@@ -26,13 +26,13 @@ def bool_from_request(params, key, default):
 
     try:
         if isinstance(value, str):
-            value = cast_bool_from_str(value)
+            value = cast_bool_from_str(value)  # type: ignore[no-untyped-call]
         return bool(int(value))
     except Exception as e:
         raise ValidationError({key: str(e)})
 
 
-def int_from_request(params, key, default):
+def int_from_request(params, key, default):  # type: ignore[no-untyped-def]
     """ Get integer from request GET, POST, etc
 
     :param params: dict POST, GET, etc
@@ -59,7 +59,7 @@ def int_from_request(params, key, default):
                                     f'It should be digit string or integer.'})
 
 
-def float_from_request(params, key, default):
+def float_from_request(params, key, default):  # type: ignore[no-untyped-def]
     """ Get float from request GET, POST, etc
 
     :param params: dict POST, GET, etc
@@ -84,7 +84,7 @@ def float_from_request(params, key, default):
                                     f'It should be digit string or float.'})
 
 
-def list_of_strings_from_request(params, key, default):
+def list_of_strings_from_request(params, key, default):  # type: ignore[no-untyped-def]
     """ Get list of strings from request GET, POST, etc
 
     :param params: dict POST, GET, etc
@@ -107,26 +107,26 @@ def list_of_strings_from_request(params, key, default):
                                     f'It should be digit string or float.'})
 
 
-def get_env(name, default=None, is_bool=False):
+def get_env(name, default=None, is_bool=False):  # type: ignore[no-untyped-def]
     for env_key in ['LABEL_STUDIO_' + name, 'HEARTEX_' + name, name]:
         value = os.environ.get(env_key)
         if value is not None:
             if is_bool:
-                return bool_from_request(os.environ, env_key, default)
+                return bool_from_request(os.environ, env_key, default)  # type: ignore[no-untyped-call]
             else:
                 return value
     return default
 
 
-def get_bool_env(key, default):
-    return get_env(key, default, is_bool=True)
+def get_bool_env(key, default):  # type: ignore[no-untyped-def]
+    return get_env(key, default, is_bool=True)  # type: ignore[no-untyped-call]
 
 
-def get_env_list_int(key, default=None):
+def get_env_list_int(key, default=None):  # type: ignore[no-untyped-def]
     """
     "1,2,3" in env variable => [1, 2, 3] in python
     """
-    value = get_env(key)
+    value = get_env(key)  # type: ignore[no-untyped-call]
     if not value:
         if default is None:
             return []
@@ -134,13 +134,13 @@ def get_env_list_int(key, default=None):
     return [int(el) for el in value.split(',')]
 
 
-def get_all_env_with_prefix(prefix=None, is_bool=True, default_value=None):
+def get_all_env_with_prefix(prefix=None, is_bool=True, default_value=None):  # type: ignore[no-untyped-def]
     out = {}
     for key in os.environ.keys():
         if not key.startswith(prefix):
             continue
         if is_bool:
-            out[key] = bool_from_request(os.environ, key, default_value)
+            out[key] = bool_from_request(os.environ, key, default_value)  # type: ignore[no-untyped-call]
         else:
             out[key] = os.environ[key]
     return out

--- a/label_studio/core/utils/sentry.py
+++ b/label_studio/core/utils/sentry.py
@@ -1,7 +1,7 @@
 from django.conf import *
 
 
-def event_processor(event, hint):
+def event_processor(event, hint):  # type: ignore[no-untyped-def]
     # skip all transactions without errors
     if 'exc_info' not in hint:
         return None
@@ -57,7 +57,7 @@ def event_processor(event, hint):
     return event  # to return all other events
 
 
-def init_sentry(release_name, release_version):
+def init_sentry(release_name, release_version):  # type: ignore[no-untyped-def]
     if settings.SENTRY_DSN:
         import sentry_sdk
         from sentry_sdk.integrations.django import DjangoIntegration

--- a/label_studio/core/utils/static_serve.py
+++ b/label_studio/core/utils/static_serve.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from django.http import (
     FileResponse, Http404, HttpResponseNotModified,
 )
-from ranged_fileresponse import RangedFileResponse
+from ranged_fileresponse import RangedFileResponse  # type: ignore[import]
 
 from django.utils._os import safe_join
 from django.utils.http import http_date
@@ -17,7 +17,7 @@ from django.utils.translation import gettext as _
 from django.views.static import was_modified_since
 
 
-def serve(request, path, document_root=None, show_indexes=False):
+def serve(request, path, document_root=None, show_indexes=False):  # type: ignore[no-untyped-def]
     """
     Serve static files below a given point in the directory structure.
 

--- a/label_studio/core/utils/windows_sqlite_fix/__init__.py
+++ b/label_studio/core/utils/windows_sqlite_fix/__init__.py
@@ -8,7 +8,7 @@ import requests
 logger = logging.getLogger('main')
 
 
-def start_fix():
+def start_fix():  # type: ignore[no-untyped-def]
     import zipfile
     import platform
 
@@ -39,7 +39,7 @@ def start_fix():
     exit()
 
 
-def windows_dll_fix():
+def windows_dll_fix():  # type: ignore[no-untyped-def]
     """ Copy sqlite.dll to the current directory and use it """
     auto_agree = any([a == '--agree-fix-sqlite' for a in sys.argv])
     force_fix = any([a == '--force-fix-sqlite' for a in sys.argv])

--- a/label_studio/core/validators.py
+++ b/label_studio/core/validators.py
@@ -4,7 +4,7 @@ from django.core.validators import BaseValidator
 
 
 class JSONSchemaValidator(BaseValidator):
-    def compare(self, input, schema):
+    def compare(self, input, schema):  # type: ignore[no-untyped-def]
         try:
             jsonschema.validate(input, schema)
         except jsonschema.exceptions.ValidationError:

--- a/label_studio/core/version.py
+++ b/label_studio/core/version.py
@@ -22,7 +22,7 @@ VERSION_OVERRIDE = os.getenv('VERSION_OVERRIDE', '')
 BRANCH_OVERRIDE = os.getenv('BRANCH_OVERRIDE', '')
 
 
-def _write_py(info):
+def _write_py(info):  # type: ignore[no-untyped-def]
     # go to current dir to package __init__.py
     cwd = os.getcwd()
     d = os.path.dirname(__file__)
@@ -39,7 +39,7 @@ def _write_py(info):
                 '\n# Do not include it to git!\n')
 
 
-def _read_py(ls=False):
+def _read_py(ls=False):  # type: ignore[no-untyped-def]
     # go to current dir to package __init__.py
     cwd = os.getcwd()
     d = os.path.dirname(__file__)
@@ -48,18 +48,18 @@ def _read_py(ls=False):
     os.chdir(d)
 
     # read version
-    def import_version_module(file_path):
+    def import_version_module(file_path):  # type: ignore[no-untyped-def]
         try:
             return __import__(os.path.splitext(file_path)[0])
         except ImportError:
             return None
 
     try:
-        version_module = import_version_module(LS_VERSION_FILE if ls else VERSION_FILE)
+        version_module = import_version_module(LS_VERSION_FILE if ls else VERSION_FILE)  # type: ignore[no-untyped-call]
 
         if not version_module and ls:
             logging.warning(f"Can't read version file: {LS_VERSION_FILE}. Fall back to: {VERSION_FILE}")
-            version_module = import_version_module(VERSION_FILE)
+            version_module = import_version_module(VERSION_FILE)  # type: ignore[no-untyped-call]
 
         if version_module:
             return version_module.info
@@ -71,7 +71,7 @@ def _read_py(ls=False):
 
 
 # get commit info: message, date, hash, branch
-def get_git_commit_info(skip_os=True, ls=False):
+def get_git_commit_info(skip_os=True, ls=False):  # type: ignore[no-untyped-def]
 
     cwd = os.getcwd()
     d = os.path.dirname(__file__)
@@ -90,7 +90,7 @@ def get_git_commit_info(skip_os=True, ls=False):
             }
         except CalledProcessError:
             os.chdir(cwd)
-            return _read_py(ls=True)
+            return _read_py(ls=True)  # type: ignore[no-untyped-call]
 
         # create package version
         version = desc.lstrip('v').rstrip().replace('-', '+', 1).replace('-', '.')
@@ -103,7 +103,7 @@ def get_git_commit_info(skip_os=True, ls=False):
                 version += '.' + os_version
         info['version'] = VERSION_OVERRIDE if VERSION_OVERRIDE else version
 
-        _write_py(info)
+        _write_py(info)  # type: ignore[no-untyped-call]
         return info
 
     except Exception as e:
@@ -113,17 +113,17 @@ def get_git_commit_info(skip_os=True, ls=False):
         os.chdir(cwd)  # back current dir
 
 
-def get_git_version(skip_os=True):
-    info = get_git_commit_info(skip_os)
+def get_git_version(skip_os=True):  # type: ignore[no-untyped-def]
+    info = get_git_commit_info(skip_os)  # type: ignore[no-untyped-call]
     return info.get('version', '')
 
 
 # get only tag from git
-def get_short_version():
-    version = get_git_version()
+def get_short_version():  # type: ignore[no-untyped-def]
+    version = get_git_version()  # type: ignore[no-untyped-call]
     return version.split('+')[0]
 
 
 if __name__ == '__main__':
     # init version_.py file
-    get_git_version()
+    get_git_version()  # type: ignore[no-untyped-call]

--- a/label_studio/core/views.py
+++ b/label_studio/core/views.py
@@ -14,13 +14,13 @@ from django.utils._os import safe_join
 from django.conf import settings
 from django.contrib.auth import logout
 from django.http import HttpResponse, HttpResponseServerError, HttpResponseForbidden, HttpResponseNotFound
-from django.shortcuts import redirect, reverse
+from django.shortcuts import redirect, reverse  # type: ignore[attr-defined]
 from django.template import loader
-from ranged_fileresponse import RangedFileResponse
+from ranged_fileresponse import RangedFileResponse  # type: ignore[import]
 from django.http import JsonResponse
 from wsgiref.util import FileWrapper
 from rest_framework.views import APIView
-from drf_yasg.utils import swagger_auto_schema
+from drf_yasg.utils import swagger_auto_schema  # type: ignore[import]
 from django.db.models import Value, F, CharField
 
 from core import utils
@@ -28,7 +28,7 @@ from core.utils.io import find_file
 from core.label_config import generate_time_series_json
 from core.utils.common import collect_versions
 from io_storages.localfiles.models import LocalFilesImportStorage
-from core.feature_flags import all_flags, get_feature_file_path
+from core.feature_flags import all_flags, get_feature_file_path  # type: ignore[attr-defined, attr-defined]
 
 
 logger = logging.getLogger(__name__)
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 _PARAGRAPH_SAMPLE = None
 
 
-def main(request):
+def main(request):  # type: ignore[no-untyped-def]
     user = request.user
 
     if user.is_authenticated:
@@ -53,14 +53,14 @@ def main(request):
     return redirect(reverse('user-login'))
 
 
-def version_page(request):
+def version_page(request):  # type: ignore[no-untyped-def]
     """ Get platform version
     """
     # update the latest version from pypi response
     # from label_studio.core.utils.common import check_for_the_latest_version
     # check_for_the_latest_version(print_message=False)
     http_page = request.path == '/version/'
-    result = collect_versions(force=http_page)
+    result = collect_versions(force=http_page)  # type: ignore[no-untyped-call]
 
     # html / json response
     if request.path == '/version/':
@@ -76,7 +76,7 @@ def version_page(request):
         return JsonResponse(result)
 
 
-def health(request):
+def health(request):  # type: ignore[no-untyped-def]
     """ System health info """
     logger.debug('Got /health request.')
     return HttpResponse(json.dumps({
@@ -84,7 +84,7 @@ def health(request):
     }))
 
 
-def metrics(request):
+def metrics(request):  # type: ignore[no-untyped-def]
     """ Empty page for metrics evaluation """
     return HttpResponse('')
 
@@ -95,25 +95,25 @@ class TriggerAPIError(APIView):
     permission_classes = ()
 
     @swagger_auto_schema(auto_schema=None)
-    def get(self, request):
+    def get(self, request):  # type: ignore[no-untyped-def]
         raise Exception('test')
 
 
-def editor_files(request):
+def editor_files(request):  # type: ignore[no-untyped-def]
     """ Get last editor files
     """
-    response = utils.common.find_editor_files()
+    response = utils.common.find_editor_files()  # type: ignore[no-untyped-call]
     return HttpResponse(json.dumps(response), status=200)
 
 
-def custom_500(request):
+def custom_500(request):  # type: ignore[no-untyped-def]
     """ Custom 500 page """
     t = loader.get_template('500.html')
     type_, value, tb = sys.exc_info()
     return HttpResponseServerError(t.render({'exception': value}))
 
 
-def samples_time_series(request):
+def samples_time_series(request):  # type: ignore[no-untyped-def]
     """ Generate time series example for preview
     """
     time_column = request.GET.get('time', '')
@@ -137,7 +137,7 @@ def samples_time_series(request):
         max_column_n = max([int(v) for v in value_columns] + [0])
         value_columns = range(1, max_column_n+1)
 
-    ts = generate_time_series_json(time_column, value_columns, time_format)
+    ts = generate_time_series_json(time_column, value_columns, time_format)  # type: ignore[no-untyped-call]
     csv_data = pd.DataFrame.from_dict(ts).to_csv(index=False, header=header, sep=separator).encode('utf-8')
 
     # generate response data as file
@@ -148,13 +148,13 @@ def samples_time_series(request):
     return response
 
 
-def samples_paragraphs(request):
+def samples_paragraphs(request):  # type: ignore[no-untyped-def]
     """ Generate paragraphs example for preview
     """
     global _PARAGRAPH_SAMPLE
 
     if _PARAGRAPH_SAMPLE is None:
-        with open(find_file('paragraphs.json'), encoding='utf-8') as f:
+        with open(find_file('paragraphs.json'), encoding='utf-8') as f:  # type: ignore[no-untyped-call]
             _PARAGRAPH_SAMPLE = json.load(f)
     name_key = request.GET.get('nameKey', 'author')
     text_key = request.GET.get('textKey', 'text')
@@ -166,7 +166,7 @@ def samples_paragraphs(request):
     return HttpResponse(json.dumps(result), content_type='application/json')
 
 
-def localfiles_data(request):
+def localfiles_data(request):  # type: ignore[no-untyped-def]
     """Serving files for LocalFilesImportStorage"""
     user = request.user
     path = request.GET.get('d')
@@ -200,12 +200,12 @@ def localfiles_data(request):
     return HttpResponseForbidden()
 
 
-def static_file_with_host_resolver(path_on_disk, content_type):
+def static_file_with_host_resolver(path_on_disk, content_type):  # type: ignore[no-untyped-def]
     """ Load any file, replace {{HOSTNAME}} => settings.HOSTNAME, send it as http response
     """
     path_on_disk = os.path.join(os.path.dirname(__file__), path_on_disk)
 
-    def serve_file(request):
+    def serve_file(request):  # type: ignore[no-untyped-def]
         with open(path_on_disk, 'r') as f:
             body = f.read()
             body = body.replace('{{HOSTNAME}}', settings.HOSTNAME)
@@ -214,7 +214,7 @@ def static_file_with_host_resolver(path_on_disk, content_type):
             out.write(body)
             out.seek(0)
 
-            wrapper = FileWrapper(out)
+            wrapper = FileWrapper(out)  # type: ignore[arg-type]
             response = HttpResponse(wrapper, content_type=content_type)
             response['Content-Length'] = len(body)
             return response
@@ -222,18 +222,18 @@ def static_file_with_host_resolver(path_on_disk, content_type):
     return serve_file
 
 
-def feature_flags(request):
+def feature_flags(request):  # type: ignore[no-untyped-def]
     user = request.user
     if not user.is_authenticated:
         return HttpResponseForbidden()
 
-    flags = all_flags(request.user)
+    flags = all_flags(request.user)  # type: ignore[no-untyped-call]
     flags['$system'] = {
         'FEATURE_FLAGS_DEFAULT_VALUE': settings.FEATURE_FLAGS_DEFAULT_VALUE,
         'FEATURE_FLAGS_FROM_FILE': settings.FEATURE_FLAGS_FROM_FILE,
-        'FEATURE_FLAGS_FILE': get_feature_file_path(),
+        'FEATURE_FLAGS_FILE': get_feature_file_path(),  # type: ignore[no-untyped-call]
         'VERSION_EDITION': settings.VERSION_EDITION,
-        'CLOUD_INSTANCE': settings.CLOUD_INSTANCE if hasattr(settings, 'CLOUD_INSTANCE') else None
+        'CLOUD_INSTANCE': settings.CLOUD_INSTANCE if hasattr(settings, 'CLOUD_INSTANCE') else None  # type: ignore[misc]
     }
 
     return HttpResponse('<pre>' + json.dumps(flags, indent=4) + '</pre>', status=200)

--- a/label_studio/data_export/mixins.py
+++ b/label_studio/data_export/mixins.py
@@ -13,8 +13,8 @@ from django.db import transaction
 from django.db.models import Prefetch
 from django.db.models.query_utils import Q
 from django.utils import dateformat, timezone
-import django_rq
-from label_studio_converter import Converter
+import django_rq  # type: ignore[import]
+from label_studio_converter import Converter  # type: ignore[import]
 from django.conf import settings
 
 from core.redis import redis_connected
@@ -39,14 +39,14 @@ logger = logging.getLogger(__name__)
 
 
 class ExportMixin:
-    def has_permission(self, user):
-        user.project = self.project  # link for activity log
-        return self.project.has_permission(user)
+    def has_permission(self, user):  # type: ignore[no-untyped-def]
+        user.project = self.project    # type: ignore[attr-defined] # link for activity log
+        return self.project.has_permission(user)  # type: ignore[attr-defined]
 
-    def get_default_title(self):
-        return f"{self.project.title.replace(' ', '-')}-at-{dateformat.format(timezone.now(), 'Y-m-d-H-i')}"
+    def get_default_title(self):  # type: ignore[no-untyped-def]
+        return f"{self.project.title.replace(' ', '-')}-at-{dateformat.format(timezone.now(), 'Y-m-d-H-i')}"  # type: ignore[attr-defined]
 
-    def _get_filtered_tasks(self, tasks, task_filter_options=None):
+    def _get_filtered_tasks(self, tasks, task_filter_options=None):  # type: ignore[no-untyped-def]
         """
         task_filter_options: None or Dict({
             view: optional int id or View
@@ -60,36 +60,36 @@ class ExportMixin:
         if 'view' in task_filter_options:
             try:
                 value = int(task_filter_options['view'])
-                prepare_params = View.objects.get(project=self.project, id=value).get_prepare_tasks_params(
+                prepare_params = View.objects.get(project=self.project, id=value).get_prepare_tasks_params(  # type: ignore[attr-defined, no-untyped-call]
                     add_selected_items=True
                 )
-                tab_tasks = Task.prepared.only_filtered(prepare_params=prepare_params).values_list('id', flat=True)
+                tab_tasks = Task.prepared.only_filtered(prepare_params=prepare_params).values_list('id', flat=True)  # type: ignore[no-untyped-call]
                 tasks = tasks.filter(id__in=tab_tasks)
             except (ValueError, View.DoesNotExist) as exc:
                 logger.warning(f'Incorrect view params {exc}')
         if 'skipped' in task_filter_options:
             value = task_filter_options['skipped']
-            if value == ONLY:
+            if value == ONLY:  # type: ignore[comparison-overlap]
                 tasks = tasks.filter(annotations__was_cancelled=True)
-            elif value == EXCLUDE:
+            elif value == EXCLUDE:  # type: ignore[comparison-overlap]
                 tasks = tasks.exclude(annotations__was_cancelled=True)
         if 'finished' in task_filter_options:
             value = task_filter_options['finished']
-            if value == ONLY:
+            if value == ONLY:  # type: ignore[comparison-overlap]
                 tasks = tasks.filter(is_labeled=True)
-            elif value == EXCLUDE:
+            elif value == EXCLUDE:  # type: ignore[comparison-overlap]
                 tasks = tasks.exclude(is_labeled=True)
         if 'annotated' in task_filter_options:
             value = task_filter_options['annotated']
             # if any annotation exists and is not cancelled
-            if value == ONLY:
+            if value == ONLY:  # type: ignore[comparison-overlap]
                 tasks = tasks.filter(annotations__was_cancelled=False)
-            elif value == EXCLUDE:
+            elif value == EXCLUDE:  # type: ignore[comparison-overlap]
                 tasks = tasks.exclude(annotations__was_cancelled=False)
 
         return tasks
 
-    def _get_filtered_annotations_queryset(self, annotation_filter_options=None):
+    def _get_filtered_annotations_queryset(self, annotation_filter_options=None):  # type: ignore[no-untyped-def]
         """
         Filtering using disjunction of conditions
 
@@ -117,8 +117,8 @@ class ExportMixin:
         return queryset.filter(q)
 
     @staticmethod
-    def _get_export_serializer_option(serialization_options):
-        options = {'expand': []}
+    def _get_export_serializer_option(serialization_options):  # type: ignore[no-untyped-def]
+        options = {'expand': []}  # type: ignore[var-annotated]
         if isinstance(serialization_options, dict):
             if (
                 'drafts' in serialization_options
@@ -136,13 +136,13 @@ class ExportMixin:
                 'annotations__completed_by'
             ].get('only_id'):
                 options['expand'].append('annotations.completed_by')
-            options['context'] = {'interpolate_key_frames': settings.INTERPOLATE_KEY_FRAMES}
+            options['context'] = {'interpolate_key_frames': settings.INTERPOLATE_KEY_FRAMES}  # type: ignore[assignment]
             if 'interpolate_key_frames' in serialization_options:
-                options['context']['interpolate_key_frames'] = serialization_options['interpolate_key_frames']
+                options['context']['interpolate_key_frames'] = serialization_options['interpolate_key_frames']  # type: ignore[call-overload]
         return options
 
-    def get_task_queryset(self, ids, annotation_filter_options):
-        annotations_qs = self._get_filtered_annotations_queryset(
+    def get_task_queryset(self, ids, annotation_filter_options):  # type: ignore[no-untyped-def]
+        annotations_qs = self._get_filtered_annotations_queryset(  # type: ignore[no-untyped-call]
             annotation_filter_options=annotation_filter_options
         )
         return Task.objects.filter(id__in=ids).prefetch_related(
@@ -154,7 +154,7 @@ class ExportMixin:
                 'predictions', 'drafts'
             )
 
-    def get_export_data(self, task_filter_options=None, annotation_filter_options=None, serialization_options=None):
+    def get_export_data(self, task_filter_options=None, annotation_filter_options=None, serialization_options=None):  # type: ignore[no-untyped-def]
         """
         serialization_options: None or Dict({
             drafts: optional
@@ -186,19 +186,19 @@ class ExportMixin:
             # counters = Project.objects.with_counts().filter(id=self.project.id)[0].get_counters()
             self.counters = {'task_number': 0}
             result = []
-            all_tasks = self.project.tasks
+            all_tasks = self.project.tasks  # type: ignore[attr-defined]
             logger.debug('Tasks filtration')
             task_ids = (
-                self._get_filtered_tasks(all_tasks, task_filter_options=task_filter_options)
+                self._get_filtered_tasks(all_tasks, task_filter_options=task_filter_options)  # type: ignore[no-untyped-call]
                 .distinct()
                 .values_list('id', flat=True)
             )
-            base_export_serializer_option = self._get_export_serializer_option(serialization_options)
+            base_export_serializer_option = self._get_export_serializer_option(serialization_options)  # type: ignore[no-untyped-call]
             i = 0
             BATCH_SIZE = 1000
-            for ids in batch(task_ids, BATCH_SIZE):
+            for ids in batch(task_ids, BATCH_SIZE):  # type: ignore[no-untyped-call]
                 i += 1
-                tasks = list(self.get_task_queryset(ids, annotation_filter_options))
+                tasks = list(self.get_task_queryset(ids, annotation_filter_options))  # type: ignore[no-untyped-call]
                 logger.debug(f'Batch: {i*BATCH_SIZE}')
                 if isinstance(task_filter_options, dict) and task_filter_options.get('only_with_annotations'):
                     tasks = [task for task in tasks if task.annotations.exists()]
@@ -209,7 +209,7 @@ class ExportMixin:
                     yield task
 
     @staticmethod
-    def eval_md5(file):
+    def eval_md5(file):  # type: ignore[no-untyped-def]
         md5_object = hashlib.md5()   # nosec
         block_size = 128 * md5_object.block_size
         chunk = file.read(block_size)
@@ -219,28 +219,28 @@ class ExportMixin:
         md5 = md5_object.hexdigest()
         return md5
 
-    def save_file(self, file, md5):
+    def save_file(self, file, md5):  # type: ignore[no-untyped-def]
         now = datetime.now()
-        file_name = f'project-{self.project.id}-at-{now.strftime("%Y-%m-%d-%H-%M")}-{md5[0:8]}.json'
+        file_name = f'project-{self.project.id}-at-{now.strftime("%Y-%m-%d-%H-%M")}-{md5[0:8]}.json'  # type: ignore[attr-defined]
         file_path = (
-            f'{self.project.id}/{file_name}'
+            f'{self.project.id}/{file_name}'  # type: ignore[attr-defined]
         )  # finally file will be in settings.DELAYED_EXPORT_DIR/self.project.id/file_name
         file_ = File(file, name=file_path)
-        self.file.save(file_path, file_)
+        self.file.save(file_path, file_)  # type: ignore[attr-defined]
         self.md5 = md5
-        self.save(update_fields=['file', 'md5', 'counters'])
+        self.save(update_fields=['file', 'md5', 'counters'])  # type: ignore[attr-defined]
 
-    def export_to_file(self, task_filter_options=None, annotation_filter_options=None, serialization_options=None):
+    def export_to_file(self, task_filter_options=None, annotation_filter_options=None, serialization_options=None):  # type: ignore[no-untyped-def]
         logger.debug(
-            f'Run export for {self.id} with params:\n'
+            f'Run export for {self.id} with params:\n'  # type: ignore[attr-defined]
             f'task_filter_options: {task_filter_options}\n'
             f'annotation_filter_options: {annotation_filter_options}\n'
             f'serialization_options: {serialization_options}\n'
         )
         try:
             iter_json = json.JSONEncoder(ensure_ascii=False).iterencode(
-                SerializableGenerator(
-                    self.get_export_data(
+                SerializableGenerator(  # type: ignore[no-untyped-call]
+                    self.get_export_data(  # type: ignore[no-untyped-call]
                         task_filter_options=task_filter_options,
                         annotation_filter_options=annotation_filter_options,
                         serialization_options=serialization_options,
@@ -253,33 +253,33 @@ class ExportMixin:
                     file.write(encoded_chunk)
                 file.seek(0)
 
-                md5 = self.eval_md5(file)
-                self.save_file(file, md5)
+                md5 = self.eval_md5(file)  # type: ignore[no-untyped-call]
+                self.save_file(file, md5)  # type: ignore[no-untyped-call]
 
-            self.status = self.Status.COMPLETED
-            self.save(update_fields=['status'])
+            self.status = self.Status.COMPLETED  # type: ignore[attr-defined]
+            self.save(update_fields=['status'])  # type: ignore[attr-defined]
 
         except Exception as exc:
-            self.status = self.Status.FAILED
-            self.save(update_fields=['status'])
+            self.status = self.Status.FAILED  # type: ignore[attr-defined]
+            self.save(update_fields=['status'])  # type: ignore[attr-defined]
             logger.exception('Export was failed')
         finally:
             self.finished_at = datetime.now()
-            self.save(update_fields=['finished_at'])
+            self.save(update_fields=['finished_at'])  # type: ignore[attr-defined]
 
-    def run_file_exporting(self, task_filter_options=None, annotation_filter_options=None, serialization_options=None):
-        if self.status == self.Status.IN_PROGRESS:
+    def run_file_exporting(self, task_filter_options=None, annotation_filter_options=None, serialization_options=None):  # type: ignore[no-untyped-def]
+        if self.status == self.Status.IN_PROGRESS:  # type: ignore[attr-defined]
             logger.warning('Try to export with in progress stage')
             return
 
-        self.status = self.Status.IN_PROGRESS
-        self.save(update_fields=['status'])
+        self.status = self.Status.IN_PROGRESS  # type: ignore[attr-defined]
+        self.save(update_fields=['status'])  # type: ignore[attr-defined]
 
-        if redis_connected():
+        if redis_connected():  # type: ignore[no-untyped-call]
             queue = django_rq.get_queue('default')
             job = queue.enqueue(
                 export_background,
-                self.id,
+                self.id,  # type: ignore[attr-defined]
                 task_filter_options,
                 annotation_filter_options,
                 serialization_options,
@@ -287,34 +287,34 @@ class ExportMixin:
                 job_timeout='3h',  # 3 hours
             )
         else:
-            self.export_to_file(
+            self.export_to_file(  # type: ignore[no-untyped-call]
                 task_filter_options=task_filter_options,
                 annotation_filter_options=annotation_filter_options,
                 serialization_options=serialization_options,
             )
 
-    def convert_file(self, to_format):
+    def convert_file(self, to_format):  # type: ignore[no-untyped-def]
         with get_temp_dir() as tmp_dir:
             OUT = 'out'
             out_dir = pathlib.Path(tmp_dir) / OUT
             out_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
 
             converter = Converter(
-                config=self.project.get_parsed_config(),
+                config=self.project.get_parsed_config(),  # type: ignore[attr-defined]
                 project_dir=None,
                 upload_dir=out_dir,
                 download_resources=False,
             )
-            input_name = pathlib.Path(self.file.name).name
+            input_name = pathlib.Path(self.file.name).name  # type: ignore[attr-defined]
             input_file_path = pathlib.Path(tmp_dir) / input_name
 
             with open(input_file_path, 'wb') as file_:
-                file_.write(self.file.open().read())
+                file_.write(self.file.open().read())  # type: ignore[attr-defined]
 
             converter.convert(input_file_path, out_dir, to_format, is_dir=False)
 
-            files = get_all_files_from_dir(out_dir)
-            dirs = get_all_dirs_from_dir(out_dir)
+            files = get_all_files_from_dir(out_dir)  # type: ignore[no-untyped-call]
+            dirs = get_all_dirs_from_dir(out_dir)  # type: ignore[no-untyped-call]
 
             if len(files) == 0 and len(dirs) == 0:
                 return None
@@ -322,18 +322,18 @@ class ExportMixin:
                 output_file = files[0]
                 filename = pathlib.Path(input_name).stem + pathlib.Path(output_file).suffix
             else:
-                shutil.make_archive(out_dir, 'zip', out_dir)
+                shutil.make_archive(out_dir, 'zip', out_dir)  # type: ignore[arg-type]
                 output_file = pathlib.Path(tmp_dir) / (str(out_dir.stem) + '.zip')
                 filename = pathlib.Path(input_name).stem + '.zip'
 
-            out = read_bytes_stream(output_file)
+            out = read_bytes_stream(output_file)  # type: ignore[no-untyped-call]
             return File(
                 out,
                 name=filename,
             )
 
 
-def export_background(
+def export_background(  # type: ignore[no-untyped-def]
     export_id, task_filter_options, annotation_filter_options, serialization_options, *args, **kwargs
 ):
     from data_export.models import Export
@@ -345,7 +345,7 @@ def export_background(
     )
 
 
-def set_export_background_failure(job, connection, type, value, traceback):
+def set_export_background_failure(job, connection, type, value, traceback):  # type: ignore[no-untyped-def]
     from data_export.models import Export
 
     export_id = job.args[0]

--- a/label_studio/data_export/serializers.py
+++ b/label_studio/data_export/serializers.py
@@ -1,8 +1,8 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
 from django.conf import settings
-from label_studio_tools.core.label_config import is_video_object_tracking
-from rest_flex_fields import FlexFieldsModelSerializer
+from label_studio_tools.core.label_config import is_video_object_tracking  # type: ignore[import]
+from rest_flex_fields import FlexFieldsModelSerializer  # type: ignore[import]
 from rest_framework import serializers
 
 from core.label_config import replace_task_data_undefined_with_config_field
@@ -13,19 +13,19 @@ from tasks.serializers import AnnotationDraftSerializer, PredictionSerializer
 from users.models import User
 from data_export.models import DataExport
 from users.serializers import UserSimpleSerializer
-from label_studio_tools.postprocessing.video import extract_key_frames
+from label_studio_tools.postprocessing.video import extract_key_frames  # type: ignore[import]
 
 from .models import Export, ConvertedFormat
 
 
-class CompletedBySerializer(serializers.ModelSerializer):
+class CompletedBySerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
     class Meta:
         model = User
         fields = ['id', 'email', 'first_name', 'last_name']
 
 
-class AnnotationSerializer(FlexFieldsModelSerializer):
-    completed_by = serializers.PrimaryKeyRelatedField(read_only=True)
+class AnnotationSerializer(FlexFieldsModelSerializer):  # type: ignore[misc]
+    completed_by = serializers.PrimaryKeyRelatedField(read_only=True)  # type: ignore[var-annotated]
     result = serializers.SerializerMethodField()
 
     class Meta:
@@ -33,7 +33,7 @@ class AnnotationSerializer(FlexFieldsModelSerializer):
         fields = '__all__'
         expandable_fields = {'completed_by': (CompletedBySerializer,)}
 
-    def get_result(self, obj):
+    def get_result(self, obj):  # type: ignore[no-untyped-def]
         # run frames extraction on param, result and result type
         if obj.result and self.context.get('interpolate_key_frames', False) and \
                 is_video_object_tracking(parsed_config=obj.project.get_parsed_config()):
@@ -41,14 +41,14 @@ class AnnotationSerializer(FlexFieldsModelSerializer):
         return obj.result
 
 
-class BaseExportDataSerializer(FlexFieldsModelSerializer):
+class BaseExportDataSerializer(FlexFieldsModelSerializer):  # type: ignore[misc]
     annotations = AnnotationSerializer(many=True, read_only=True)
     file_upload = serializers.ReadOnlyField(source='file_upload_name')
-    drafts = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
-    predictions = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+    drafts = serializers.PrimaryKeyRelatedField(many=True, read_only=True)  # type: ignore[var-annotated]
+    predictions = serializers.PrimaryKeyRelatedField(many=True, read_only=True)  # type: ignore[var-annotated]
 
     # resolve $undefined$ key in task data, if any
-    def to_representation(self, task):
+    def to_representation(self, task):  # type: ignore[no-untyped-def]
         # avoid long project initializations
         project = getattr(self, '_project', None)
         if project is None:
@@ -59,7 +59,7 @@ class BaseExportDataSerializer(FlexFieldsModelSerializer):
         # add interpolate_key_frames param to annotations serializer
         if 'annotations' in self.fields:
             self.fields['annotations'].context['interpolate_key_frames'] = self.context.get('interpolate_key_frames', False)
-        replace_task_data_undefined_with_config_field(data, project)
+        replace_task_data_undefined_with_config_field(data, project)  # type: ignore[no-untyped-call]
 
         return super().to_representation(task)
 
@@ -73,13 +73,13 @@ class BaseExportDataSerializer(FlexFieldsModelSerializer):
         }
 
 
-class ConvertedFormatSerializer(serializers.ModelSerializer):
+class ConvertedFormatSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
     class Meta:
         model = ConvertedFormat
         fields = ['id', 'status', 'export_type', 'traceback']
 
 
-class ExportSerializer(serializers.ModelSerializer):
+class ExportSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
     class Meta:
         model = Export
         read_only = [
@@ -105,7 +105,7 @@ ONLY_OR_EXCLUDE_CHOICE = [
 ]
 
 
-class TaskFilterOptionsSerializer(serializers.Serializer):
+class TaskFilterOptionsSerializer(serializers.Serializer):  # type: ignore[type-arg]
     view = serializers.IntegerField(
         required=False,
         help_text='Apply filters from the view ID (a tab from the Data Manager)'
@@ -131,7 +131,7 @@ class TaskFilterOptionsSerializer(serializers.Serializer):
     )
 
 
-class AnnotationFilterOptionsSerializer(serializers.Serializer):
+class AnnotationFilterOptionsSerializer(serializers.Serializer):  # type: ignore[type-arg]
     usual = serializers.BooleanField(
         allow_null=True, required=False, default=True,
         help_text='Include not skipped and not ground truth annotations'
@@ -146,8 +146,8 @@ class AnnotationFilterOptionsSerializer(serializers.Serializer):
     )
 
 
-class SerializationOptionsSerializer(serializers.Serializer):
-    class SerializationOption(serializers.Serializer):
+class SerializationOptionsSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    class SerializationOption(serializers.Serializer):  # type: ignore[type-arg]
         only_id = serializers.BooleanField(
             default=False, required=False,
             help_text='Include a full json body or IDs only'
@@ -163,12 +163,12 @@ class SerializationOptionsSerializer(serializers.Serializer):
     )
 
 
-class ExportConvertSerializer(serializers.Serializer):
+class ExportConvertSerializer(serializers.Serializer):  # type: ignore[type-arg]
     export_type = serializers.CharField(help_text='Export file format.')
 
-    def validate_export_type(self, value):
+    def validate_export_type(self, value):  # type: ignore[no-untyped-def]
         project = self.context.get('project')
-        export_formats = [f['name'] for f in DataExport.get_export_formats(project)]
+        export_formats = [f['name'] for f in DataExport.get_export_formats(project)]  # type: ignore[no-untyped-call]
         if value not in export_formats:
             raise serializers.ValidationError(f'{value} is not supported export format')
         return value
@@ -187,7 +187,7 @@ class ExportCreateSerializer(ExportSerializer):
     serialization_options = SerializationOptionsSerializer(required=False, default=None)
 
 
-class ExportParamSerializer(serializers.Serializer):
+class ExportParamSerializer(serializers.Serializer):  # type: ignore[type-arg]
     interpolate_key_frames = serializers.BooleanField(default=settings.INTERPOLATE_KEY_FRAMES,
                                                       help_text='Interpolate video key frames.',
                                                       required=False)
@@ -209,4 +209,4 @@ class BaseExportDataSerializerForInteractive(InteractiveMixin, BaseExportDataSer
     pass
 
 
-ExportDataSerializer = load_func(settings.EXPORT_DATA_SERIALIZER)
+ExportDataSerializer = load_func(settings.EXPORT_DATA_SERIALIZER)  # type: ignore[no-untyped-call]

--- a/label_studio/data_import/models.py
+++ b/label_studio/data_import/models.py
@@ -8,17 +8,17 @@ from collections import Counter
 try:
     import ujson as json
 except:
-    import json
+    import json  # type: ignore[no-redef]
 
 from django.db import models
-from core.feature_flags import flag_set
+from core.feature_flags import flag_set  # type: ignore[attr-defined]
 from django.conf import settings
 from rest_framework.exceptions import ValidationError
 
 logger = logging.getLogger(__name__)
 
 
-def upload_name_generator(instance, filename):
+def upload_name_generator(instance, filename):  # type: ignore[no-untyped-def]
     project = str(instance.project_id)
     project_dir = os.path.join(settings.MEDIA_ROOT, settings.UPLOAD_DIR, project)
     os.makedirs(project_dir, exist_ok=True)
@@ -31,18 +31,18 @@ class FileUpload(models.Model):
     project = models.ForeignKey('projects.Project', related_name='file_uploads', on_delete=models.CASCADE)
     file = models.FileField(upload_to=upload_name_generator)
 
-    def has_permission(self, user):
+    def has_permission(self, user):  # type: ignore[no-untyped-def]
         user.project = self.project  # link for activity log
         return self.project.has_permission(user)
 
     @property
-    def filepath(self):
+    def filepath(self):  # type: ignore[no-untyped-def]
         return self.file.name
 
     @property
-    def url(self):
+    def url(self):  # type: ignore[no-untyped-def]
         if settings.HOSTNAME and settings.CLOUD_FILE_STORAGE_ENABLED:
-            if flag_set('ff_back_dev_2915_storage_nginx_proxy_26092022_short', self.project.organization.created_by):
+            if flag_set('ff_back_dev_2915_storage_nginx_proxy_26092022_short', self.project.organization.created_by):  # type: ignore[no-untyped-call, union-attr]
                 return self.file.url
             else:
                 return settings.HOSTNAME + self.file.url
@@ -52,7 +52,7 @@ class FileUpload(models.Model):
             return self.file.url
 
     @property
-    def format(self):
+    def format(self):  # type: ignore[no-untyped-def]
         filepath = self.file.name
         file_format = None
         try:
@@ -64,7 +64,7 @@ class FileUpload(models.Model):
         return file_format
 
     @property
-    def content(self):
+    def content(self):  # type: ignore[no-untyped-def]
         # cache file body
         if hasattr(self, '_file_body'):
             body = getattr(self, '_file_body')
@@ -73,22 +73,22 @@ class FileUpload(models.Model):
             setattr(self, '_file_body', body)
         return body
 
-    def read_tasks_list_from_csv(self, sep=','):
+    def read_tasks_list_from_csv(self, sep=','):  # type: ignore[no-untyped-def]
         logger.debug('Read tasks list from CSV file {}'.format(self.file.name))
         tasks = pd.read_csv(self.file.open(), sep=sep).fillna('').to_dict('records')
         tasks = [{'data': task} for task in tasks]
         return tasks
 
-    def read_tasks_list_from_tsv(self):
-        return self.read_tasks_list_from_csv('\t')
+    def read_tasks_list_from_tsv(self):  # type: ignore[no-untyped-def]
+        return self.read_tasks_list_from_csv('\t')  # type: ignore[no-untyped-call]
 
-    def read_tasks_list_from_txt(self):
+    def read_tasks_list_from_txt(self):  # type: ignore[no-untyped-def]
         logger.debug('Read tasks list from text file {}'.format(self.file.name))
         lines = self.content.splitlines()
         tasks = [{'data': {settings.DATA_UNDEFINED_NAME: line}} for line in lines]
         return tasks
 
-    def read_tasks_list_from_json(self):
+    def read_tasks_list_from_json(self):  # type: ignore[no-untyped-def]
         logger.debug('Read tasks list from JSON file {}'.format(self.file.name))
 
         raw_data = self.content
@@ -108,13 +108,13 @@ class FileUpload(models.Model):
             tasks_formatted.append(task)
         return tasks_formatted
 
-    def read_task_from_hypertext_body(self):
+    def read_task_from_hypertext_body(self):  # type: ignore[no-untyped-def]
         logger.debug('Read 1 task from hypertext file {}'.format(self.file.name))
         body = self.content
         tasks = [{'data': {settings.DATA_UNDEFINED_NAME: body}}]
         return tasks
 
-    def read_task_from_uploaded_file(self):
+    def read_task_from_uploaded_file(self):  # type: ignore[no-untyped-def]
         logger.debug('Read 1 task from uploaded file {}'.format(self.file.name))
         if settings.CLOUD_FILE_STORAGE_ENABLED:
             tasks = [{'data': {settings.DATA_UNDEFINED_NAME: self.file.name}}]
@@ -123,21 +123,21 @@ class FileUpload(models.Model):
         return tasks
 
     @property
-    def format_could_be_tasks_list(self):
+    def format_could_be_tasks_list(self):  # type: ignore[no-untyped-def]
         return self.format in ('.csv', '.tsv', '.txt')
 
-    def read_tasks(self, file_as_tasks_list=True):
+    def read_tasks(self, file_as_tasks_list=True):  # type: ignore[no-untyped-def]
         file_format = self.format
         try:
             # file as tasks list
             if file_format == '.csv' and file_as_tasks_list:
-                tasks = self.read_tasks_list_from_csv()
+                tasks = self.read_tasks_list_from_csv()  # type: ignore[no-untyped-call]
             elif file_format == '.tsv' and file_as_tasks_list:
-                tasks = self.read_tasks_list_from_tsv()
+                tasks = self.read_tasks_list_from_tsv()  # type: ignore[no-untyped-call]
             elif file_format == '.txt' and file_as_tasks_list:
-                tasks = self.read_tasks_list_from_txt()
+                tasks = self.read_tasks_list_from_txt()  # type: ignore[no-untyped-call]
             elif file_format == '.json':
-                tasks = self.read_tasks_list_from_json()
+                tasks = self.read_tasks_list_from_json()  # type: ignore[no-untyped-call]
 
             # otherwise - only one object tag should be presented in label config
             elif not self.project.one_object_in_label_config:
@@ -147,19 +147,19 @@ class FileUpload(models.Model):
 
             # file as a single asset
             elif file_format in ('.html', '.htm', '.xml'):
-                tasks = self.read_task_from_hypertext_body()
+                tasks = self.read_task_from_hypertext_body()  # type: ignore[no-untyped-call]
             else:
-                tasks = self.read_task_from_uploaded_file()
+                tasks = self.read_task_from_uploaded_file()  # type: ignore[no-untyped-call]
 
         except Exception as exc:
             raise ValidationError('Failed to parse input file ' + self.file.name + ': ' + str(exc))
         return tasks
 
     @classmethod
-    def load_tasks_from_uploaded_files(cls, project, file_upload_ids=None, formats=None, files_as_tasks_list=True, trim_size=None):
+    def load_tasks_from_uploaded_files(cls, project, file_upload_ids=None, formats=None, files_as_tasks_list=True, trim_size=None):  # type: ignore[no-untyped-def]
         tasks = []
         fileformats = []
-        common_data_fields = set()
+        common_data_fields = set()  # type: ignore[var-annotated]
 
         # scan all files
         file_uploads = FileUpload.objects.filter(project=project)
@@ -169,7 +169,7 @@ class FileUpload(models.Model):
             file_format = file_upload.format
             if formats and file_format not in formats:
                 continue
-            new_tasks = file_upload.read_tasks(files_as_tasks_list)
+            new_tasks = file_upload.read_tasks(files_as_tasks_list)  # type: ignore[no-untyped-call]
             for task in new_tasks:
                 task['file_upload_id'] = file_upload.id
 
@@ -178,7 +178,7 @@ class FileUpload(models.Model):
                 common_data_fields = new_data_fields
             elif not common_data_fields.intersection(new_data_fields):
                 raise ValidationError(
-                    _old_vs_new_data_keys_inconsistency_message(
+                    _old_vs_new_data_keys_inconsistency_message(  # type: ignore[no-untyped-call]
                         new_data_fields, common_data_fields, file_upload.file.name
                     )
                 )
@@ -195,7 +195,7 @@ class FileUpload(models.Model):
         return tasks, dict(Counter(fileformats)), common_data_fields
 
 
-def _old_vs_new_data_keys_inconsistency_message(new_data_keys, old_data_keys, current_file):
+def _old_vs_new_data_keys_inconsistency_message(new_data_keys, old_data_keys, current_file):  # type: ignore[no-untyped-def]
     new_data_keys_list = ','.join(new_data_keys)
     old_data_keys_list = ','.join(old_data_keys)
     common_prefix = "You're trying to import inconsistent data:\n"

--- a/label_studio/data_import/serializers.py
+++ b/label_studio/data_import/serializers.py
@@ -8,7 +8,7 @@ from tasks.serializers import (
 from .models import FileUpload
 
 
-class ImportApiSerializer(TaskSerializer):
+class ImportApiSerializer(TaskSerializer):  # type: ignore[misc]
     """ Tasks serializer for Import API (TaskBulkCreateAPI)
     """
     annotations = AnnotationSerializer(many=True, default=[])
@@ -20,7 +20,7 @@ class ImportApiSerializer(TaskSerializer):
         exclude = ('is_labeled', 'project')
 
 
-class FileUploadSerializer(serializers.ModelSerializer):
+class FileUploadSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
     file = serializers.FileField(use_url=False)
 
     class Meta:

--- a/label_studio/data_manager/actions/__init__.py
+++ b/label_studio/data_manager/actions/__init__.py
@@ -16,12 +16,12 @@ from django.conf import settings
 from rest_framework.exceptions import PermissionDenied as DRFPermissionDenied
 
 from data_manager.functions import DataManagerException
-from core.feature_flags import flag_set
+from core.feature_flags import flag_set  # type: ignore[attr-defined]
 
 logger = logging.getLogger('django')
 
 
-def check_permissions(user, action):
+def check_permissions(user, action):  # type: ignore[no-untyped-def]
     """ Actions must have permissions, if only one is in the user role then the action is allowed
     """
     if 'permission' not in action:
@@ -31,7 +31,7 @@ def check_permissions(user, action):
     return user.has_perm(action['permission'])
 
 
-def get_all_actions(user, project):
+def get_all_actions(user, project):  # type: ignore[no-untyped-def]
     """ Return dict with registered actions
 
     :param user: list with user permissions
@@ -44,11 +44,11 @@ def get_all_actions(user, project):
     actions = [
         {key: action[key] for key in action if key != 'entry_point'}
         for action in actions if not action.get('hidden', False)
-        and check_permissions(user, action)
+        and check_permissions(user, action)  # type: ignore[no-untyped-call]
     ]
     # remove experimental features if they are disabled
     if not (
-            flag_set('ff_back_experimental_features', user=project.organization.created_by)
+            flag_set('ff_back_experimental_features', user=project.organization.created_by)  # type: ignore[no-untyped-call]
             or settings.EXPERIMENTAL_FEATURES
     ):
         actions = [action for action in actions if not action.get('experimental', False)]
@@ -62,7 +62,7 @@ def get_all_actions(user, project):
     return actions
 
 
-def register_action(entry_point, title, order, **kwargs):
+def register_action(entry_point, title, order, **kwargs):  # type: ignore[no-untyped-def]
     """ Register action in global _action instance,
         action_id will be automatically extracted from entry_point function name
     """
@@ -79,7 +79,7 @@ def register_action(entry_point, title, order, **kwargs):
     }
 
 
-def register_actions_from_dir(base_module, action_dir):
+def register_actions_from_dir(base_module, action_dir):  # type: ignore[no-untyped-def]
     """ Find all python files nearby this file and try to load 'actions' from them
     """
     for path in os.listdir(action_dir):
@@ -98,11 +98,11 @@ def register_actions_from_dir(base_module, action_dir):
             continue
 
         for action in module_actions:
-            register_action(**action)
+            register_action(**action)  # type: ignore[no-untyped-call]
             logger.debug('Action registered: ' + str(action['entry_point'].__name__))
 
 
-def perform_action(action_id, project, queryset, user, **kwargs):
+def perform_action(action_id, project, queryset, user, **kwargs):  # type: ignore[no-untyped-def]
     """ Perform action using entry point from actions
     """
     if action_id not in settings.DATA_MANAGER_ACTIONS:
@@ -111,7 +111,7 @@ def perform_action(action_id, project, queryset, user, **kwargs):
     action = settings.DATA_MANAGER_ACTIONS[action_id]
 
     # check user permissions for this action
-    if not check_permissions(user, action):
+    if not check_permissions(user, action):  # type: ignore[no-untyped-call]
         raise DRFPermissionDenied(f'Action is not allowed for the current user: {action["id"]}')
 
 
@@ -125,4 +125,4 @@ def perform_action(action_id, project, queryset, user, **kwargs):
     return result
 
 
-register_actions_from_dir('data_manager.actions', os.path.dirname(__file__))
+register_actions_from_dir('data_manager.actions', os.path.dirname(__file__))  # type: ignore[no-untyped-call]

--- a/label_studio/data_manager/actions/basic.py
+++ b/label_studio/data_manager/actions/basic.py
@@ -20,17 +20,17 @@ all_permissions = AllPermissions()
 logger = logging.getLogger(__name__)
 
 
-def retrieve_tasks_predictions(project, queryset, **kwargs):
+def retrieve_tasks_predictions(project, queryset, **kwargs):  # type: ignore[no-untyped-def]
     """ Retrieve predictions by tasks ids
 
     :param project: project instance
     :param queryset: filtered tasks db queryset
     """
-    evaluate_predictions(queryset)
+    evaluate_predictions(queryset)  # type: ignore[no-untyped-call]
     return {'processed_items': queryset.count(), 'detail': 'Retrieved ' + str(queryset.count()) + ' predictions'}
 
 
-def delete_tasks(project, queryset, **kwargs):
+def delete_tasks(project, queryset, **kwargs):  # type: ignore[no-untyped-def]
     """ Delete tasks by ids
 
     :param project: project instance
@@ -45,13 +45,13 @@ def delete_tasks(project, queryset, **kwargs):
     queryset.update(project=None)
     # delete all project tasks
     if count == project_count:
-        start_job_async_or_sync(Task.delete_tasks_without_signals_from_task_ids, tasks_ids_list)
+        start_job_async_or_sync(Task.delete_tasks_without_signals_from_task_ids, tasks_ids_list)  # type: ignore[no-untyped-call]
         project.summary.reset()
 
     # delete only specific tasks
     else:
         # update project summary and delete tasks
-        start_job_async_or_sync(async_project_summary_recalculation, tasks_ids_list, project.id)
+        start_job_async_or_sync(async_project_summary_recalculation, tasks_ids_list, project.id)  # type: ignore[no-untyped-call]
 
     project.update_tasks_states(
         maximum_annotations_changed=False,
@@ -59,7 +59,7 @@ def delete_tasks(project, queryset, **kwargs):
         tasks_number_changed=True
     )
     # emit webhooks for project
-    emit_webhooks_for_instance(project.organization, project, WebhookAction.TASKS_DELETED, tasks_ids)
+    emit_webhooks_for_instance(project.organization, project, WebhookAction.TASKS_DELETED, tasks_ids)  # type: ignore[no-untyped-call]
 
     # remove all tabs if there are no tasks in project
     reload = False
@@ -71,7 +71,7 @@ def delete_tasks(project, queryset, **kwargs):
             'detail': 'Deleted ' + str(count) + ' tasks'}
 
 
-def delete_tasks_annotations(project, queryset, **kwargs):
+def delete_tasks_annotations(project, queryset, **kwargs):  # type: ignore[no-untyped-def]
     """ Delete all annotations by tasks ids
 
     :param project: project instance
@@ -87,7 +87,7 @@ def delete_tasks_annotations(project, queryset, **kwargs):
     # remove deleted annotations from project.summary
     project.summary.remove_created_annotations_and_labels(annotations)
     annotations.delete()
-    emit_webhooks_for_instance(project.organization, project, WebhookAction.ANNOTATIONS_DELETED, annotations_ids)
+    emit_webhooks_for_instance(project.organization, project, WebhookAction.ANNOTATIONS_DELETED, annotations_ids)  # type: ignore[no-untyped-call]
     request = kwargs['request']
 
     tasks = Task.objects.filter(id__in=real_task_ids)
@@ -96,7 +96,7 @@ def delete_tasks_annotations(project, queryset, **kwargs):
     project.update_tasks_counters_and_is_labeled(tasks_queryset=real_task_ids)
 
     # LSE postprocess
-    postprocess = load_func(settings.DELETE_TASKS_ANNOTATIONS_POSTPROCESS)
+    postprocess = load_func(settings.DELETE_TASKS_ANNOTATIONS_POSTPROCESS)  # type: ignore[no-untyped-call]
     if postprocess is not None:
         tasks = Task.objects.filter(id__in=task_ids)
         postprocess(project, tasks, **kwargs)
@@ -105,7 +105,7 @@ def delete_tasks_annotations(project, queryset, **kwargs):
             'detail': 'Deleted ' + str(count) + ' annotations'}
 
 
-def delete_tasks_predictions(project, queryset, **kwargs):
+def delete_tasks_predictions(project, queryset, **kwargs):  # type: ignore[no-untyped-def]
     """ Delete all predictions by tasks ids
 
     :param project: project instance
@@ -120,12 +120,12 @@ def delete_tasks_predictions(project, queryset, **kwargs):
     return {'processed_items': count, 'detail': 'Deleted ' + str(count) + ' predictions'}
 
 
-def async_project_summary_recalculation(tasks_ids_list, project_id):
+def async_project_summary_recalculation(tasks_ids_list, project_id):  # type: ignore[no-untyped-def]
     queryset = Task.objects.filter(id__in=tasks_ids_list)
     project = Project.objects.get(id=project_id)
     project.summary.remove_created_annotations_and_labels(Annotation.objects.filter(task__in=queryset))
     project.summary.remove_data_columns(queryset)
-    Task.delete_tasks_without_signals(queryset)
+    Task.delete_tasks_without_signals(queryset)  # type: ignore[no-untyped-call]
 
 
 actions = [

--- a/label_studio/data_manager/actions/next_task.py
+++ b/label_studio/data_manager/actions/next_task.py
@@ -12,7 +12,7 @@ from tasks.serializers import NextTaskSerializer
 logger = logging.getLogger(__name__)
 
 
-def next_task(project, queryset, **kwargs):
+def next_task(project, queryset, **kwargs):  # type: ignore[no-untyped-def]
     """ Generate next task for labeling stream
 
     :param project: project
@@ -21,8 +21,8 @@ def next_task(project, queryset, **kwargs):
     """
 
     request = kwargs['request']
-    dm_queue = filters_ordering_selected_items_exist(request.data)
-    next_task, queue_info = get_next_task(request.user, queryset, project, dm_queue)
+    dm_queue = filters_ordering_selected_items_exist(request.data)  # type: ignore[no-untyped-call]
+    next_task, queue_info = get_next_task(request.user, queryset, project, dm_queue)  # type: ignore[no-untyped-call]
 
     if next_task is None:
         raise NotFound(

--- a/label_studio/data_manager/actions/predictions_to_annotations.py
+++ b/label_studio/data_manager/actions/predictions_to_annotations.py
@@ -14,7 +14,7 @@ all_permissions = AllPermissions()
 logger = logging.getLogger(__name__)
 
 
-def predictions_to_annotations(project, queryset, **kwargs):
+def predictions_to_annotations(project, queryset, **kwargs):  # type: ignore[no-untyped-def]
     request = kwargs['request']
     user = request.user
     model_version = request.data.get('model_version')
@@ -50,19 +50,19 @@ def predictions_to_annotations(project, queryset, **kwargs):
     count = len(annotations)
     logger.debug(f'{count} predictions will be converter to annotations')
     db_annotations = [Annotation(**annotation) for annotation in annotations]
-    db_annotations = Annotation.objects.bulk_create(db_annotations)
+    db_annotations = Annotation.objects.bulk_create(db_annotations)  # type: ignore[no-untyped-call]
     Task.objects.filter(id__in=tasks_ids).update(updated_at=now(), updated_by=request.user)
 
     if db_annotations:
         TaskSerializerBulk.post_process_annotations(user, db_annotations, 'prediction')
         # Execute webhook for created annotations
-        emit_webhooks_for_instance(user.active_organization, project, WebhookAction.ANNOTATIONS_CREATED, db_annotations)
+        emit_webhooks_for_instance(user.active_organization, project, WebhookAction.ANNOTATIONS_CREATED, db_annotations)  # type: ignore[no-untyped-call]
         # Update counters for tasks and is_labeled. It should be a single operation as counters affect bulk is_labeled update
         project.update_tasks_counters_and_is_labeled(Task.objects.filter(id__in=tasks_ids))
     return {'response_code': 200, 'detail': f'Created {count} annotations'}
 
 
-def predictions_to_annotations_form(user, project):
+def predictions_to_annotations_form(user, project):  # type: ignore[no-untyped-def]
     versions = project.get_model_versions()
 
     # put the current model version on the top of the list

--- a/label_studio/data_manager/api.py
+++ b/label_studio/data_manager/api.py
@@ -2,18 +2,18 @@
 """
 import logging
 
-from django_filters.rest_framework import DjangoFilterBackend
+from django_filters.rest_framework import DjangoFilterBackend  # type: ignore[import]
 from django.utils.decorators import method_decorator
 from rest_framework import viewsets, generics
 from rest_framework.decorators import action
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from drf_yasg.utils import swagger_auto_schema
-from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema  # type: ignore[import]
+from drf_yasg import openapi  # type: ignore[import]
 from django.conf import settings
 
-from core.utils.common import int_from_request, load_func
+from core.utils.common import int_from_request, load_func  # type: ignore[attr-defined]
 from core.utils.params import bool_from_request
 from core.permissions import all_permissions, ViewClassPermission
 from projects.models import Project
@@ -89,7 +89,7 @@ logger = logging.getLogger(__name__)
             description='View ID'),
     ],
 ))
-class ViewAPI(viewsets.ModelViewSet):
+class ViewAPI(viewsets.ModelViewSet):  # type: ignore[type-arg]
     serializer_class = ViewSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["project"]
@@ -101,7 +101,7 @@ class ViewAPI(viewsets.ModelViewSet):
         DELETE=all_permissions.tasks_delete,
     )
 
-    def perform_create(self, serializer):
+    def perform_create(self, serializer):  # type: ignore[no-untyped-def]
         serializer.save(user=self.request.user)
 
     @swagger_auto_schema(
@@ -111,16 +111,16 @@ class ViewAPI(viewsets.ModelViewSet):
         request_body=ViewResetSerializer,
     )
     @action(detail=False, methods=["delete"])
-    def reset(self, request):
+    def reset(self, request):  # type: ignore[no-untyped-def]
         serializer = ViewResetSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        project = generics.get_object_or_404(Project.objects.for_user(request.user), pk=serializer.validated_data['project'].id)
-        queryset = self.filter_queryset(self.get_queryset()).filter(project=project)
+        project = generics.get_object_or_404(Project.objects.for_user(request.user), pk=serializer.validated_data['project'].id)  # type: ignore[no-untyped-call]
+        queryset = self.filter_queryset(self.get_queryset()).filter(project=project)  # type: ignore[no-untyped-call]
         queryset.all().delete()
         return Response(status=204)
 
-    def get_queryset(self):
-        return View.objects.filter(project__organization=self.request.user.active_organization).order_by('id')
+    def get_queryset(self):  # type: ignore[no-untyped-def]
+        return View.objects.filter(project__organization=self.request.user.active_organization).order_by('id')  # type: ignore[misc, union-attr]
 
 
 class TaskPagination(PageNumberPagination):
@@ -130,23 +130,23 @@ class TaskPagination(PageNumberPagination):
     total_predictions = 0
     max_page_size = settings.TASK_API_PAGE_SIZE_MAX
 
-    def paginate_queryset(self, queryset, request, view=None):
+    def paginate_queryset(self, queryset, request, view=None):  # type: ignore[no-untyped-def]
         self.total_predictions = Prediction.objects.filter(task_id__in=queryset).count()
         self.total_annotations = Annotation.objects.filter(task_id__in=queryset, was_cancelled=False).count()
         return super().paginate_queryset(queryset, request, view)
 
-    def get_paginated_response(self, data):
+    def get_paginated_response(self, data):  # type: ignore[no-untyped-def]
         return Response(
             {
                 "total_annotations": self.total_annotations,
                 "total_predictions": self.total_predictions,
-                "total": self.page.paginator.count,
+                "total": self.page.paginator.count,  # type: ignore[union-attr]
                 "tasks": data,
             }
         )
 
 
-class TaskListAPI(generics.ListCreateAPIView):
+class TaskListAPI(generics.ListCreateAPIView):  # type: ignore[type-arg]
     task_serializer_class = DataManagerTaskSerializer
     permission_required = ViewClassPermission(
         GET=all_permissions.tasks_view,
@@ -157,11 +157,11 @@ class TaskListAPI(generics.ListCreateAPIView):
     )
 
     @staticmethod
-    def get_task_serializer_context(request, project):
+    def get_task_serializer_context(request, project):  # type: ignore[no-untyped-def]
         all_fields = request.GET.get('fields', None) == 'all'  # false by default
 
         return {
-            'resolve_uri': bool_from_request(request.GET, 'resolve_uri', True),
+            'resolve_uri': bool_from_request(request.GET, 'resolve_uri', True),  # type: ignore[no-untyped-call]
             'request': request,
             'project': project,
             'drafts': all_fields,
@@ -169,11 +169,11 @@ class TaskListAPI(generics.ListCreateAPIView):
             'annotations': all_fields
         }
 
-    def get_task_queryset(self, request, prepare_params):
-        return Task.prepared.only_filtered(prepare_params=prepare_params)
+    def get_task_queryset(self, request, prepare_params):  # type: ignore[no-untyped-def]
+        return Task.prepared.only_filtered(prepare_params=prepare_params)  # type: ignore[no-untyped-call]
 
     @staticmethod
-    def prefetch(queryset):
+    def prefetch(queryset):  # type: ignore[no-untyped-def]
         return queryset.prefetch_related(
             'annotations', 'predictions', 'annotations__completed_by', 'project',
             'io_storages_azureblobimportstoragelink',
@@ -184,10 +184,10 @@ class TaskListAPI(generics.ListCreateAPIView):
             'file_upload'
         )
 
-    def get(self, request):
+    def get(self, request):  # type: ignore[no-untyped-def]
         # get project
-        view_pk = int_from_request(request.GET, 'view', 0) or int_from_request(request.data, 'view', 0)
-        project_pk = int_from_request(request.GET, 'project', 0) or int_from_request(request.data, 'project', 0)
+        view_pk = int_from_request(request.GET, 'view', 0) or int_from_request(request.data, 'view', 0)  # type: ignore[no-untyped-call]
+        project_pk = int_from_request(request.GET, 'project', 0) or int_from_request(request.data, 'project', 0)  # type: ignore[no-untyped-call]
         if project_pk:
             project = generics.get_object_or_404(Project, pk=project_pk)
             self.check_object_permissions(request, project)
@@ -198,9 +198,9 @@ class TaskListAPI(generics.ListCreateAPIView):
         else:
             return Response({'detail': 'Neither project nor view id specified'}, status=404)
         # get prepare params (from view or from payload directly)
-        prepare_params = get_prepare_params(request, project)
-        queryset = self.get_task_queryset(request, prepare_params)
-        context = self.get_task_serializer_context(self.request, project)
+        prepare_params = get_prepare_params(request, project)  # type: ignore[no-untyped-call]
+        queryset = self.get_task_queryset(request, prepare_params)  # type: ignore[no-untyped-call]
+        context = self.get_task_serializer_context(self.request, project)  # type: ignore[no-untyped-call]
 
         # paginated tasks
         self.pagination_class = TaskPagination
@@ -208,8 +208,8 @@ class TaskListAPI(generics.ListCreateAPIView):
 
         # get request params
         all_fields = 'all' if request.GET.get('fields', None) == 'all' else None
-        fields_for_evaluation = get_fields_for_evaluation(prepare_params, request.user)
-        review = bool_from_request(self.request.GET, 'review', False)
+        fields_for_evaluation = get_fields_for_evaluation(prepare_params, request.user)  # type: ignore[no-untyped-call]
+        review = bool_from_request(self.request.GET, 'review', False)  # type: ignore[no-untyped-call]
 
         if review:
             fields_for_evaluation = ['annotators', 'reviewed']
@@ -217,8 +217,8 @@ class TaskListAPI(generics.ListCreateAPIView):
         if page is not None:
             ids = [task.id for task in page]  # page is a list already
             tasks = list(
-                self.prefetch(
-                    Task.prepared.annotate_queryset(
+                self.prefetch(  # type: ignore[no-untyped-call]
+                    Task.prepared.annotate_queryset(  # type: ignore[no-untyped-call]
                         Task.objects.filter(id__in=ids),
                         fields_for_evaluation=fields_for_evaluation,
                         all_fields=all_fields,
@@ -233,15 +233,15 @@ class TaskListAPI(generics.ListCreateAPIView):
             # retrieve ML predictions if tasks don't have them
             if not review and project.evaluate_predictions_automatically:
                 tasks_for_predictions = Task.objects.filter(id__in=ids, predictions__isnull=True)
-                evaluate_predictions(tasks_for_predictions)
+                evaluate_predictions(tasks_for_predictions)  # type: ignore[no-untyped-call]
                 [tasks_by_ids[_id].refresh_from_db() for _id in ids]
 
             serializer = self.task_serializer_class(page, many=True, context=context)
             return self.get_paginated_response(serializer.data)
         # all tasks
         if project.evaluate_predictions_automatically:
-            evaluate_predictions(queryset.filter(predictions__isnull=True))
-        queryset = Task.prepared.annotate_queryset(
+            evaluate_predictions(queryset.filter(predictions__isnull=True))  # type: ignore[no-untyped-call]
+        queryset = Task.prepared.annotate_queryset(  # type: ignore[no-untyped-call]
             queryset, fields_for_evaluation=fields_for_evaluation, all_fields=all_fields, request=request
         )
         serializer = self.task_serializer_class(queryset, many=True, context=context)
@@ -256,11 +256,11 @@ class TaskListAPI(generics.ListCreateAPIView):
 class ProjectColumnsAPI(APIView):
     permission_required = all_permissions.projects_view
 
-    def get(self, request):
-        pk = int_from_request(request.GET, "project", 1)
+    def get(self, request):  # type: ignore[no-untyped-def]
+        pk = int_from_request(request.GET, "project", 1)  # type: ignore[no-untyped-call]
         project = generics.get_object_or_404(Project, pk=pk)
         self.check_object_permissions(request, project)
-        GET_ALL_COLUMNS = load_func(settings.DATA_MANAGER_GET_ALL_COLUMNS)
+        GET_ALL_COLUMNS = load_func(settings.DATA_MANAGER_GET_ALL_COLUMNS)  # type: ignore[no-untyped-call]
         data = GET_ALL_COLUMNS(project, request.user)
         return Response(data)
 
@@ -273,8 +273,8 @@ class ProjectColumnsAPI(APIView):
 class ProjectStateAPI(APIView):
     permission_required = all_permissions.projects_view
 
-    def get(self, request):
-        pk = int_from_request(request.GET, "project", 1)  # replace 1 to None, it's for debug only
+    def get(self, request):  # type: ignore[no-untyped-def]
+        pk = int_from_request(request.GET, "project", 1)    # type: ignore[no-untyped-call] # replace 1 to None, it's for debug only
         project = generics.get_object_or_404(Project, pk=pk)
         self.check_object_permissions(request, project)
         data = ProjectSerializer(project).data
@@ -288,7 +288,7 @@ class ProjectStateAPI(APIView):
                 "target_syncing": False,
                 "task_count": project.tasks.count(),
                 "annotation_count": Annotation.objects.filter(project=project).count(),
-                'config_has_control_tags': len(project.get_parsed_config()) > 0
+                'config_has_control_tags': len(project.get_parsed_config()) > 0  # type: ignore[no-untyped-call]
             }
         )
         return Response(data)
@@ -310,18 +310,18 @@ class ProjectActionsAPI(APIView):
         POST=all_permissions.projects_view,
     )
 
-    def get(self, request):
-        pk = int_from_request(request.GET, "project", 1)  # replace 1 to None, it's for debug only
+    def get(self, request):  # type: ignore[no-untyped-def]
+        pk = int_from_request(request.GET, "project", 1)    # type: ignore[no-untyped-call] # replace 1 to None, it's for debug only
         project = generics.get_object_or_404(Project, pk=pk)
         self.check_object_permissions(request, project)
-        return Response(get_all_actions(request.user, project))
+        return Response(get_all_actions(request.user, project))  # type: ignore[no-untyped-call]
 
-    def post(self, request):
-        pk = int_from_request(request.GET, "project", None)
+    def post(self, request):  # type: ignore[no-untyped-def]
+        pk = int_from_request(request.GET, "project", None)  # type: ignore[no-untyped-call]
         project = generics.get_object_or_404(Project, pk=pk)
         self.check_object_permissions(request, project)
 
-        queryset = get_prepared_queryset(request, project)
+        queryset = get_prepared_queryset(request, project)  # type: ignore[no-untyped-call]
 
         # wrong action id
         action_id = request.GET.get('id', None)
@@ -331,7 +331,7 @@ class ProjectActionsAPI(APIView):
 
         # perform action and return the result dict
         kwargs = {'request': request}  # pass advanced params to actions
-        result = perform_action(action_id, project, queryset, request.user, **kwargs)
+        result = perform_action(action_id, project, queryset, request.user, **kwargs)  # type: ignore[no-untyped-call]
         code = result.pop('response_code', 200)
 
         return Response(result, status=code)

--- a/label_studio/data_manager/functions.py
+++ b/label_studio/data_manager/functions.py
@@ -7,12 +7,12 @@ from collections import OrderedDict
 from django.conf import settings
 from rest_framework.generics import get_object_or_404
 
-from core.utils.common import int_from_request
+from core.utils.common import int_from_request  # type: ignore[attr-defined]
 from data_manager.prepare_params import PrepareParams
 from data_manager.models import View
 from tasks.models import Task
 from urllib.parse import unquote
-from core.feature_flags import flag_set
+from core.feature_flags import flag_set  # type: ignore[attr-defined]
 
 TASKS = 'tasks:'
 logger = logging.getLogger(__name__)
@@ -22,16 +22,16 @@ class DataManagerException(Exception):
     pass
 
 
-def get_all_columns(project, *_):
+def get_all_columns(project, *_):  # type: ignore[no-untyped-def]
     """ Make columns info for the frontend data manager
     """
-    result = {'columns': []}
+    result = {'columns': []}  # type: ignore[var-annotated]
 
     # frontend uses MST data model, so we need two directional referencing parent <-> child
     task_data_children = []
     i = 0
 
-    data_types = OrderedDict()
+    data_types = OrderedDict()  # type: ignore[var-annotated]
 
     # add data types from config again
     project_data_types = {}
@@ -94,7 +94,7 @@ def get_all_columns(project, *_):
         }
     ]
 
-    if flag_set('ff_back_2070_inner_id_12052022_short', user=project.organization.created_by):
+    if flag_set('ff_back_2070_inner_id_12052022_short', user=project.organization.created_by):  # type: ignore[no-untyped-call]
         result['columns'] += [{
             'id': 'inner_id',
             'title': "Inner ID",
@@ -323,18 +323,18 @@ def get_all_columns(project, *_):
     return result
 
 
-def get_prepare_params(request, project):
+def get_prepare_params(request, project):  # type: ignore[no-untyped-def]
     """ This function extract prepare_params from
         * view_id if it's inside of request data
         * selectedItems, filters, ordering if they are in request and there is no view id
     """
     # use filters and selected items from view
-    view_id = int_from_request(request.GET, 'view', 0) or int_from_request(request.data, 'view', 0)
+    view_id = int_from_request(request.GET, 'view', 0) or int_from_request(request.data, 'view', 0)  # type: ignore[no-untyped-call]
     if view_id > 0:
         view = get_object_or_404(View, pk=view_id)
         if view.project.pk != project.pk:
             raise DataManagerException('Project and View mismatch')
-        prepare_params = view.get_prepare_tasks_params(add_selected_items=True)
+        prepare_params = view.get_prepare_tasks_params(add_selected_items=True)  # type: ignore[no-untyped-call]
         prepare_params.request = request
 
     # use filters and selected items from request if it's specified
@@ -352,18 +352,18 @@ def get_prepare_params(request, project):
                                        '"excluded | included": [...task_ids...]}')
         filters = data.get('filters', None)
         ordering = data.get('ordering', [])
-        prepare_params = PrepareParams(project=project.id, selectedItems=selected, data=data,
+        prepare_params = PrepareParams(project=project.id, selectedItems=selected, data=data,  # type: ignore[arg-type]
                                        filters=filters, ordering=ordering, request=request)
     return prepare_params
 
 
-def get_prepared_queryset(request, project):
-    prepare_params = get_prepare_params(request, project)
-    queryset = Task.prepared.only_filtered(prepare_params=prepare_params)
+def get_prepared_queryset(request, project):  # type: ignore[no-untyped-def]
+    prepare_params = get_prepare_params(request, project)  # type: ignore[no-untyped-call]
+    queryset = Task.prepared.only_filtered(prepare_params=prepare_params)  # type: ignore[no-untyped-call]
     return queryset
 
 
-def evaluate_predictions(tasks):
+def evaluate_predictions(tasks):  # type: ignore[no-untyped-def]
     """ Call ML backend for prediction evaluation of the task queryset
     """
     if not tasks:
@@ -376,19 +376,19 @@ def evaluate_predictions(tasks):
         ml_backend.predict_tasks(tasks)
 
 
-def filters_ordering_selected_items_exist(data):
+def filters_ordering_selected_items_exist(data):  # type: ignore[no-untyped-def]
     return data.get('filters') or data.get('ordering') or data.get('selectedItems')
 
 
-def custom_filter_expressions(*args, **kwargs):
+def custom_filter_expressions(*args, **kwargs):  # type: ignore[no-untyped-def]
     pass
 
 
-def preprocess_filter(_filter, *_):
+def preprocess_filter(_filter, *_):  # type: ignore[no-untyped-def]
     return _filter
 
 
-def preprocess_field_name(raw_field_name, only_undefined_field=False):
+def preprocess_field_name(raw_field_name, only_undefined_field=False):  # type: ignore[no-untyped-def]
     field_name = raw_field_name.replace("filter:", "")
     field_name = field_name.replace("tasks:", "")
     ascending = False if field_name[0] == '-' else True  # detect direction

--- a/label_studio/data_manager/managers.py
+++ b/label_studio/data_manager/managers.py
@@ -1,5 +1,6 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
+from typing import TYPE_CHECKING
 import re
 import ujson as json
 import logging
@@ -17,8 +18,13 @@ from django.db.models import FloatField, Count
 from datetime import datetime
 
 from data_manager.prepare_params import ConjunctionEnum
-from label_studio.core.utils.params import cast_bool_from_str
-from label_studio.core.utils.common import load_func
+
+if TYPE_CHECKING:
+    from core.utils.params import cast_bool_from_str
+    from core.utils.common import load_func
+else:
+    from label_studio.core.utils.params import cast_bool_from_str
+    from label_studio.core.utils.common import load_func
 from core.feature_flags import flag_set
 
 logger = logging.getLogger(__name__)
@@ -97,7 +103,10 @@ def get_fields_for_evaluation(prepare_params, user):
     # visible fields calculation
     fields = prepare_params.data.get('hiddenColumns', None)
     if fields:
-        from label_studio.data_manager.functions import TASKS
+        if TYPE_CHECKING:
+            from data_manager.functions import TASKS
+        else:
+            from label_studio.data_manager.functions import TASKS
         GET_ALL_COLUMNS = load_func(settings.DATA_MANAGER_GET_ALL_COLUMNS)
         all_columns = GET_ALL_COLUMNS(Project.objects.get(id=prepare_params.project), user)
         all_columns = set([TASKS + ('data.' if c.get('parent', None) == 'data' else '') + c['id']

--- a/label_studio/data_manager/models.py
+++ b/label_studio/data_manager/models.py
@@ -31,7 +31,7 @@ class ProjectViewMixin(models.Model):
         "projects.Project", related_name="views", on_delete=models.CASCADE, help_text="Project ID"
     )
 
-    def has_permission(self, user):
+    def has_permission(self, user):  # type: ignore[no-untyped-def]
         user.project = self.project  # link for activity log
         if self.project.organization == user.active_organization:
             return True
@@ -42,7 +42,7 @@ class ProjectViewMixin(models.Model):
 
 
 class View(ViewBaseModel, ProjectViewMixin):
-    def get_prepare_tasks_params(self, add_selected_items=False):
+    def get_prepare_tasks_params(self, add_selected_items=False):  # type: ignore[no-untyped-def]
         # convert filters to PrepareParams structure
         filters = None
         if self.filter_group:
@@ -66,7 +66,7 @@ class View(ViewBaseModel, ProjectViewMixin):
         if add_selected_items and self.selected_items:
             selected_items = self.selected_items
 
-        return PrepareParams(project=self.project_id, ordering=ordering, filters=filters,
+        return PrepareParams(project=self.project_id, ordering=ordering, filters=filters,  # type: ignore[arg-type]
                              data=self.data, selectedItems=selected_items)
 
 

--- a/label_studio/data_manager/prepare_params.py
+++ b/label_studio/data_manager/prepare_params.py
@@ -14,7 +14,7 @@ class Filter(BaseModel):
     filter: str
     operator: str
     type: str
-    value: Union[StrictInt, StrictFloat, StrictBool, StrictStr, FilterIn, list]
+    value: Union[StrictInt, StrictFloat, StrictBool, StrictStr, FilterIn, list]  # type: ignore[type-arg]
 
 
 class ConjunctionEnum(Enum):
@@ -38,5 +38,5 @@ class PrepareParams(BaseModel):
     ordering: List[str] = []
     selectedItems: Optional[SelectedItems] = None
     filters: Optional[Filters] = None
-    data: Optional[dict] = None
+    data: Optional[dict] = None  # type: ignore[type-arg]
     request: Optional[Any] = None

--- a/label_studio/data_manager/serializers.py
+++ b/label_studio/data_manager/serializers.py
@@ -11,16 +11,16 @@ from data_manager.models import View, Filter, FilterGroup
 from tasks.models import Task
 from tasks.serializers import TaskSerializer, AnnotationSerializer, PredictionSerializer, AnnotationDraftSerializer
 from projects.models import Project
-from label_studio.core.utils.common import round_floats
+from label_studio.core.utils.common import round_floats  # type: ignore[import]
 
 
-class FilterSerializer(serializers.ModelSerializer):
+class FilterSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
     class Meta:
         model = Filter
         fields = "__all__"
 
 
-class FilterGroupSerializer(serializers.ModelSerializer):
+class FilterGroupSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
     filters = FilterSerializer(many=True)
 
     class Meta:
@@ -28,14 +28,14 @@ class FilterGroupSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
-class ViewSerializer(serializers.ModelSerializer):
+class ViewSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
     filter_group = FilterGroupSerializer(required=False)
 
     class Meta:
         model = View
         fields = "__all__"
 
-    def to_internal_value(self, data):
+    def to_internal_value(self, data):  # type: ignore[no-untyped-def]
         """
         map old filters structure to models
         "filters": {  ===> FilterGroup model
@@ -79,7 +79,7 @@ class ViewSerializer(serializers.ModelSerializer):
 
         return super().to_internal_value(data)
 
-    def to_representation(self, instance):
+    def to_representation(self, instance):  # type: ignore[no-untyped-def]
         result = super().to_representation(instance)
         filters = result.pop("filter_group", {})
         if filters:
@@ -108,28 +108,28 @@ class ViewSerializer(serializers.ModelSerializer):
         return result
 
     @staticmethod
-    def _create_filters(filter_group, filters_data):
+    def _create_filters(filter_group, filters_data):  # type: ignore[no-untyped-def]
         filter_index = 0
         for filter_data in filters_data:
             filter_data["index"] = filter_index
             filter_group.filters.add(Filter.objects.create(**filter_data))
             filter_index += 1
 
-    def create(self, validated_data):
+    def create(self, validated_data):  # type: ignore[no-untyped-def]
         with transaction.atomic():
             filter_group_data = validated_data.pop("filter_group", None)
             if filter_group_data:
                 filters_data = filter_group_data.pop("filters", [])
                 filter_group = FilterGroup.objects.create(**filter_group_data)
 
-                self._create_filters(filter_group=filter_group, filters_data=filters_data)
+                self._create_filters(filter_group=filter_group, filters_data=filters_data)  # type: ignore[no-untyped-call]
 
                 validated_data["filter_group_id"] = filter_group.id
             view = self.Meta.model.objects.create(**validated_data)
 
             return view
 
-    def update(self, instance, validated_data):
+    def update(self, instance, validated_data):  # type: ignore[no-untyped-def]
         with transaction.atomic():
             filter_group_data = validated_data.pop("filter_group", None)
             if filter_group_data:
@@ -145,7 +145,7 @@ class ViewSerializer(serializers.ModelSerializer):
                     filter_group.save()
 
                 filter_group.filters.clear()
-                self._create_filters(filter_group=filter_group, filters_data=filters_data)
+                self._create_filters(filter_group=filter_group, filters_data=filters_data)  # type: ignore[no-untyped-call]
 
             ordering = validated_data.pop("ordering", None)
             if ordering and ordering != instance.ordering:
@@ -159,7 +159,7 @@ class ViewSerializer(serializers.ModelSerializer):
             return instance
 
 
-class DataManagerTaskSerializer(TaskSerializer):
+class DataManagerTaskSerializer(TaskSerializer):  # type: ignore[misc]
     predictions = serializers.SerializerMethodField(required=False, read_only=True)
     annotations = AnnotationSerializer(required=False, many=True, default=[], read_only=True)
     drafts = serializers.SerializerMethodField(required=False, read_only=True)
@@ -189,7 +189,7 @@ class DataManagerTaskSerializer(TaskSerializer):
         fields = '__all__'
         expandable_fields = {'annotations': (AnnotationSerializer, {'many': True})}
 
-    def to_representation(self, obj):
+    def to_representation(self, obj):  # type: ignore[no-untyped-def]
         """ Dynamically manage including of some fields in the API result
         """
         ret = super(DataManagerTaskSerializer, self).to_representation(obj)
@@ -199,7 +199,7 @@ class DataManagerTaskSerializer(TaskSerializer):
             ret.pop('predictions', None)
         return ret
 
-    def _pretty_results(self, task, field, unique=False):
+    def _pretty_results(self, task, field, unique=False):  # type: ignore[no-untyped-def]
         if not hasattr(task, field) or getattr(task, field) is None:
             return ''
 
@@ -207,7 +207,7 @@ class DataManagerTaskSerializer(TaskSerializer):
         if isinstance(result, str):
             output = result
             if unique:
-                output = list(set(output.split(',')))
+                output = list(set(output.split(',')))  # type: ignore[assignment]
                 output = ','.join(output)
 
         elif isinstance(result, int):
@@ -221,32 +221,32 @@ class DataManagerTaskSerializer(TaskSerializer):
 
         return output[:self.CHAR_LIMITS].replace(',"', ', "').replace('],[', "] [").replace('"', '')
 
-    def get_annotations_results(self, task):
-        return self._pretty_results(task, 'annotations_results')
+    def get_annotations_results(self, task):  # type: ignore[no-untyped-def]
+        return self._pretty_results(task, 'annotations_results')  # type: ignore[no-untyped-call]
 
-    def get_predictions_results(self, task):
-        return self._pretty_results(task, 'predictions_results')
+    def get_predictions_results(self, task):  # type: ignore[no-untyped-def]
+        return self._pretty_results(task, 'predictions_results')  # type: ignore[no-untyped-call]
 
-    def get_predictions(self, task):
+    def get_predictions(self, task):  # type: ignore[no-untyped-def]
         return PredictionSerializer(task.predictions, many=True, default=[], read_only=True).data
 
     @staticmethod
-    def get_file_upload(task):
+    def get_file_upload(task):  # type: ignore[no-untyped-def]
         if hasattr(task, 'file_upload_field'):
             file_upload = task.file_upload_field
             return os.path.basename(task.file_upload_field) if file_upload else None
         return None
 
     @staticmethod
-    def get_storage_filename(task):
+    def get_storage_filename(task):  # type: ignore[no-untyped-def]
         return task.storage_filename
 
     @staticmethod
-    def get_updated_by(obj):
+    def get_updated_by(obj):  # type: ignore[no-untyped-def]
         return [{"user_id": obj.updated_by_id}] if obj.updated_by_id else []
 
     @staticmethod
-    def get_annotators(obj):
+    def get_annotators(obj):  # type: ignore[no-untyped-def]
         if not hasattr(obj, 'annotators'):
             return []
 
@@ -260,21 +260,21 @@ class DataManagerTaskSerializer(TaskSerializer):
         annotators = [a for a in annotators if a is not None]
         return annotators if hasattr(obj, 'annotators') and annotators else []
 
-    def get_annotations_ids(self, task):
-        return self._pretty_results(task, 'annotations_ids', unique=True)
+    def get_annotations_ids(self, task):  # type: ignore[no-untyped-def]
+        return self._pretty_results(task, 'annotations_ids', unique=True)  # type: ignore[no-untyped-call]
 
-    def get_predictions_model_versions(self, task):
-        return self._pretty_results(task, 'predictions_model_versions', unique=True)
+    def get_predictions_model_versions(self, task):  # type: ignore[no-untyped-def]
+        return self._pretty_results(task, 'predictions_model_versions', unique=True)  # type: ignore[no-untyped-call]
 
-    def get_drafts_serializer(self):
+    def get_drafts_serializer(self):  # type: ignore[no-untyped-def]
         return AnnotationDraftSerializer
 
-    def get_drafts_queryset(self, user, drafts):
+    def get_drafts_queryset(self, user, drafts):  # type: ignore[no-untyped-def]
         """ Get all user's draft
         """
         return drafts.filter(user=user)
 
-    def get_drafts(self, task):
+    def get_drafts(self, task):  # type: ignore[no-untyped-def]
         """Return drafts only for the current user"""
         # it's for swagger documentation
         if not isinstance(task, Task) or not self.context.get('drafts'):
@@ -283,18 +283,18 @@ class DataManagerTaskSerializer(TaskSerializer):
         drafts = task.drafts
         if 'request' in self.context and hasattr(self.context['request'], 'user'):
             user = self.context['request'].user
-            drafts = self.get_drafts_queryset(user, drafts)
+            drafts = self.get_drafts_queryset(user, drafts)  # type: ignore[no-untyped-call]
 
-        serializer_class = self.get_drafts_serializer()
+        serializer_class = self.get_drafts_serializer()  # type: ignore[no-untyped-call]
         return serializer_class(drafts, many=True, read_only=True, default=True, context=self.context).data
 
 
-class SelectedItemsSerializer(serializers.Serializer):
+class SelectedItemsSerializer(serializers.Serializer):  # type: ignore[type-arg]
     all = serializers.BooleanField()
     included = serializers.ListField(child=serializers.IntegerField(), required=False)
     excluded = serializers.ListField(child=serializers.IntegerField(), required=False)
 
-    def validate(self, data):
+    def validate(self, data):  # type: ignore[no-untyped-def]
         if data["all"] is True and data.get("included"):
             raise serializers.ValidationError("included not allowed with all==true")
         if data["all"] is False and data.get("excluded"):
@@ -310,5 +310,5 @@ class SelectedItemsSerializer(serializers.Serializer):
         return data
 
 
-class ViewResetSerializer(serializers.Serializer):
+class ViewResetSerializer(serializers.Serializer):  # type: ignore[type-arg]
     project = serializers.PrimaryKeyRelatedField(queryset=Project.objects.all())

--- a/label_studio/data_manager/views.py
+++ b/label_studio/data_manager/views.py
@@ -8,9 +8,9 @@ from core.version import get_short_version
 
 
 @login_required
-def task_page(request, pk):
+def task_page(request, pk):  # type: ignore[no-untyped-def]
     response = {
-        'version': get_short_version()
+        'version': get_short_version()  # type: ignore[no-untyped-call]
     }
-    response.update(find_editor_files())
+    response.update(find_editor_files())  # type: ignore[no-untyped-call]
     return render(request, 'base.html', response)

--- a/label_studio/io_storages/all_api.py
+++ b/label_studio/io_storages/all_api.py
@@ -1,5 +1,6 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
+from typing import TYPE_CHECKING
 import logging
 
 from django.conf import settings
@@ -12,7 +13,10 @@ from django.utils.decorators import method_decorator
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
 
-from label_studio.core.utils.common import load_func
+if TYPE_CHECKING:
+    from core.utils.common import load_func
+else:
+    from label_studio.core.utils.common import load_func
 from .azure_blob.serializers import AzureBlobImportStorageSerializer
 from .gcs.serializers import GCSImportStorageSerializer
 from .localfiles.api import LocalFilesImportStorageListAPI, LocalFilesExportStorageListAPI

--- a/label_studio/io_storages/all_api.py
+++ b/label_studio/io_storages/all_api.py
@@ -10,8 +10,8 @@ from core.permissions import all_permissions
 from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
 from rest_framework.response import Response
 from django.utils.decorators import method_decorator
-from drf_yasg.utils import swagger_auto_schema
-from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema  # type: ignore[import]
+from drf_yasg import openapi  # type: ignore[import]
 
 if TYPE_CHECKING:
     from core.utils.common import load_func
@@ -25,10 +25,10 @@ logger = logging.getLogger(__name__)
 # TODO: replace hardcoded apps lists with search over included storage apps
 
 
-get_storage_list = load_func(settings.GET_STORAGE_LIST)
+get_storage_list = load_func(settings.GET_STORAGE_LIST)  # type: ignore[no-untyped-call]
 
 
-def _get_common_storage_list():
+def _get_common_storage_list():  # type: ignore[no-untyped-def]
     storage_list = get_storage_list()
     if settings.ENABLE_LOCAL_FILES_STORAGE:
         storage_list += [{
@@ -41,7 +41,7 @@ def _get_common_storage_list():
     return storage_list
 
 
-_common_storage_list = _get_common_storage_list()
+_common_storage_list = _get_common_storage_list()  # type: ignore[no-untyped-call]
 
 
 @method_decorator(name='get', decorator=swagger_auto_schema(
@@ -53,7 +53,7 @@ _common_storage_list = _get_common_storage_list()
 class AllImportStorageTypesAPI(APIView):
     permission_required = all_permissions.projects_change
 
-    def get(self, request, **kwargs):
+    def get(self, request, **kwargs):  # type: ignore[no-untyped-def]
         return Response([{'name': s['name'], 'title': s['title']} for s in _common_storage_list])
 
 
@@ -66,7 +66,7 @@ class AllImportStorageTypesAPI(APIView):
 class AllExportStorageTypesAPI(APIView):
     permission_required = all_permissions.projects_change
 
-    def get(self, request, **kwargs):
+    def get(self, request, **kwargs):  # type: ignore[no-untyped-def]
         return Response([{'name': s['name'], 'title': s['title']} for s in _common_storage_list])
 
 
@@ -83,12 +83,12 @@ class AllExportStorageTypesAPI(APIView):
         ],
         responses={200: "List of ImportStorageSerializer"}
     ))
-class AllImportStorageListAPI(generics.ListAPIView):
+class AllImportStorageListAPI(generics.ListAPIView):  # type: ignore[type-arg]
 
     parser_classes = (JSONParser, FormParser, MultiPartParser)
     permission_required = all_permissions.projects_change
 
-    def _get_response(self, api, request, *args, **kwargs):
+    def _get_response(self, api, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         try:
             view = api.as_view()
             response = view(request._request, *args, **kwargs)
@@ -100,9 +100,9 @@ class AllImportStorageListAPI(generics.ListAPIView):
             logger.error(f"Can't process {api.__class__.__name__}", exc_info=True)
             return []
 
-    def list(self, request, *args, **kwargs):
-        list_responses = sum([
-            self._get_response(s['import_list_api'], request, *args, **kwargs) for s in _common_storage_list], [])
+    def list(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
+        list_responses = sum([  # type: ignore[var-annotated]
+            self._get_response(s['import_list_api'], request, *args, **kwargs) for s in _common_storage_list], [])  # type: ignore[no-untyped-call]
         return Response(list_responses)
 
 
@@ -119,17 +119,17 @@ class AllImportStorageListAPI(generics.ListAPIView):
         ],
         responses={200: "List of ExportStorageSerializer"}
     ))
-class AllExportStorageListAPI(generics.ListAPIView):
+class AllExportStorageListAPI(generics.ListAPIView):  # type: ignore[type-arg]
 
     parser_classes = (JSONParser, FormParser, MultiPartParser)
     permission_required = all_permissions.projects_change
 
-    def _get_response(self, api, request, *args, **kwargs):
+    def _get_response(self, api, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         view = api.as_view()
         response = view(request._request, *args, **kwargs)
         return response.data
 
-    def list(self, request, *args, **kwargs):
-        list_responses = sum([
-            self._get_response(s['export_list_api'], request, *args, **kwargs) for s in _common_storage_list], [])
+    def list(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
+        list_responses = sum([  # type: ignore[var-annotated]
+            self._get_response(s['export_list_api'], request, *args, **kwargs) for s in _common_storage_list], [])  # type: ignore[no-untyped-call]
         return Response(list_responses)

--- a/label_studio/io_storages/api.py
+++ b/label_studio/io_storages/api.py
@@ -8,9 +8,9 @@ from rest_framework import generics
 from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
 from rest_framework.response import Response
 from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
-from drf_yasg import openapi as openapi
+from drf_yasg import openapi as openapi  # type: ignore[import]
 from django.conf import settings
-from drf_yasg.utils import swagger_auto_schema
+from drf_yasg.utils import swagger_auto_schema  # type: ignore[import]
 
 from core.permissions import all_permissions
 from core.utils.io import read_yaml
@@ -20,12 +20,12 @@ from projects.models import Project
 logger = logging.getLogger(__name__)
 
 
-class ImportStorageListAPI(generics.ListCreateAPIView):
+class ImportStorageListAPI(generics.ListCreateAPIView):  # type: ignore[type-arg]
     parser_classes = (JSONParser, FormParser, MultiPartParser)
     permission_required = all_permissions.projects_change
     serializer_class = ImportStorageSerializer
 
-    def get_queryset(self):
+    def get_queryset(self):  # type: ignore[no-untyped-def]
         project_pk = self.request.query_params.get('project')
         project = generics.get_object_or_404(Project, pk=project_pk)
         self.check_object_permissions(self.request, project)
@@ -33,11 +33,11 @@ class ImportStorageListAPI(generics.ListCreateAPIView):
         storages = StorageClass.objects.filter(project_id=project.id)
 
         # check failed jobs and sync their statuses
-        StorageClass.ensure_storage_statuses(storages)
+        StorageClass.ensure_storage_statuses(storages)  # type: ignore[no-untyped-call]
         return storages
 
 
-class ImportStorageDetailAPI(generics.RetrieveUpdateDestroyAPIView):
+class ImportStorageDetailAPI(generics.RetrieveUpdateDestroyAPIView):  # type: ignore[type-arg]
     """RUD storage by pk specified in URL"""
 
     parser_classes = (JSONParser, FormParser, MultiPartParser)
@@ -45,16 +45,16 @@ class ImportStorageDetailAPI(generics.RetrieveUpdateDestroyAPIView):
     permission_required = all_permissions.projects_change
 
     @swagger_auto_schema(auto_schema=None)
-    def put(self, request, *args, **kwargs):
+    def put(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         return super(ImportStorageDetailAPI, self).put(request, *args, **kwargs)
 
 
-class ExportStorageListAPI(generics.ListCreateAPIView):
+class ExportStorageListAPI(generics.ListCreateAPIView):  # type: ignore[type-arg]
     parser_classes = (JSONParser, FormParser, MultiPartParser)
     permission_required = all_permissions.projects_change
     serializer_class = ExportStorageSerializer
 
-    def get_queryset(self):
+    def get_queryset(self):  # type: ignore[no-untyped-def]
         project_pk = self.request.query_params.get('project')
         project = generics.get_object_or_404(Project, pk=project_pk)
         self.check_object_permissions(self.request, project)
@@ -62,24 +62,24 @@ class ExportStorageListAPI(generics.ListCreateAPIView):
         storages = StorageClass.objects.filter(project_id=project.id)
 
         # check failed jobs and sync their statuses
-        StorageClass.ensure_storage_statuses(storages)
+        StorageClass.ensure_storage_statuses(storages)  # type: ignore[no-untyped-call]
         return storages
 
-    def perform_create(self, serializer):
+    def perform_create(self, serializer):  # type: ignore[no-untyped-def]
         # double check: not export storages don't validate connection in serializer,
         # just make another explicit check here, note: in this create API we have credentials in request.data
         instance = serializer.Meta.model(**serializer.validated_data)
         try:
             instance.validate_connection()
         except Exception as exc:
-            raise ValidationError(exc)
+            raise ValidationError(exc)  # type: ignore[arg-type]
 
         storage = serializer.save()
         if settings.SYNC_ON_TARGET_STORAGE_CREATION:
             storage.sync()
 
 
-class ExportStorageDetailAPI(generics.RetrieveUpdateDestroyAPIView):
+class ExportStorageDetailAPI(generics.RetrieveUpdateDestroyAPIView):  # type: ignore[type-arg]
     """RUD storage by pk specified in URL"""
 
     parser_classes = (JSONParser, FormParser, MultiPartParser)
@@ -87,21 +87,21 @@ class ExportStorageDetailAPI(generics.RetrieveUpdateDestroyAPIView):
     permission_required = all_permissions.projects_change
 
     @swagger_auto_schema(auto_schema=None)
-    def put(self, request, *args, **kwargs):
+    def put(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         return super(ExportStorageDetailAPI, self).put(request, *args, **kwargs)
 
 
-class ImportStorageSyncAPI(generics.GenericAPIView):
+class ImportStorageSyncAPI(generics.GenericAPIView):  # type: ignore[type-arg]
 
     parser_classes = (JSONParser, FormParser, MultiPartParser)
     permission_required = all_permissions.projects_change
     serializer_class = ImportStorageSerializer
 
-    def get_queryset(self):
+    def get_queryset(self):  # type: ignore[no-untyped-def]
         ImportStorageClass = self.serializer_class.Meta.model
         return ImportStorageClass.objects.all()
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         storage = self.get_object()
         # check connectivity & access, raise an exception if not satisfied
         storage.validate_connection()
@@ -110,17 +110,17 @@ class ImportStorageSyncAPI(generics.GenericAPIView):
         return Response(self.serializer_class(storage).data)
 
 
-class ExportStorageSyncAPI(generics.GenericAPIView):
+class ExportStorageSyncAPI(generics.GenericAPIView):  # type: ignore[type-arg]
 
     parser_classes = (JSONParser, FormParser, MultiPartParser)
     permission_required = all_permissions.projects_change
     serializer_class = ExportStorageSerializer
 
-    def get_queryset(self):
+    def get_queryset(self):  # type: ignore[no-untyped-def]
         ExportStorageClass = self.serializer_class.Meta.model
         return ExportStorageClass.objects.all()
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         storage = self.get_object()
         # check connectivity & access, raise an exception if not satisfied
         storage.validate_connection()
@@ -129,15 +129,15 @@ class ExportStorageSyncAPI(generics.GenericAPIView):
         return Response(self.serializer_class(storage).data)
 
 
-class StorageValidateAPI(generics.CreateAPIView):
+class StorageValidateAPI(generics.CreateAPIView):  # type: ignore[type-arg]
     parser_classes = (JSONParser, FormParser, MultiPartParser)
     permission_required = all_permissions.projects_change
 
-    def create(self, request, *args, **kwargs):
+    def create(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         storage_id = request.data.get('id')
         instance = None
         if storage_id:
-            instance = generics.get_object_or_404(self.serializer_class.Meta.model.objects.all(), pk=storage_id)
+            instance = generics.get_object_or_404(self.serializer_class.Meta.model.objects.all(), pk=storage_id)  # type: ignore[union-attr, union-attr]
             if not instance.has_permission(request.user):
                 raise PermissionDenied()
 
@@ -149,17 +149,17 @@ class StorageValidateAPI(generics.CreateAPIView):
         if instance:
             instance = serializer.update(instance, serializer.validated_data)
         else:
-            instance = serializer.Meta.model(**serializer.validated_data)
+            instance = serializer.Meta.model(**serializer.validated_data)  # type: ignore[attr-defined]
 
         # double check: not all storages validate connection in serializer, just make another explicit check here
         try:
             instance.validate_connection()
         except Exception as exc:
-            raise ValidationError(exc)
+            raise ValidationError(exc)  # type: ignore[arg-type]
         return Response()
 
 
-class StorageFormLayoutAPI(generics.RetrieveAPIView):
+class StorageFormLayoutAPI(generics.RetrieveAPIView):  # type: ignore[type-arg]
 
     parser_classes = (JSONParser, FormParser, MultiPartParser)
     permission_required = all_permissions.projects_change
@@ -167,16 +167,16 @@ class StorageFormLayoutAPI(generics.RetrieveAPIView):
     storage_type = None
 
     @swagger_auto_schema(auto_schema=None)
-    def get(self, request, *args, **kwargs):
+    def get(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         form_layout_file = os.path.join(os.path.dirname(inspect.getfile(self.__class__)), 'form_layout.yml')
         if not os.path.exists(form_layout_file):
             raise NotFound(f'"form_layout.yml" is not found for {self.__class__.__name__}')
 
-        form_layout = read_yaml(form_layout_file)
-        form_layout = self.post_process_form(form_layout)
+        form_layout = read_yaml(form_layout_file)  # type: ignore[no-untyped-call]
+        form_layout = self.post_process_form(form_layout)  # type: ignore[no-untyped-call]
         return Response(form_layout[self.storage_type])
 
-    def post_process_form(self, form_layout):
+    def post_process_form(self, form_layout):  # type: ignore[no-untyped-def]
         return form_layout
 
 
@@ -189,8 +189,8 @@ class ExportStorageValidateAPI(StorageValidateAPI):
 
 
 class ImportStorageFormLayoutAPI(StorageFormLayoutAPI):
-    storage_type = 'ImportStorage'
+    storage_type = 'ImportStorage'  # type: ignore[assignment]
 
 
 class ExportStorageFormLayoutAPI(StorageFormLayoutAPI):
-    storage_type = 'ExportStorage'
+    storage_type = 'ExportStorage'  # type: ignore[assignment]

--- a/label_studio/io_storages/azure_blob/api.py
+++ b/label_studio/io_storages/azure_blob/api.py
@@ -1,8 +1,8 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
 from django.utils.decorators import method_decorator
-from drf_yasg.utils import swagger_auto_schema
-from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema  # type: ignore[import]
+from drf_yasg import openapi  # type: ignore[import]
 from io_storages.azure_blob.models import AzureBlobImportStorage, AzureBlobExportStorage
 from io_storages.azure_blob.serializers import AzureBlobImportStorageSerializer, AzureBlobExportStorageSerializer
 from io_storages.api import (

--- a/label_studio/io_storages/azure_blob/models.py
+++ b/label_studio/io_storages/azure_blob/models.py
@@ -1,5 +1,6 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
+from typing import TYPE_CHECKING
 import logging
 import json
 import re
@@ -25,7 +26,10 @@ from io_storages.base_models import (
     ProjectStorageMixin
 )
 
-from label_studio.io_storages.azure_blob.utils import AZURE
+if TYPE_CHECKING:
+    from io_storages.azure_blob.utils import AZURE
+else:
+    from label_studio.io_storages.azure_blob.utils import AZURE
 
 logger = logging.getLogger(__name__)
 logging.getLogger('azure.core.pipeline.policies.http_logging_policy').setLevel(logging.WARNING)

--- a/label_studio/io_storages/azure_blob/serializers.py
+++ b/label_studio/io_storages/azure_blob/serializers.py
@@ -16,26 +16,26 @@ class AzureBlobImportStorageSerializer(ImportStorageSerializer):
         model = AzureBlobImportStorage
         fields = '__all__'
 
-    def to_representation(self, instance):
+    def to_representation(self, instance):  # type: ignore[no-untyped-def]
         result = super().to_representation(instance)
         result.pop('account_name')
         result.pop('account_key')
         return result
 
-    def validate(self, data):
+    def validate(self, data):  # type: ignore[no-untyped-def]
         data = super(AzureBlobImportStorageSerializer, self).validate(data)
         storage = AzureBlobImportStorage(**data)
         try:
-            storage.validate_connection()
+            storage.validate_connection()  # type: ignore[no-untyped-call]
         except Exception as exc:
-            raise ValidationError(exc)
+            raise ValidationError(exc)  # type: ignore[arg-type]
         return data
 
 
 class AzureBlobExportStorageSerializer(ExportStorageSerializer):
     type = serializers.ReadOnlyField(default='azure')
 
-    def to_representation(self, instance):
+    def to_representation(self, instance):  # type: ignore[no-untyped-def]
         result = super().to_representation(instance)
         result.pop('account_name')
         result.pop('account_key')

--- a/label_studio/io_storages/azure_blob/utils.py
+++ b/label_studio/io_storages/azure_blob/utils.py
@@ -10,10 +10,10 @@ logger = logging.getLogger(__name__)
 
 class AZURE(object):
     @classmethod
-    def get_client_and_container(cls, container, account_name=None, account_key=None):
+    def get_client_and_container(cls, container, account_name=None, account_key=None):  # type: ignore[no-untyped-def]
         # get account name and key from params or from environment variables
-        account_name = str(account_name) if account_name else get_env('AZURE_BLOB_ACCOUNT_NAME')
-        account_key = str(account_key) if account_key else get_env('AZURE_BLOB_ACCOUNT_KEY')
+        account_name = str(account_name) if account_name else get_env('AZURE_BLOB_ACCOUNT_NAME')  # type: ignore[no-untyped-call]
+        account_key = str(account_key) if account_key else get_env('AZURE_BLOB_ACCOUNT_KEY')  # type: ignore[no-untyped-call]
         # check that both account name and key are set
         if not account_name or not account_key:
             raise ValueError('Azure account name and key must be set using '
@@ -28,8 +28,8 @@ class AZURE(object):
     def get_blob_metadata(cls,
                           url: str,
                           container: str,
-                          account_name: str = None,
-                          account_key: str = None) -> dict:
+                          account_name: str = None,  # type: ignore[assignment]
+                          account_key: str = None) -> dict:  # type: ignore[assignment, type-arg]
         """
         Get blob metadata by url
         :param url: Object key
@@ -38,6 +38,6 @@ class AZURE(object):
         :param account_key: Azure account key
         :return: Object metadata dict("name": "value")
         """
-        _, container = cls.get_client_and_container(container, account_name=account_name, account_key=account_key)
-        blob = container.get_blob_client(url)
+        _, container = cls.get_client_and_container(container, account_name=account_name, account_key=account_key)  # type: ignore[no-untyped-call]
+        blob = container.get_blob_client(url)  # type: ignore[attr-defined]
         return dict(blob.get_blob_properties())

--- a/label_studio/io_storages/filesystem.py
+++ b/label_studio/io_storages/filesystem.py
@@ -6,156 +6,156 @@ import logging
 
 from copy import deepcopy
 from core.utils.io import json_load, delete_dir_content, iter_files, remove_file_or_dir
-from .base import BaseStorage, BaseForm, CloudStorage
+from .base import BaseStorage, BaseForm, CloudStorage  # type: ignore[import]
 
 
 logger = logging.getLogger(__name__)
 
 
-class JSONStorage(BaseStorage):
+class JSONStorage(BaseStorage):  # type: ignore[misc]
 
     description = 'JSON task file'
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs):  # type: ignore[no-untyped-def]
         super(JSONStorage, self).__init__(**kwargs)
         tasks = {}
         if os.path.exists(self.path):
-            tasks = json_load(self.path, int_keys=True)
+            tasks = json_load(self.path, int_keys=True)  # type: ignore[no-untyped-call]
         if len(tasks) == 0:
             self.data = {}
         elif isinstance(tasks, dict):
             self.data = tasks
         elif isinstance(self.data, list):
             self.data = {int(task['id']): task for task in tasks}
-        self._save()
+        self._save()  # type: ignore[no-untyped-call]
 
-    def _save(self):
+    def _save(self):  # type: ignore[no-untyped-def]
         with open(self.path, mode='w', encoding='utf8') as fout:
             json.dump(self.data, fout, ensure_ascii=False)
 
     @property
-    def readable_path(self):
+    def readable_path(self):  # type: ignore[no-untyped-def]
         return self.path
 
-    def get(self, id):
+    def get(self, id):  # type: ignore[no-untyped-def]
         return self.data.get(int(id))
 
-    def set(self, id, value):
+    def set(self, id, value):  # type: ignore[no-untyped-def]
         self.data[int(id)] = value
-        self._save()
+        self._save()  # type: ignore[no-untyped-call]
 
-    def __contains__(self, id):
+    def __contains__(self, id):  # type: ignore[no-untyped-def]
         return id in self.data
 
-    def set_many(self, ids, values):
+    def set_many(self, ids, values):  # type: ignore[no-untyped-def]
         for id, value in zip(ids, values):
             self.data[int(id)] = value
-        self._save()
+        self._save()  # type: ignore[no-untyped-call]
 
-    def ids(self):
+    def ids(self):  # type: ignore[no-untyped-def]
         return self.data.keys()
 
-    def max_id(self):
-        return max(self.ids(), default=-1)
+    def max_id(self):  # type: ignore[no-untyped-def]
+        return max(self.ids(), default=-1)  # type: ignore[no-untyped-call]
 
-    def items(self):
+    def items(self):  # type: ignore[no-untyped-def]
         return self.data.items()
 
-    def remove(self, key):
+    def remove(self, key):  # type: ignore[no-untyped-def]
         self.data.pop(int(key), None)
-        self._save()
+        self._save()  # type: ignore[no-untyped-call]
 
-    def remove_all(self, ids=None):
+    def remove_all(self, ids=None):  # type: ignore[no-untyped-def]
         if ids is None:
             self.data = {}
         else:
             [self.data.pop(i, None) for i in ids]
-        self._save()
+        self._save()  # type: ignore[no-untyped-call]
 
-    def empty(self):
+    def empty(self):  # type: ignore[no-untyped-def]
         return len(self.data) == 0
 
-    def sync(self):
+    def sync(self):  # type: ignore[no-untyped-def]
         pass
 
 
-def already_exists_error(what, path):
+def already_exists_error(what, path):  # type: ignore[no-untyped-def]
     raise RuntimeError('{path} {what} already exists. Use "--force" option to recreate it.'.format(
         path=path, what=what))
 
 
-class DirJSONsStorage(BaseStorage):
+class DirJSONsStorage(BaseStorage):  # type: ignore[misc]
 
     description = 'Directory with JSON task files'
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs):  # type: ignore[no-untyped-def]
         super(DirJSONsStorage, self).__init__(**kwargs)
         os.makedirs(self.path, exist_ok=True)
         self.cache = {}
 
     @property
-    def readable_path(self):
+    def readable_path(self):  # type: ignore[no-untyped-def]
         return self.path
 
-    def get(self, id):
+    def get(self, id):  # type: ignore[no-untyped-def]
         if id in self.cache:
             return self.cache[id]
         else:
             filename = os.path.join(self.path, str(id) + '.json')
             if os.path.exists(filename):
-                data = json_load(filename)
+                data = json_load(filename)  # type: ignore[no-untyped-call]
                 self.cache[id] = data
                 return data
 
-    def __contains__(self, id):
-        return id in set(self.ids())
+    def __contains__(self, id):  # type: ignore[no-untyped-def]
+        return id in set(self.ids())  # type: ignore[no-untyped-call]
 
-    def set(self, id, value):
+    def set(self, id, value):  # type: ignore[no-untyped-def]
         filename = os.path.join(self.path, str(id) + '.json')
         with open(filename, 'w', encoding='utf8') as fout:
             json.dump(value, fout, indent=2, sort_keys=True)
         self.cache[id] = value
 
-    def set_many(self, keys, values):
+    def set_many(self, keys, values):  # type: ignore[no-untyped-def]
         self.cache.clear()
         raise NotImplementedError
 
-    def ids(self):
-        for f in iter_files(self.path, '.json'):
+    def ids(self):  # type: ignore[no-untyped-def]
+        for f in iter_files(self.path, '.json'):  # type: ignore[no-untyped-call]
             yield int(os.path.splitext(os.path.basename(f))[0])
 
-    def max_id(self):
-        return max(self.ids(), default=-1)
+    def max_id(self):  # type: ignore[no-untyped-def]
+        return max(self.ids(), default=-1)  # type: ignore[no-untyped-call]
 
-    def sync(self):
+    def sync(self):  # type: ignore[no-untyped-def]
         pass
 
-    def items(self):
-        for id in self.ids():
+    def items(self):  # type: ignore[no-untyped-def]
+        for id in self.ids():  # type: ignore[no-untyped-call]
             filename = os.path.join(self.path, str(id) + '.json')
-            yield id, self.cache[id] if id in self.cache else json_load(filename)
+            yield id, self.cache[id] if id in self.cache else json_load(filename)  # type: ignore[no-untyped-call]
 
-    def remove(self, id):
+    def remove(self, id):  # type: ignore[no-untyped-def]
         filename = os.path.join(self.path, str(id) + '.json')
         if os.path.exists(filename):
             os.remove(filename)
             self.cache.pop(id, None)
 
-    def remove_all(self, ids=None):
+    def remove_all(self, ids=None):  # type: ignore[no-untyped-def]
         if ids is None:
             self.cache.clear()
-            delete_dir_content(self.path)
+            delete_dir_content(self.path)  # type: ignore[no-untyped-call]
         else:
             for i in ids:
                 self.cache.pop(i, None)
                 path = os.path.join(self.path, str(i) + '.json')
                 try:
-                    remove_file_or_dir(path)
+                    remove_file_or_dir(path)  # type: ignore[no-untyped-call]
                 except OSError:
                     logger.warning('Storage file already removed: ' + path)
 
-    def empty(self):
-        return next(self.ids(), None) is None
+    def empty(self):  # type: ignore[no-untyped-def]
+        return next(self.ids(), None) is None  # type: ignore[no-untyped-call]
 
 
 class TasksJSONStorage(JSONStorage):
@@ -163,18 +163,18 @@ class TasksJSONStorage(JSONStorage):
     form = BaseForm
     description = 'Local [loading tasks from "tasks.json" file]'
 
-    def __init__(self, path, project_path, **kwargs):
-        super(TasksJSONStorage, self).__init__(
+    def __init__(self, path, project_path, **kwargs):  # type: ignore[no-untyped-def]
+        super(TasksJSONStorage, self).__init__(  # type: ignore[no-untyped-call]
             project_path=project_path,
             path=os.path.join(project_path, 'tasks.json'))
 
 
-class ExternalTasksJSONStorage(CloudStorage):
+class ExternalTasksJSONStorage(CloudStorage):  # type: ignore[misc]
 
     form = BaseForm
     description = 'Local [loading tasks from "tasks.json" file]'
 
-    def __init__(self, name, path, project_path, prefix=None, create_local_copy=False, regex='.*', **kwargs):
+    def __init__(self, name, path, project_path, prefix=None, create_local_copy=False, regex='.*', **kwargs):  # type: ignore[no-untyped-def]
         super(ExternalTasksJSONStorage, self).__init__(
             name=name,
             project_path=project_path,
@@ -189,53 +189,53 @@ class ExternalTasksJSONStorage(CloudStorage):
         # data is used as a local cache for tasks.json file
         self.data = {}
 
-    def _save(self):
+    def _save(self):  # type: ignore[no-untyped-def]
         with open(self.path, mode='w', encoding='utf8') as fout:
             json.dump(self.data, fout, ensure_ascii=False)
 
-    def _get_client(self):
+    def _get_client(self):  # type: ignore[no-untyped-def]
         pass
 
-    def validate_connection(self):
+    def validate_connection(self):  # type: ignore[no-untyped-def]
         pass
 
     @property
-    def url_prefix(self):
+    def url_prefix(self):  # type: ignore[no-untyped-def]
         return ''
 
     @property
-    def readable_path(self):
+    def readable_path(self):  # type: ignore[no-untyped-def]
         return self.path
 
-    def _get_value(self, key, inplace=False):
+    def _get_value(self, key, inplace=False):  # type: ignore[no-untyped-def]
         return self.data[int(key)] if inplace else deepcopy(self.data[int(key)])
 
-    def _set_value(self, key, value):
+    def _set_value(self, key, value):  # type: ignore[no-untyped-def]
         self.data[int(key)] = value
 
-    def set(self, id, value):
+    def set(self, id, value):  # type: ignore[no-untyped-def]
         with self.thread_lock:
             super(ExternalTasksJSONStorage, self).set(id, value)
-            self._save()
+            self._save()  # type: ignore[no-untyped-call]
 
-    def set_many(self, ids, values):
+    def set_many(self, ids, values):  # type: ignore[no-untyped-def]
         with self.thread_lock:
             for id, value in zip(ids, values):
                 super(ExternalTasksJSONStorage, self)._pre_set(id, value)
             self._save_ids()
-            self._save()
+            self._save()  # type: ignore[no-untyped-call]
 
-    def _extract_task_id(self, full_key):
+    def _extract_task_id(self, full_key):  # type: ignore[no-untyped-def]
         return int(full_key.split(self.key_prefix, 1)[-1])
 
-    def iter_full_keys(self):
-        return (self.key_prefix + key for key in self._get_objects())
+    def iter_full_keys(self):  # type: ignore[no-untyped-def]
+        return (self.key_prefix + key for key in self._get_objects())  # type: ignore[no-untyped-call]
 
-    def _get_objects(self):
-        self.data = json_load(self.path, int_keys=True)
+    def _get_objects(self):  # type: ignore[no-untyped-def]
+        self.data = json_load(self.path, int_keys=True)  # type: ignore[no-untyped-call]
         return (str(id) for id in self.data)
 
-    def _remove_id_from_keys_map(self, id):
+    def _remove_id_from_keys_map(self, id):  # type: ignore[no-untyped-def]
         full_key = self.key_prefix + str(id)
         assert id in self._ids_keys_map, 'No such task id: ' + str(id)
         assert self._ids_keys_map[id]['key'] == full_key, (self._ids_keys_map[id]['key'], full_key)
@@ -243,25 +243,25 @@ class ExternalTasksJSONStorage(CloudStorage):
         self._ids_keys_map.pop(id)
         self._keys_ids_map.pop(full_key)
 
-    def remove(self, id):
+    def remove(self, id):  # type: ignore[no-untyped-def]
         with self.thread_lock:
             id = int(id)
 
             logger.debug('Remove id=' + str(id) + ' from ids.json')
-            self._remove_id_from_keys_map(id)
+            self._remove_id_from_keys_map(id)  # type: ignore[no-untyped-call]
             self._save_ids()
 
             logger.debug('Remove id=' + str(id) + ' from tasks.json')
             self.data.pop(id, None)
-            self._save()
+            self._save()  # type: ignore[no-untyped-call]
 
-    def remove_all(self, ids=None):
+    def remove_all(self, ids=None):  # type: ignore[no-untyped-def]
         with self.thread_lock:
             remove_ids = self.data if ids is None else ids
 
             logger.debug('Remove ' + str(len(remove_ids)) + ' records from ids.json')
             for id in remove_ids:
-                self._remove_id_from_keys_map(id)
+                self._remove_id_from_keys_map(id)  # type: ignore[no-untyped-call]
             self._save_ids()
 
             logger.debug('Remove all data from tasks.json')
@@ -271,7 +271,7 @@ class ExternalTasksJSONStorage(CloudStorage):
             else:
                 for id in remove_ids:
                     self.data.pop(id, None)
-            self._save()
+            self._save()  # type: ignore[no-untyped-call]
 
 
 class AnnotationsDirStorage(DirJSONsStorage):
@@ -279,8 +279,8 @@ class AnnotationsDirStorage(DirJSONsStorage):
     form = BaseForm
     description = 'Local [annotations are in "annotations" directory]'
 
-    def __init__(self, name, path, project_path, **kwargs):
-        super(AnnotationsDirStorage, self).__init__(
+    def __init__(self, name, path, project_path, **kwargs):  # type: ignore[no-untyped-def]
+        super(AnnotationsDirStorage, self).__init__(  # type: ignore[no-untyped-call]
             name=name,
             project_path=project_path,
             path=os.path.join(project_path, 'annotations'))

--- a/label_studio/io_storages/functions.py
+++ b/label_studio/io_storages/functions.py
@@ -9,7 +9,7 @@ from .redis.api import RedisImportStorageListAPI, RedisExportStorageListAPI
 logger = logging.getLogger(__name__)
 
 
-def get_storage_list():
+def get_storage_list():  # type: ignore[no-untyped-def]
     return [
         {
             'name': 's3',

--- a/label_studio/io_storages/gcs/api.py
+++ b/label_studio/io_storages/gcs/api.py
@@ -1,8 +1,8 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
 from django.utils.decorators import method_decorator
-from drf_yasg.utils import swagger_auto_schema
-from drf_yasg import openapi as openapi
+from drf_yasg.utils import swagger_auto_schema  # type: ignore[import]
+from drf_yasg import openapi as openapi  # type: ignore[import]
 from io_storages.gcs.models import GCSImportStorage, GCSExportStorage
 from io_storages.gcs.serializers import GCSImportStorageSerializer, GCSExportStorageSerializer
 from io_storages.api import (

--- a/label_studio/io_storages/gcs/models.py
+++ b/label_studio/io_storages/gcs/models.py
@@ -43,28 +43,28 @@ class GCSStorageMixin(models.Model):
         _('Google Project ID'), null=True, blank=True,
         help_text='Google project ID')
 
-    def get_client(self):
+    def get_client(self):  # type: ignore[no-untyped-def]
         return GCS.get_client(
-            google_project_id=self.google_project_id,
-            google_application_credentials=self.google_application_credentials
+            google_project_id=self.google_project_id,  # type: ignore[arg-type]
+            google_application_credentials=self.google_application_credentials  # type: ignore[arg-type]
         )
 
-    def get_bucket(self, client=None, bucket_name=None):
+    def get_bucket(self, client=None, bucket_name=None):  # type: ignore[no-untyped-def]
         if not client:
-            client = self.get_client()
+            client = self.get_client()  # type: ignore[no-untyped-call]
         return client.get_bucket(bucket_name or self.bucket)
 
-    def validate_connection(self):
+    def validate_connection(self):  # type: ignore[no-untyped-def]
         GCS.validate_connection(
-            self.bucket,
-            self.google_project_id,
-            self.google_application_credentials,
+            self.bucket,  # type: ignore[arg-type]
+            self.google_project_id,  # type: ignore[arg-type]
+            self.google_application_credentials,  # type: ignore[arg-type]
             # we don't need to validate path for export storage, it will be created automatically
-            None if 'Export' in self.__class__.__name__ else self.prefix
+            None if 'Export' in self.__class__.__name__ else self.prefix  # type: ignore[arg-type]
         )
 
 
-class GCSImportStorageBase(GCSStorageMixin, ImportStorage):
+class GCSImportStorageBase(GCSStorageMixin, ImportStorage):  # type: ignore[misc]
     url_scheme = 'gs'
 
     presign = models.BooleanField(
@@ -75,61 +75,61 @@ class GCSImportStorageBase(GCSStorageMixin, ImportStorage):
         help_text='Presigned URLs TTL (in minutes)'
     )
 
-    def iterkeys(self):
+    def iterkeys(self):  # type: ignore[no-untyped-def]
         return GCS.iter_blobs(
-            client=self.get_client(),
-            bucket_name=self.bucket,
-            prefix=self.prefix,
-            regex_filter=self.regex_filter,
+            client=self.get_client(),  # type: ignore[no-untyped-call]
+            bucket_name=self.bucket,  # type: ignore[arg-type]
+            prefix=self.prefix,  # type: ignore[arg-type]
+            regex_filter=self.regex_filter,  # type: ignore[arg-type]
             return_key=True
         )
 
-    def get_data(self, key):
+    def get_data(self, key):  # type: ignore[no-untyped-def]
         if self.use_blob_urls:
-            return {settings.DATA_UNDEFINED_NAME: GCS.get_uri(self.bucket, key)}
+            return {settings.DATA_UNDEFINED_NAME: GCS.get_uri(self.bucket, key)}  # type: ignore[no-untyped-call]
         return GCS.read_file(
-            client=self.get_client(),
-            bucket_name=self.bucket,
+            client=self.get_client(),  # type: ignore[no-untyped-call]
+            bucket_name=self.bucket,  # type: ignore[arg-type]
             key=key,
             convert_to=GCS.ConvertBlobTo.JSON_DICT
         )
         
-    def generate_http_url(self, url):
+    def generate_http_url(self, url):  # type: ignore[no-untyped-def]
         return GCS.generate_http_url(
             url=url,
-            google_application_credentials=self.google_application_credentials,
-            google_project_id=self.google_project_id,
+            google_application_credentials=self.google_application_credentials,  # type: ignore[arg-type]
+            google_project_id=self.google_project_id,  # type: ignore[arg-type]
             presign_ttl=self.presign_ttl
         )
 
-    def scan_and_create_links(self):
-        return self._scan_and_create_links(GCSImportStorageLink)
+    def scan_and_create_links(self):  # type: ignore[no-untyped-def]
+        return self._scan_and_create_links(GCSImportStorageLink)  # type: ignore[no-untyped-call]
 
-    def get_blob_metadata(self, key):
+    def get_blob_metadata(self, key):  # type: ignore[no-untyped-def]
         return GCS.get_blob_metadata(
             url=key,
-            google_application_credentials=self.google_application_credentials,
-            google_project_id=self.google_project_id
+            google_application_credentials=self.google_application_credentials,  # type: ignore[arg-type]
+            google_project_id=self.google_project_id  # type: ignore[arg-type]
         )
 
     class Meta:
         abstract = True
 
 
-class GCSImportStorage(ProjectStorageMixin, GCSImportStorageBase):
+class GCSImportStorage(ProjectStorageMixin, GCSImportStorageBase):  # type: ignore[misc]
     class Meta:
         abstract = False
 
 
-class GCSExportStorage(GCSStorageMixin, ExportStorage):
+class GCSExportStorage(GCSStorageMixin, ExportStorage):  # type: ignore[misc]
 
-    def save_annotation(self, annotation):
-        bucket = self.get_bucket()
+    def save_annotation(self, annotation):  # type: ignore[no-untyped-def]
+        bucket = self.get_bucket()  # type: ignore[no-untyped-call]
         logger.debug(f'Creating new object on {self.__class__.__name__} Storage {self} for annotation {annotation}')
-        ser_annotation = self._get_serialized_data(annotation)
+        ser_annotation = self._get_serialized_data(annotation)  # type: ignore[no-untyped-call]
 
         # get key that identifies this object in storage
-        key = GCSExportStorageLink.get_key(annotation)
+        key = GCSExportStorageLink.get_key(annotation)  # type: ignore[no-untyped-call]
         key = str(self.prefix) + '/' + key if self.prefix else key
 
         # put object into storage
@@ -137,10 +137,10 @@ class GCSExportStorage(GCSStorageMixin, ExportStorage):
         blob.upload_from_string(json.dumps(ser_annotation))
 
         # create link if everything ok
-        GCSExportStorageLink.create(annotation, self)
+        GCSExportStorageLink.create(annotation, self)  # type: ignore[no-untyped-call]
 
 
-def async_export_annotation_to_gcs_storages(annotation):
+def async_export_annotation_to_gcs_storages(annotation):  # type: ignore[no-untyped-def]
     project = annotation.project
     if hasattr(project, 'io_storages_gcsexportstorages'):
         for storage in project.io_storages_gcsexportstorages.all():
@@ -149,10 +149,10 @@ def async_export_annotation_to_gcs_storages(annotation):
 
 
 @receiver(post_save, sender=Annotation)
-def export_annotation_to_gcs_storages(sender, instance, **kwargs):
+def export_annotation_to_gcs_storages(sender, instance, **kwargs):  # type: ignore[no-untyped-def]
     storages = getattr(instance.project, 'io_storages_gcsexportstorages', None)
     if storages and storages.exists():  # avoid excess jobs in rq
-        start_job_async_or_sync(async_export_annotation_to_gcs_storages, instance)
+        start_job_async_or_sync(async_export_annotation_to_gcs_storages, instance)  # type: ignore[no-untyped-call]
 
 
 class GCSImportStorageLink(ImportStorageLink):

--- a/label_studio/io_storages/gcs/serializers.py
+++ b/label_studio/io_storages/gcs/serializers.py
@@ -15,12 +15,12 @@ class GCSImportStorageSerializer(ImportStorageSerializer):
         model = GCSImportStorage
         fields = '__all__'
 
-    def to_representation(self, instance):
+    def to_representation(self, instance):  # type: ignore[no-untyped-def]
         result = super().to_representation(instance)
         result.pop('google_application_credentials')
         return result
 
-    def validate(self, data):
+    def validate(self, data):  # type: ignore[no-untyped-def]
         data = super().validate(data)
         storage = self.instance
         if storage:
@@ -29,16 +29,16 @@ class GCSImportStorageSerializer(ImportStorageSerializer):
         else:
             storage = self.Meta.model(**data)
         try:
-            storage.validate_connection()
+            storage.validate_connection()  # type: ignore[union-attr]
         except Exception as exc:
-            raise ValidationError(exc)
+            raise ValidationError(exc)  # type: ignore[arg-type]
         return data
 
 
 class GCSExportStorageSerializer(ExportStorageSerializer):
     type = serializers.ReadOnlyField(default=os.path.basename(os.path.dirname(__file__)))
 
-    def to_representation(self, instance):
+    def to_representation(self, instance):  # type: ignore[no-untyped-def]
         result = super().to_representation(instance)
         result.pop('google_application_credentials')
         return result

--- a/label_studio/io_storages/localfiles/api.py
+++ b/label_studio/io_storages/localfiles/api.py
@@ -1,8 +1,8 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
 from django.utils.decorators import method_decorator
-from drf_yasg.utils import swagger_auto_schema
-from drf_yasg import openapi as openapi
+from drf_yasg.utils import swagger_auto_schema  # type: ignore[import]
+from drf_yasg import openapi as openapi  # type: ignore[import]
 from io_storages.localfiles.models import LocalFilesImportStorage, LocalFilesExportStorage
 from io_storages.localfiles.serializers import LocalFilesImportStorageSerializer, LocalFilesExportStorageSerializer
 from io_storages.api import (

--- a/label_studio/io_storages/localfiles/models.py
+++ b/label_studio/io_storages/localfiles/models.py
@@ -37,8 +37,8 @@ class LocalFilesMixin(models.Model):
         _('use_blob_urls'), default=False,
         help_text='Interpret objects as BLOBs and generate URLs')
 
-    def validate_connection(self):
-        path = Path(self.path)
+    def validate_connection(self):  # type: ignore[no-untyped-def]
+        path = Path(self.path)  # type: ignore[arg-type]
         document_root = Path(settings.LOCAL_FILES_DOCUMENT_ROOT)
         if not path.exists():
             raise ValidationError(f'Path {self.path} does not exist')
@@ -52,14 +52,14 @@ class LocalFilesMixin(models.Model):
                                   'please check docs: https://labelstud.io/guide/storage.html#Local-storage')
 
 
-class LocalFilesImportStorageBase(LocalFilesMixin, ImportStorage):
+class LocalFilesImportStorageBase(LocalFilesMixin, ImportStorage):  # type: ignore[misc]
     url_scheme = 'https'
 
-    def can_resolve_url(self, url):
+    def can_resolve_url(self, url):  # type: ignore[no-untyped-def]
         return False
 
-    def iterkeys(self):
-        path = Path(self.path)
+    def iterkeys(self):  # type: ignore[no-untyped-def]
+        path = Path(self.path)  # type: ignore[arg-type]
         regex = re.compile(str(self.regex_filter)) if self.regex_filter else None
         # For better control of imported tasks, file reading has been changed to ascending order of filenames.
         # In other words, the task IDs are sorted by filename order.
@@ -71,7 +71,7 @@ class LocalFilesImportStorageBase(LocalFilesMixin, ImportStorage):
                     continue
                 yield str(file)
 
-    def get_data(self, key):
+    def get_data(self, key):  # type: ignore[no-untyped-def]
         path = Path(key)
         if self.use_blob_urls:
             # include self-hosted links pointed to local resources via
@@ -92,34 +92,34 @@ class LocalFilesImportStorageBase(LocalFilesMixin, ImportStorage):
             raise ValueError(f"Error on key {key}: For {self.__class__.__name__} your JSON file must be a dictionary with one task.")  # noqa
         return value
 
-    def scan_and_create_links(self):
-        return self._scan_and_create_links(LocalFilesImportStorageLink)
+    def scan_and_create_links(self):  # type: ignore[no-untyped-def]
+        return self._scan_and_create_links(LocalFilesImportStorageLink)  # type: ignore[no-untyped-call]
 
     class Meta:
         abstract = True
 
 
-class LocalFilesImportStorage(ProjectStorageMixin, LocalFilesImportStorageBase):
+class LocalFilesImportStorage(ProjectStorageMixin, LocalFilesImportStorageBase):  # type: ignore[misc, misc, misc, misc]
     class Meta:
         abstract = False
 
 
-class LocalFilesExportStorage(LocalFilesMixin, ExportStorage):
+class LocalFilesExportStorage(LocalFilesMixin, ExportStorage):  # type: ignore[misc, misc, misc]
 
-    def save_annotation(self, annotation):
+    def save_annotation(self, annotation):  # type: ignore[no-untyped-def]
         logger.debug(f'Creating new object on {self.__class__.__name__} Storage {self} for annotation {annotation}')
-        ser_annotation = self._get_serialized_data(annotation)
+        ser_annotation = self._get_serialized_data(annotation)  # type: ignore[no-untyped-call]
 
         # get key that identifies this object in storage
-        key = LocalFilesExportStorageLink.get_key(annotation)
-        key = os.path.join(self.path, f"{key}")
+        key = LocalFilesExportStorageLink.get_key(annotation)  # type: ignore[no-untyped-call]
+        key = os.path.join(self.path, f"{key}")  # type: ignore[arg-type]
 
         # put object into storage
         with open(key, mode='w') as f:
             json.dump(ser_annotation, f, indent=2)
 
         # Create export storage link
-        LocalFilesExportStorageLink.create(annotation, self)
+        LocalFilesExportStorageLink.create(annotation, self)  # type: ignore[no-untyped-call]
 
 
 class LocalFilesImportStorageLink(ImportStorageLink):
@@ -131,7 +131,7 @@ class LocalFilesExportStorageLink(ExportStorageLink):
 
 
 @receiver(post_save, sender=Annotation)
-def export_annotation_to_local_files(sender, instance, **kwargs):
+def export_annotation_to_local_files(sender, instance, **kwargs):  # type: ignore[no-untyped-def]
     project = instance.project
     if hasattr(project, 'io_storages_localfilesexportstorages'):
         for storage in project.io_storages_localfilesexportstorages.all():

--- a/label_studio/io_storages/localfiles/serializers.py
+++ b/label_studio/io_storages/localfiles/serializers.py
@@ -14,14 +14,14 @@ class LocalFilesImportStorageSerializer(ImportStorageSerializer):
         model = LocalFilesImportStorage
         fields = '__all__'
 
-    def validate(self, data):
+    def validate(self, data):  # type: ignore[no-untyped-def]
         # Validate local file path
         data = super(LocalFilesImportStorageSerializer, self).validate(data)
         storage = LocalFilesImportStorage(**data)
         try:
-            storage.validate_connection()
+            storage.validate_connection()  # type: ignore[no-untyped-call]
         except Exception as exc:
-            raise ValidationError(exc)
+            raise ValidationError(exc)  # type: ignore[arg-type]
         return data
 
 
@@ -32,7 +32,7 @@ class LocalFilesExportStorageSerializer(ExportStorageSerializer):
         model = LocalFilesExportStorage
         fields = '__all__'
     
-    def validate(self, data):
+    def validate(self, data):  # type: ignore[no-untyped-def]
         # Validate local file path
         data = super(LocalFilesExportStorageSerializer, self).validate(data)
         return data

--- a/label_studio/io_storages/models.py
+++ b/label_studio/io_storages/models.py
@@ -1,12 +1,16 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
 from django.conf import settings
+from typing import TYPE_CHECKING
 
 from .azure_blob.models import AzureBlobImportStorage, AzureBlobImportStorageLink, AzureBlobExportStorage, AzureBlobExportStorageLink
 from .s3.models import S3ImportStorage, S3ImportStorageLink, S3ExportStorage, S3ExportStorageLink
 from .gcs.models import GCSImportStorage, GCSImportStorageLink, GCSExportStorage, GCSExportStorageLink
 from .redis.models import RedisImportStorage, RedisImportStorageLink, RedisExportStorage, RedisExportStorageLink
-from label_studio.core.utils.common import load_func
+if TYPE_CHECKING:
+    from core.utils.common import load_func
+else:
+    from label_studio.core.utils.common import load_func
 
 
 def get_storage_classes(storage_type='import'):

--- a/label_studio/io_storages/models.py
+++ b/label_studio/io_storages/models.py
@@ -13,13 +13,13 @@ else:
     from label_studio.core.utils.common import load_func
 
 
-def get_storage_classes(storage_type='import'):
+def get_storage_classes(storage_type='import'):  # type: ignore[no-untyped-def]
     """Helper function to return all registered ***ImportStorage classes.
     It's been made through the APIViews rather than using models directly to make it consistent with what we expose.
     Note: this func doesn't include LocalFiles storages!
     storage_type: import, export
     """
-    storage_list = load_func(settings.GET_STORAGE_LIST)
+    storage_list = load_func(settings.GET_STORAGE_LIST)  # type: ignore[no-untyped-call]
     storage_classes = []
     for storage_decl in storage_list():
         storage_api_class = storage_decl[f'{storage_type}_list_api']

--- a/label_studio/io_storages/redis/api.py
+++ b/label_studio/io_storages/redis/api.py
@@ -1,8 +1,8 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
 from django.utils.decorators import method_decorator
-from drf_yasg.utils import swagger_auto_schema
-from drf_yasg import openapi as openapi
+from drf_yasg.utils import swagger_auto_schema  # type: ignore[import]
+from drf_yasg import openapi as openapi  # type: ignore[import]
 from io_storages.redis.models import RedisImportStorage, RedisExportStorage
 from io_storages.redis.serializers import RedisImportStorageSerializer, RedisExportStorageSerializer
 from io_storages.api import (
@@ -86,7 +86,7 @@ class RedisImportStorageDetailAPI(ImportStorageDetailAPI):
     ),
 )
 class RedisImportStorageSyncAPI(ExportStorageSyncAPI):
-    serializer_class = RedisImportStorageSerializer
+    serializer_class = RedisImportStorageSerializer  # type: ignore[assignment]
 
 
 @method_decorator(

--- a/label_studio/io_storages/redis/models.py
+++ b/label_studio/io_storages/redis/models.py
@@ -42,7 +42,7 @@ class RedisStorageMixin(models.Model):
         _('use_blob_urls'), default=False,
         help_text='Interpret objects as BLOBs and generate URLs')
 
-    def get_redis_connection(self, db=None, redis_config={}):
+    def get_redis_connection(self, db=None, redis_config={}):  # type: ignore[no-untyped-def]
         """Get a redis connection from the provided arguments.
 
         Args:
@@ -68,13 +68,13 @@ class RedisStorageMixin(models.Model):
         r.ping()
         return r
 
-    def get_client(self):
+    def get_client(self):  # type: ignore[no-untyped-def]
         redis_config = {}
         if self.host: redis_config["host"] = self.host
         if self.port: redis_config["port"] = self.port
         if self.password: redis_config["password"] = self.password
 
-        return self.get_redis_connection(db=self.db, redis_config=redis_config)
+        return self.get_redis_connection(db=self.db, redis_config=redis_config)  # type: ignore[attr-defined, no-untyped-call]
 
 
 class RedisImportStorageBase(ImportStorage, RedisStorageMixin):
@@ -82,28 +82,28 @@ class RedisImportStorageBase(ImportStorage, RedisStorageMixin):
         _('db'), default=1,
         help_text='Server Database')
 
-    def can_resolve_url(self, url):
+    def can_resolve_url(self, url):  # type: ignore[no-untyped-def]
         return False
 
-    def iterkeys(self):
-        client = self.get_client()
+    def iterkeys(self):  # type: ignore[no-untyped-def]
+        client = self.get_client()  # type: ignore[no-untyped-call]
         path = str(self.path)
         for key in client.keys(path + '*'):
             yield key
 
-    def get_data(self, key):
-        client = self.get_client()
+    def get_data(self, key):  # type: ignore[no-untyped-def]
+        client = self.get_client()  # type: ignore[no-untyped-call]
         value = client.get(key)
         if not value:
             return
         return json.loads(value)
 
-    def scan_and_create_links(self):
-        return self._scan_and_create_links(RedisImportStorageLink)
+    def scan_and_create_links(self):  # type: ignore[no-untyped-def]
+        return self._scan_and_create_links(RedisImportStorageLink)  # type: ignore[no-untyped-call]
 
-    def validate_connection(self, client=None):
+    def validate_connection(self, client=None):  # type: ignore[no-untyped-def]
         if client is None:
-            client = self.get_client()
+            client = self.get_client()  # type: ignore[no-untyped-call]
         client.ping()
 
     class Meta:
@@ -120,23 +120,23 @@ class RedisExportStorage(RedisStorageMixin, ExportStorage):
         _('db'), default=2,
         help_text='Server Database')
 
-    def save_annotation(self, annotation):
-        client = self.get_client()
+    def save_annotation(self, annotation):  # type: ignore[no-untyped-def]
+        client = self.get_client()  # type: ignore[no-untyped-call]
         logger.debug(f'Creating new object on {self.__class__.__name__} Storage {self} for annotation {annotation}')
-        ser_annotation = self._get_serialized_data(annotation)
+        ser_annotation = self._get_serialized_data(annotation)  # type: ignore[no-untyped-call]
 
         # get key that identifies this object in storage
-        key = RedisExportStorageLink.get_key(annotation)
+        key = RedisExportStorageLink.get_key(annotation)  # type: ignore[no-untyped-call]
 
         # put object into storage
         client.set(key, json.dumps(ser_annotation))
 
         # create link if everything ok
-        RedisExportStorageLink.create(annotation, self)
+        RedisExportStorageLink.create(annotation, self)  # type: ignore[no-untyped-call]
 
 
 @receiver(post_save, sender=Annotation)
-def export_annotation_to_redis_storages(sender, instance, **kwargs):
+def export_annotation_to_redis_storages(sender, instance, **kwargs):  # type: ignore[no-untyped-def]
     project = instance.project
     if hasattr(project, 'io_storages_redisexportstorages'):
         for storage in project.io_storages_redisexportstorages.all():

--- a/label_studio/io_storages/redis/serializers.py
+++ b/label_studio/io_storages/redis/serializers.py
@@ -14,17 +14,17 @@ class RedisImportStorageSerializer(ImportStorageSerializer):
         model = RedisImportStorage
         fields = '__all__'
 
-    def to_representation(self, instance):
+    def to_representation(self, instance):  # type: ignore[no-untyped-def]
         result = super().to_representation(instance)
         result.pop('password')
         return result
 
-    def validate(self, data):
+    def validate(self, data):  # type: ignore[no-untyped-def]
         data = super(RedisImportStorageSerializer, self).validate(data)
 
         storage = RedisImportStorage(**data)
         try:
-            storage.validate_connection()
+            storage.validate_connection()  # type: ignore[no-untyped-call]
         except:
             raise ValidationError("Can't connect to Redis server.")
         return data
@@ -32,7 +32,7 @@ class RedisImportStorageSerializer(ImportStorageSerializer):
 class RedisExportStorageSerializer(ExportStorageSerializer):
     type = serializers.ReadOnlyField(default=os.path.basename(os.path.dirname(__file__)))
 
-    def to_representation(self, instance):
+    def to_representation(self, instance):  # type: ignore[no-untyped-def]
         result = super().to_representation(instance)
         result.pop('password')
         return result

--- a/label_studio/io_storages/s3/api.py
+++ b/label_studio/io_storages/s3/api.py
@@ -1,8 +1,8 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
 from django.utils.decorators import method_decorator
-from drf_yasg.utils import swagger_auto_schema
-from drf_yasg import openapi as openapi
+from drf_yasg.utils import swagger_auto_schema  # type: ignore[import]
+from drf_yasg import openapi as openapi  # type: ignore[import]
 
 from io_storages.s3.models import S3ImportStorage, S3ExportStorage
 from io_storages.s3.serializers import S3ImportStorageSerializer, S3ExportStorageSerializer

--- a/label_studio/io_storages/s3/models.py
+++ b/label_studio/io_storages/s3/models.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 import re
 import logging
 import json
-import boto3
+import boto3  # type: ignore[import]
 
 from core.redis import start_job_async_or_sync
 from django.db import models
@@ -14,9 +14,9 @@ from django.dispatch import receiver
 from django.db.models.signals import post_save, pre_delete
 
 from io_storages.s3.utils import get_client_and_resource, resolve_s3_url
-from tasks.validation import ValidationError as TaskValidationError
+from tasks.validation import ValidationError as TaskValidationError  # type: ignore[attr-defined]
 from tasks.models import Annotation
-from core.feature_flags import flag_set
+from core.feature_flags import flag_set  # type: ignore[attr-defined]
 from io_storages.base_models import (
     ExportStorage,
     ExportStorageLink,
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 logging.getLogger('botocore').setLevel(logging.CRITICAL)
 boto3.set_stream_logger(level=logging.INFO)
 
-clients_cache = {}
+clients_cache = {}  # type: ignore[var-annotated]
 
 
 class S3StorageMixin(models.Model):
@@ -66,49 +66,49 @@ class S3StorageMixin(models.Model):
         _('s3_endpoint'), null=True, blank=True,
         help_text='S3 Endpoint')
 
-    def get_client_and_resource(self):
+    def get_client_and_resource(self):  # type: ignore[no-untyped-def]
         # s3 client initialization ~ 100 ms, for 30 tasks it's a 3 seconds, so we need to cache it
         cache_key = f'{self.aws_access_key_id}:{self.aws_secret_access_key}:{self.aws_session_token}:{self.region_name}:{self.s3_endpoint}'
         if cache_key in clients_cache:
             return clients_cache[cache_key]
 
-        result = get_client_and_resource(
+        result = get_client_and_resource(  # type: ignore[no-untyped-call]
             self.aws_access_key_id, self.aws_secret_access_key, self.aws_session_token, self.region_name,
             self.s3_endpoint)
         clients_cache[cache_key] = result
         return result
 
-    def get_client(self):
-        client, _ = self.get_client_and_resource()
+    def get_client(self):  # type: ignore[no-untyped-def]
+        client, _ = self.get_client_and_resource()  # type: ignore[no-untyped-call]
         return client
 
-    def get_client_and_bucket(self, validate_connection=True):
-        client, s3 = self.get_client_and_resource()
+    def get_client_and_bucket(self, validate_connection=True):  # type: ignore[no-untyped-def]
+        client, s3 = self.get_client_and_resource()  # type: ignore[no-untyped-call]
         if validate_connection:
-            self.validate_connection(client)
+            self.validate_connection(client)  # type: ignore[no-untyped-call]
         return client, s3.Bucket(self.bucket)
 
-    def validate_connection(self, client=None):
+    def validate_connection(self, client=None):  # type: ignore[no-untyped-def]
         logger.debug('validate_connection')
         if client is None:
-            client = self.get_client()
+            client = self.get_client()  # type: ignore[no-untyped-call]
         # we need to check path existence for Import storages only
         if self.prefix and 'Export' not in self.__class__.__name__:
             logger.debug(f'Test connection to bucket {self.bucket} with prefix {self.prefix}')
             result = client.list_objects_v2(Bucket=self.bucket, Prefix=self.prefix, MaxKeys=1)
             if not result.get('KeyCount'):
-                raise KeyError(f'{self.url_scheme}://{self.bucket}/{self.prefix} not found.')
+                raise KeyError(f'{self.url_scheme}://{self.bucket}/{self.prefix} not found.')  # type: ignore[attr-defined]
         else:
             logger.debug(f'Test connection to bucket {self.bucket}')
             client.head_bucket(Bucket=self.bucket)
 
     @property
-    def path_full(self):
+    def path_full(self):  # type: ignore[no-untyped-def]
         prefix = self.prefix or ''
-        return f'{self.url_scheme}://{self.bucket}/{prefix}'
+        return f'{self.url_scheme}://{self.bucket}/{prefix}'  # type: ignore[attr-defined]
 
     @property
-    def type_full(self):
+    def type_full(self):  # type: ignore[no-untyped-def]
         return 'Amazon AWS S3'
 
     class Meta:
@@ -129,8 +129,8 @@ class S3ImportStorageBase(S3StorageMixin, ImportStorage):
         _('recursive scan'), default=False,
         help_text=_('Perform recursive scan over the bucket content'))
 
-    def iterkeys(self):
-        client, bucket = self.get_client_and_bucket()
+    def iterkeys(self):  # type: ignore[no-untyped-def]
+        client, bucket = self.get_client_and_bucket()  # type: ignore[no-untyped-call]
         if self.prefix:
             list_kwargs = {'Prefix': self.prefix.rstrip('/') + '/'}
             if not self.recursive_scan:
@@ -149,10 +149,10 @@ class S3ImportStorageBase(S3StorageMixin, ImportStorage):
                 continue
             yield key
 
-    def scan_and_create_links(self):
-        return self._scan_and_create_links(S3ImportStorageLink)
+    def scan_and_create_links(self):  # type: ignore[no-untyped-def]
+        return self._scan_and_create_links(S3ImportStorageLink)  # type: ignore[no-untyped-call]
 
-    def _get_validated_task(self, parsed_data, key):
+    def _get_validated_task(self, parsed_data, key):  # type: ignore[no-untyped-def]
         """ Validate parsed data with labeling config and task structure
         """
         if not isinstance(parsed_data, dict):
@@ -160,28 +160,28 @@ class S3ImportStorageBase(S3StorageMixin, ImportStorage):
                                       'Cloud storage supports one task (one dict object) per JSON file only. ')
         return parsed_data
 
-    def get_data(self, key):
+    def get_data(self, key):  # type: ignore[no-untyped-def]
         uri = f'{self.url_scheme}://{self.bucket}/{key}'
         if self.use_blob_urls:
             data_key = settings.DATA_UNDEFINED_NAME
             return {data_key: uri}
 
         # read task json from bucket and validate it
-        _, s3 = self.get_client_and_resource()
+        _, s3 = self.get_client_and_resource()  # type: ignore[no-untyped-call]
         bucket = s3.Bucket(self.bucket)
         obj = s3.Object(bucket.name, key).get()['Body'].read().decode('utf-8')
         value = json.loads(obj)
         if not isinstance(value, dict):
             raise ValueError(f"Error on key {key}: For S3 your JSON file must be a dictionary with one task")
 
-        value = self._get_validated_task(value, key)
+        value = self._get_validated_task(value, key)  # type: ignore[no-untyped-call]
         return value
 
-    def generate_http_url(self, url):
-        return resolve_s3_url(url, self.get_client(), self.presign, expires_in=self.presign_ttl * 60)
+    def generate_http_url(self, url):  # type: ignore[no-untyped-def]
+        return resolve_s3_url(url, self.get_client(), self.presign, expires_in=self.presign_ttl * 60)  # type: ignore[no-untyped-call, no-untyped-call]
 
-    def get_blob_metadata(self, key):
-        return AWS.get_blob_metadata(key, self.bucket, aws_access_key_id=self.aws_access_key_id,
+    def get_blob_metadata(self, key):  # type: ignore[no-untyped-def]
+        return AWS.get_blob_metadata(key, self.bucket, aws_access_key_id=self.aws_access_key_id,  # type: ignore[arg-type]
                                      aws_secret_access_key=self.aws_secret_access_key,
                                      aws_session_token=self.aws_session_token, region_name=self.region_name,
                                      s3_endpoint=self.s3_endpoint)
@@ -197,18 +197,18 @@ class S3ImportStorage(ProjectStorageMixin, S3ImportStorageBase):
 
 class S3ExportStorage(S3StorageMixin, ExportStorage):
 
-    def save_annotation(self, annotation):
-        client, s3 = self.get_client_and_resource()
+    def save_annotation(self, annotation):  # type: ignore[no-untyped-def]
+        client, s3 = self.get_client_and_resource()  # type: ignore[no-untyped-call]
         logger.debug(f'Creating new object on {self.__class__.__name__} Storage {self} for annotation {annotation}')
-        ser_annotation = self._get_serialized_data(annotation)
+        ser_annotation = self._get_serialized_data(annotation)  # type: ignore[no-untyped-call]
 
         # get key that identifies this object in storage
-        key = S3ExportStorageLink.get_key(annotation)
+        key = S3ExportStorageLink.get_key(annotation)  # type: ignore[no-untyped-call]
         key = str(self.prefix) + '/' + key if self.prefix else key
 
         # put object into storage
         additional_params = {}
-        if flag_set('fflag_feat_back_lsdv_3958_server_side_encryption_for_target_storage_short', user='auto'):
+        if flag_set('fflag_feat_back_lsdv_3958_server_side_encryption_for_target_storage_short', user='auto'):  # type: ignore[no-untyped-call]
             additional_params = {'ServerSideEncryption': 'AES256'}
         s3.Object(self.bucket, key).put(
             Body=json.dumps(ser_annotation),
@@ -216,14 +216,14 @@ class S3ExportStorage(S3StorageMixin, ExportStorage):
         )
 
         # create link if everything ok
-        S3ExportStorageLink.create(annotation, self)
+        S3ExportStorageLink.create(annotation, self)  # type: ignore[no-untyped-call]
 
-    def delete_annotation(self, annotation):
-        client, s3 = self.get_client_and_resource()
+    def delete_annotation(self, annotation):  # type: ignore[no-untyped-def]
+        client, s3 = self.get_client_and_resource()  # type: ignore[no-untyped-call]
         logger.debug(f'Deleting object on {self.__class__.__name__} Storage {self} for annotation {annotation}')
 
         # get key that identifies this object in storage
-        key = S3ExportStorageLink.get_key(annotation)
+        key = S3ExportStorageLink.get_key(annotation)  # type: ignore[no-untyped-call]
         key = str(self.prefix) + '/' + key if self.prefix else key
 
         # delete object from storage
@@ -233,7 +233,7 @@ class S3ExportStorage(S3StorageMixin, ExportStorage):
         S3ExportStorageLink.objects.filter(storage=self, annotation=annotation).delete()
 
 
-def async_export_annotation_to_s3_storages(annotation):
+def async_export_annotation_to_s3_storages(annotation):  # type: ignore[no-untyped-def]
     project = annotation.project
     if hasattr(project, 'io_storages_s3exportstorages'):
         for storage in project.io_storages_s3exportstorages.all():
@@ -242,28 +242,28 @@ def async_export_annotation_to_s3_storages(annotation):
 
 
 @receiver(post_save, sender=Annotation)
-def export_annotation_to_s3_storages(sender, instance, **kwargs):
+def export_annotation_to_s3_storages(sender, instance, **kwargs):  # type: ignore[no-untyped-def]
     storages = getattr(instance.project, 'io_storages_s3exportstorages', None)
     if storages and storages.exists():  # avoid excess jobs in rq
-        start_job_async_or_sync(async_export_annotation_to_s3_storages, instance)
+        start_job_async_or_sync(async_export_annotation_to_s3_storages, instance)  # type: ignore[no-untyped-call]
 
 
 @receiver(pre_delete, sender=Annotation)
-def delete_annotation_from_s3_storages(sender, instance, **kwargs):
+def delete_annotation_from_s3_storages(sender, instance, **kwargs):  # type: ignore[no-untyped-def]
     links = S3ExportStorageLink.objects.filter(annotation=instance)
     for link in links:
         storage = link.storage
         if storage.can_delete_objects:
             logger.debug(f'Delete {instance} from S3 storage {storage}')  # nosec
-            storage.delete_annotation(instance)
+            storage.delete_annotation(instance)  # type: ignore[no-untyped-call]
 
 
 class S3ImportStorageLink(ImportStorageLink):
     storage = models.ForeignKey(S3ImportStorage, on_delete=models.CASCADE, related_name='links')
 
     @classmethod
-    def exists(cls, key, storage):
-        storage_link_exists = super(S3ImportStorageLink, cls).exists(key, storage)
+    def exists(cls, key, storage):  # type: ignore[no-untyped-def]
+        storage_link_exists = super(S3ImportStorageLink, cls).exists(key, storage)  # type: ignore[no-untyped-call]
         # TODO: this is a workaround to be compatible with old keys version - remove it later
         prefix = str(storage.prefix) or ''
         return storage_link_exists or \

--- a/label_studio/io_storages/s3/models.py
+++ b/label_studio/io_storages/s3/models.py
@@ -1,5 +1,6 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
+from typing import TYPE_CHECKING
 import re
 import logging
 import json
@@ -24,7 +25,10 @@ from io_storages.base_models import (
     ProjectStorageMixin
 )
 
-from label_studio.io_storages.s3.utils import AWS
+if TYPE_CHECKING:
+    from io_storages.s3.utils import AWS
+else:
+    from label_studio.io_storages.s3.utils import AWS
 
 logger = logging.getLogger(__name__)
 logging.getLogger('botocore').setLevel(logging.CRITICAL)

--- a/label_studio/io_storages/s3/serializers.py
+++ b/label_studio/io_storages/s3/serializers.py
@@ -5,7 +5,7 @@ import os
 from rest_framework.exceptions import ValidationError
 from rest_framework import serializers
 from rest_framework.mixins import UpdateModelMixin
-from botocore.exceptions import ParamValidationError, ClientError
+from botocore.exceptions import ParamValidationError, ClientError  # type: ignore[import]
 from io_storages.serializers import ImportStorageSerializer, ExportStorageSerializer
 from io_storages.s3.models import S3ImportStorage, S3ExportStorage
 
@@ -18,13 +18,13 @@ class S3ImportStorageSerializer(ImportStorageSerializer):
         model = S3ImportStorage
         fields = '__all__'
 
-    def to_representation(self, instance):
+    def to_representation(self, instance):  # type: ignore[no-untyped-def]
         result = super().to_representation(instance)
         result.pop('aws_access_key_id')
         result.pop('aws_secret_access_key')
         return result
 
-    def validate(self, data):
+    def validate(self, data):  # type: ignore[no-untyped-def]
         data = super(S3ImportStorageSerializer, self).validate(data)
         if not data.get('bucket', None):
             return data
@@ -36,16 +36,16 @@ class S3ImportStorageSerializer(ImportStorageSerializer):
         else:
             storage = S3ImportStorage(**data)
         try:
-            storage.validate_connection()
+            storage.validate_connection()  # type: ignore[union-attr]
         except ParamValidationError:
-            raise ValidationError('Wrong credentials for S3 {bucket_name}'.format(bucket_name=storage.bucket))
+            raise ValidationError('Wrong credentials for S3 {bucket_name}'.format(bucket_name=storage.bucket))  # type: ignore[union-attr]
         except ClientError as e:
             if '403' == e.response.get('Error').get('Code'):
                 raise ValidationError('Cannot connect to S3 {bucket_name} with specified AWS credentials'.format(
-                    bucket_name=storage.bucket))
+                    bucket_name=storage.bucket))  # type: ignore[union-attr]
             if '404' in e.response.get('Error').get('Code'):
                 raise ValidationError('Cannot find bucket {bucket_name} in S3'.format(
-                    bucket_name=storage.bucket))
+                    bucket_name=storage.bucket))  # type: ignore[union-attr]
         except TypeError as e:
             raise ValidationError(f'It seems access keys are incorrect: {e}')
         return data
@@ -54,7 +54,7 @@ class S3ImportStorageSerializer(ImportStorageSerializer):
 class S3ExportStorageSerializer(ExportStorageSerializer):
     type = serializers.ReadOnlyField(default=os.path.basename(os.path.dirname(__file__)))
 
-    def to_representation(self, instance):
+    def to_representation(self, instance):  # type: ignore[no-untyped-def]
         result = super().to_representation(instance)
         result.pop('aws_access_key_id')
         result.pop('aws_secret_access_key')

--- a/label_studio/io_storages/s3/utils.py
+++ b/label_studio/io_storages/s3/utils.py
@@ -2,9 +2,9 @@
 """
 import logging
 import base64
-import boto3
+import boto3  # type: ignore[import]
 
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError  # type: ignore[import]
 from urllib.parse import urlparse
 from core.utils.params import get_env
 
@@ -12,16 +12,16 @@ from core.utils.params import get_env
 logger = logging.getLogger(__name__)
 
 
-def get_client_and_resource(
+def get_client_and_resource(  # type: ignore[no-untyped-def]
     aws_access_key_id=None,
     aws_secret_access_key=None,
     aws_session_token=None,
     region_name=None,
     s3_endpoint=None
 ):
-    aws_access_key_id = aws_access_key_id or get_env('AWS_ACCESS_KEY_ID')
-    aws_secret_access_key = aws_secret_access_key or get_env('AWS_SECRET_ACCESS_KEY')
-    aws_session_token = aws_session_token or get_env('AWS_SESSION_TOKEN')
+    aws_access_key_id = aws_access_key_id or get_env('AWS_ACCESS_KEY_ID')  # type: ignore[no-untyped-call]
+    aws_secret_access_key = aws_secret_access_key or get_env('AWS_SECRET_ACCESS_KEY')  # type: ignore[no-untyped-call]
+    aws_session_token = aws_session_token or get_env('AWS_SESSION_TOKEN')  # type: ignore[no-untyped-call]
     logger.debug(f'Create boto3 session with '
                  f'access key id={aws_access_key_id}, '
                  f'secret key={aws_secret_access_key[:4] + "..." if aws_secret_access_key else None}, '
@@ -32,9 +32,9 @@ def get_client_and_resource(
         aws_session_token=aws_session_token
     )
     settings = {
-        'region_name': region_name or get_env('S3_region') or 'us-east-1'
+        'region_name': region_name or get_env('S3_region') or 'us-east-1'  # type: ignore[no-untyped-call]
     }
-    s3_endpoint = s3_endpoint or get_env('S3_ENDPOINT')
+    s3_endpoint = s3_endpoint or get_env('S3_ENDPOINT')  # type: ignore[no-untyped-call]
     if s3_endpoint:
         settings['endpoint_url'] = s3_endpoint
     client = session.client('s3', config=boto3.session.Config(signature_version='s3v4'), **settings)
@@ -42,7 +42,7 @@ def get_client_and_resource(
     return client, resource
 
 
-def resolve_s3_url(url, client, presign=True, expires_in=3600):
+def resolve_s3_url(url, client, presign=True, expires_in=3600):  # type: ignore[no-untyped-def]
     r = urlparse(url, allow_fragments=False)
     bucket_name = r.netloc
     key = r.path.lstrip('/')
@@ -72,7 +72,7 @@ def resolve_s3_url(url, client, presign=True, expires_in=3600):
 class AWS(object):
 
     @classmethod
-    def get_blob_metadata(cls,
+    def get_blob_metadata(cls,  # type: ignore[no-untyped-def, no-untyped-def]
                           url: str,
                           bucket_name: str,
                           client=None,
@@ -91,7 +91,7 @@ class AWS(object):
         :return: Object metadata dict("name": "value")
         """
         if client is None:
-            client, _ = get_client_and_resource(aws_access_key_id=aws_access_key_id,
+            client, _ = get_client_and_resource(aws_access_key_id=aws_access_key_id,  # type: ignore[no-untyped-call]
                                                 aws_secret_access_key=aws_secret_access_key,
                                                 aws_session_token=aws_session_token,
                                                 region_name=region_name,

--- a/label_studio/io_storages/serializers.py
+++ b/label_studio/io_storages/serializers.py
@@ -9,7 +9,7 @@ from tasks.serializers import AnnotationSerializer, TaskSerializer
 from tasks.models import Task
 
 
-class ImportStorageSerializer(serializers.ModelSerializer):
+class ImportStorageSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
     type = serializers.ReadOnlyField(default=os.path.basename(os.path.dirname(__file__)))
 
     class Meta:
@@ -17,7 +17,7 @@ class ImportStorageSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
-class ExportStorageSerializer(serializers.ModelSerializer):
+class ExportStorageSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
     type = serializers.ReadOnlyField(default=os.path.basename(os.path.dirname(__file__)))
 
     class Meta:
@@ -25,8 +25,8 @@ class ExportStorageSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
-class StorageTaskSerializer(TaskSerializer):
-    def __init__(self, *args, **kwargs):
+class StorageTaskSerializer(TaskSerializer):  # type: ignore[misc]
+    def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         # task is nested into the annotation, we don't need annotations in the task again
         kwargs['context'] = {
             'resolve_uri': False
@@ -38,12 +38,12 @@ class StorageTaskSerializer(TaskSerializer):
         fields = '__all__'
 
 
-class StorageCompletedBySerializer(serializers.ModelSerializer):
+class StorageCompletedBySerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
     class Meta:
         model = User
         fields = ('id', 'first_name', 'last_name', 'email')
 
 
 class StorageAnnotationSerializer(AnnotationSerializer):
-    task = StorageTaskSerializer(read_only=True, omit=['annotations'])
-    completed_by = StorageCompletedBySerializer(read_only=True)
+    task = StorageTaskSerializer(read_only=True, omit=['annotations'])  # type: ignore[no-untyped-call]
+    completed_by = StorageCompletedBySerializer(read_only=True)  # type: ignore[assignment]

--- a/label_studio/io_storages/urls.py
+++ b/label_studio/io_storages/urls.py
@@ -63,7 +63,7 @@ _api_urlpatterns = [
     path('export/redis/validate', RedisExportStorageValidateAPI.as_view(), name='export-storage-redis-validate'),
     path('export/redis/form', RedisExportStorageFormLayoutAPI.as_view(), name='export-storage-redis-form'),
 ]
-if settings.ENABLE_LOCAL_FILES_STORAGE:
+if settings.ENABLE_LOCAL_FILES_STORAGE:  # type: ignore[name-defined]
     _api_urlpatterns += [
         # Local files
         path('localfiles/', LocalFilesImportStorageListAPI.as_view(), name='storage-localfiles-list'),

--- a/label_studio/io_storages/utils.py
+++ b/label_studio/io_storages/utils.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 uri_regex = r"([\"'])(?P<uri>(?P<storage>{})://[^\1=]*)\1"
 
 
-def get_uri_via_regex(data, prefixes=('s3', 'gs')):
+def get_uri_via_regex(data, prefixes=('s3', 'gs')):  # type: ignore[no-untyped-def]
     data = str(data).strip()
     middle_check = False
 

--- a/label_studio/labels_manager/api.py
+++ b/label_studio/labels_manager/api.py
@@ -3,8 +3,8 @@ import logging
 from django.db.models import CharField, Count, F, Q
 from django.db.models.functions import Cast
 from django.utils.decorators import method_decorator
-from django_filters.rest_framework import DjangoFilterBackend
-from drf_yasg.utils import swagger_auto_schema
+from django_filters.rest_framework import DjangoFilterBackend  # type: ignore[import]
+from drf_yasg.utils import swagger_auto_schema  # type: ignore[import]
 from rest_framework import views, viewsets
 from rest_framework import views, viewsets
 from rest_framework.pagination import PageNumberPagination
@@ -68,7 +68,7 @@ logger = logging.getLogger(__name__)
     ),
 )
 @method_decorator(name='update', decorator=swagger_auto_schema(auto_schema=None))
-class LabelAPI(viewsets.ModelViewSet):
+class LabelAPI(viewsets.ModelViewSet):  # type: ignore[type-arg]
     pagination_class = PageNumberPagination
     serializer_class = LabelSerializer
     permission_required = ViewClassPermission(
@@ -78,19 +78,19 @@ class LabelAPI(viewsets.ModelViewSet):
         DELETE=all_permissions.labels_delete,
     )
 
-    def get_serializer(self, *args, **kwargs):
+    def get_serializer(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         '''POST request is bulk by default'''
         if self.action == 'create':
             kwargs['many'] = True
         return super().get_serializer(*args, **kwargs)
 
-    def perform_create(self, serializer):
-        serializer.save(created_by=self.request.user, organization=self.request.user.active_organization)
+    def perform_create(self, serializer):  # type: ignore[no-untyped-def]
+        serializer.save(created_by=self.request.user, organization=self.request.user.active_organization)  # type: ignore[union-attr]
 
-    def get_queryset(self):
-        return Label.objects.filter(organization=self.request.user.active_organization).prefetch_related('links')
+    def get_queryset(self):  # type: ignore[no-untyped-def]
+        return Label.objects.filter(organization=self.request.user.active_organization).prefetch_related('links')  # type: ignore[misc, union-attr]
 
-    def get_serializer_class(self):
+    def get_serializer_class(self):  # type: ignore[no-untyped-def]
         if self.request.method == 'POST':
             return LabelCreateSerializer
 
@@ -144,7 +144,7 @@ class LabelAPI(viewsets.ModelViewSet):
     ),
 )
 @method_decorator(name='update', decorator=swagger_auto_schema(auto_schema=None))
-class LabelLinkAPI(viewsets.ModelViewSet):
+class LabelLinkAPI(viewsets.ModelViewSet):  # type: ignore[type-arg]
     filter_backends = [DjangoFilterBackend]
     filterset_fields = {
         'project': ['exact'],
@@ -160,8 +160,8 @@ class LabelLinkAPI(viewsets.ModelViewSet):
         DELETE=all_permissions.labels_delete,
     )
 
-    def get_queryset(self):
-        return LabelLink.objects.filter(label__organization=self.request.user.active_organization).annotate(
+    def get_queryset(self):  # type: ignore[no-untyped-def]
+        return LabelLink.objects.filter(label__organization=self.request.user.active_organization).annotate(  # type: ignore[misc, union-attr]
             annotations_count=Count(
                 'project__tasks__annotations',
                 filter=Q(
@@ -170,12 +170,12 @@ class LabelLinkAPI(viewsets.ModelViewSet):
             )
         )
 
-    @api_webhook('LABEL_LINK_UPDATED')
-    def update(self, request, *args, **kwargs):
+    @api_webhook('LABEL_LINK_UPDATED')  # type: ignore[no-untyped-call]
+    def update(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         return super().update(request, *args, **kwargs)
 
-    @api_webhook_for_delete('LABEL_LINK_DELETED')
-    def destroy(self, request, *args, **kwargs):
+    @api_webhook_for_delete('LABEL_LINK_DELETED')  # type: ignore[no-untyped-call]
+    def destroy(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         return super().destroy(request, *args, **kwargs)
 
 
@@ -192,17 +192,17 @@ class LabelLinkAPI(viewsets.ModelViewSet):
 class LabelBulkUpdateAPI(views.APIView):
     permission_required = all_permissions.labels_change
 
-    def post(self, request):
+    def post(self, request):  # type: ignore[no-untyped-def]
         serializer = LabelBulkUpdateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         project = serializer.validated_data['project']
         if project is not None:
             self.check_object_permissions(self.request, project)
 
-        updated_count = bulk_update_label(
+        updated_count = bulk_update_label(  # type: ignore[no-untyped-call]
             old_label=serializer.validated_data['old_label'],
             new_label=serializer.validated_data['new_label'],
-            organization=self.request.user.active_organization,
+            organization=self.request.user.active_organization,  # type: ignore[union-attr]
             project=project,
         )
         return Response({'annotations_updated': updated_count})

--- a/label_studio/labels_manager/exceptions.py
+++ b/label_studio/labels_manager/exceptions.py
@@ -4,4 +4,4 @@ from core.utils.exceptions import LabelStudioAPIException
 
 
 class LabelBulkUpdateError(LabelStudioAPIException):
-    status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
+    status_code = status.HTTP_422_UNPROCESSABLE_ENTITY  # type: ignore[assignment]

--- a/label_studio/labels_manager/functions.py
+++ b/label_studio/labels_manager/functions.py
@@ -3,7 +3,7 @@ from django.db import transaction
 from tasks.models import Annotation
 
 
-def bulk_update_label(old_label, new_label, organization, project=None):
+def bulk_update_label(old_label, new_label, organization, project=None):  # type: ignore[no-untyped-def]
     annotations = Annotation.objects.filter(project__organization=organization)
     if project is not None:
         annotations = annotations.filter(project=project)

--- a/label_studio/labels_manager/models.py
+++ b/label_studio/labels_manager/models.py
@@ -24,7 +24,7 @@ class Label(models.Model):
     projects = models.ManyToManyField('projects.Project', through='LabelLink')
     organization = models.ForeignKey('organizations.Organization', related_name='labels', on_delete=models.CASCADE)
 
-    def has_permission(self, user):
+    def has_permission(self, user):  # type: ignore[no-untyped-def]
         return self.organization_id == user.active_organization_id
 
     class Meta:
@@ -42,6 +42,6 @@ class LabelLink(models.Model):
             models.UniqueConstraint(fields=['project', 'label'], name='unique_label_project')
         ]
 
-    def has_permission(self, user):
+    def has_permission(self, user):  # type: ignore[no-untyped-def]
         user.project = self.project  # link for activity log
         return self.project.has_permission(user)

--- a/label_studio/labels_manager/serializers.py
+++ b/label_studio/labels_manager/serializers.py
@@ -5,19 +5,19 @@ from rest_framework.exceptions import ValidationError
 
 from organizations.models import Organization
 from projects.models import Project
-from rest_flex_fields import FlexFieldsModelSerializer
+from rest_flex_fields import FlexFieldsModelSerializer  # type: ignore[import]
 from users.models import User
 
 from .models import Label, LabelLink
 
 
-class LabelListSerializer(serializers.ListSerializer):
-    def validate(self, items):
+class LabelListSerializer(serializers.ListSerializer):  # type: ignore[type-arg]
+    def validate(self, items):  # type: ignore[no-untyped-def]
         if len(set(item['project'] for item in items)) > 1:
             raise ValidationError('Creating labels for different projects in one request not allowed')
         return items
 
-    def create(self, validated_data):
+    def create(self, validated_data):  # type: ignore[no-untyped-def]
         ''' Bulk creation objects of Label model with related LabelLink
         reusing already existing labels
         '''
@@ -62,8 +62,8 @@ class LabelListSerializer(serializers.ListSerializer):
             for index, label in enumerate(labels):
                 if label.id is None:
                     label = created_labels[label.title]
-                label.project = labels_data[index]['project']
-                label.from_name = labels_data[index]['from_name']
+                label.project = labels_data[index]['project']  # type: ignore[attr-defined]
+                label.from_name = labels_data[index]['from_name']  # type: ignore[attr-defined]
                 result.append(label)
                 links.append(
                     LabelLink(
@@ -78,16 +78,16 @@ class LabelListSerializer(serializers.ListSerializer):
             links = LabelLink.objects.bulk_create(links, ignore_conflicts=True)
             # webhooks processing
             # bulk_create with ignore_conflicts doesn't return ids, reloading links
-            project = labels[0].project
+            project = labels[0].project  # type: ignore[attr-defined]
             label_ids = [label.id for label in result]
-            links = LabelLink.objects.filter(label_id__in=label_ids, project=project).all()
+            links = LabelLink.objects.filter(label_id__in=label_ids, project=project).all()  # type: ignore[assignment]
             if links:
-                emit_webhooks_for_instance(self.context['request'].user.active_organization, links[0].project, 'LABEL_LINK_CREATED', links)
+                emit_webhooks_for_instance(self.context['request'].user.active_organization, links[0].project, 'LABEL_LINK_CREATED', links)  # type: ignore[no-untyped-call]
 
         return result
 
 
-class LabelCreateSerializer(serializers.ModelSerializer):
+class LabelCreateSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
     created_by = serializers.PrimaryKeyRelatedField(queryset=User.objects.all(), required=False)
     organization = serializers.PrimaryKeyRelatedField(queryset=Organization.objects.all(), required=False)
     project = serializers.PrimaryKeyRelatedField(queryset=Project.objects.all())
@@ -99,7 +99,7 @@ class LabelCreateSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
-class LabelLinkSerializer(FlexFieldsModelSerializer):
+class LabelLinkSerializer(FlexFieldsModelSerializer):  # type: ignore[misc]
     annotations_count = serializers.IntegerField(read_only=True)
     class Meta:
         model = LabelLink
@@ -107,8 +107,8 @@ class LabelLinkSerializer(FlexFieldsModelSerializer):
         expandable_fields = {'label': ('labels_manager.serializers.LabelSerializer', {'omit': ['links', 'projects']})}
 
 
-class LabelSerializer(FlexFieldsModelSerializer):
-    links = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+class LabelSerializer(FlexFieldsModelSerializer):  # type: ignore[misc]
+    links = serializers.PrimaryKeyRelatedField(many=True, read_only=True)  # type: ignore[var-annotated]
 
     class Meta:
         model = Label
@@ -116,7 +116,7 @@ class LabelSerializer(FlexFieldsModelSerializer):
         expandable_fields = {'links': ('labels_manager.serializers.LabelLinkSerializer', {'many': True})}
 
 
-class LabelBulkUpdateSerializer(serializers.Serializer):
+class LabelBulkUpdateSerializer(serializers.Serializer):  # type: ignore[type-arg]
     project = serializers.PrimaryKeyRelatedField(queryset=Project.objects.all(), required=False, default=None)
     old_label = serializers.JSONField()
     new_label = serializers.JSONField()

--- a/label_studio/ml/api_connector.py
+++ b/label_studio/ml/api_connector.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from requests.adapters import HTTPAdapter
 from core.version import get_git_version
 from data_export.serializers import ExportDataSerializer
-from label_studio.core.utils.params import get_env
+from core.utils.params import get_env
 from core.feature_flags import flag_set
 from core.utils.common import load_func
 

--- a/label_studio/ml/api_connector.py
+++ b/label_studio/ml/api_connector.py
@@ -13,22 +13,22 @@ from requests.adapters import HTTPAdapter
 from core.version import get_git_version
 from data_export.serializers import ExportDataSerializer
 from core.utils.params import get_env
-from core.feature_flags import flag_set
+from core.feature_flags import flag_set  # type: ignore[attr-defined]
 from core.utils.common import load_func
 
-version = get_git_version()
+version = get_git_version()  # type: ignore[no-untyped-call]
 logger = logging.getLogger(__name__)
 
-CONNECTION_TIMEOUT = float(get_env('ML_CONNECTION_TIMEOUT', 1))  # seconds
-TIMEOUT_DEFAULT = float(get_env('ML_TIMEOUT_DEFAULT', 100))  # seconds
+CONNECTION_TIMEOUT = float(get_env('ML_CONNECTION_TIMEOUT', 1))    # type: ignore[no-untyped-call] # seconds
+TIMEOUT_DEFAULT = float(get_env('ML_TIMEOUT_DEFAULT', 100))    # type: ignore[no-untyped-call] # seconds
 
-TIMEOUT_TRAIN = float(get_env('ML_TIMEOUT_TRAIN', 30))
-TIMEOUT_PREDICT = float(get_env('ML_TIMEOUT_PREDICT', 100))
-TIMEOUT_HEALTH = float(get_env('ML_TIMEOUT_HEALTH', 1))
-TIMEOUT_SETUP = float(get_env('ML_TIMEOUT_SETUP', 3))
-TIMEOUT_DUPLICATE_MODEL = float(get_env('ML_TIMEOUT_DUPLICATE_MODEL', 1))
-TIMEOUT_DELETE = float(get_env('ML_TIMEOUT_DELETE', 1))
-TIMEOUT_TRAIN_JOB_STATUS = float(get_env('ML_TIMEOUT_TRAIN_JOB_STATUS', 1))
+TIMEOUT_TRAIN = float(get_env('ML_TIMEOUT_TRAIN', 30))  # type: ignore[no-untyped-call]
+TIMEOUT_PREDICT = float(get_env('ML_TIMEOUT_PREDICT', 100))  # type: ignore[no-untyped-call]
+TIMEOUT_HEALTH = float(get_env('ML_TIMEOUT_HEALTH', 1))  # type: ignore[no-untyped-call]
+TIMEOUT_SETUP = float(get_env('ML_TIMEOUT_SETUP', 3))  # type: ignore[no-untyped-call]
+TIMEOUT_DUPLICATE_MODEL = float(get_env('ML_TIMEOUT_DUPLICATE_MODEL', 1))  # type: ignore[no-untyped-call]
+TIMEOUT_DELETE = float(get_env('ML_TIMEOUT_DELETE', 1))  # type: ignore[no-untyped-call]
+TIMEOUT_TRAIN_JOB_STATUS = float(get_env('ML_TIMEOUT_TRAIN_JOB_STATUS', 1))  # type: ignore[no-untyped-call]
 
 
 class BaseHTTPAPI(object):
@@ -37,15 +37,15 @@ class BaseHTTPAPI(object):
         'User-Agent': 'heartex/' + (version or ''),
     }
 
-    def __init__(self, url, timeout=None, connection_timeout=None, max_retries=None, headers=None, **kwargs):
+    def __init__(self, url, timeout=None, connection_timeout=None, max_retries=None, headers=None, **kwargs):  # type: ignore[no-untyped-def]
         self._url = url
         self._timeout = timeout or TIMEOUT_DEFAULT
         self._connection_timeout = connection_timeout or CONNECTION_TIMEOUT
         self._headers = headers or {}
         self._max_retries = max_retries or self.MAX_RETRIES
-        self._sessions = {self._session_key(): self.create_session()}
+        self._sessions = {self._session_key(): self.create_session()}  # type: ignore[no-untyped-call, no-untyped-call]
 
-    def create_session(self):
+    def create_session(self):  # type: ignore[no-untyped-def]
         session = requests.Session()
         session.headers.update(self.HEADERS)
         session.headers.update(self._headers)
@@ -53,20 +53,20 @@ class BaseHTTPAPI(object):
         session.mount('https://', HTTPAdapter(max_retries=self._max_retries))
         return session
 
-    def _session_key(self):
+    def _session_key(self):  # type: ignore[no-untyped-def]
         return os.getpid()
 
     @property
-    def http(self):
-        key = self._session_key()
+    def http(self):  # type: ignore[no-untyped-def]
+        key = self._session_key()  # type: ignore[no-untyped-call]
         if key in self._sessions:
             return self._sessions[key]
         else:
-            session = self.create_session()
+            session = self.create_session()  # type: ignore[no-untyped-call]
             self._sessions[key] = session
             return session
 
-    def _prepare_kwargs(self, kwargs):
+    def _prepare_kwargs(self, kwargs):  # type: ignore[no-untyped-def]
         # add timeout if it's not presented
         if 'timeout' not in kwargs:
             kwargs['timeout'] = self._connection_timeout, self._timeout
@@ -75,62 +75,62 @@ class BaseHTTPAPI(object):
         elif isinstance(kwargs['timeout'], float) or isinstance(kwargs['timeout'], int):
             kwargs['timeout'] = (self._connection_timeout, kwargs['timeout'])
 
-    def request(self, method, *args, **kwargs):
-        self._prepare_kwargs(kwargs)
+    def request(self, method, *args, **kwargs):  # type: ignore[no-untyped-def]
+        self._prepare_kwargs(kwargs)  # type: ignore[no-untyped-call]
         return self.http.request(method, *args, **kwargs)
 
-    def get(self, *args, **kwargs):
-        return self.request('GET', *args, **kwargs)
+    def get(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        return self.request('GET', *args, **kwargs)  # type: ignore[no-untyped-call]
 
-    def post(self, *args, **kwargs):
-        return self.request('POST', *args, **kwargs)
+    def post(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        return self.request('POST', *args, **kwargs)  # type: ignore[no-untyped-call]
 
 
 @attr.s
 class MLApiResult(object):
-    url = attr.ib(default='')
-    request = attr.ib(default='')
-    response = attr.ib(default=attr.Factory(dict))
-    headers = attr.ib(default=attr.Factory(dict))
-    type = attr.ib(default='ok')
-    status_code = attr.ib(default=200)
+    url = attr.ib(default='')  # type: ignore[var-annotated]
+    request = attr.ib(default='')  # type: ignore[var-annotated]
+    response = attr.ib(default=attr.Factory(dict))  # type: ignore[var-annotated]
+    headers = attr.ib(default=attr.Factory(dict))  # type: ignore[var-annotated]
+    type = attr.ib(default='ok')  # type: ignore[var-annotated]
+    status_code = attr.ib(default=200)  # type: ignore[var-annotated]
 
     @property
-    def is_error(self):
+    def is_error(self):  # type: ignore[no-untyped-def]
         return self.type == 'error'
 
     @property
-    def error_message(self):
-        return self.response.get('error')
+    def error_message(self):  # type: ignore[no-untyped-def]
+        return self.response.get('error')  # type: ignore[arg-type]
 
 
 @attr.s
 class MLApiScheme(object):
-    tag_name = attr.ib()
-    tag_type = attr.ib()
-    source_name = attr.ib()
-    source_type = attr.ib()
-    source_value = attr.ib()
+    tag_name = attr.ib()  # type: ignore[var-annotated]
+    tag_type = attr.ib()  # type: ignore[var-annotated]
+    source_name = attr.ib()  # type: ignore[var-annotated]
+    source_type = attr.ib()  # type: ignore[var-annotated]
+    source_value = attr.ib()  # type: ignore[var-annotated]
 
-    def to_dict(self):
+    def to_dict(self):  # type: ignore[no-untyped-def]
         return attr.asdict(self)
 
 
 class MLApi(BaseHTTPAPI):
 
-    def __init__(self, **kwargs):
-        super(MLApi, self).__init__(**kwargs)
+    def __init__(self, **kwargs):  # type: ignore[no-untyped-def]
+        super(MLApi, self).__init__(**kwargs)  # type: ignore[no-untyped-call]
         self._validate_request_timeout = 10
 
-    def _get_url(self, url_suffix):
+    def _get_url(self, url_suffix):  # type: ignore[no-untyped-def]
         url = self._url
         if url[-1] != '/':
             url += '/'
         return urllib.parse.urljoin(url, url_suffix)
 
-    def _request(self, url_suffix, request=None, verbose=True, method='POST', *args, **kwargs):
+    def _request(self, url_suffix, request=None, verbose=True, method='POST', *args, **kwargs):  # type: ignore[no-untyped-def]
         assert method in ('POST', 'GET')
-        url = self._get_url(url_suffix)
+        url = self._get_url(url_suffix)  # type: ignore[no-untyped-call]
         request = request or {}
         headers = dict(self.http.headers)
         # if verbose:
@@ -138,13 +138,13 @@ class MLApi(BaseHTTPAPI):
         response = None
         try:
             if method == 'POST':
-                response = self.post(url=url, json=request, *args, **kwargs)
+                response = self.post(url=url, json=request, *args, **kwargs)  # type: ignore[no-untyped-call]
             else:
-                response = self.get(url=url, *args, **kwargs)
+                response = self.get(url=url, *args, **kwargs)  # type: ignore[no-untyped-call]
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             # Extending error details in case of failed request
-            if flag_set('fix_back_dev_3351_ml_validation_error_extension_short', AnonymousUser):
+            if flag_set('fix_back_dev_3351_ml_validation_error_extension_short', AnonymousUser):  # type: ignore[no-untyped-call]
                 error_string = str(e) + (" " + str(response.text) if response else "")
             else:
                 error_string = str(e)
@@ -163,20 +163,20 @@ class MLApi(BaseHTTPAPI):
         #     logger.info(f'Response from {url}: {json.dumps(response, indent=2)}')
         return MLApiResult(url, request, response, headers, status_code=status_code)
 
-    def _create_project_uid(self, project):
+    def _create_project_uid(self, project):  # type: ignore[no-untyped-def]
         time_id = int(project.created_at.timestamp())
         return f'{project.id}.{time_id}'
 
-    def train(self, project, use_ground_truth=False):
+    def train(self, project, use_ground_truth=False):  # type: ignore[no-untyped-def]
         # TODO Replace AnonymousUser with real user from request
         user = AnonymousUser()
         # Identify if feature flag is turned on
-        if flag_set('ff_back_dev_1417_start_training_mlbackend_webhooks_250122_long', user):
+        if flag_set('ff_back_dev_1417_start_training_mlbackend_webhooks_250122_long', user):  # type: ignore[no-untyped-call]
             request = {
                 'action': 'PROJECT_UPDATED',
-                'project': load_func(settings.WEBHOOK_SERIALIZERS['project'])(instance=project).data
+                'project': load_func(settings.WEBHOOK_SERIALIZERS['project'])(instance=project).data  # type: ignore[no-untyped-call]
             }
-            return self._request('webhook', request, verbose=False, timeout=TIMEOUT_PREDICT)
+            return self._request('webhook', request, verbose=False, timeout=TIMEOUT_PREDICT)  # type: ignore[no-untyped-call]
         else:
             # get only tasks with annotations
             tasks = project.tasks.annotate(num_annotations=Count('annotations')).filter(num_annotations__gt=0)
@@ -185,20 +185,20 @@ class MLApi(BaseHTTPAPI):
             logger.debug(f'{len(tasks_ser)} tasks with annotations are sent to ML backend for training.')
             request = {
                 'annotations': tasks_ser,
-                'project': self._create_project_uid(project),
+                'project': self._create_project_uid(project),  # type: ignore[no-untyped-call]
                 'label_config': project.label_config,
                 'params': {
                     'login': project.task_data_login,
                     'password': project.task_data_password
                 }
             }
-            return self._request('train', request, verbose=False, timeout=TIMEOUT_PREDICT)
+            return self._request('train', request, verbose=False, timeout=TIMEOUT_PREDICT)  # type: ignore[no-untyped-call]
 
-    def make_predictions(self, tasks, model_version, project, context=None):
+    def make_predictions(self, tasks, model_version, project, context=None):  # type: ignore[no-untyped-def]
         request = {
             'tasks': tasks,
             'model_version': model_version,
-            'project': self._create_project_uid(project),
+            'project': self._create_project_uid(project),  # type: ignore[no-untyped-call]
             'label_config': project.label_config,
             'params': {
                 'login': project.task_data_login,
@@ -206,47 +206,47 @@ class MLApi(BaseHTTPAPI):
                 'context': context,
             },
         }
-        return self._request('predict', request, verbose=False, timeout=TIMEOUT_PREDICT)
+        return self._request('predict', request, verbose=False, timeout=TIMEOUT_PREDICT)  # type: ignore[no-untyped-call]
 
-    def health(self):
-        return self._request('health', method='GET', timeout=TIMEOUT_HEALTH)
+    def health(self):  # type: ignore[no-untyped-def]
+        return self._request('health', method='GET', timeout=TIMEOUT_HEALTH)  # type: ignore[no-untyped-call]
 
-    def validate(self, config):
-        return self._request('validate', request={'config': config}, timeout=self._validate_request_timeout)
+    def validate(self, config):  # type: ignore[no-untyped-def]
+        return self._request('validate', request={'config': config}, timeout=self._validate_request_timeout)  # type: ignore[no-untyped-call]
 
-    def setup(self, project, model_version=None):
-        return self._request('setup', request={
-            'project': self._create_project_uid(project),
+    def setup(self, project, model_version=None):  # type: ignore[no-untyped-def]
+        return self._request('setup', request={  # type: ignore[no-untyped-call]
+            'project': self._create_project_uid(project),  # type: ignore[no-untyped-call]
             'schema': project.label_config,
             'hostname': settings.HOSTNAME if settings.HOSTNAME else ('http://localhost:' + settings.INTERNAL_PORT),
             'access_token': project.created_by.auth_token.key,
             'model_version': model_version
         }, timeout=TIMEOUT_SETUP)
 
-    def duplicate_model(self, project_src, project_dst):
-        return self._request('duplicate_model', request={
-            'project_src': self._create_project_uid(project_src),
-            'project_dst': self._create_project_uid(project_dst)
+    def duplicate_model(self, project_src, project_dst):  # type: ignore[no-untyped-def]
+        return self._request('duplicate_model', request={  # type: ignore[no-untyped-call]
+            'project_src': self._create_project_uid(project_src),  # type: ignore[no-untyped-call]
+            'project_dst': self._create_project_uid(project_dst)  # type: ignore[no-untyped-call]
         }, timeout=TIMEOUT_DUPLICATE_MODEL)
 
-    def delete(self, project):
-        return self._request('delete', request={'project': self._create_project_uid(project)}, timeout=TIMEOUT_DELETE)
+    def delete(self, project):  # type: ignore[no-untyped-def]
+        return self._request('delete', request={'project': self._create_project_uid(project)}, timeout=TIMEOUT_DELETE)  # type: ignore[no-untyped-call, no-untyped-call]
 
-    def get_train_job_status(self, train_job):
-        return self._request('job_status', request={'job': train_job.job_id}, timeout=TIMEOUT_TRAIN_JOB_STATUS)
+    def get_train_job_status(self, train_job):  # type: ignore[no-untyped-def]
+        return self._request('job_status', request={'job': train_job.job_id}, timeout=TIMEOUT_TRAIN_JOB_STATUS)  # type: ignore[no-untyped-call]
 
-    def get_versions(self, project):
-        return self._request('versions', request={
-            'project': self._create_project_uid(project)
+    def get_versions(self, project):  # type: ignore[no-untyped-def]
+        return self._request('versions', request={  # type: ignore[no-untyped-call]
+            'project': self._create_project_uid(project)  # type: ignore[no-untyped-call]
         }, timeout=TIMEOUT_SETUP, method='GET')
 
 
-def get_ml_api(project):
+def get_ml_api(project):  # type: ignore[no-untyped-def]
     if project.ml_backend_active_connection is None:
         return None
     if project.ml_backend_active_connection.ml_backend is None:
         return None
-    return MLApi(
+    return MLApi(  # type: ignore[no-untyped-call]
         url=project.ml_backend_active_connection.ml_backend.url,
         timeout=project.ml_backend_active_connection.ml_backend.timeout
     )

--- a/label_studio/ml/mixins.py
+++ b/label_studio/ml/mixins.py
@@ -3,10 +3,10 @@ from tasks.serializers import AnnotationDraftSerializer
 
 
 class InteractiveMixin:
-    def to_representation(self, task):
-        user = self.context.get('user')
+    def to_representation(self, task):  # type: ignore[no-untyped-def]
+        user = self.context.get('user')  # type: ignore[attr-defined]
         drafts = AnnotationDraft.objects.filter(task=task, user=user)
         drafts_ser = AnnotationDraftSerializer(drafts, many=True, default=[], read_only=True).data
-        data = super().to_representation(task)
+        data = super().to_representation(task)  # type: ignore[misc]
         data['drafts'] = drafts_ser
         return data

--- a/label_studio/ml/serializers.py
+++ b/label_studio/ml/serializers.py
@@ -5,16 +5,16 @@ from rest_framework import serializers
 from ml.models import MLBackend
 from core.utils.io import validate_upload_url
 
-class MLBackendSerializer(serializers.ModelSerializer):
-    def validate_url(self, value):
-        validate_upload_url(value, block_local_urls=settings.ML_BLOCK_LOCAL_IP)
+class MLBackendSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
+    def validate_url(self, value):  # type: ignore[no-untyped-def]
+        validate_upload_url(value, block_local_urls=settings.ML_BLOCK_LOCAL_IP)  # type: ignore[no-untyped-call]
 
         return value
 
-    def validate(self, attrs):
+    def validate(self, attrs):  # type: ignore[no-untyped-def]
         attrs = super(MLBackendSerializer, self).validate(attrs)
         url = attrs['url']
-        healthcheck_response = MLBackend.healthcheck_(url)
+        healthcheck_response = MLBackend.healthcheck_(url)  # type: ignore[no-untyped-call]
         if healthcheck_response.is_error:
             raise serializers.ValidationError(
                 f"Can't connect to ML backend {url}, health check failed. "
@@ -23,7 +23,7 @@ class MLBackendSerializer(serializers.ModelSerializer):
                 f' about how to set up an ML backend. Additional info:' + healthcheck_response.error_message
             )
         project = attrs['project']
-        setup_response = MLBackend.setup_(url, project)
+        setup_response = MLBackend.setup_(url, project)  # type: ignore[no-untyped-call]
         if setup_response.is_error:
             raise serializers.ValidationError(
                 f"Successfully connected to {url} but it doesn't look like a valid ML backend. "
@@ -38,12 +38,12 @@ class MLBackendSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
-class MLInteractiveAnnotatingRequest(serializers.Serializer):
+class MLInteractiveAnnotatingRequest(serializers.Serializer):  # type: ignore[type-arg]
     task = serializers.IntegerField(
         help_text='ID of task to annotate',
         required=True,
     )
-    context = serializers.JSONField(
+    context = serializers.JSONField(  # type: ignore[assignment]
         help_text='Context for ML model',
         allow_null=True,
         default=None,

--- a/label_studio/mypy.ini
+++ b/label_studio/mypy.ini
@@ -1,0 +1,12 @@
+[mypy]
+plugins =
+    mypy_django_plugin.main
+check_untyped_defs = True
+explicit_package_bases = True
+exclude = (?x)(
+    ^__init__.py$    # files named "one.py"
+    | .*/migrations/.*.py$  # migrations
+  )
+
+[mypy.plugins.django-stubs]
+django_settings_module = "core.settings.label_studio"

--- a/label_studio/mypy.ini
+++ b/label_studio/mypy.ini
@@ -3,6 +3,8 @@ plugins =
     mypy_django_plugin.main
 check_untyped_defs = True
 explicit_package_bases = True
+strict = True
+cache_dir = /label_studio/data/.mypy_cache
 exclude = (?x)(
     ^__init__.py$    # files named "one.py"
     | .*/migrations/.*.py$  # migrations

--- a/label_studio/mypy.ini
+++ b/label_studio/mypy.ini
@@ -4,11 +4,12 @@ plugins =
 check_untyped_defs = True
 explicit_package_bases = True
 strict = True
-cache_dir = /label_studio/data/.mypy_cache
+cache_dir = ../data/.mypy_cache
 exclude = (?x)(
-    ^__init__.py$    # files named "one.py"
+    ^__init__.py$    # the root `__init__.py`
     | .*/migrations/.*.py$  # migrations
   )
 
 [mypy.plugins.django-stubs]
 django_settings_module = "core.settings.label_studio"
+

--- a/label_studio/organizations/api.py
+++ b/label_studio/organizations/api.py
@@ -14,8 +14,8 @@ from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
 from django.utils.decorators import method_decorator
 
-from label_studio.core.permissions import all_permissions, ViewClassPermission
-from label_studio.core.utils.params import bool_from_request
+from core.permissions import all_permissions, ViewClassPermission
+from core.utils.params import bool_from_request
 
 from organizations.models import Organization
 from organizations.serializers import (

--- a/label_studio/organizations/api.py
+++ b/label_studio/organizations/api.py
@@ -10,8 +10,8 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.pagination import PageNumberPagination
 
-from drf_yasg.utils import swagger_auto_schema
-from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema  # type: ignore[import]
+from drf_yasg import openapi  # type: ignore[import]
 from django.utils.decorators import method_decorator
 
 from core.permissions import all_permissions, ViewClassPermission
@@ -22,7 +22,7 @@ from organizations.serializers import (
     OrganizationSerializer, OrganizationIdSerializer, OrganizationMemberUserSerializer, OrganizationInviteSerializer,
     OrganizationsParamsSerializer
 )
-from core.feature_flags import flag_set
+from core.feature_flags import flag_set  # type: ignore[attr-defined]
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
         Return a list of the organizations you've created or that you have access to.
         """
     ))
-class OrganizationListAPI(generics.ListCreateAPIView):
+class OrganizationListAPI(generics.ListCreateAPIView):  # type: ignore[type-arg]
     queryset = Organization.objects.all()
     parser_classes = (JSONParser, FormParser, MultiPartParser)
     permission_required = ViewClassPermission(
@@ -46,14 +46,14 @@ class OrganizationListAPI(generics.ListCreateAPIView):
     )
     serializer_class = OrganizationIdSerializer
 
-    def filter_queryset(self, queryset):
+    def filter_queryset(self, queryset):  # type: ignore[no-untyped-def]
         return queryset.filter(users=self.request.user).distinct()
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         return super(OrganizationListAPI, self).get(request, *args, **kwargs)
 
     @swagger_auto_schema(auto_schema=None)
-    def post(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         return super(OrganizationListAPI, self).post(request, *args, **kwargs)
 
 
@@ -61,7 +61,7 @@ class OrganizationMemberPagination(PageNumberPagination):
     page_size = 20
     page_size_query_param = 'page_size'
 
-    def get_page_size(self, request):
+    def get_page_size(self, request):  # type: ignore[no-untyped-def]
         # emulate "unlimited" page_size
         if self.page_size_query_param in request.query_params and request.query_params[self.page_size_query_param] == '-1':
             return 1000000
@@ -80,7 +80,7 @@ class OrganizationMemberPagination(PageNumberPagination):
                 description='A unique integer value identifying this organization.'),
         ],
     ))
-class OrganizationMemberListAPI(generics.ListAPIView):
+class OrganizationMemberListAPI(generics.ListAPIView):  # type: ignore[type-arg]
 
     parser_classes = (JSONParser, FormParser, MultiPartParser)
     permission_required = ViewClassPermission(
@@ -92,15 +92,15 @@ class OrganizationMemberListAPI(generics.ListAPIView):
     serializer_class = OrganizationMemberUserSerializer
     pagination_class = OrganizationMemberPagination
 
-    def get_serializer_context(self):
+    def get_serializer_context(self):  # type: ignore[no-untyped-def]
         return {
-            'contributed_to_projects': bool_from_request(self.request.GET, 'contributed_to_projects', False),
+            'contributed_to_projects': bool_from_request(self.request.GET, 'contributed_to_projects', False),  # type: ignore[no-untyped-call]
             'request': self.request
         }
 
-    def get_queryset(self):
-        org = generics.get_object_or_404(self.request.user.organizations, pk=self.kwargs[self.lookup_field])
-        if flag_set('fix_backend_dev_3134_exclude_deactivated_users', self.request.user):
+    def get_queryset(self):  # type: ignore[no-untyped-def]
+        org = generics.get_object_or_404(self.request.user.organizations, pk=self.kwargs[self.lookup_field])  # type: ignore[union-attr]
+        if flag_set('fix_backend_dev_3134_exclude_deactivated_users', self.request.user):  # type: ignore[no-untyped-call]
             serializer = OrganizationsParamsSerializer(data=self.request.GET)
             serializer.is_valid(raise_exception=True)
             active = serializer.validated_data.get('active')
@@ -125,7 +125,7 @@ class OrganizationMemberListAPI(generics.ListAPIView):
         operation_summary='Update organization settings',
         operation_description='Update the settings for a specific organization by ID.'
     ))
-class OrganizationAPI(generics.RetrieveUpdateAPIView):
+class OrganizationAPI(generics.RetrieveUpdateAPIView):  # type: ignore[type-arg]
 
     parser_classes = (JSONParser, FormParser, MultiPartParser)
     queryset = Organization.objects.all()
@@ -135,14 +135,14 @@ class OrganizationAPI(generics.RetrieveUpdateAPIView):
     redirect_route = 'organizations-dashboard'
     redirect_kwarg = 'pk'
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         return super(OrganizationAPI, self).get(request, *args, **kwargs)
 
-    def patch(self, request, *args, **kwargs):
+    def patch(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         return super(OrganizationAPI, self).patch(request, *args, **kwargs)
 
     @swagger_auto_schema(auto_schema=None)
-    def put(self, request, *args, **kwargs):
+    def put(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         return super(OrganizationAPI, self).put(request, *args, **kwargs)
 
 
@@ -152,12 +152,12 @@ class OrganizationAPI(generics.RetrieveUpdateAPIView):
         operation_description='Get a link to use to invite a new member to an organization in Label Studio Enterprise.',
         responses={200: OrganizationInviteSerializer()}
     ))
-class OrganizationInviteAPI(generics.RetrieveAPIView):
+class OrganizationInviteAPI(generics.RetrieveAPIView):  # type: ignore[type-arg]
     parser_classes = (JSONParser,)
     queryset = Organization.objects.all()
     permission_required = all_permissions.organizations_change
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         org = request.user.active_organization
         invite_url = '{}?token={}'.format(reverse('user-signup'), org.token)
         if hasattr(settings, 'FORCE_SCRIPT_NAME') and settings.FORCE_SCRIPT_NAME:
@@ -177,7 +177,7 @@ class OrganizationResetTokenAPI(APIView):
     permission_required = all_permissions.organizations_invite
     parser_classes = (JSONParser,)
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         org = request.user.active_organization
         org.reset_token()
         logger.debug(f'New token for organization {org.pk} is {org.token}')

--- a/label_studio/organizations/forms.py
+++ b/label_studio/organizations/forms.py
@@ -7,7 +7,7 @@ from .models import Organization, OrganizationMember
 from django.forms import Textarea, ModelForm, TextInput, Form, FileField, Select, HiddenInput, CharField
 
 
-class OrganizationForm(ModelForm):
+class OrganizationForm(ModelForm):  # type: ignore[type-arg]
     """
     """
     org_update = CharField(widget=HiddenInput(), required=False)
@@ -17,7 +17,7 @@ class OrganizationForm(ModelForm):
         fields = ('title',)
 
 
-class OrganizationSignupForm(ModelForm):
+class OrganizationSignupForm(ModelForm):  # type: ignore[type-arg]
     """
     """
     class Meta:

--- a/label_studio/organizations/functions.py
+++ b/label_studio/organizations/functions.py
@@ -5,15 +5,15 @@ from organizations.models import Organization, OrganizationMember
 from projects.models import Project
 
 
-def create_organization(title, created_by):
+def create_organization(title, created_by):  # type: ignore[no-untyped-def]
     with transaction.atomic():
         org = Organization.objects.create(title=title, created_by=created_by)
         OrganizationMember.objects.create(user=created_by, organization=org)
         return org
 
 
-def destroy_organization(org):
-    with temporary_disconnect_all_signals():
+def destroy_organization(org):  # type: ignore[no-untyped-def]
+    with temporary_disconnect_all_signals():  # type: ignore[no-untyped-call]
         Project.objects.filter(organization=org).delete()
         if hasattr(org, 'saml'):
             org.saml.delete()

--- a/label_studio/organizations/management/commands/destroy_organization.py
+++ b/label_studio/organizations/management/commands/destroy_organization.py
@@ -10,10 +10,10 @@ log = logging.getLogger(__name__)
 class Command(BaseCommand):
     help = 'Destroy organization'
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser):  # type: ignore[no-untyped-def]
         parser.add_argument('organization_id', type=int)
 
-    def handle(self, *args, **options):
+    def handle(self, *args, **options):  # type: ignore[no-untyped-def]
         org = Organization.objects.filter(pk=options['organization_id']).first()
         if org is None:
             print(f'Organization with id: {options["organization_id"]} not found')
@@ -22,4 +22,4 @@ class Command(BaseCommand):
             f'You are trying to remove organization with id: {org.id} and title: "{org.title}". This is not reversible!! Are you sure? yes/no: '
         )
         if yes == 'yes':
-            destroy_organization(org)
+            destroy_organization(org)  # type: ignore[no-untyped-call]

--- a/label_studio/organizations/middleware.py
+++ b/label_studio/organizations/middleware.py
@@ -9,10 +9,10 @@ logger = logging.getLogger(__name__)
 
 
 class DummyGetSessionMiddleware:
-    def __init__(self, get_response):
+    def __init__(self, get_response):  # type: ignore[no-untyped-def]
         self.get_response = get_response
 
-    def __call__(self, request):
+    def __call__(self, request):  # type: ignore[no-untyped-def]
         org = Organization.objects.first()
         user = request.user
         if user and user.is_authenticated and user.active_organization is None:

--- a/label_studio/organizations/mixins.py
+++ b/label_studio/organizations/mixins.py
@@ -1,4 +1,4 @@
 class OrganizationMixin:
     @property
-    def active_members(self):
-        return self.members
+    def active_members(self):  # type: ignore[no-untyped-def]
+        return self.members  # type: ignore[attr-defined]

--- a/label_studio/organizations/models.py
+++ b/label_studio/organizations/models.py
@@ -29,24 +29,24 @@ class OrganizationMember(models.Model):
     updated_at = models.DateTimeField(_('updated at'), auto_now=True)
 
     @classmethod
-    def find_by_user(cls, user_or_user_pk, organization_pk):
+    def find_by_user(cls, user_or_user_pk, organization_pk):  # type: ignore[no-untyped-def]
         from users.models import User
 
         user_pk = user_or_user_pk.pk if isinstance(user_or_user_pk, User) else user_or_user_pk
         return OrganizationMember.objects.get(user=user_pk, organization=organization_pk)
 
     @property
-    def is_owner(self):
-        return self.user.id == self.organization.created_by.id
+    def is_owner(self):  # type: ignore[no-untyped-def]
+        return self.user.id == self.organization.created_by.id  # type: ignore[union-attr]
 
     class Meta:
         ordering = ['pk']
 
 
-OrganizationMixin = load_func(settings.ORGANIZATION_MIXIN)
+OrganizationMixin = load_func(settings.ORGANIZATION_MIXIN)  # type: ignore[no-untyped-call]
 
 
-class Organization(OrganizationMixin, models.Model):
+class Organization(OrganizationMixin, models.Model):  # type: ignore[misc, valid-type]
     """
     """
     title = models.CharField(_('organization title'), max_length=1000, null=False)
@@ -61,41 +61,41 @@ class Organization(OrganizationMixin, models.Model):
     created_at = models.DateTimeField(_('created at'), auto_now_add=True)
     updated_at = models.DateTimeField(_('updated at'), auto_now=True)
 
-    def __str__(self):
+    def __str__(self):  # type: ignore[no-untyped-def]
         return self.title + ', id=' + str(self.pk)
 
     @classmethod
-    def create_organization(cls, created_by=None, title='Your Organization'):
-        _create_organization = load_func(settings.CREATE_ORGANIZATION)
+    def create_organization(cls, created_by=None, title='Your Organization'):  # type: ignore[no-untyped-def]
+        _create_organization = load_func(settings.CREATE_ORGANIZATION)  # type: ignore[no-untyped-call]
         return _create_organization(title=title, created_by=created_by)
     
     @classmethod
-    def find_by_user(cls, user):
+    def find_by_user(cls, user):  # type: ignore[no-untyped-def]
         memberships = OrganizationMember.objects.filter(user=user).prefetch_related('organization')
         if not memberships.exists():
             raise ValueError(f'No memberships found for user {user}')
-        return memberships.first().organization
+        return memberships.first().organization  # type: ignore[union-attr]
 
     @classmethod
-    def find_by_invite_url(cls, url):
+    def find_by_invite_url(cls, url):  # type: ignore[no-untyped-def]
         token = url.strip('/').split('/')[-1]
         if len(token):
             return Organization.objects.get(token=token)
         else:
             raise KeyError(f'Can\'t find Organization by welcome URL: {url}')
 
-    def has_user(self, user):
+    def has_user(self, user):  # type: ignore[no-untyped-def]
         return self.users.filter(pk=user.pk).exists()
 
-    def has_project_member(self, user):
+    def has_project_member(self, user):  # type: ignore[no-untyped-def]
         return self.projects.filter(members__user=user).exists()
 
-    def has_permission(self, user):
+    def has_permission(self, user):  # type: ignore[no-untyped-def]
         if self in user.organizations.all():
             return True
         return False
 
-    def add_user(self, user):
+    def add_user(self, user):  # type: ignore[no-untyped-def]
         if self.users.filter(pk=user.pk).exists():
             logger.debug('User already exists in organization.')
             return
@@ -106,31 +106,31 @@ class Organization(OrganizationMixin, models.Model):
 
             return om    
 
-    def remove_user(self, user):
+    def remove_user(self, user):  # type: ignore[no-untyped-def]
         OrganizationMember.objects.filter(user=user, organization=self).delete()
         if user.active_organization_id == self.id:
             user.active_organization = user.organizations.first()
             user.save(update_fields=['active_organization'])
     
-    def reset_token(self):
-        self.token = create_hash()
+    def reset_token(self):  # type: ignore[no-untyped-def]
+        self.token = create_hash()  # type: ignore[no-untyped-call]
         self.save()
 
-    def check_max_projects(self):
+    def check_max_projects(self):  # type: ignore[no-untyped-def]
         """This check raise an exception if the projects limit is hit
         """
         pass
 
-    def projects_sorted_by_created_at(self):
+    def projects_sorted_by_created_at(self):  # type: ignore[no-untyped-def]
         return self.projects.all().order_by('-created_at').annotate(
             tasks_count=Count('tasks'),
             labeled_tasks_count=Count('tasks', filter=Q(tasks__is_labeled=True))
         ).prefetch_related('created_by')
 
-    def created_at_prettify(self):
+    def created_at_prettify(self):  # type: ignore[no-untyped-def]
         return self.created_at.strftime("%d %b %Y %H:%M:%S")
 
-    def per_project_invited_users(self):
+    def per_project_invited_users(self):  # type: ignore[no-untyped-def]
         from users.models import User
 
         invited_ids = self.projects.values_list('members__user__pk', flat=True).distinct()
@@ -138,11 +138,11 @@ class Organization(OrganizationMixin, models.Model):
         return per_project_invited_users
 
     @property
-    def secure_mode(self):
+    def secure_mode(self):  # type: ignore[no-untyped-def]
         return False
 
     @property
-    def members(self):
+    def members(self):  # type: ignore[no-untyped-def]
         return OrganizationMember.objects.filter(organization=self)
 
     class Meta:

--- a/label_studio/organizations/serializers.py
+++ b/label_studio/organizations/serializers.py
@@ -3,43 +3,43 @@
 import ujson as json
 
 from rest_framework import serializers
-from drf_dynamic_fields import DynamicFieldsMixin
+from drf_dynamic_fields import DynamicFieldsMixin  # type: ignore[import]
 
 from organizations.models import Organization, OrganizationMember
 from users.serializers import UserSerializer
 from collections import OrderedDict
 
 
-class OrganizationIdSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+class OrganizationIdSerializer(DynamicFieldsMixin, serializers.ModelSerializer):  # type: ignore[misc, type-arg]
     class Meta:
         model = Organization
         fields = ['id', 'title']
 
 
-class OrganizationSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+class OrganizationSerializer(DynamicFieldsMixin, serializers.ModelSerializer):  # type: ignore[misc, type-arg]
     class Meta:
         model = Organization
         fields = '__all__'
 
 
-class OrganizationMemberSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+class OrganizationMemberSerializer(DynamicFieldsMixin, serializers.ModelSerializer):  # type: ignore[misc, type-arg]
     class Meta:
         model = OrganizationMember
         fields = ['id', 'organization', 'user']
 
 
-class UserSerializerWithProjects(UserSerializer):
+class UserSerializerWithProjects(UserSerializer):  # type: ignore[misc]
     created_projects = serializers.SerializerMethodField(read_only=True)
     contributed_to_projects = serializers.SerializerMethodField(read_only=True)
 
-    def get_created_projects(self, user):
+    def get_created_projects(self, user):  # type: ignore[no-untyped-def]
         if not self.context.get('contributed_to_projects', False):
             return None
 
         current_user = self.context['request'].user
         return user.created_projects.filter(organization=current_user.active_organization).values('id', 'title')
 
-    def get_contributed_to_projects(self, user):
+    def get_contributed_to_projects(self, user):  # type: ignore[no-untyped-def]
         if not self.context.get('contributed_to_projects', False):
             return None
 
@@ -49,14 +49,14 @@ class UserSerializerWithProjects(UserSerializer):
             .values('project__id', 'project__title')
         contributed_to = [(json.dumps({'id': p['project__id'], 'title': p['project__title']}), 0)
                           for p in projects]
-        contributed_to = OrderedDict(contributed_to)  # remove duplicates without ordering losing
-        return [json.loads(key) for key in contributed_to]
+        contributed_to = OrderedDict(contributed_to)    # type: ignore[assignment] # remove duplicates without ordering losing
+        return [json.loads(key) for key in contributed_to]  # type: ignore[arg-type]
 
-    class Meta(UserSerializer.Meta):
+    class Meta(UserSerializer.Meta):  # type: ignore[misc]
         fields = UserSerializer.Meta.fields + ('created_projects', 'contributed_to_projects')
 
 
-class OrganizationMemberUserSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+class OrganizationMemberUserSerializer(DynamicFieldsMixin, serializers.ModelSerializer):  # type: ignore[misc, type-arg]
     """Adds all user properties"""
     user = UserSerializerWithProjects()
 
@@ -65,11 +65,11 @@ class OrganizationMemberUserSerializer(DynamicFieldsMixin, serializers.ModelSeri
         fields = ['id', 'organization', 'user']
 
 
-class OrganizationInviteSerializer(serializers.Serializer):
+class OrganizationInviteSerializer(serializers.Serializer):  # type: ignore[type-arg]
     token = serializers.CharField(required=False)
     invite_url = serializers.CharField(required=False)
 
 
-class OrganizationsParamsSerializer(serializers.Serializer):
+class OrganizationsParamsSerializer(serializers.Serializer):  # type: ignore[type-arg]
     active = serializers.BooleanField(required=False, default=False)
     contributed_to_projects = serializers.BooleanField(required=False, default=False)

--- a/label_studio/organizations/views.py
+++ b/label_studio/organizations/views.py
@@ -5,9 +5,9 @@ from django.contrib.auth.decorators import login_required
 
 
 @login_required
-def organization_people_list(request):
+def organization_people_list(request):  # type: ignore[no-untyped-def]
     return render(request, 'organizations/people_list.html')
 
 @login_required
-def simple_view(request):
+def simple_view(request):  # type: ignore[no-untyped-def]
     return render(request, 'organizations/people_list.html')

--- a/label_studio/projects/functions/__init__.py
+++ b/label_studio/projects/functions/__init__.py
@@ -2,35 +2,35 @@ from django.db.models import Count, Q, OuterRef
 
 from core.utils.db import SQCount
 from tasks.models import Annotation, Task, Prediction
-from core.feature_flags import flag_set
+from core.feature_flags import flag_set  # type: ignore[attr-defined]
 
 
-def annotate_task_number(queryset):
-    if flag_set('fflag_fix_back_LSDV_4748_annotate_task_number_14032023_short', user='auto'):
+def annotate_task_number(queryset):  # type: ignore[no-untyped-def]
+    if flag_set('fflag_fix_back_LSDV_4748_annotate_task_number_14032023_short', user='auto'):  # type: ignore[no-untyped-call]
         tasks = Task.objects.filter(project=OuterRef('id')).values_list('id')
         return queryset.annotate(task_number=SQCount(tasks))
     else:
         return queryset.annotate(task_number=Count('tasks', distinct=True))
 
 
-def annotate_finished_task_number(queryset):
-    if flag_set('fflag_fix_back_LSDV_4748_annotate_task_number_14032023_short', user='auto'):
+def annotate_finished_task_number(queryset):  # type: ignore[no-untyped-def]
+    if flag_set('fflag_fix_back_LSDV_4748_annotate_task_number_14032023_short', user='auto'):  # type: ignore[no-untyped-call]
         tasks = Task.objects.filter(project=OuterRef('id'), is_labeled=True).values_list('id')
         return queryset.annotate(finished_task_number=SQCount(tasks))
     else:
         return queryset.annotate(finished_task_number=Count('tasks', distinct=True, filter=Q(tasks__is_labeled=True)))
 
 
-def annotate_total_predictions_number(queryset):
-    if flag_set("fflag_fix_back_lsdv_4719_improve_performance_of_project_annotations", user='auto'):
+def annotate_total_predictions_number(queryset):  # type: ignore[no-untyped-def]
+    if flag_set("fflag_fix_back_lsdv_4719_improve_performance_of_project_annotations", user='auto'):  # type: ignore[no-untyped-call]
         predictions = Prediction.objects.filter(task__project=OuterRef('id')).values('id')
         return queryset.annotate(total_predictions_number=SQCount(predictions))
     else:
         return queryset.annotate(total_predictions_number=Count('tasks__predictions', distinct=True))
 
 
-def annotate_total_annotations_number(queryset):
-    if flag_set('fflag_fix_back_LSDV_961_project_list_09022023_short', user='auto'):
+def annotate_total_annotations_number(queryset):  # type: ignore[no-untyped-def]
+    if flag_set('fflag_fix_back_LSDV_961_project_list_09022023_short', user='auto'):  # type: ignore[no-untyped-call]
         subquery = Annotation.objects.filter(
             Q(project=OuterRef('pk'))
             & Q(was_cancelled=False)
@@ -42,11 +42,11 @@ def annotate_total_annotations_number(queryset):
         ))
 
 
-def annotate_num_tasks_with_annotations(queryset):
+def annotate_num_tasks_with_annotations(queryset):  # type: ignore[no-untyped-def]
     # @todo: check do we really need this counter?
     # this function is very slow because of tasks__id and distinct
 
-    if flag_set('fflag_fix_back_LSDV_961_project_list_09022023_short', user='auto'):
+    if flag_set('fflag_fix_back_LSDV_961_project_list_09022023_short', user='auto'):  # type: ignore[no-untyped-call]
         subquery = Annotation.objects.filter(
             Q(project=OuterRef('pk'))
             & Q(ground_truth=False)
@@ -65,8 +65,8 @@ def annotate_num_tasks_with_annotations(queryset):
         ))
 
 
-def annotate_useful_annotation_number(queryset):
-    if flag_set('fflag_fix_back_LSDV_961_project_list_09022023_short', user='auto'):
+def annotate_useful_annotation_number(queryset):  # type: ignore[no-untyped-def]
+    if flag_set('fflag_fix_back_LSDV_961_project_list_09022023_short', user='auto'):  # type: ignore[no-untyped-call]
         subquery = Annotation.objects.filter(
             Q(project=OuterRef('pk'))
             & Q(was_cancelled=False)
@@ -84,8 +84,8 @@ def annotate_useful_annotation_number(queryset):
         ))
 
 
-def annotate_ground_truth_number(queryset):
-    if flag_set('fflag_fix_back_LSDV_961_project_list_09022023_short', user='auto'):
+def annotate_ground_truth_number(queryset):  # type: ignore[no-untyped-def]
+    if flag_set('fflag_fix_back_LSDV_961_project_list_09022023_short', user='auto'):  # type: ignore[no-untyped-call]
         subquery = Annotation.objects.filter(
             Q(project=OuterRef('pk'))
             & Q(ground_truth=True)
@@ -97,8 +97,8 @@ def annotate_ground_truth_number(queryset):
         ))
 
 
-def annotate_skipped_annotations_number(queryset):
-    if flag_set('fflag_fix_back_LSDV_961_project_list_09022023_short', user='auto'):
+def annotate_skipped_annotations_number(queryset):  # type: ignore[no-untyped-def]
+    if flag_set('fflag_fix_back_LSDV_961_project_list_09022023_short', user='auto'):  # type: ignore[no-untyped-call]
         subquery = Annotation.objects.filter(
             Q(project=OuterRef('pk'))
             & Q(was_cancelled=True)

--- a/label_studio/projects/functions/stream_history.py
+++ b/label_studio/projects/functions/stream_history.py
@@ -8,7 +8,7 @@ TASK_ID_KEY = 'taskId'
 ANNOTATION_ID_KEY = 'annotationId'
 
 
-def add_stream_history(next_task, user, project):
+def add_stream_history(next_task, user, project):  # type: ignore[no-untyped-def]
     if next_task is not None:
         with transaction.atomic():
             history, created = LabelStreamHistory.objects.get_or_create(user=user, project=project)
@@ -24,7 +24,7 @@ def add_stream_history(next_task, user, project):
             history.save()
 
 
-def fill_history_annotation(user, task, annotation):
+def fill_history_annotation(user, task, annotation):  # type: ignore[no-untyped-def]
     history = user.histories.filter(project=task.project).first()
     if history and history.data:
         for item in history.data:
@@ -33,8 +33,8 @@ def fill_history_annotation(user, task, annotation):
         history.save()
 
 
-def get_label_stream_history(user, project):
-    result = []
+def get_label_stream_history(user, project):  # type: ignore[no-untyped-def]
+    result = []  # type: ignore[var-annotated]
 
     with transaction.atomic():
         history = user.histories.filter(project=project).first()

--- a/label_studio/projects/functions/utils.py
+++ b/label_studio/projects/functions/utils.py
@@ -1,7 +1,7 @@
 from tasks.models import Task
 
 
-def make_queryset_from_iterable(tasks_list):
+def make_queryset_from_iterable(tasks_list):  # type: ignore[no-untyped-def]
     """
     Make queryset from list/set of int/Tasks
     :param tasks_list: Iterable of Tasks or IDs

--- a/label_studio/projects/mixins.py
+++ b/label_studio/projects/mixins.py
@@ -2,21 +2,21 @@ from core.redis import start_job_async_or_sync
 
 
 class ProjectMixin:
-    def rearrange_overlap_cohort(self):
+    def rearrange_overlap_cohort(self):  # type: ignore[no-untyped-def]
         """
         Async start rearrange overlap depending on annotation count in tasks
         """
-        start_job_async_or_sync(self._rearrange_overlap_cohort)
+        start_job_async_or_sync(self._rearrange_overlap_cohort)  # type: ignore[attr-defined, no-untyped-call]
 
-    def update_tasks_counters(self, tasks_queryset, from_scratch=True):
+    def update_tasks_counters(self, tasks_queryset, from_scratch=True):  # type: ignore[no-untyped-def]
         """
         Async start updating tasks counters
         :param tasks_queryset: Tasks to update queryset
         :param from_scratch: Skip calculated tasks
         """
-        start_job_async_or_sync(self._update_tasks_counters, tasks_queryset, from_scratch=from_scratch)
+        start_job_async_or_sync(self._update_tasks_counters, tasks_queryset, from_scratch=from_scratch)  # type: ignore[attr-defined, no-untyped-call]
 
-    def update_tasks_counters_and_is_labeled(self, tasks_queryset, from_scratch=True):
+    def update_tasks_counters_and_is_labeled(self, tasks_queryset, from_scratch=True):  # type: ignore[no-untyped-def]
         """
         Async start updating tasks counters and than is_labeled
         :param tasks_queryset: Tasks to update queryset
@@ -25,9 +25,9 @@ class ProjectMixin:
         # get only id from queryset to decrease data size in job
         if not (isinstance(tasks_queryset, set) or isinstance(tasks_queryset, list)):
             tasks_queryset = set(tasks_queryset.values_list('id', flat=True))
-        start_job_async_or_sync(self._update_tasks_counters_and_is_labeled, list(tasks_queryset), from_scratch=from_scratch)
+        start_job_async_or_sync(self._update_tasks_counters_and_is_labeled, list(tasks_queryset), from_scratch=from_scratch)  # type: ignore[attr-defined, no-untyped-call]
 
-    def update_tasks_counters_and_task_states(self, tasks_queryset, maximum_annotations_changed,
+    def update_tasks_counters_and_task_states(self, tasks_queryset, maximum_annotations_changed,  # type: ignore[no-untyped-def]
                                             overlap_cohort_percentage_changed, tasks_number_changed, from_scratch=True):
         """
         Async start updating tasks counters and than rearrange
@@ -40,10 +40,10 @@ class ProjectMixin:
         # get only id from queryset to decrease data size in job
         if not (isinstance(tasks_queryset, set) or isinstance(tasks_queryset, list)):
             tasks_queryset = set(tasks_queryset.values_list('id', flat=True))
-        start_job_async_or_sync(self._update_tasks_counters_and_task_states, tasks_queryset, maximum_annotations_changed,
+        start_job_async_or_sync(self._update_tasks_counters_and_task_states, tasks_queryset, maximum_annotations_changed,  # type: ignore[attr-defined, no-untyped-call]
                                 overlap_cohort_percentage_changed, tasks_number_changed, from_scratch=from_scratch)
 
-    def update_tasks_states(self,
+    def update_tasks_states(self,  # type: ignore[no-untyped-def]
                             maximum_annotations_changed,
                             overlap_cohort_percentage_changed,
                             tasks_number_changed):
@@ -53,19 +53,19 @@ class ProjectMixin:
         :param overlap_cohort_percentage_changed: If cohort_percentage param changed
         :param tasks_number_changed: If tasks number changed in project
         """
-        start_job_async_or_sync(self._update_tasks_states,
+        start_job_async_or_sync(self._update_tasks_states,  # type: ignore[attr-defined, no-untyped-call]
                                 maximum_annotations_changed,
                                 overlap_cohort_percentage_changed,
                                 tasks_number_changed)
 
-    def has_permission(self, user):
+    def has_permission(self, user):  # type: ignore[no-untyped-def]
         """
         Dummy stub for has_permission
         """
         user.project = self  # link for activity log
         return True
 
-    def _can_use_overlap(self):
+    def _can_use_overlap(self):  # type: ignore[no-untyped-def]
         """
         Returns if we can use overlap for is_labeled calculation
         :return:

--- a/label_studio/projects/serializers.py
+++ b/label_studio/projects/serializers.py
@@ -1,7 +1,7 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
 from rest_framework import serializers
-from rest_flex_fields import FlexFieldsModelSerializer
+from rest_flex_fields import FlexFieldsModelSerializer  # type: ignore[import]
 from rest_framework.serializers import SerializerMethodField
 import bleach
 from users.serializers import UserSimpleSerializer
@@ -14,11 +14,11 @@ from projects.models import Project, ProjectOnboarding, ProjectSummary, ProjectI
 class CreatedByFromContext:
     requires_context = True
 
-    def __call__(self, serializer_field):
+    def __call__(self, serializer_field):  # type: ignore[no-untyped-def]
         return serializer_field.context.get('created_by')
 
 
-class ProjectSerializer(FlexFieldsModelSerializer):
+class ProjectSerializer(FlexFieldsModelSerializer):  # type: ignore[misc]
     """ Serializer get numbers from project queryset annotation,
         make sure, that you use correct one(Project.objects.with_counts())
     """
@@ -54,18 +54,18 @@ class ProjectSerializer(FlexFieldsModelSerializer):
     finished_task_number = serializers.IntegerField(default=None, read_only=True, help_text='Finished tasks')
 
     @staticmethod
-    def get_config_has_control_tags(project):
+    def get_config_has_control_tags(project):  # type: ignore[no-untyped-def]
         return len(project.get_parsed_config()) > 0
 
     @staticmethod
-    def get_parsed_label_config(project):
+    def get_parsed_label_config(project):  # type: ignore[no-untyped-def]
         return project.get_parsed_config()
 
-    def get_start_training_on_annotation_update(self, instance):
+    def get_start_training_on_annotation_update(self, instance):  # type: ignore[no-untyped-def]
         # FIXME: remake this logic with start_training_on_annotation_update
         return True if instance.min_annotations_to_start_training else False
 
-    def to_internal_value(self, data):
+    def to_internal_value(self, data):  # type: ignore[no-untyped-def]
         # FIXME: remake this logic with start_training_on_annotation_update
         initial_data = data
         data = super().to_internal_value(data)
@@ -92,60 +92,60 @@ class ProjectSerializer(FlexFieldsModelSerializer):
                   'config_has_control_tags', 'skip_queue', 'reveal_preannotations_interactively', 'pinned_at',
                   'finished_task_number']
 
-    def validate_label_config(self, value):
+    def validate_label_config(self, value):  # type: ignore[no-untyped-def]
         if self.instance is None:
             # No project created yet
-            Project.validate_label_config(value)
+            Project.validate_label_config(value)  # type: ignore[no-untyped-call]
         else:
             # Existing project is updated
             self.instance.validate_config(value)
         return value
 
 
-class ProjectOnboardingSerializer(serializers.ModelSerializer):
+class ProjectOnboardingSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
     class Meta:
         model = ProjectOnboarding
         fields = '__all__'
 
 
-class ProjectLabelConfigSerializer(serializers.Serializer):
+class ProjectLabelConfigSerializer(serializers.Serializer):  # type: ignore[type-arg]
     label_config = serializers.CharField(help_text=Project.label_config.field.help_text)
 
-    def validate_label_config(self, config):
-        Project.validate_label_config(config)
+    def validate_label_config(self, config):  # type: ignore[no-untyped-def]
+        Project.validate_label_config(config)  # type: ignore[no-untyped-call]
         return config
 
 
-class ProjectSummarySerializer(serializers.ModelSerializer):
+class ProjectSummarySerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
 
     class Meta:
         model = ProjectSummary
         fields = '__all__'
 
 
-class ProjectImportSerializer(serializers.ModelSerializer):
+class ProjectImportSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
 
     class Meta:
         model = ProjectImport
         fields = '__all__'
 
 
-class ProjectReimportSerializer(serializers.ModelSerializer):
+class ProjectReimportSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
 
     class Meta:
         model = ProjectReimport
         fields = '__all__'
 
 
-class GetFieldsSerializer(serializers.Serializer):
+class GetFieldsSerializer(serializers.Serializer):  # type: ignore[type-arg]
     include = serializers.CharField(required=False)
     filter = serializers.CharField(required=False, default='all')
 
-    def validate_include(self, value):
+    def validate_include(self, value):  # type: ignore[no-untyped-def]
         if value is not None:
             value = value.split(',')
         return value
 
-    def validate_filter(self, value):
+    def validate_filter(self, value):  # type: ignore[no-untyped-def]
         if value in ['all', 'pinned_only', 'exclude_pinned']:
             return value

--- a/label_studio/projects/templatetags/custom_filters.py
+++ b/label_studio/projects/templatetags/custom_filters.py
@@ -6,7 +6,7 @@ register = template.Library()
 
 
 @register.filter(name='seconds_to_pretty_time')
-def seconds_to_pretty_time(value, show_seconds=False):
+def seconds_to_pretty_time(value, show_seconds=False):  # type: ignore[no-untyped-def]
     if value is None:
         return 'N/A'
     if value < 60:

--- a/label_studio/projects/views.py
+++ b/label_studio/projects/views.py
@@ -20,16 +20,16 @@ logger = logging.getLogger(__name__)
 
 
 @login_required
-def project_list(request):
+def project_list(request):  # type: ignore[no-untyped-def]
     return render(request, 'projects/list.html')
 
 
 @login_required
-def project_settings(request, pk, sub_path):
+def project_settings(request, pk, sub_path):  # type: ignore[no-untyped-def]
     return render(request, 'projects/settings.html')
 
 
-def playground_replacements(request, task_data):
+def playground_replacements(request, task_data):  # type: ignore[no-untyped-def]
     if request.GET.get('playground', '0') == '1':
         for key in task_data:
             if "/samples/time-series.csv" in task_data[key]:
@@ -38,23 +38,23 @@ def playground_replacements(request, task_data):
 
 
 @require_http_methods(['GET', 'POST'])
-def upload_example_using_config(request):
+def upload_example_using_config(request):  # type: ignore[no-untyped-def]
     """ Generate upload data example by config only
     """
     config = request.GET.get('label_config', '')
     if not config:
         config = request.POST.get('label_config', '')
 
-    org_pk = get_organization_from_request(request)
+    org_pk = get_organization_from_request(request)  # type: ignore[no-untyped-call]
     secure_mode = False
     if org_pk is not None:
         org = generics.get_object_or_404(Organization, pk=org_pk)
         secure_mode = org.secure_mode
 
     try:
-        Project.validate_label_config(config)
-        task_data, _, _ = get_sample_task(config, secure_mode)
-        task_data = playground_replacements(request, task_data)
+        Project.validate_label_config(config)  # type: ignore[no-untyped-call]
+        task_data, _, _ = get_sample_task(config, secure_mode)  # type: ignore[no-untyped-call]
+        task_data = playground_replacements(request, task_data)  # type: ignore[no-untyped-call]
     except (ValueError, ValidationError, lxml.etree.Error):
         response = HttpResponse('error while example generating', status=status.HTTP_400_BAD_REQUEST)
     else:

--- a/label_studio/server.py
+++ b/label_studio/server.py
@@ -1,5 +1,7 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
+from typing import TYPE_CHECKING
+
 import sys
 import logging
 import socket
@@ -15,9 +17,10 @@ if sys.platform == 'win32':
     init(convert=True)
 
 # on windows there will be problems with sqlite and json1 support, so fix it
-from label_studio.core.utils.windows_sqlite_fix import windows_dll_fix
+if not TYPE_CHECKING:
+    from label_studio.core.utils.windows_sqlite_fix import windows_dll_fix
 
-windows_dll_fix()
+    windows_dll_fix()
 
 from django.core.management import call_command
 from django.core.wsgi import get_wsgi_application
@@ -25,8 +28,12 @@ from django.db import connections, DEFAULT_DB_ALIAS, IntegrityError
 from django.db.backends.signals import connection_created
 from django.db.migrations.executor import MigrationExecutor
 
-from label_studio.core.argparser import parse_input_args
-from label_studio.core.utils.params import get_env
+if TYPE_CHECKING:
+    from core.argparser import parse_input_args
+    from core.utils.params import get_env
+else:
+    from label_studio.core.argparser import parse_input_args
+    from label_studio.core.utils.params import get_env
 
 logger = logging.getLogger(__name__)
 
@@ -296,7 +303,10 @@ def main():
     _setup_env()
     _apply_database_migrations()
 
-    from label_studio.core.utils.common import collect_versions
+    if TYPE_CHECKING:
+        from core.utils.common import collect_versions
+    else:
+        from label_studio.core.utils.common import collect_versions
     versions = collect_versions()
 
     if input_args.command == 'reset_password':
@@ -350,7 +360,10 @@ def main():
 
     # start with migrations from old projects, '.' project_name means 'label-studio start' without project name
     elif input_args.command == 'start' and input_args.project_name != '.':
-        from label_studio.core.old_ls_migration import migrate_existing_project
+        if TYPE_CHECKING:
+            from core.old_ls_migration import migrate_existing_project
+        else:
+            from label_studio.core.old_ls_migration import migrate_existing_project
         from projects.models import Project
         sampling_map = {'sequential': Project.SEQUENCE, 'uniform': Project.UNIFORM,
                         'prediction-score-min': Project.UNCERTAINTY}
@@ -394,7 +407,10 @@ def main():
 
     # on `start` command, launch browser if --no-browser is not specified and start label studio server
     if input_args.command == 'start' or input_args.command is None:
-        from label_studio.core.utils.common import start_browser
+        if TYPE_CHECKING:
+            from core.utils.common import start_browser
+        else:
+            from label_studio.core.utils.common import start_browser
 
         if get_env('USERNAME') and get_env('PASSWORD') or input_args.username:
             _create_user(input_args, config)

--- a/label_studio/tasks/exceptions.py
+++ b/label_studio/tasks/exceptions.py
@@ -4,5 +4,5 @@ from core.utils.exceptions import LabelStudioAPIException
 
 
 class AnnotationDuplicateError(LabelStudioAPIException):
-    status_code = status.HTTP_409_CONFLICT
+    status_code = status.HTTP_409_CONFLICT  # type: ignore[assignment]
     default_detail = 'Annotation with this unique id already exists'

--- a/label_studio/tasks/functions.py
+++ b/label_studio/tasks/functions.py
@@ -19,7 +19,7 @@ from data_export.mixins import ExportMixin
 logger = logging.getLogger(__name__)
 
 
-def calculate_stats_all_orgs(from_scratch, redis, migration_name='0018_manual_migrate_counters'):
+def calculate_stats_all_orgs(from_scratch, redis, migration_name='0018_manual_migrate_counters'):  # type: ignore[no-untyped-def]
     logger = logging.getLogger(__name__)
     organizations = Organization.objects.order_by('-id')
 
@@ -27,7 +27,7 @@ def calculate_stats_all_orgs(from_scratch, redis, migration_name='0018_manual_mi
         logger.debug(f"Start recalculating stats for Organization {org.id}")
 
         # start async calculation job on redis
-        start_job_async_or_sync(
+        start_job_async_or_sync(  # type: ignore[no-untyped-call]
             redis_job_for_calculation, org, from_scratch,
             redis=redis,
             queue_name='critical',
@@ -40,7 +40,7 @@ def calculate_stats_all_orgs(from_scratch, redis, migration_name='0018_manual_mi
     logger.debug("All organizations were recalculated")
 
 
-def redis_job_for_calculation(org, from_scratch, migration_name='0018_manual_migrate_counters'):
+def redis_job_for_calculation(org, from_scratch, migration_name='0018_manual_migrate_counters'):  # type: ignore[no-untyped-def]
     """
     Recalculate counters for projects list
     :param org: Organization to recalculate
@@ -78,13 +78,13 @@ def redis_job_for_calculation(org, from_scratch, migration_name='0018_manual_mig
         )
 
 
-def export_project(project_id, export_format, path, serializer_context=None):
+def export_project(project_id, export_format, path, serializer_context=None):  # type: ignore[no-untyped-def]
     logger = logging.getLogger(__name__)
 
     project = Project.objects.get(id=project_id)
 
     export_format = export_format.upper()
-    supported_formats = [s['name'] for s in DataExport.get_export_formats(project)]
+    supported_formats = [s['name'] for s in DataExport.get_export_formats(project)]  # type: ignore[no-untyped-call]
     assert export_format in supported_formats, f'Export format is not supported, please use {supported_formats}'
 
     task_ids = (
@@ -98,11 +98,11 @@ def export_project(project_id, export_format, path, serializer_context=None):
     # serializer context
     if isinstance(serializer_context, str):
         serializer_context = json.loads(serializer_context)
-    serializer_options = ExportMixin._get_export_serializer_option(serializer_context)
+    serializer_options = ExportMixin._get_export_serializer_option(serializer_context)  # type: ignore[no-untyped-call]
 
     # export cycle
     tasks = []
-    for _task_ids in batch(task_ids, 1000):
+    for _task_ids in batch(task_ids, 1000):  # type: ignore[no-untyped-call]
         tasks += ExportDataSerializer(
             _task_ids,
             many=True,
@@ -110,7 +110,7 @@ def export_project(project_id, export_format, path, serializer_context=None):
         ).data
 
     # convert to output format
-    export_stream, _, filename = DataExport.generate_export_file(
+    export_stream, _, filename = DataExport.generate_export_file(  # type: ignore[no-untyped-call]
         project, tasks, export_format, settings.CONVERTER_DOWNLOAD_RESOURCES, {}
     )
 
@@ -124,16 +124,16 @@ def export_project(project_id, export_format, path, serializer_context=None):
     return filepath
 
 
-def _fill_annotations_project(project_id):
+def _fill_annotations_project(project_id):  # type: ignore[no-untyped-def]
     Annotation.objects.filter(task__project_id=project_id).update(project_id=project_id)
 
 
-def fill_annotations_project():
+def fill_annotations_project():  # type: ignore[no-untyped-def]
     logger.info('Start filling project field for Annotation model')
 
     projects = Project.objects.all()
     for project in projects:
-        start_job_async_or_sync(_fill_annotations_project, project.id)
+        start_job_async_or_sync(_fill_annotations_project, project.id)  # type: ignore[no-untyped-call]
 
     logger.info('Finished filling project field for Annotation model')
 

--- a/label_studio/tasks/management/commands/annotations_fill_updated_by.py
+++ b/label_studio/tasks/management/commands/annotations_fill_updated_by.py
@@ -5,9 +5,9 @@ from django.core.management.base import BaseCommand
 class Command(BaseCommand):
     help = 'Fill updated_by field for Annotations'
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser):  # type: ignore[no-untyped-def]
         pass
 
-    def handle(self, *args, **options):
+    def handle(self, *args, **options):  # type: ignore[no-untyped-def]
         migration = importlib.import_module('tasks.migrations.0033_annotation_updated_by_fill')
         migration._fill_annotations_updated_by()

--- a/label_studio/tasks/management/commands/calculate_stats.py
+++ b/label_studio/tasks/management/commands/calculate_stats.py
@@ -10,10 +10,10 @@ logger = logging.getLogger(__name__)
 class Command(BaseCommand):
     help = 'Recalculate organization project stats (total_annotations, etc)'
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser):  # type: ignore[no-untyped-def]
         parser.add_argument('organization', type=int, help='organization id')
 
-    def handle(self, *args, **options):
+    def handle(self, *args, **options):  # type: ignore[no-untyped-def]
         logger.debug(f"Start recalculating for Organization {options['organization']}.")
         projects = Project.objects.filter(organization_id=options['organization'])
 

--- a/label_studio/tasks/management/commands/calculate_stats_all_orgs.py
+++ b/label_studio/tasks/management/commands/calculate_stats_all_orgs.py
@@ -4,7 +4,7 @@ from django.core.management.base import BaseCommand
 class Command(BaseCommand):
     help = 'Recalculate project stats (total_annotations, etc) for all organizations'
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser):  # type: ignore[no-untyped-def]
         parser.add_argument(
             '--from-scratch',
             dest='from_scratch',
@@ -20,7 +20,7 @@ class Command(BaseCommand):
             help='Use rq workers with redis (async background processing)'
         )
 
-    def handle(self, *args, **options):
+    def handle(self, *args, **options):  # type: ignore[no-untyped-def]
         from tasks.functions import calculate_stats_all_orgs
 
-        calculate_stats_all_orgs(from_scratch=options['from_scratch'], redis=options['redis'])
+        calculate_stats_all_orgs(from_scratch=options['from_scratch'], redis=options['redis'])  # type: ignore[no-untyped-call]

--- a/label_studio/tasks/mixins.py
+++ b/label_studio/tasks/mixins.py
@@ -2,19 +2,19 @@ from django.db import models
 
 
 class TaskMixin:
-    def _get_is_labeled_value(self):
-        n = self.completed_annotations.count()
-        return n >= self.overlap
+    def _get_is_labeled_value(self):  # type: ignore[no-untyped-def]
+        n = self.completed_annotations.count()  # type: ignore[attr-defined]
+        return n >= self.overlap  # type: ignore[attr-defined]
 
-    def update_is_labeled(self, *args, **kwargs):
-        self.is_labeled = self._get_is_labeled_value()
+    def update_is_labeled(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        self.is_labeled = self._get_is_labeled_value()  # type: ignore[no-untyped-call]
 
     @classmethod
-    def post_process_bulk_update_stats(cls, tasks):
+    def post_process_bulk_update_stats(cls, tasks):  # type: ignore[no-untyped-def]
         pass
 
 
 class AnnotationMixin(models.Model):
     class Meta:
         abstract = True
-        indexes = []
+        indexes = []  # type: ignore[var-annotated]

--- a/label_studio/tasks/validation.py
+++ b/label_studio/tasks/validation.py
@@ -44,20 +44,20 @@ logger = logging.getLogger(__name__)
 class TaskValidator:
     """ Task Validator with project scheme configs validation. It is equal to TaskSerializer from django backend.
     """
-    def __init__(self, project, instance=None):
+    def __init__(self, project, instance=None):  # type: ignore[no-untyped-def]
         self.project = project
         self.instance = instance
         self.annotation_count = 0
         self.prediction_count = 0
 
     @staticmethod
-    def check_data(project, data):
+    def check_data(project, data):  # type: ignore[no-untyped-def]
         """ Validate data from task['data']
         """
         if data is None:
             raise ValidationError('Task is empty (None)')
 
-        replace_task_data_undefined_with_config_field(data, project)
+        replace_task_data_undefined_with_config_field(data, project)  # type: ignore[no-untyped-call]
 
         # iterate over data types from project
         for data_key, data_type in project.data_types.items():
@@ -80,7 +80,7 @@ class TaskValidator:
             if is_array:
                 expected_types = (list, )
             else:
-                expected_types = _DATA_TYPES.get(data_type, (str,))
+                expected_types = _DATA_TYPES.get(data_type, (str,))  # type: ignore[assignment]
 
             if not isinstance(data_item, tuple(expected_types)):
                 raise ValidationError('data[\'{data_key}\']={data_value} is of type \'{type}\', '
@@ -92,7 +92,7 @@ class TaskValidator:
         return data
 
     @staticmethod
-    def check_data_and_root(project, data, dict_is_root=False):
+    def check_data_and_root(project, data, dict_is_root=False):  # type: ignore[no-untyped-def]
         """ Check data consistent and data is dict with task or dict['task'] is task
 
         :param project:
@@ -101,15 +101,15 @@ class TaskValidator:
         :return:
         """
         try:
-            TaskValidator.check_data(project, data)
+            TaskValidator.check_data(project, data)  # type: ignore[no-untyped-call]
         except ValidationError as e:
             if dict_is_root:
-                raise ValidationError(e.detail[0] + ' [assume: item as is = task root with values] ')
+                raise ValidationError(e.detail[0] + ' [assume: item as is = task root with values] ')  # type: ignore[index, operator, operator]
             else:
-                raise ValidationError(e.detail[0] + ' [assume: item["data"] = task root with values]')
+                raise ValidationError(e.detail[0] + ' [assume: item["data"] = task root with values]')  # type: ignore[index, operator, operator]
 
     @staticmethod
-    def check_allowed(task):
+    def check_allowed(task):  # type: ignore[no-untyped-def]
         # task is required
         if 'data' not in task:
             return False
@@ -118,7 +118,7 @@ class TaskValidator:
         return True
 
     @staticmethod
-    def raise_if_wrong_class(task, key, class_def):
+    def raise_if_wrong_class(task, key, class_def):  # type: ignore[no-untyped-def]
         if key in task and not isinstance(task[key], class_def):
             if isinstance(class_def, tuple):
                 class_def = ' or '.join([c.__name__ for c in class_def])
@@ -126,12 +126,12 @@ class TaskValidator:
                 class_def = class_def.__name__
             raise ValidationError('Task[{key}] must be {class_def}'.format(key=key, class_def=class_def))
 
-    def validate(self, task):
+    def validate(self, task):  # type: ignore[no-untyped-def]
         """ Validate whole task with task['data'] and task['annotations']. task['predictions']
         """
         # task is class
         if hasattr(task, 'data'):
-            self.check_data_and_root(self.project, task.data)
+            self.check_data_and_root(self.project, task.data)  # type: ignore[no-untyped-call]
             return task
 
         # self.instance is loaded by get_object of view
@@ -145,7 +145,7 @@ class TaskValidator:
                     raise ValidationError("Can't parse task data: " + str(e))
             else:
                 raise ValidationError('Field "data" must be string or dict, but not "' + type(self.instance.data) + '"')
-            self.check_data_and_root(self.instance.project, data)
+            self.check_data_and_root(self.instance.project, data)  # type: ignore[no-untyped-call]
             return task
 
         # check task is dict
@@ -153,14 +153,14 @@ class TaskValidator:
             raise ValidationError('Task root must be dict with "data", "meta", "annotations", "predictions" fields')
 
         # task[data] | task[annotations] | task[predictions] | task[meta]
-        if self.check_allowed(task):
+        if self.check_allowed(task):  # type: ignore[no-untyped-call]
             # task[data]
-            self.raise_if_wrong_class(task, 'data', (dict, list))
-            self.check_data_and_root(self.project, task['data'])
+            self.raise_if_wrong_class(task, 'data', (dict, list))  # type: ignore[no-untyped-call]
+            self.check_data_and_root(self.project, task['data'])  # type: ignore[no-untyped-call]
 
             # task[annotations]: we can't use AnnotationSerializer for validation
             # because it's much different with validation we need here
-            self.raise_if_wrong_class(task, 'annotations', list)
+            self.raise_if_wrong_class(task, 'annotations', list)  # type: ignore[no-untyped-call]
             for annotation in task.get('annotations', []):
                 if not isinstance(annotation, dict):
                     logger.warning('Annotation must be dict, but "%s" found', str(type(annotation)))
@@ -175,7 +175,7 @@ class TaskValidator:
                     raise ValidationError('"result" field in annotation must be list')
 
             # task[predictions]
-            self.raise_if_wrong_class(task, 'predictions', list)
+            self.raise_if_wrong_class(task, 'predictions', list)  # type: ignore[no-untyped-call]
             for prediction in task.get('predictions', []):
                 if not isinstance(prediction, dict):
                     logger.warning('Prediction must be dict, but "%s" found', str(type(prediction)))
@@ -186,17 +186,17 @@ class TaskValidator:
                     raise ValidationError('Prediction must have "result" fields')
 
             # task[meta]
-            self.raise_if_wrong_class(task, 'meta', (dict, list))
+            self.raise_if_wrong_class(task, 'meta', (dict, list))  # type: ignore[no-untyped-call]
 
         # task is data as is, validate task as data and move it to task['data']
         else:
-            self.check_data_and_root(self.project, task, dict_is_root=True)
+            self.check_data_and_root(self.project, task, dict_is_root=True)  # type: ignore[no-untyped-call]
             task = {'data': task}
 
         return task
 
     @staticmethod
-    def format_error(i, detail, item):
+    def format_error(i, detail, item):  # type: ignore[no-untyped-def]
         if len(detail) == 1:
             code = (str(detail[0].code + ' ')) if detail[0].code != "invalid" else ''
             return 'Error {code} at item {i}: {detail} :: {item}'\
@@ -207,7 +207,7 @@ class TaskValidator:
             return 'Errors {codes} at item {i}: {errors} :: {item}'\
                 .format(codes=codes, i=i, errors=errors, item=item)
 
-    def to_internal_value(self, data):
+    def to_internal_value(self, data):  # type: ignore[no-untyped-def]
         """ Body of run_validation for all data items
         """
         if data is None:
@@ -223,9 +223,9 @@ class TaskValidator:
         self.annotation_count, self.prediction_count = 0, 0
         for i, item in enumerate(data):
             try:
-                validated = self.validate(item)
+                validated = self.validate(item)  # type: ignore[no-untyped-call]
             except ValidationError as exc:
-                error = self.format_error(i, exc.detail, item)
+                error = self.format_error(i, exc.detail, item)  # type: ignore[no-untyped-call]
                 errors.append(error)
                 # do not print to user too many errors
                 if len(errors) >= 100:
@@ -247,7 +247,7 @@ class TaskValidator:
         return ret
 
 
-def is_url(string):
+def is_url(string):  # type: ignore[no-untyped-def]
     try:
         result = urlparse(string.strip())
         return all([result.scheme, result.netloc])

--- a/label_studio/tests/__init__.py
+++ b/label_studio/tests/__init__.py
@@ -2,8 +2,8 @@
 """
 
 try:
-    from requests._internal_utils import HEADER_VALIDATORS
-    from tavern.util.formatted_str import FormattedString
+    from requests._internal_utils import HEADER_VALIDATORS  # type: ignore[import]
+    from tavern.util.formatted_str import FormattedString  # type: ignore[import]
 
     HEADER_VALIDATORS[FormattedString] = HEADER_VALIDATORS[str]
 except ImportError:

--- a/label_studio/tests/conftest.py
+++ b/label_studio/tests/conftest.py
@@ -6,15 +6,15 @@ import os
 import pytest
 import mock
 import ujson as json
-import requests_mock
+import requests_mock  # type: ignore[import]
 import re
-import boto3
+import boto3  # type: ignore[import]
 import logging
 import shutil
 import tempfile
 
-from unittest import mock
-from moto import mock_s3
+from unittest import mock  # type: ignore[no-redef]
+from moto import mock_s3  # type: ignore[import]
 from copy import deepcopy
 from pathlib import Path
 from datetime import timedelta
@@ -33,7 +33,7 @@ else:
 
 # if we haven't this package, pytest.ini::env doesn't work 
 try:
-    import pytest_env.plugin
+    import pytest_env.plugin  # type: ignore[import, import]
 except ImportError:
     print('\n\n !!! Please, pip install pytest-env \n\n')
     exit(-100)
@@ -47,35 +47,35 @@ boto3.set_stream_logger('botocore.credentials', logging.DEBUG)
 
 
 @pytest.fixture(autouse=False)
-def enable_csrf():
+def enable_csrf():  # type: ignore[no-untyped-def]
     settings.USE_ENFORCE_CSRF_CHECKS = True
 
 
 @pytest.fixture(autouse=False)
-def label_stream_history_limit():
+def label_stream_history_limit():  # type: ignore[no-untyped-def]
     settings.LABEL_STREAM_HISTORY_LIMIT = 1
 
 
 @pytest.fixture(autouse=True)
-def disable_sentry():
+def disable_sentry():  # type: ignore[no-untyped-def]
     settings.SENTRY_RATE = 0
     settings.SENTRY_DSN = None
 
 
 @pytest.fixture()
-def debug_modal_exceptions_false(settings):
+def debug_modal_exceptions_false(settings):  # type: ignore[no-untyped-def]
     settings.DEBUG_MODAL_EXCEPTIONS = False
 
 
 @pytest.fixture(scope="function")
-def enable_sentry():
+def enable_sentry():  # type: ignore[no-untyped-def]
     settings.SENTRY_RATE = 0
     # it's disabled key, but this is correct
     settings.SENTRY_DSN = 'https://44f7a50de5ab425ca6bc406ef69b2122@o227124.ingest.sentry.io/5820521'
 
 
 @pytest.fixture(scope='function')
-def aws_credentials():
+def aws_credentials():  # type: ignore[no-untyped-def]
     """Mocked AWS Credentials for moto."""
     os.environ['AWS_ACCESS_KEY_ID'] = 'testing'
     os.environ['AWS_SECRET_ACCESS_KEY'] = 'testing'
@@ -84,20 +84,20 @@ def aws_credentials():
 
 
 @pytest.fixture(autouse=True)
-def azure_credentials():
+def azure_credentials():  # type: ignore[no-untyped-def]
     """Mocked Azure credentials"""
     os.environ['AZURE_BLOB_ACCOUNT_NAME'] = 'testing'
     os.environ['AZURE_BLOB_ACCOUNT_KEY'] = 'testing'
 
 
 @pytest.fixture(scope='function')
-def s3(aws_credentials):
+def s3(aws_credentials):  # type: ignore[no-untyped-def]
     with mock_s3():
         yield boto3.client('s3', region_name='us-east-1')
 
 
 @pytest.fixture(autouse=True)
-def s3_with_images(s3):
+def s3_with_images(s3):  # type: ignore[no-untyped-def]
     """
     Bucket structure:
     s3://pytest-s3-images/image1.jpg
@@ -113,7 +113,7 @@ def s3_with_images(s3):
     yield s3
 
 
-def s3_remove_bucket():
+def s3_remove_bucket():  # type: ignore[no-untyped-def]
     """
     Remove pytest-s3-images
     """
@@ -128,7 +128,7 @@ def s3_remove_bucket():
 
 
 @pytest.fixture(autouse=True)
-def s3_with_jsons(s3):
+def s3_with_jsons(s3):  # type: ignore[no-untyped-def]
     bucket_name = 'pytest-s3-jsons'
     s3.create_bucket(Bucket=bucket_name)
     s3.put_object(Bucket=bucket_name, Key='test.json', Body=json.dumps({'image_url': 'http://ggg.com/image.jpg'}))
@@ -136,7 +136,7 @@ def s3_with_jsons(s3):
 
 
 @pytest.fixture(autouse=True)
-def s3_with_hypertext_s3_links(s3):
+def s3_with_hypertext_s3_links(s3):  # type: ignore[no-untyped-def]
     bucket_name = 'pytest-s3-jsons-hypertext'
     s3.create_bucket(Bucket=bucket_name)
     s3.put_object(Bucket=bucket_name, Key='test.json', Body=json.dumps({
@@ -145,7 +145,7 @@ def s3_with_hypertext_s3_links(s3):
     yield s3
 
 @pytest.fixture(autouse=True)
-def s3_with_partially_encoded_s3_links(s3):
+def s3_with_partially_encoded_s3_links(s3):  # type: ignore[no-untyped-def]
     bucket_name = 'pytest-s3-json-partially-encoded'
     s3.create_bucket(Bucket=bucket_name)
     s3.put_object(Bucket=bucket_name, Key='test.json', Body=json.dumps({
@@ -154,7 +154,7 @@ def s3_with_partially_encoded_s3_links(s3):
     yield s3
 
 @pytest.fixture(autouse=True)
-def s3_with_unexisted_links(s3):
+def s3_with_unexisted_links(s3):  # type: ignore[no-untyped-def]
     bucket_name = 'pytest-s3-jsons-unexisted_links'
     s3.create_bucket(Bucket=bucket_name)
     s3.put_object(Bucket=bucket_name, Key='some-existed-image.jpg', Body='qwerty')
@@ -162,14 +162,14 @@ def s3_with_unexisted_links(s3):
 
 
 @pytest.fixture(autouse=True)
-def s3_export_bucket(s3):
+def s3_export_bucket(s3):  # type: ignore[no-untyped-def]
     bucket_name = 'pytest-export-s3-bucket'
     s3.create_bucket(Bucket=bucket_name)
     yield s3
 
 
 @pytest.fixture(autouse=True)
-def s3_export_bucket_sse(s3):
+def s3_export_bucket_sse(s3):  # type: ignore[no-untyped-def]
     bucket_name = 'pytest-export-s3-bucket-with-sse'
     s3.create_bucket(Bucket=bucket_name)
 
@@ -228,44 +228,44 @@ def s3_export_bucket_sse(s3):
 
 
 @pytest.fixture(autouse=True)
-def gcs_client():
+def gcs_client():  # type: ignore[no-untyped-def]
     with gcs_client_mock():
         yield
 
 
 @pytest.fixture(autouse=True)
-def azure_client():
+def azure_client():  # type: ignore[no-untyped-def]
     with azure_client_mock():
         yield
 
 
 @pytest.fixture(autouse=True)
-def redis_client():
+def redis_client():  # type: ignore[no-untyped-def]
     with redis_client_mock():
         yield
 
 
 @pytest.fixture(autouse=True)
-def ml_backend():
+def ml_backend():  # type: ignore[no-untyped-def]
     with ml_backend_mock() as m:
         yield m
 
 
 @pytest.fixture(name='import_from_url')
-def import_from_url():
+def import_from_url():  # type: ignore[no-untyped-def]
     with import_from_url_mock() as m:
         yield m
 
 
 @pytest.fixture(autouse=True)
-def ml_backend_1(ml_backend):
-    register_ml_backend_mock(ml_backend, url='https://test.heartex.mlbackend.com:9090', setup_model_version='Fri Feb 19 17:10:44 2021')
-    register_ml_backend_mock(ml_backend, url='https://test.heartex.mlbackend.com:9091', health_connect_timeout=True)
-    register_ml_backend_mock(ml_backend, url='http://localhost:8999', predictions={'results': []})
+def ml_backend_1(ml_backend):  # type: ignore[no-untyped-def]
+    register_ml_backend_mock(ml_backend, url='https://test.heartex.mlbackend.com:9090', setup_model_version='Fri Feb 19 17:10:44 2021')  # type: ignore[no-untyped-call]
+    register_ml_backend_mock(ml_backend, url='https://test.heartex.mlbackend.com:9091', health_connect_timeout=True)  # type: ignore[no-untyped-call]
+    register_ml_backend_mock(ml_backend, url='http://localhost:8999', predictions={'results': []})  # type: ignore[no-untyped-call]
     yield ml_backend
 
 
-def pytest_configure():
+def pytest_configure():  # type: ignore[no-untyped-def]
     for q in settings.RQ_QUEUES.values():
         q['ASYNC'] = False
 
@@ -273,16 +273,16 @@ def pytest_configure():
 class URLS:
     """ This class keeps urls with api
     """
-    def __init__(self):
+    def __init__(self):  # type: ignore[no-untyped-def]
         self.project_create = '/api/projects/'
         self.task_bulk = None
 
-    def set_project(self, pk):
+    def set_project(self, pk):  # type: ignore[no-untyped-def]
         self.task_bulk = f'/api/projects/{pk}/tasks/bulk/'
         self.plots = f'/projects/{pk}/plots'
 
 
-def project_ranker():
+def project_ranker():  # type: ignore[no-untyped-def]
     label = '''<View>
          <HyperText name="hypertext_markup" value="$markup"></HyperText>
          <List name="ranker" value="$replies" elementValue="$text" elementTag="Text" 
@@ -291,7 +291,7 @@ def project_ranker():
     return {'label_config': label, 'title': 'test'}
 
 
-def project_dialog():
+def project_dialog():  # type: ignore[no-untyped-def]
     """ Simple project with dialog configs
 
     :return: config of project with task
@@ -307,7 +307,7 @@ def project_dialog():
     return {'label_config': label, 'title': 'test'}
 
 
-def project_choices():
+def project_choices():  # type: ignore[no-untyped-def]
     label = """<View>
     <Choices name="animals" toName="xxx" choice="single-radio">
       <Choice value="Cat"></Choice>
@@ -330,7 +330,7 @@ def project_choices():
     return {'label_config': label, 'title': 'test'}
 
 
-def setup_project(client, project_template, do_auth=True):
+def setup_project(client, project_template, do_auth=True):  # type: ignore[no-untyped-def]
     """ Create new test@gmail.com user, login via client, create test project.
     Project configs are thrown over params and automatically grabs from functions names started with 'project_'
 
@@ -341,21 +341,21 @@ def setup_project(client, project_template, do_auth=True):
     client = deepcopy(client)
     email = "test@gmail.com"
     password = "test"
-    urls = URLS()
+    urls = URLS()  # type: ignore[no-untyped-call]
     project_config = project_template()
 
     # we work in empty database, so let's create business user and login
     user = User.objects.create(email=email)
     user.set_password(password)  # set password without hash
 
-    create_business(user)
-    org = Organization.create_organization(created_by=user, title=user.first_name)
+    create_business(user)  # type: ignore[no-untyped-call]
+    org = Organization.create_organization(created_by=user, title=user.first_name)  # type: ignore[no-untyped-call]
     user.active_organization = org
     user.save()
 
     if do_auth:
 
-        assert signin(client, email, password).status_code == 302
+        assert signin(client, email, password).status_code == 302  # type: ignore[no-untyped-call]
         # create project
         with requests_mock.Mocker() as m:
             m.register_uri('POST', re.compile(r'ml\.heartex\.net/\d+/validate'), text=json.dumps({'status': 'ok'}))
@@ -366,8 +366,8 @@ def setup_project(client, project_template, do_auth=True):
 
         # get project id and prepare url
         project = Project.objects.filter(title=project_config['title']).first()
-        urls.set_project(project.pk)
-        print('Project id:', project.id)
+        urls.set_project(project.pk)  # type: ignore[no-untyped-call, union-attr]
+        print('Project id:', project.id)  # type: ignore[union-attr]
 
         client.project = project
 
@@ -379,37 +379,37 @@ def setup_project(client, project_template, do_auth=True):
 
 
 @pytest.fixture
-def setup_project_dialog(client):
-    return setup_project(client, project_dialog)
+def setup_project_dialog(client):  # type: ignore[no-untyped-def]
+    return setup_project(client, project_dialog)  # type: ignore[no-untyped-call]
 
 
 @pytest.fixture
-def setup_project_for_token(client):
-    return setup_project(client, project_dialog, do_auth=False)
+def setup_project_for_token(client):  # type: ignore[no-untyped-def]
+    return setup_project(client, project_dialog, do_auth=False)  # type: ignore[no-untyped-call]
 
 
 @pytest.fixture
-def setup_project_ranker(client):
-    return setup_project(client, project_ranker)
+def setup_project_ranker(client):  # type: ignore[no-untyped-def]
+    return setup_project(client, project_ranker)  # type: ignore[no-untyped-call]
 
 
 @pytest.fixture
-def setup_project_choices(client):
-    return setup_project(client, project_choices)
+def setup_project_choices(client):  # type: ignore[no-untyped-def]
+    return setup_project(client, project_choices)  # type: ignore[no-untyped-call]
 
 
 @pytest.fixture
-def business_client(client):
+def business_client(client):  # type: ignore[no-untyped-def]
     # we work in empty database, so let's create business user and login
     client = deepcopy(client)
     email = 'business@pytest.net'
     password = 'pytest'
     user = User.objects.create(email=email)
     user.set_password(password)  # set password without hash
-    business = create_business(user)
+    business = create_business(user)  # type: ignore[no-untyped-call]
 
     user.save()
-    org = Organization.create_organization(created_by=user, title=user.first_name)
+    org = Organization.create_organization(created_by=user, title=user.first_name)  # type: ignore[no-untyped-call]
     client.business = business if business else SimpleNamespace(admin=user)
     client.team = None if business else SimpleNamespace(id=1)
     client.admin = user
@@ -417,13 +417,13 @@ def business_client(client):
     client.user = user
     client.organization = org
 
-    if signin(client, email, password).status_code != 302:
+    if signin(client, email, password).status_code != 302:  # type: ignore[no-untyped-call]
         print(f'User {user} failed to login!')
     return client
 
 
 @pytest.fixture
-def annotator_client(client):
+def annotator_client(client):  # type: ignore[no-untyped-def]
     # we work in empty database, so let's create business user and login
     client = deepcopy(client)
     email = 'annotator@pytest.net'
@@ -431,9 +431,9 @@ def annotator_client(client):
     user = User.objects.create(email=email)
     user.set_password(password)  # set password without hash
     user.save()
-    business = create_business(user)
-    Organization.create_organization(created_by=user, title=user.first_name)
-    if signin(client, email, password).status_code != 302:
+    business = create_business(user)  # type: ignore[no-untyped-call]
+    Organization.create_organization(created_by=user, title=user.first_name)  # type: ignore[no-untyped-call]
+    if signin(client, email, password).status_code != 302:  # type: ignore[no-untyped-call]
         print(f'User {user} failed to login!')
     client.user = user
     client.annotator = user
@@ -441,7 +441,7 @@ def annotator_client(client):
 
 
 @pytest.fixture
-def annotator2_client(client):
+def annotator2_client(client):  # type: ignore[no-untyped-def]
     # we work in empty database, so let's create business user and login
     client = deepcopy(client)
     email = 'annotator2@pytest.net'
@@ -449,9 +449,9 @@ def annotator2_client(client):
     user = User.objects.create(email=email)
     user.set_password(password)  # set password without hash
     user.save()
-    business = create_business(user)
-    Organization.create_organization(created_by=user, title=user.first_name)
-    if signin(client, email, password).status_code != 302:
+    business = create_business(user)  # type: ignore[no-untyped-call]
+    Organization.create_organization(created_by=user, title=user.first_name)  # type: ignore[no-untyped-call]
+    if signin(client, email, password).status_code != 302:  # type: ignore[no-untyped-call]
         print(f'User {user} failed to login!')
     client.user = user
     client.annotator = user
@@ -459,7 +459,7 @@ def annotator2_client(client):
 
 
 @pytest.fixture(params=['business', 'annotator'])
-def any_client(request, business_client, annotator_client):
+def any_client(request, business_client, annotator_client):  # type: ignore[no-untyped-def]
     if request.param == 'business':
         return business_client
     elif request.param == 'annotator':
@@ -467,7 +467,7 @@ def any_client(request, business_client, annotator_client):
 
 
 @pytest.fixture
-def configured_project(business_client, annotator_client):
+def configured_project(business_client, annotator_client):  # type: ignore[no-untyped-def]
     _project_for_text_choices_onto_A_B_classes = dict(
         title='Test',
         label_config='''
@@ -487,7 +487,7 @@ def configured_project(business_client, annotator_client):
 
     # get user to be owner
     users = User.objects.filter(email='business@pytest.net')  # TODO: @nik: how to get proper email for business here?
-    project = make_project(_project_for_text_choices_onto_A_B_classes, users[0])
+    project = make_project(_project_for_text_choices_onto_A_B_classes, users[0])  # type: ignore[no-untyped-call]
 
     assert project.ml_backends.first().url == 'http://localhost:8999'
 
@@ -496,67 +496,67 @@ def configured_project(business_client, annotator_client):
 
 
 @pytest.fixture(name="django_live_url")
-def get_server_url(live_server):
+def get_server_url(live_server):  # type: ignore[no-untyped-def]
     yield live_server.url
 
 
 @pytest.fixture(name="async_import_off", autouse=True)
-def async_import_off():
-    from core.feature_flags import flag_set
-    def fake_flag_set(*args, **kwargs):
+def async_import_off():  # type: ignore[no-untyped-def]
+    from core.feature_flags import flag_set  # type: ignore[attr-defined]
+    def fake_flag_set(*args, **kwargs):  # type: ignore[no-untyped-def]
         if args[0] == 'fflag_feat_all_lsdv_4915_async_task_import_13042023_short':
             return False
-        return flag_set(*args, **kwargs)
+        return flag_set(*args, **kwargs)  # type: ignore[no-untyped-call]
     with mock.patch('data_import.api.flag_set', wraps=fake_flag_set):
         yield
 
 
 @pytest.fixture(name="fflag_fix_all_lsdv_4711_cors_errors_accessing_task_data_short_on")
-def fflag_fix_all_lsdv_4711_cors_errors_accessing_task_data_short_on():
-    from core.feature_flags import flag_set
-    def fake_flag_set(*args, **kwargs):
+def fflag_fix_all_lsdv_4711_cors_errors_accessing_task_data_short_on():  # type: ignore[no-untyped-def]
+    from core.feature_flags import flag_set  # type: ignore[attr-defined]
+    def fake_flag_set(*args, **kwargs):  # type: ignore[no-untyped-def]
         if args[0] == 'fflag_fix_all_lsdv_4711_cors_errors_accessing_task_data_short':
             return True
-        return flag_set(*args, **kwargs)
+        return flag_set(*args, **kwargs)  # type: ignore[no-untyped-call]
     with mock.patch('tasks.models.flag_set', wraps=fake_flag_set):
         yield
 
 
 @pytest.fixture(name="fflag_fix_all_lsdv_4711_cors_errors_accessing_task_data_short_off")
-def fflag_fix_all_lsdv_4711_cors_errors_accessing_task_data_short_off():
-    from core.feature_flags import flag_set
-    def fake_flag_set(*args, **kwargs):
+def fflag_fix_all_lsdv_4711_cors_errors_accessing_task_data_short_off():  # type: ignore[no-untyped-def]
+    from core.feature_flags import flag_set  # type: ignore[attr-defined]
+    def fake_flag_set(*args, **kwargs):  # type: ignore[no-untyped-def]
         if args[0] == 'fflag_fix_all_lsdv_4711_cors_errors_accessing_task_data_short':
             return False
-        return flag_set(*args, **kwargs)
+        return flag_set(*args, **kwargs)  # type: ignore[no-untyped-call]
     with mock.patch('tasks.models.flag_set', wraps=fake_flag_set):
         yield
 
 
 @pytest.fixture(name="fflag_fix_all_lsdv_4813_async_export_conversion_22032023_short_on")
-def fflag_fix_all_lsdv_4813_async_export_conversion_22032023_short_on():
-    from core.feature_flags import flag_set
-    def fake_flag_set(*args, **kwargs):
+def fflag_fix_all_lsdv_4813_async_export_conversion_22032023_short_on():  # type: ignore[no-untyped-def]
+    from core.feature_flags import flag_set  # type: ignore[attr-defined]
+    def fake_flag_set(*args, **kwargs):  # type: ignore[no-untyped-def]
         if args[0] == 'fflag_fix_all_lsdv_4813_async_export_conversion_22032023_short':
             return True
-        return flag_set(*args, **kwargs)
+        return flag_set(*args, **kwargs)  # type: ignore[no-untyped-call]
     with mock.patch('data_export.api.flag_set', wraps=fake_flag_set):
         yield
 
 
 @pytest.fixture(name="ff_back_dev_4664_remove_storage_file_on_export_delete_29032023_short_on")
-def ff_back_dev_4664_remove_storage_file_on_export_delete_29032023_short_on():
-    from core.feature_flags import flag_set
-    def fake_flag_set(*args, **kwargs):
+def ff_back_dev_4664_remove_storage_file_on_export_delete_29032023_short_on():  # type: ignore[no-untyped-def]
+    from core.feature_flags import flag_set  # type: ignore[attr-defined]
+    def fake_flag_set(*args, **kwargs):  # type: ignore[no-untyped-def]
         if args[0] == 'ff_back_dev_4664_remove_storage_file_on_export_delete_29032023_short':
             return True
-        return flag_set(*args, **kwargs)
+        return flag_set(*args, **kwargs)  # type: ignore[no-untyped-call]
     with mock.patch('data_export.api.flag_set', wraps=fake_flag_set):
         yield
 
 
 @pytest.fixture(name="local_files_storage")
-def local_files_storage(settings):
+def local_files_storage(settings):  # type: ignore[no-untyped-def]
     settings.LOCAL_FILES_SERVING_ENABLED = True
     tempdir = Path(tempfile.gettempdir()) / Path('files')
     subdir = tempdir / Path('subdir')
@@ -567,25 +567,25 @@ def local_files_storage(settings):
 
 
 @pytest.fixture(name="local_files_document_root_tempdir")
-def local_files_document_root_tempdir(settings):
+def local_files_document_root_tempdir(settings):  # type: ignore[no-untyped-def]
     tempdir = Path(tempfile.gettempdir())
     settings.LOCAL_FILES_DOCUMENT_ROOT = tempdir.root
 
 
 @pytest.fixture(name="local_files_document_root_subdir")
-def local_files_document_root_subdir(settings):
+def local_files_document_root_subdir(settings):  # type: ignore[no-untyped-def]
     tempdir = Path(tempfile.gettempdir()) / Path('files')
     settings.LOCAL_FILES_DOCUMENT_ROOT = str(tempdir)
 
 
 @pytest.fixture(name="testing_session_timeouts")
-def set_testing_session_timeouts(settings):
+def set_testing_session_timeouts(settings):  # type: ignore[no-untyped-def]
     # TODO: functional tests should not rely on exact timings
-    settings.MAX_SESSION_AGE = int(get_env('MAX_SESSION_AGE', timedelta(seconds=6).total_seconds()))
-    settings.MAX_TIME_BETWEEN_ACTIVITY = int(get_env('MAX_TIME_BETWEEN_ACTIVITY', timedelta(seconds=2).total_seconds()))
+    settings.MAX_SESSION_AGE = int(get_env('MAX_SESSION_AGE', timedelta(seconds=6).total_seconds()))  # type: ignore[no-untyped-call]
+    settings.MAX_TIME_BETWEEN_ACTIVITY = int(get_env('MAX_TIME_BETWEEN_ACTIVITY', timedelta(seconds=2).total_seconds()))  # type: ignore[no-untyped-call]
 
 @pytest.fixture
-def mock_ml_auto_update(name="mock_ml_auto_update"):
+def mock_ml_auto_update(name="mock_ml_auto_update"):  # type: ignore[no-untyped-def]
     url = 'http://localhost:9090'
     with requests_mock.Mocker(real_http=True) as m:
         m.register_uri('POST', f'{url}/setup', [
@@ -601,7 +601,7 @@ def mock_ml_auto_update(name="mock_ml_auto_update"):
         yield m
 
 @pytest.fixture(name="mock_ml_backend_auto_update_disabled")
-def mock_ml_backend_auto_update_disabled():
+def mock_ml_backend_auto_update_disabled():  # type: ignore[no-untyped-def]
     with ml_backend_mock(setup_model_version='version1') as m:
         m.register_uri('GET', f'http://localhost:9090/setup', [
             {'json': {'model_version': '', 'status': 'ok'}, 'status_code': 200},

--- a/label_studio/tests/conftest.py
+++ b/label_studio/tests/conftest.py
@@ -1,5 +1,7 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
+from typing import TYPE_CHECKING
+
 import os
 import pytest
 import mock
@@ -24,7 +26,10 @@ from users.models import User
 from organizations.models import Organization
 from types import SimpleNamespace
 
-from label_studio.core.utils.params import get_bool_env, get_env
+if TYPE_CHECKING:
+    from core.utils.params import get_env
+else:
+    from label_studio.core.utils.params import get_env
 
 # if we haven't this package, pytest.ini::env doesn't work 
 try:

--- a/label_studio/tests/data_import/test_uploader.py
+++ b/label_studio/tests/data_import/test_uploader.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from rest_framework.exceptions import ValidationError
 
 from core.utils.exceptions import InvalidUploadUrlError
-from data_import.uploader import load_tasks, check_tasks_max_file_size, validate_upload_url
+from data_import.uploader import load_tasks, check_tasks_max_file_size, validate_upload_url  # type: ignore[attr-defined]
 
 pytestmark = pytest.mark.django_db
 
@@ -13,61 +13,61 @@ pytestmark = pytest.mark.django_db
 class MockedRequest:
     FILES = ()
 
-    def __init__(self, url):
+    def __init__(self, url):  # type: ignore[no-untyped-def]
         self.url = url
 
     @property
-    def content_type(self):
+    def content_type(self):  # type: ignore[no-untyped-def]
         return "application/x-www-form-urlencoded"
 
     @property
-    def data(self):
+    def data(self):  # type: ignore[no-untyped-def]
         return {"url": self.url}
 
     @property
-    def user(self):
+    def user(self):  # type: ignore[no-untyped-def]
         return None
 
 
 class TestUploader:
     @pytest.fixture
-    def project(self, configured_project, settings):
+    def project(self, configured_project, settings):  # type: ignore[no-untyped-def]
         return configured_project
 
     class TestLoadTasks:
         @mock.patch('data_import.uploader.validate_upload_url', wraps=validate_upload_url)
         @pytest.mark.parametrize("url", ("file:///etc/passwd", "ftp://example.org"))
-        def test_raises_for_unsafe_urls(self, validate_upload_url_mock, url, project):
-            request = MockedRequest(url=url)
+        def test_raises_for_unsafe_urls(self, validate_upload_url_mock, url, project):  # type: ignore[no-untyped-def]
+            request = MockedRequest(url=url)  # type: ignore[no-untyped-call]
 
             with pytest.raises(ValidationError) as e:
-                load_tasks(request, project)
-                assert 'The provided URL was not valid.' in e.value
+                load_tasks(request, project)  # type: ignore[no-untyped-call]
+                assert 'The provided URL was not valid.' in e.value  # type: ignore[operator]
 
             validate_upload_url_mock.assert_called_once_with(url, block_local_urls=False)
 
         @mock.patch('data_import.uploader.validate_upload_url', wraps=validate_upload_url)
-        def test_raises_for_local_urls_with_ssrf_protection_enabled(self, validate_upload_url_mock, project, settings):
+        def test_raises_for_local_urls_with_ssrf_protection_enabled(self, validate_upload_url_mock, project, settings):  # type: ignore[no-untyped-def]
             settings.SSRF_PROTECTION_ENABLED = True
-            request = MockedRequest(url='http://0.0.0.0')
+            request = MockedRequest(url='http://0.0.0.0')  # type: ignore[no-untyped-call]
 
             with pytest.raises(ValidationError) as e:
-                load_tasks(request, project)
-                assert 'The provided URL was not valid.' in e.value
+                load_tasks(request, project)  # type: ignore[no-untyped-call]
+                assert 'The provided URL was not valid.' in e.value  # type: ignore[operator]
 
             validate_upload_url_mock.assert_called_once_with('http://0.0.0.0', block_local_urls=True)
 
 
 class TestTasksFileChecks:
     @pytest.mark.parametrize("value", (0, settings.TASKS_MAX_FILE_SIZE - 1))
-    def test_check_tasks_max_file_size_does_not_raise_for_correct_value(self, value):
-        check_tasks_max_file_size(value)
+    def test_check_tasks_max_file_size_does_not_raise_for_correct_value(self, value):  # type: ignore[no-untyped-def]
+        check_tasks_max_file_size(value)  # type: ignore[no-untyped-call]
 
-    def test_check_tasks_max_file_size_raises_for_too_big_value(self):
+    def test_check_tasks_max_file_size_raises_for_too_big_value(self):  # type: ignore[no-untyped-def]
         value = settings.TASKS_MAX_FILE_SIZE + 1
 
         with pytest.raises(ValidationError) as e:
-            check_tasks_max_file_size(value)
+            check_tasks_max_file_size(value)  # type: ignore[no-untyped-call]
 
         correct_error_message = (
             f'Maximum total size of all files is {settings.TASKS_MAX_FILE_SIZE} bytes, '

--- a/label_studio/tests/data_manager/test_api_actions.py
+++ b/label_studio/tests/data_manager/test_api_actions.py
@@ -16,7 +16,7 @@ from projects.models import Project
     ],
 )
 @pytest.mark.django_db
-def test_action_delete_all_tasks(tasks_count, annotations_count, predictions_count, business_client, project_id):
+def test_action_delete_all_tasks(tasks_count, annotations_count, predictions_count, business_client, project_id):  # type: ignore[no-untyped-def]
     # create
     payload = dict(project=project_id, data={"test": 1})
     response = business_client.post(
@@ -30,14 +30,14 @@ def test_action_delete_all_tasks(tasks_count, annotations_count, predictions_cou
 
     project = Project.objects.get(pk=project_id)
     for _ in range(0, tasks_count):
-        task_id = make_task({"data": {}}, project).id
+        task_id = make_task({"data": {}}, project).id  # type: ignore[no-untyped-call]
         print('TASK_ID: %s' % task_id)
         for _ in range(0, annotations_count):
             print('COMPLETION')
-            make_annotation({"result": []}, task_id)
+            make_annotation({"result": []}, task_id)  # type: ignore[no-untyped-call]
 
         for _ in range(0, predictions_count):
-            make_prediction({"result": []}, task_id)
+            make_prediction({"result": []}, task_id)  # type: ignore[no-untyped-call]
     with transaction.atomic():
         business_client.post(f"/api/dm/actions?project={project_id}&id=delete_tasks",
                              json={'selectedItems': {"all": True, "excluded": []}})
@@ -51,7 +51,7 @@ def test_action_delete_all_tasks(tasks_count, annotations_count, predictions_cou
     ],
 )
 @pytest.mark.django_db
-def test_action_delete_all_annotations(tasks_count, annotations_count, predictions_count, business_client, project_id):
+def test_action_delete_all_annotations(tasks_count, annotations_count, predictions_count, business_client, project_id):  # type: ignore[no-untyped-def]
     # create
     payload = dict(project=project_id, data={"test": 1})
     response = business_client.post(
@@ -65,14 +65,14 @@ def test_action_delete_all_annotations(tasks_count, annotations_count, predictio
 
     project = Project.objects.get(pk=project_id)
     for _ in range(0, tasks_count):
-        task_id = make_task({"data": {}}, project).id
+        task_id = make_task({"data": {}}, project).id  # type: ignore[no-untyped-call]
         print('TASK_ID: %s' % task_id)
         for _ in range(0, annotations_count):
             print('COMPLETION')
-            make_annotation({"result": []}, task_id)
+            make_annotation({"result": []}, task_id)  # type: ignore[no-untyped-call]
 
         for _ in range(0, predictions_count):
-            make_prediction({"result": []}, task_id)
+            make_prediction({"result": []}, task_id)  # type: ignore[no-untyped-call]
     # get next task - should be 0
     status = business_client.post(f"/api/dm/actions?project={project_id}&id=next_task",
                          json={'selectedItems': {"all": True, "excluded": []}})

--- a/label_studio/tests/data_manager/test_api_tasks.py
+++ b/label_studio/tests/data_manager/test_api_tasks.py
@@ -8,7 +8,7 @@ from projects.models import Project
 
 
 @pytest.mark.django_db
-def test_views_tasks_api(business_client, project_id):
+def test_views_tasks_api(business_client, project_id):  # type: ignore[no-untyped-def]
     # create
     payload = dict(project=project_id, data={"test": 1})
     response = business_client.post(
@@ -29,11 +29,11 @@ def test_views_tasks_api(business_client, project_id):
 
     project = Project.objects.get(pk=project_id)
     task_data = {"text": "bbb"}
-    task_id = make_task({"data": task_data}, project).id
+    task_id = make_task({"data": task_data}, project).id  # type: ignore[no-untyped-call]
 
     annotation_result = {"from_name": "my_class", "to_name": "text", "type": "choices", "value": {"choices": ["pos"]}}
-    make_annotation({"result": [annotation_result]}, task_id)
-    make_annotation(
+    make_annotation({"result": [annotation_result]}, task_id)  # type: ignore[no-untyped-call]
+    make_annotation(  # type: ignore[no-untyped-call]
         {
             "result": [annotation_result],
             "was_cancelled": True,
@@ -41,7 +41,7 @@ def test_views_tasks_api(business_client, project_id):
         task_id,
     )
     prediction_result = {"from_name": "my_class", "to_name": "text", "type": "choices", "value": {"choices": ["pos"]}}
-    make_prediction(
+    make_prediction(  # type: ignore[no-untyped-call]
         {
             "result": [prediction_result],
         },
@@ -98,7 +98,7 @@ def test_views_tasks_api(business_client, project_id):
     ],
 )
 @pytest.mark.django_db
-def test_views_total_counters(tasks_count, annotations_count, predictions_count, business_client, project_id):
+def test_views_total_counters(tasks_count, annotations_count, predictions_count, business_client, project_id):  # type: ignore[no-untyped-def]
     # create
     payload = dict(project=project_id, data={"test": 1})
     response = business_client.post(
@@ -112,13 +112,13 @@ def test_views_total_counters(tasks_count, annotations_count, predictions_count,
 
     project = Project.objects.get(pk=project_id)
     for _ in range(0, tasks_count):
-        task_id = make_task({"data": {}}, project).id
+        task_id = make_task({"data": {}}, project).id  # type: ignore[no-untyped-call]
         print('TASK_ID: %s' % task_id)
         for _ in range(0, annotations_count):
-            make_annotation({"result": []}, task_id)
+            make_annotation({"result": []}, task_id)  # type: ignore[no-untyped-call]
 
         for _ in range(0, predictions_count):
-            make_prediction({"result": []}, task_id)
+            make_prediction({"result": []}, task_id)  # type: ignore[no-untyped-call]
 
     response = business_client.get(f"/api/tasks?fields=all&view={view_id}")
 

--- a/label_studio/tests/data_manager/test_columns_api.py
+++ b/label_studio/tests/data_manager/test_columns_api.py
@@ -4,7 +4,7 @@ import pytest
 pytestmark = pytest.mark.django_db
 
 
-def _get_columns(business_client, label_config=None):
+def _get_columns(business_client, label_config=None):  # type: ignore[no-untyped-def]
     r = business_client.post(
         "/api/projects/",
         data=json.dumps(
@@ -25,8 +25,8 @@ def _get_columns(business_client, label_config=None):
     return r_json['columns']
 
 
-def test_columns_api_returns_expected_ids(business_client):
-    columns = _get_columns(business_client)
+def test_columns_api_returns_expected_ids(business_client):  # type: ignore[no-untyped-def]
+    columns = _get_columns(business_client)  # type: ignore[no-untyped-call]
 
     assert [c['id'] for c in columns] == [
         'id',
@@ -52,15 +52,15 @@ def test_columns_api_returns_expected_ids(business_client):
     ]
 
 
-def test_columns_api_annotates_default_columns_with_project_defined_false(business_client):
-    columns = _get_columns(business_client)
+def test_columns_api_annotates_default_columns_with_project_defined_false(business_client):  # type: ignore[no-untyped-def]
+    columns = _get_columns(business_client)  # type: ignore[no-untyped-call]
 
     for c in columns:
         assert 'project_defined' in c
         assert c['project_defined'] is False
 
 
-def test_columns_api_annotates_config_defined_columns_with_project_defined_true(business_client):
+def test_columns_api_annotates_config_defined_columns_with_project_defined_true(business_client):  # type: ignore[no-untyped-def]
     config_with_text_column = (
         """
         <View>
@@ -74,7 +74,7 @@ def test_columns_api_annotates_config_defined_columns_with_project_defined_true(
         """
     )
 
-    columns = _get_columns(business_client, config_with_text_column)
+    columns = _get_columns(business_client, config_with_text_column)  # type: ignore[no-untyped-call]
 
     for c in columns:
         assert 'project_defined' in c

--- a/label_studio/tests/data_manager/test_ordering_filters.py
+++ b/label_studio/tests/data_manager/test_ordering_filters.py
@@ -39,7 +39,7 @@ from django.utils.timezone import now
     ],
 )
 @pytest.mark.django_db
-def test_views_ordering(ordering, element_index, undefined, business_client, project_id):
+def test_views_ordering(ordering, element_index, undefined, business_client, project_id):  # type: ignore[no-untyped-def]
 
     payload = dict(
         project=project_id,
@@ -63,16 +63,16 @@ def test_views_ordering(ordering, element_index, undefined, business_client, pro
 
     file_upload1 = FileUpload.objects.create(user=project.created_by, project=project, file=ContentFile('', name='file_upload1'))
 
-    task_id_1 = make_task({"data": {task_field_name: 1}, 'file_upload': file_upload1}, project).id
-    make_annotation({"result": [{"1": True}]}, task_id_1)
-    make_prediction({"result": [{"1": True}], "score": 1}, task_id_1)
+    task_id_1 = make_task({"data": {task_field_name: 1}, 'file_upload': file_upload1}, project).id  # type: ignore[no-untyped-call]
+    make_annotation({"result": [{"1": True}]}, task_id_1)  # type: ignore[no-untyped-call]
+    make_prediction({"result": [{"1": True}], "score": 1}, task_id_1)  # type: ignore[no-untyped-call]
 
     file_upload2 = FileUpload.objects.create(user=project.created_by, project=project, file=ContentFile('', name='file_upload2'))
-    task_id_2 = make_task({"data": {task_field_name: 2}, 'file_upload': file_upload2}, project).id
+    task_id_2 = make_task({"data": {task_field_name: 2}, 'file_upload': file_upload2}, project).id  # type: ignore[no-untyped-call]
     for _ in range(0, 2):
-        make_annotation({"result": [{"2": True}], "was_cancelled": True}, task_id_2)
+        make_annotation({"result": [{"2": True}], "was_cancelled": True}, task_id_2)  # type: ignore[no-untyped-call]
     for _ in range(0, 2):
-        make_prediction({"result": [{"2": True}], "score": 2}, task_id_2)
+        make_prediction({"result": [{"2": True}], "score": 2}, task_id_2)  # type: ignore[no-untyped-call]
 
     task_ids = [task_id_1, task_id_2]
 
@@ -296,10 +296,10 @@ def test_views_ordering(ordering, element_index, undefined, business_client, pro
     ],
 )
 @pytest.mark.django_db
-def test_views_filters(filters, ids, business_client, project_id):
+def test_views_filters(filters, ids, business_client, project_id):  # type: ignore[no-untyped-def]
     project = Project.objects.get(pk=project_id)
-    ann1 = make_annotator({'email': 'ann1@testheartex.com'}, project)
-    ann2 = make_annotator({'email': 'ann2@testheartex.com'}, project)
+    ann1 = make_annotator({'email': 'ann1@testheartex.com'}, project)  # type: ignore[no-untyped-call]
+    ann2 = make_annotator({'email': 'ann2@testheartex.com'}, project)  # type: ignore[no-untyped-call]
 
     ann_ids = {
         '$ANN1_ID': ann1.id,
@@ -325,20 +325,20 @@ def test_views_filters(filters, ids, business_client, project_id):
 
     task_data_field_name = settings.DATA_UNDEFINED_NAME
 
-    task_id_1 = make_task({"data": {task_data_field_name: "some text1"}}, project).id
-    make_annotation({"result": [{"from_name": "1_first", "to_name": "", "value": {}}], "completed_by": ann1}, task_id_1)
-    make_prediction({"result": [{"from_name": "1_first", "to_name": "", "value": {}}], "score": 1}, task_id_1)
+    task_id_1 = make_task({"data": {task_data_field_name: "some text1"}}, project).id  # type: ignore[no-untyped-call]
+    make_annotation({"result": [{"from_name": "1_first", "to_name": "", "value": {}}], "completed_by": ann1}, task_id_1)  # type: ignore[no-untyped-call]
+    make_prediction({"result": [{"from_name": "1_first", "to_name": "", "value": {}}], "score": 1}, task_id_1)  # type: ignore[no-untyped-call]
 
-    task_id_2 = make_task({"data": {task_data_field_name: "some text2"}}, project).id
+    task_id_2 = make_task({"data": {task_data_field_name: "some text2"}}, project).id  # type: ignore[no-untyped-call]
     for ann in (ann1, ann2):
-        make_annotation({"result": [{"from_name": "2_second", "to_name": "", "value": {}}], "was_cancelled": True, "completed_by": ann}, task_id_2)
+        make_annotation({"result": [{"from_name": "2_second", "to_name": "", "value": {}}], "was_cancelled": True, "completed_by": ann}, task_id_2)  # type: ignore[no-untyped-call]
     for _ in range(0, 2):
-        make_prediction({"result": [{"from_name": "2_second", "to_name": "", "value": {}}], "score": 2}, task_id_2)
+        make_prediction({"result": [{"from_name": "2_second", "to_name": "", "value": {}}], "score": 2}, task_id_2)  # type: ignore[no-untyped-call]
 
     task_ids = [0, task_id_1, task_id_2]
 
     for _ in range(0, 2):
-        task_id = make_task({"data": {task_data_field_name: "some text_"}}, project).id
+        task_id = make_task({"data": {task_data_field_name: "some text_"}}, project).id  # type: ignore[no-untyped-call]
         task_ids.append(task_id)
 
     for item in filters['items']:

--- a/label_studio/tests/data_manager/test_views_api.py
+++ b/label_studio/tests/data_manager/test_views_api.py
@@ -10,7 +10,7 @@ from ..utils import project_id
 pytestmark = pytest.mark.django_db
 
 
-def test_views_api(business_client, project_id):
+def test_views_api(business_client, project_id):  # type: ignore[no-untyped-def]
     # create
     payload = dict(project=project_id, data={"test": 1})
     response = business_client.post(
@@ -59,7 +59,7 @@ def test_views_api(business_client, project_id):
     assert response.json() == []
 
 
-def test_views_api_filter_project(business_client):
+def test_views_api_filter_project(business_client):  # type: ignore[no-untyped-def]
     # create project
     response = business_client.post(
         "/api/projects/",
@@ -109,7 +109,7 @@ def test_views_api_filter_project(business_client):
     assert response.json()[0]["project"] == project2_id
 
 
-def test_views_api_filters(business_client, project_id):
+def test_views_api_filters(business_client, project_id):  # type: ignore[no-untyped-def]
     # create
     payload = dict(
         project=project_id,
@@ -190,7 +190,7 @@ def test_views_api_filters(business_client, project_id):
     assert response.json()["data"] == updated_payload["data"]
 
 
-def test_views_ordered_by_id(business_client, project_id):
+def test_views_ordered_by_id(business_client, project_id):  # type: ignore[no-untyped-def]
     views = [{"view_data": 1}, {"view_data": 2}, {"view_data": 3}]
 
     for view in views:

--- a/label_studio/tests/loadtests/locustfile.py
+++ b/label_studio/tests/loadtests/locustfile.py
@@ -4,12 +4,12 @@ import json
 import random
 
 from uuid import uuid4
-from locust import HttpUser, TaskSet, task, between
+from locust import HttpUser, TaskSet, task, between  # type: ignore[import]
 
 
-class UserWorksWithProject(TaskSet):
+class UserWorksWithProject(TaskSet):  # type: ignore[misc]
 
-    def on_start(self):
+    def on_start(self):  # type: ignore[no-untyped-def]
         # user creates the new project
         title = str(uuid4())
         payload = json.dumps({
@@ -34,49 +34,49 @@ class UserWorksWithProject(TaskSet):
                 print(f'Project {self.project_id} has been created by user {self.client.name}')
 
     @task(5)
-    def project_list(self):
+    def project_list(self):  # type: ignore[no-untyped-def]
         self.client.get('/projects/')
 
     @task(5)
-    def project_dashboard(self):
+    def project_dashboard(self):  # type: ignore[no-untyped-def]
         self.client.get('/projects/%i' % self.project_id, name='/projects/<id>')
 
     @task(5)
-    def project_data(self):
+    def project_data(self):  # type: ignore[no-untyped-def]
         self.client.get('/projects/%i/data' % self.project_id, name='/projects/<id>/data')
 
     @task(20)
-    def label_stream(self):
+    def label_stream(self):  # type: ignore[no-untyped-def]
         self.client.get('/projects/%i/label-stream' % self.project_id, name='/projects/<id>/label-stream')
 
     @task(5)
     def expert_page(self):
         self.client.get('/projects/%i/experts' % self.project_id, name='/projects/<id>/experts')
 
-    @task(5)
+    @task(5)  # type: ignore[no-redef]
     def expert_page(self):
         self.client.get('/projects/%i/experts' % self.project_id, name='/projects/<id>/experts')
 
     @task(5)
-    def stats(self):
+    def stats(self):  # type: ignore[no-untyped-def]
         self.client.get('/business/stats')
 
     @task(5)
-    def project_stats(self):
+    def project_stats(self):  # type: ignore[no-untyped-def]
         self.client.get('/projects/%i/plots' % self.project_id, name='/projects/<id>/plots')
 
     @task(5)
-    def experts(self):
+    def experts(self):  # type: ignore[no-untyped-def]
         self.client.get('/business/experts')
 
     @task(5)
-    def import_tasks(self):
+    def import_tasks(self):  # type: ignore[no-untyped-def]
         payload = json.dumps([{"text": "example positive review"}, {"text": "example negative review"}])
         headers = {'content-type': 'application/json', 'Authorization': f'Token {self.client.token}'}
         self.client.post('/api/projects/%i/tasks/bulk' % self.project_id, payload, headers=headers, name='/api/projects/<id>/tasks/bulk')
 
     @task(20)
-    def complete_task_via_api(self):
+    def complete_task_via_api(self):  # type: ignore[no-untyped-def]
         r = self.client.get('/api/projects/%i/tasks' % self.project_id, headers={'Authorization': f'Token {self.client.token}'}, name='/api/projects/<id>/tasks')
         tasks_list = r.json()
         if len(tasks_list):
@@ -86,18 +86,18 @@ class UserWorksWithProject(TaskSet):
             self.client.post('/api/tasks/%i/annotations' % any_task["id"], payload, headers=headers, name='/api/tasks/<id>/annotations')
 
     @task(1)
-    def stop(self):
+    def stop(self):  # type: ignore[no-untyped-def]
         self.interrupt()
 
 
-class WebsiteUser(HttpUser):
+class WebsiteUser(HttpUser):  # type: ignore[misc]
     wait_time = between(3, 9)
     tasks = {UserWorksWithProject: 10}
 
-    def on_start(self):
-        self.signup()
+    def on_start(self):  # type: ignore[no-untyped-def]
+        self.signup()  # type: ignore[no-untyped-call]
 
-    def signup(self):
+    def signup(self):  # type: ignore[no-untyped-def]
         response = self.client.get('/')
         csrftoken = response.cookies['csrftoken']
         username = str(uuid4())

--- a/label_studio/tests/loadtests/locustfile_collabs.py
+++ b/label_studio/tests/loadtests/locustfile_collabs.py
@@ -4,10 +4,10 @@ import json
 import random
 import string
 
-from locust import HttpUser, TaskSet, task, between
+from locust import HttpUser, TaskSet, task, between  # type: ignore[import]
 
 
-def randomString(stringLength):
+def randomString(stringLength):  # type: ignore[no-untyped-def]
     """Generate a random string of fixed length """
     letters = string.ascii_lowercase
     return ''.join(random.choice(letters) for i in range(stringLength))
@@ -17,7 +17,7 @@ all_labels = ['Person', 'Organization', 'Fact', 'Money', 'Date', 'Time', 'Ordina
               'Location']
 
 
-def get_result(text):
+def get_result(text):  # type: ignore[no-untyped-def]
     start = random.randint(0, len(text))
     end = min(len(text), start + random.randint(3, 30))
     results = []
@@ -35,38 +35,38 @@ def get_result(text):
     return results
 
 
-class UserWorksWithProject(TaskSet):
+class UserWorksWithProject(TaskSet):  # type: ignore[misc]
 
-    def on_start(self):
+    def on_start(self):  # type: ignore[no-untyped-def]
         r = self.client.get('/api/annotator/projects')
         all_projects = r.json()
         self.project_id = random.choice(all_projects)
 
     @task(100)
-    def complete_task_via_api(self):
+    def complete_task_via_api(self):  # type: ignore[no-untyped-def]
         r = self.client.get('/api/projects/%i/next/' % self.project_id, name='/api/projects/<id>/next')
         task = r.json()
         task_id = task['id']
         task_text = task['data']['text']
-        results = get_result(task_text)
+        results = get_result(task_text)  # type: ignore[no-untyped-call]
         payload = json.dumps({'result': results})
         headers = {'content-type': 'application/json'}
         self.client.post('/api/tasks/%i/annotations' % task_id, payload, headers=headers, name='/api/tasks/<id>/annotations')
 
     @task(1)
-    def stop(self):
+    def stop(self):  # type: ignore[no-untyped-def]
         self.interrupt()
 
 
-class WebsiteUser(HttpUser):
+class WebsiteUser(HttpUser):  # type: ignore[misc]
     wait_time = between(3, 9)
 
     tasks = {UserWorksWithProject: 10}
 
-    def on_start(self):
-        self.login()
+    def on_start(self):  # type: ignore[no-untyped-def]
+        self.login()  # type: ignore[no-untyped-call]
 
-    def login(self):
+    def login(self):  # type: ignore[no-untyped-def]
         response = self.client.get('/')
         csrftoken = response.cookies['csrftoken']
         num_collabs = 100

--- a/label_studio/tests/loadtests/locustfile_db_load.py
+++ b/label_studio/tests/loadtests/locustfile_db_load.py
@@ -5,18 +5,18 @@ import random
 import string
 
 from uuid import uuid4
-from locust import HttpUser, TaskSet, task, between
+from locust import HttpUser, TaskSet, task, between  # type: ignore[import]
 
 
-def randomString(stringLength):
+def randomString(stringLength):  # type: ignore[no-untyped-def]
     """Generate a random string of fixed length """
     letters = string.ascii_lowercase
     return ''.join(random.choice(letters) for i in range(stringLength))
 
 
-class UserWorksWithProject(TaskSet):
+class UserWorksWithProject(TaskSet):  # type: ignore[misc]
 
-    def on_start(self):
+    def on_start(self):  # type: ignore[no-untyped-def]
         # user creates the new project
         title = str(uuid4())
         payload = json.dumps({
@@ -45,7 +45,7 @@ class UserWorksWithProject(TaskSet):
         for i in range(10000):
             one_task = {
                 'data': {
-                    'text': randomString(random.randint(5, 200))
+                    'text': randomString(random.randint(5, 200))  # type: ignore[no-untyped-call]
                 },
                 'annotations': [{
                     'ground_truth': False,
@@ -61,43 +61,43 @@ class UserWorksWithProject(TaskSet):
         self.import_tasks(tasks, name='Initial tasks upload')
 
     @task(5)
-    def project_list(self):
+    def project_list(self):  # type: ignore[no-untyped-def]
         self.client.get('/projects/')
 
     @task(5)
-    def project_dashboard(self):
+    def project_dashboard(self):  # type: ignore[no-untyped-def]
         self.client.get('/projects/%i' % self.project_id, name='/projects/<id>')
 
     @task(5)
-    def project_data(self):
+    def project_data(self):  # type: ignore[no-untyped-def]
         self.client.get('/projects/%i/data' % self.project_id, name='/projects/<id>/data')
 
     @task(20)
-    def label_stream(self):
+    def label_stream(self):  # type: ignore[no-untyped-def]
         self.client.get('/projects/%i/label-stream' % self.project_id, name='/projects/<id>/label-stream')
 
     @task(5)
-    def expert_page(self):
+    def expert_page(self):  # type: ignore[no-untyped-def]
         self.client.get('/projects/%i/experts' % self.project_id, name='/projects/<id>/experts')
 
     @task(5)
-    def ml_page(self):
+    def ml_page(self):  # type: ignore[no-untyped-def]
         self.client.get('/projects/%i/ml' % self.project_id, name='/projects/<id>/ml')
 
     @task(5)
-    def stats(self):
+    def stats(self):  # type: ignore[no-untyped-def]
         self.client.get('/business/stats')
 
     @task(5)
-    def project_stats(self):
+    def project_stats(self):  # type: ignore[no-untyped-def]
         self.client.get('/projects/%i/plots' % self.project_id, name='/projects/<id>/plots')
 
     @task(5)
-    def experts(self):
+    def experts(self):  # type: ignore[no-untyped-def]
         self.client.get('/business/experts')
 
     @task(5)
-    def import_tasks(self, tasks=None, name=None):
+    def import_tasks(self, tasks=None, name=None):  # type: ignore[no-untyped-def]
         if tasks is None:
             payload = json.dumps([{"text": "example positive review"}, {"text": "example negative review"}])
         else:
@@ -106,7 +106,7 @@ class UserWorksWithProject(TaskSet):
         self.client.post('/api/projects/%i/tasks/bulk' % self.project_id, payload, headers=headers, name=name or '/api/projects/<id>/tasks/bulk')
 
     @task(20)
-    def complete_task_via_api(self):
+    def complete_task_via_api(self):  # type: ignore[no-untyped-def]
         r = self.client.get('/api/projects/%i/tasks' % self.project_id, headers={'Authorization': f'Token {self.client.token}'}, name='/api/projects/<id>/tasks')
         tasks_list = r.json()
         if len(tasks_list):
@@ -116,19 +116,19 @@ class UserWorksWithProject(TaskSet):
             self.client.post('/api/tasks/%i/annotations' % any_task["id"], payload, headers=headers, name='/api/tasks/<id>/annotations')
 
     @task(1)
-    def stop(self):
+    def stop(self):  # type: ignore[no-untyped-def]
         self.interrupt()
 
 
-class WebsiteUser(HttpUser):
+class WebsiteUser(HttpUser):  # type: ignore[misc]
     wait_time = between(3, 9)
 
     tasks = {UserWorksWithProject: 10}
 
-    def on_start(self):
-        self.signup()
+    def on_start(self):  # type: ignore[no-untyped-def]
+        self.signup()  # type: ignore[no-untyped-call]
 
-    def signup(self):
+    def signup(self):  # type: ignore[no-untyped-def]
         response = self.client.get('/')
         csrftoken = response.cookies['csrftoken']
         username = str(uuid4())

--- a/label_studio/tests/loadtests/one_imports_other_annotate.py
+++ b/label_studio/tests/loadtests/one_imports_other_annotate.py
@@ -5,10 +5,10 @@ import pandas as pd
 import numpy as np
 
 from uuid import uuid4
-from locust import HttpUser, between, constant, task, tag, events
+from locust import HttpUser, between, constant, task, tag, events  # type: ignore[import]
 
 
-def get_project_id(client):
+def get_project_id(client):  # type: ignore[no-untyped-def]
     with client.get('/api/projects', catch_response=True) as r:
         if r.status_code != 200:
             print(r.status_code)
@@ -22,7 +22,7 @@ def get_project_id(client):
             return random.choice(ids)
 
 
-def signup(client):
+def signup(client):  # type: ignore[no-untyped-def]
     username = str(uuid4())[:8]
     response = client.get('/')
     csrftoken = response.cookies['csrftoken']
@@ -35,12 +35,12 @@ def signup(client):
     return username
 
 
-class Admin(HttpUser):
+class Admin(HttpUser):  # type: ignore[misc]
     weight = 1
     wait_time = constant(10)
 
-    def on_start(self):
-        username = signup(self.client)
+    def on_start(self):  # type: ignore[no-untyped-def]
+        username = signup(self.client)  # type: ignore[no-untyped-call]
         with self.client.post(
             '/api/projects',
             json={
@@ -55,10 +55,10 @@ class Admin(HttpUser):
             print('Get response: ', rdata)
             self.project_id = rdata['id']
             print(f'Project {self.project_id} has been created by user {self.client}')
-            self.import_data()
+            self.import_data()  # type: ignore[no-untyped-call]
 
     @task
-    def view_data_manager(self):
+    def view_data_manager(self):  # type: ignore[no-untyped-def]
         self.client.get(
             f'/projects/{self.project_id}/data',
             name='projects/<pk>/data'
@@ -66,7 +66,7 @@ class Admin(HttpUser):
 
     # @tag('import')
     # @task
-    def import_data(self):
+    def import_data(self):  # type: ignore[no-untyped-def]
         self.client.post(
             '/api/projects/%i/import' % self.project_id,
             name='/api/projects/<pk>/import',
@@ -74,21 +74,21 @@ class Admin(HttpUser):
             # headers={'content-type': 'multipart/form-data'})
 
 
-class Annotator(HttpUser):
-    weight = int(os.environ.get('LOCUST_USERS')) - 1
+class Annotator(HttpUser):  # type: ignore[misc]
+    weight = int(os.environ.get('LOCUST_USERS')) - 1  # type: ignore[arg-type]
     wait_time = between(1, 3)
 
-    def on_start(self):
-        signup(self.client)
+    def on_start(self):  # type: ignore[no-untyped-def]
+        signup(self.client)  # type: ignore[no-untyped-call]
 
     @tag('select project')
     @task(1)
-    def select_project(self):
-        self.project_id = get_project_id(self.client)
+    def select_project(self):  # type: ignore[no-untyped-def]
+        self.project_id = get_project_id(self.client)  # type: ignore[no-untyped-call]
 
     @tag('labeling')
     @task(10)
-    def do_labeling(self):
+    def do_labeling(self):  # type: ignore[no-untyped-def]
         if not hasattr(self, 'project_id') or not self.project_id:
             print('No projects yet...')
             return
@@ -105,14 +105,14 @@ class Annotator(HttpUser):
             )
 
 
-def randomString(stringLength):
+def randomString(stringLength):  # type: ignore[no-untyped-def]
     """Generate a random string of fixed length """
     letters = string.ascii_lowercase
     return ''.join(random.choice(letters) for i in range(stringLength))
 
 
 @events.test_start.add_listener
-def on_test_start(environment, **kwargs):
+def on_test_start(environment, **kwargs):  # type: ignore[no-untyped-def]
     rows = int(os.environ.get('IMPORTED_TASKS', 50000))
     print(f'Generating file with {rows} rows...')
     numbers = np.random.randint(low=0, high=100, size=(rows, 10)).tolist()

--- a/label_studio/tests/tasks/test_functions.py
+++ b/label_studio/tests/tasks/test_functions.py
@@ -11,16 +11,16 @@ from tasks.functions import export_project
 pytestmark = pytest.mark.django_db
 
 
-def memory_limit(max_mem):
+def memory_limit(max_mem):  # type: ignore[no-untyped-def]
     try:
         import resource
     except ImportError:
-        def decorator(f):
+        def decorator(f):  # type: ignore[no-untyped-def]
             return f
         return decorator
 
-    def decorator(f):
-        def wrapper(*args, **kwargs):
+    def decorator(f):  # type: ignore[no-untyped-def, no-redef]
+        def wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
             process = psutil.Process(os.getpid())
             prev_limits = resource.getrlimit(resource.RLIMIT_AS)
             resource.setrlimit(
@@ -37,17 +37,17 @@ def memory_limit(max_mem):
 
 class TestExportProject:
     @pytest.fixture
-    def generate_export_file(self, mocker):
+    def generate_export_file(self, mocker):  # type: ignore[no-untyped-def]
         return mocker.patch(
             "tasks.functions.DataExport.generate_export_file",
             return_value=(io.BytesIO(b"stream"), "application/json", "project.json"),
         )
 
     @pytest.fixture
-    def project(self, configured_project):
+    def project(self, configured_project):  # type: ignore[no-untyped-def]
         return configured_project
 
-    def test_export_project(self, mocker, generate_export_file, project):
+    def test_export_project(self, mocker, generate_export_file, project):  # type: ignore[no-untyped-def]
         data = ExportDataSerializer(
             project.tasks.all(),
             many=True,
@@ -55,7 +55,7 @@ class TestExportProject:
         ).data
 
         with mocker.patch("builtins.open"):
-            filepath = export_project(project.id, "JSON", settings.EXPORT_DIR)
+            filepath = export_project(project.id, "JSON", settings.EXPORT_DIR)  # type: ignore[no-untyped-call]
 
         assert filepath == os.path.join(settings.EXPORT_DIR, "project.json")
 
@@ -63,9 +63,9 @@ class TestExportProject:
             project, data, "JSON", settings.CONVERTER_DOWNLOAD_RESOURCES, {}
         )
 
-    def test_project_does_not_exist(self, mocker, generate_export_file):
+    def test_project_does_not_exist(self, mocker, generate_export_file):  # type: ignore[no-untyped-def]
         with mocker.patch("builtins.open"):
             with pytest.raises(Exception):
-                export_project(1, "JSON", settings.EXPORT_DIR)
+                export_project(1, "JSON", settings.EXPORT_DIR)  # type: ignore[no-untyped-call]
 
         generate_export_file.assert_not_called()

--- a/label_studio/tests/tasks/test_presign_storage_data.py
+++ b/label_studio/tests/tasks/test_presign_storage_data.py
@@ -14,32 +14,32 @@ from projects.models import Project
 @pytest.mark.django_db
 class TestPresignStorageData:
     @pytest.fixture
-    def view(self):
+    def view(self):  # type: ignore[no-untyped-def]
         view = PresignStorageData.as_view()
-        view.authentication_classes = []
-        view.permission_classes = []
+        view.authentication_classes = []  # type: ignore[attr-defined]
+        view.permission_classes = []  # type: ignore[attr-defined]
         return view
 
     @pytest.fixture
-    def project(self):
-        project = Project(pk=1, title="testproject")
+    def project(self):  # type: ignore[no-untyped-def]
+        project = Project(pk=1, title="testproject")  # type: ignore[no-untyped-call]
         project.has_permission = MagicMock()
         return project
 
     @pytest.fixture
-    def task(self, project):
+    def task(self, project):  # type: ignore[no-untyped-def]
         task = Task(pk=1, data={}, project=project)
-        task.resolve_storage_uri = MagicMock()
+        task.resolve_storage_uri = MagicMock()  # type: ignore[method-assign]
         return task
 
     @pytest.fixture
-    def user(self):
-        user = User.objects.create_user(
+    def user(self):  # type: ignore[no-untyped-def]
+        user = User.objects.create_user(  # type: ignore[no-untyped-call]
             username="testuser", email="testuser@email.com", password="testpassword"
         )
         return user
 
-    def test_missing_parameters(self, view, user):
+    def test_missing_parameters(self, view, user):  # type: ignore[no-untyped-def]
         request = APIRequestFactory().get(
             reverse("data_import:storage-data-presign", kwargs={"task_id": 1})
         )
@@ -50,7 +50,7 @@ class TestPresignStorageData:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
-    def test_task_not_found(self, view, user):
+    def test_task_not_found(self, view, user):  # type: ignore[no-untyped-def]
         request = APIRequestFactory().get(
             reverse("data_import:storage-data-presign", kwargs={"task_id": 2})
             + "?fileuri=fileuri"
@@ -61,12 +61,12 @@ class TestPresignStorageData:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
-    def test_task_not_found(self, view, task, project, user, monkeypatch):
+    def test_task_not_found(self, view, task, project, user, monkeypatch):  # type: ignore[no-untyped-def, no-redef]
         task.resolve_storage_uri.return_value = None
         project.has_permission.return_value = True
         task.project = project
 
-        def mock_task_get(*args, **kwargs):
+        def mock_task_get(*args, **kwargs):  # type: ignore[no-untyped-def]
             if kwargs["pk"] == 1:
                 return task
             else:
@@ -86,7 +86,7 @@ class TestPresignStorageData:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
-    def test_file_uri_not_hashed(self, view, task, project, user, monkeypatch):
+    def test_file_uri_not_hashed(self, view, task, project, user, monkeypatch):  # type: ignore[no-untyped-def]
         task.resolve_storage_uri.return_value = dict(
             url="https://presigned-url.com/fileuri",
             presign_ttl=3600,
@@ -94,7 +94,7 @@ class TestPresignStorageData:
         project.has_permission.return_value = True
         task.project = project
 
-        def mock_task_get(*args, **kwargs):
+        def mock_task_get(*args, **kwargs):  # type: ignore[no-untyped-def]
             if kwargs["pk"] == 1:
                 return task
             else:
@@ -116,7 +116,7 @@ class TestPresignStorageData:
         assert response.status_code == status.HTTP_303_SEE_OTHER
         assert response.url == "https://presigned-url.com/fileuri"
 
-    def test_successful_request(self, view, task, project, user, monkeypatch):
+    def test_successful_request(self, view, task, project, user, monkeypatch):  # type: ignore[no-untyped-def]
         task.resolve_storage_uri.return_value = dict(
             url="https://presigned-url.com/fileuri",
             presign_ttl=3600,
@@ -124,7 +124,7 @@ class TestPresignStorageData:
         project.has_permission.return_value = True
         task.project = project
 
-        def mock_task_get(*args, **kwargs):
+        def mock_task_get(*args, **kwargs):  # type: ignore[no-untyped-def]
             if kwargs["pk"] == 1:
                 return task
             else:
@@ -146,7 +146,7 @@ class TestPresignStorageData:
         assert response.status_code == status.HTTP_303_SEE_OTHER
         assert response.url == "https://presigned-url.com/fileuri"
 
-    def test_successful_request_with_long_fileuri(
+    def test_successful_request_with_long_fileuri(  # type: ignore[no-untyped-def]
         self, view, task, project, user, monkeypatch
     ):
         task.resolve_storage_uri.return_value = dict(
@@ -156,7 +156,7 @@ class TestPresignStorageData:
         project.has_permission.return_value = True
         task.project = project
 
-        def mock_task_get(*args, **kwargs):
+        def mock_task_get(*args, **kwargs):  # type: ignore[no-untyped-def]
             if kwargs["pk"] == 1:
                 return task
             else:

--- a/label_studio/tests/test_api.py
+++ b/label_studio/tests/test_api.py
@@ -2,7 +2,7 @@
 """
 import pytest
 import json
-import requests_mock
+import requests_mock  # type: ignore[import]
 from unittest import mock
 
 from rest_framework.authtoken.models import Token
@@ -15,16 +15,16 @@ from tasks.models import Annotation, Task
 
 
 @pytest.fixture
-def client_and_token(business_client):
+def client_and_token(business_client):  # type: ignore[no-untyped-def]
     token = Token.objects.get(user=business_client.business.admin)
     client = APIClient()
     client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
-    client.organization_pk = business_client.organization.pk
+    client.organization_pk = business_client.organization.pk  # type: ignore[attr-defined]
     return client, token
 
 
 @pytest.fixture(params=['business_authorized', 'user_with_token'])
-def any_api_client(request, client_and_token, business_client):
+def any_api_client(request, client_and_token, business_client):  # type: ignore[no-untyped-def]
     client, token = client_and_token
     result = {
         'type': request.param,
@@ -64,7 +64,7 @@ def any_api_client(request, client_and_token, business_client):
     )
 ])
 @pytest.mark.django_db
-def test_create_project(client_and_token, payload, response, status_code):
+def test_create_project(client_and_token, payload, response, status_code):  # type: ignore[no-untyped-def]
     client, token = client_and_token
     payload['organization_pk'] = client.organization_pk
     with ml_backend_mock():
@@ -112,7 +112,7 @@ def test_create_project(client_and_token, payload, response, status_code):
     )
 ])
 @pytest.mark.django_db
-def test_patch_project(client_and_token, configured_project, payload, response, status_code):
+def test_patch_project(client_and_token, configured_project, payload, response, status_code):  # type: ignore[no-untyped-def]
     client, token = client_and_token
     payload['organization_pk'] = client.organization_pk
     r = client.patch(
@@ -134,7 +134,7 @@ def test_patch_project(client_and_token, configured_project, payload, response, 
     (201, 'http://my.super.ai', 4),
 ])
 @pytest.mark.django_db
-def test_creating_activating_new_ml_backend(
+def test_creating_activating_new_ml_backend(  # type: ignore[no-untyped-def]
     mock_validate_upload_url, client_and_token, configured_project, external_status_code,
     current_active_ml_backend_url, ml_backend_call_count, settings
 ):
@@ -169,7 +169,7 @@ def test_creating_activating_new_ml_backend(
 
 
 @pytest.mark.django_db
-def test_delete_annotations(business_client, configured_project):
+def test_delete_annotations(business_client, configured_project):  # type: ignore[no-untyped-def]
     business_client.delete(f'/api/projects/{configured_project.id}/annotations/')
     assert not Annotation.objects.filter(task__project=configured_project.id).exists()
 
@@ -191,7 +191,7 @@ def test_delete_annotations(business_client, configured_project):
     )
 ])
 @pytest.mark.django_db
-def test_get_task(client_and_token, configured_project, response, status_code):
+def test_get_task(client_and_token, configured_project, response, status_code):  # type: ignore[no-untyped-def]
     client, token = client_and_token
     task = configured_project.tasks.order_by('-id').all()[0]
     response['project'] = configured_project.id
@@ -224,7 +224,7 @@ def test_get_task(client_and_token, configured_project, response, status_code):
     )
 ])
 @pytest.mark.django_db
-def test_patch_task(client_and_token, configured_project, payload, response, status_code):
+def test_patch_task(client_and_token, configured_project, payload, response, status_code):  # type: ignore[no-untyped-def]
     client, token = client_and_token
     task = configured_project.tasks.order_by('-updated_at').all()[0]
     payload['project'] = configured_project.id

--- a/label_studio/tests/test_block_objects.py
+++ b/label_studio/tests/test_block_objects.py
@@ -7,7 +7,7 @@ from tasks.models import Task, Annotation, Prediction, bulk_update_stats_project
 
 
 @pytest.mark.django_db
-def test_export(business_client, configured_project):
+def test_export(business_client, configured_project):  # type: ignore[no-untyped-def]
     task_query = Task.objects.filter(project=configured_project.id)
     task_query.update(is_labeled=True)
     if db_is_not_sqlite():
@@ -19,10 +19,10 @@ def test_export(business_client, configured_project):
         assert Task.objects.filter(is_labeled=True).count() == 2
         time.sleep(70)
     assert Task.objects.filter(is_labeled=True).count() == 2
-    bulk_update_stats_project_tasks(task_query)
+    bulk_update_stats_project_tasks(task_query)  # type: ignore[no-untyped-call]
     assert Task.objects.filter(is_labeled=True).count() == 0
 
 
-def worker_change_stats(tasks):
+def worker_change_stats(tasks):  # type: ignore[no-untyped-def]
     tasks = Task.objects.filter(id__in=tasks)
-    bulk_update_stats_project_tasks(tasks)
+    bulk_update_stats_project_tasks(tasks)  # type: ignore[no-untyped-call]

--- a/label_studio/tests/test_bulk_operations.py
+++ b/label_studio/tests/test_bulk_operations.py
@@ -1,12 +1,13 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
+
 import pytest
 import os
 import datetime
 
 from users.models import User
 from projects.models import Project
-from label_studio.tests.test_data.gen_tasks_and_annotations import gen_tasks
+from tests.test_data.gen_tasks_and_annotations import gen_tasks
 from django.conf import settings
 
 

--- a/label_studio/tests/test_bulk_operations.py
+++ b/label_studio/tests/test_bulk_operations.py
@@ -12,7 +12,7 @@ from django.conf import settings
 
 
 @pytest.mark.django_db
-def test_load_tasks_and_annotations(business_client, annotator_client, configured_project):
+def test_load_tasks_and_annotations(business_client, annotator_client, configured_project):  # type: ignore[no-untyped-def]
     """
         this test loads tasks_and_annotations.json
         with 1000 tasks and 5000 annotations and recalc accuracy
@@ -40,7 +40,7 @@ def test_load_tasks_and_annotations(business_client, annotator_client, configure
     p.created_by.active_organization.add_user(user)
     p.add_collaborator(user)
 
-    gen_tasks(user.id)
+    gen_tasks(user.id)  # type: ignore[no-untyped-call]
 
     dt1 = datetime.datetime.now()
     filename = 'tasks_and_annotations.json'

--- a/label_studio/tests/test_cli.py
+++ b/label_studio/tests/test_cli.py
@@ -8,17 +8,17 @@ from tests.utils import make_project, make_task, make_annotation
 
 
 @pytest.mark.django_db
-def test_create_user():
-    input_args = parse_input_args(['init', 'test', '--username', 'default@localhost', '--password', '12345678'])
-    config = {}
-    user = _create_user(input_args, config)
+def test_create_user():  # type: ignore[no-untyped-def]
+    input_args = parse_input_args(['init', 'test', '--username', 'default@localhost', '--password', '12345678'])  # type: ignore[no-untyped-call]
+    config = {}  # type: ignore[var-annotated]
+    user = _create_user(input_args, config)  # type: ignore[no-untyped-call]
     assert user.active_organization is not None
 
 
 @pytest.mark.django_db
-def test_user_active_organization_counters():
-    input_args = parse_input_args(['init', 'test', '--username', 'default@localhost', '--password', '12345678'])
-    user = _create_user(input_args, {})
+def test_user_active_organization_counters():  # type: ignore[no-untyped-def]
+    input_args = parse_input_args(['init', 'test', '--username', 'default@localhost', '--password', '12345678'])  # type: ignore[no-untyped-call]
+    user = _create_user(input_args, {})  # type: ignore[no-untyped-call]
 
     project_config = dict(
             title='Test',
@@ -33,17 +33,17 @@ def test_user_active_organization_counters():
                 </View>'''
         )
 
-    def make_test_project():
-        project = make_project(project_config, user, False, org=user.active_organization)
-        task1 = make_task({'data': {'location': 'London', 'text': 'text A'}}, project)
-        task2 = make_task({'data': {'location': 'London', 'text': 'text A'}}, project)
-        make_annotation({'result': [{'result': [{'r': 1}], 'ground_truth': True}], 'completed_by': user}, task1.id)
-        make_annotation({'result': [{'result': [{'r': 1}], 'ground_truth': True}], 'completed_by': user}, task1.id)
-        make_annotation({'result': [{'result': [{'r': 1}], 'ground_truth': True}], 'completed_by': user}, task2.id)
+    def make_test_project():  # type: ignore[no-untyped-def]
+        project = make_project(project_config, user, False, org=user.active_organization)  # type: ignore[no-untyped-call]
+        task1 = make_task({'data': {'location': 'London', 'text': 'text A'}}, project)  # type: ignore[no-untyped-call]
+        task2 = make_task({'data': {'location': 'London', 'text': 'text A'}}, project)  # type: ignore[no-untyped-call]
+        make_annotation({'result': [{'result': [{'r': 1}], 'ground_truth': True}], 'completed_by': user}, task1.id)  # type: ignore[no-untyped-call]
+        make_annotation({'result': [{'result': [{'r': 1}], 'ground_truth': True}], 'completed_by': user}, task1.id)  # type: ignore[no-untyped-call]
+        make_annotation({'result': [{'result': [{'r': 1}], 'ground_truth': True}], 'completed_by': user}, task2.id)  # type: ignore[no-untyped-call]
 
-    make_test_project()
-    make_test_project()
-    make_test_project()
+    make_test_project()  # type: ignore[no-untyped-call]
+    make_test_project()  # type: ignore[no-untyped-call]
+    make_test_project()  # type: ignore[no-untyped-call]
 
     assert user.active_organization_annotations().count() == 9
     assert user.active_organization_contributed_project_number() == 3

--- a/label_studio/tests/test_cli.py
+++ b/label_studio/tests/test_cli.py
@@ -3,7 +3,7 @@
 import pytest
 
 from server import _create_user
-from label_studio.core.argparser import parse_input_args
+from core.argparser import parse_input_args
 from tests.utils import make_project, make_task, make_annotation
 
 

--- a/label_studio/tests/test_config_validation.py
+++ b/label_studio/tests/test_config_validation.py
@@ -9,7 +9,7 @@ import yaml
 import logging
 
 from core.label_config import parse_config, validate_label_config, parse_config_to_json
-from label_studio.tests.utils import make_task, make_annotation, make_prediction, project_id
+from tests.utils import make_task, make_annotation, make_prediction
 from projects.models import Project
 
 logger = logging.getLogger(__name__)

--- a/label_studio/tests/test_config_validation.py
+++ b/label_studio/tests/test_config_validation.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
     ],
 )
 @pytest.mark.django_db
-def test_change_label_config_repeater(tasks_count, annotations_count, predictions_count, business_client, project_id):
+def test_change_label_config_repeater(tasks_count, annotations_count, predictions_count, business_client, project_id):  # type: ignore[no-untyped-def]
     # Change label config to Repeater
     payload = {'label_config': '<View> <Repeater on="$images" indexFlag="{{idx}}"> <Image name="page_{{idx}}" value="$images" maxWidth="100%"/>     <Header value="Utterance Review"/>     <RectangleLabels name="labels_{{idx}}" toName="page_{{idx}}">       <Label value="Header" hotkey="1"/> <Label value="Body" hotkey="2"/> <Label value="Footer" hotkey="3"/> </RectangleLabels> </Repeater> </View>'}
     response = business_client.patch(
@@ -33,7 +33,7 @@ def test_change_label_config_repeater(tasks_count, annotations_count, prediction
     # cr
     project = Project.objects.get(pk=project_id)
     for _ in range(0, tasks_count):
-        task_id = make_task({"data": {
+        task_id = make_task({"data": {  # type: ignore[no-untyped-call]
             "images": [
                 {
                     "url": "https://htx-pub.s3.amazonaws.com/demo/images/demo_stock_purchase_agreement/0001.jpg"
@@ -49,7 +49,7 @@ def test_change_label_config_repeater(tasks_count, annotations_count, prediction
         print('TASK_ID: %s' % task_id)
         for _ in range(0, annotations_count):
             print('COMPLETION')
-            make_annotation({"result": [
+            make_annotation({"result": [  # type: ignore[no-untyped-call]
                 {
                     "id": "_565WKjviN",
                     "type": "rectanglelabels",
@@ -73,7 +73,7 @@ def test_change_label_config_repeater(tasks_count, annotations_count, prediction
             ]}, task_id)
 
         for _ in range(0, predictions_count):
-            make_prediction({"result": []}, task_id)
+            make_prediction({"result": []}, task_id)  # type: ignore[no-untyped-call]
 
     # no changes - no errors
     payload = {'label_config': '<View> <Repeater on="$images" indexFlag="{{idx}}"> <Image name="page_{{idx}}" value="$images" maxWidth="100%"/>     <Header value="Utterance Review"/>     <RectangleLabels name="labels_{{idx}}" toName="page_{{idx}}"> <Label value="Header" hotkey="1"/> <Label value="Body" hotkey="2"/> <Label value="Footer" hotkey="3"/> </RectangleLabels> </Repeater> </View>'}
@@ -104,20 +104,20 @@ def test_change_label_config_repeater(tasks_count, annotations_count, prediction
 
 
 @pytest.mark.django_db
-def test_parse_all_configs():
+def test_parse_all_configs():  # type: ignore[no-untyped-def]
     folder_wildcard = "./label_studio/annotation_templates"
     result = [y for x in os.walk(folder_wildcard) for y in glob.glob(os.path.join(x[0], '*.xml'))]
     for file in result:
         print(f"Parsing config: {file}")
         with open(file, mode='r') as f:
             config = f.read()
-            assert parse_config(config)
-            assert parse_config_to_json(config)
-            validate_label_config(config)
+            assert parse_config(config)  # type: ignore[no-untyped-call]
+            assert parse_config_to_json(config)  # type: ignore[no-untyped-call]
+            validate_label_config(config)  # type: ignore[no-untyped-call]
 
 
 @pytest.mark.django_db
-def test_config_validation_for_choices_workaround(business_client, project_id):
+def test_config_validation_for_choices_workaround(business_client, project_id):  # type: ignore[no-untyped-def]
     """
     Validate Choices tag for 1 choice with workaround
     Example bug DEV-3635
@@ -147,7 +147,7 @@ def test_config_validation_for_choices_workaround(business_client, project_id):
 
 
 @pytest.mark.django_db
-def test_parse_wrong_xml(business_client, project_id):
+def test_parse_wrong_xml(business_client, project_id):  # type: ignore[no-untyped-def]
     # Change label config to Repeater
     payload = {
         'label_config': '<View> <Repeater on="$images" indexFlag="{{idx}}"> <Image name="page_{{idx}}" value="$images" maxWidth="100%"/>     <Header value="Utterance Review"/>     <RectangleLabels name="labels_{{idx}}" toName="page_{{idx}}">       <Label value="Header" hotkey="1"/> <Label value="Body" hotkey="2"/> <Label value="Footer" hotkey="3"/> </RectangleLabels> </Repeater> </View>'}
@@ -168,7 +168,7 @@ def test_parse_wrong_xml(business_client, project_id):
     assert response.status_code == 400
 
 @pytest.mark.django_db
-def test_label_config_versions(business_client, project_id):
+def test_label_config_versions(business_client, project_id):  # type: ignore[no-untyped-def]
     with io.open(os.path.join(os.path.dirname(__file__), 'test_data/data_for_test_label_config_matrix.yml')) as f:
         test_suites = yaml.safe_load(f)
     for test_name, test_content in test_suites.items():

--- a/label_studio/tests/test_config_validation.py
+++ b/label_studio/tests/test_config_validation.py
@@ -9,7 +9,7 @@ import yaml
 import logging
 
 from core.label_config import parse_config, validate_label_config, parse_config_to_json
-from tests.utils import make_task, make_annotation, make_prediction
+from tests.utils import make_task, make_annotation, make_prediction, project_id
 from projects.models import Project
 
 logger = logging.getLogger(__name__)

--- a/label_studio/tests/test_core.py
+++ b/label_studio/tests/test_core.py
@@ -1,5 +1,6 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
+from typing import TYPE_CHECKING
 import pytest
 import types
 from core.utils.common import int_from_request
@@ -69,7 +70,10 @@ def test_core_int_from_request(param, result):
 
 @pytest.mark.django_db
 def test_user_info(business_client):
-    from label_studio.server import _get_user_info, _create_user
+    if TYPE_CHECKING:
+        from server import _get_user_info, _create_user
+    else:
+        from label_studio.server import _get_user_info, _create_user
 
     user_data = _get_user_info(business_client.admin.email)
     assert 'token' in user_data
@@ -109,7 +113,10 @@ def test_main(mocker, command_line, result):
 
 
 def test_string_is_url():
-    from label_studio.core.utils.common import string_is_url
+    if TYPE_CHECKING:
+        from core.utils.common import string_is_url
+    else:
+        from label_studio.core.utils.common import string_is_url
 
     assert string_is_url('http://test.com') is True
     assert string_is_url('https://test.com') is True
@@ -117,7 +124,10 @@ def test_string_is_url():
 
 
 def test_get_client_ip():
-    from label_studio.core.utils.common import get_client_ip
+    if TYPE_CHECKING:
+        from core.utils.common import get_client_ip
+    else:
+        from label_studio.core.utils.common import get_client_ip
 
     ip = get_client_ip(types.SimpleNamespace(META={'HTTP_X_FORWARDED_FOR': '127.0.0.1'}))
     assert ip == '127.0.0.1'
@@ -127,14 +137,20 @@ def test_get_client_ip():
 
 
 def test_timestamp_now():
-    from label_studio.core.utils.common import timestamp_now
+    if TYPE_CHECKING:
+        from core.utils.common import timestamp_now
+    else:
+        from label_studio.core.utils.common import timestamp_now
 
     t = timestamp_now()
     assert t is not None
 
 
 def test_start_browser():
-    from label_studio.core.utils.common import start_browser
+    if TYPE_CHECKING:
+        from core.utils.common import start_browser
+    else:
+        from label_studio.core.utils.common import start_browser
 
     assert start_browser('http://localhost:8080', True) is None
     assert start_browser('http://localhost:8080', False) is None

--- a/label_studio/tests/test_core.py
+++ b/label_studio/tests/test_core.py
@@ -3,7 +3,7 @@
 from typing import TYPE_CHECKING
 import pytest
 import types
-from core.utils.common import int_from_request
+from core.utils.common import int_from_request  # type: ignore[attr-defined]
 from core.utils.params import bool_from_request
 from core.utils.io import validate_upload_url
 from core.utils.exceptions import InvalidUploadUrlError
@@ -23,14 +23,14 @@ from rest_framework.exceptions import ValidationError
     (None, False)
 ])
 @pytest.mark.django_db
-def test_core_bool_from_request(param, result):
+def test_core_bool_from_request(param, result):  # type: ignore[no-untyped-def]
     params = {'test': param} if param is not None else {}
 
     # incorrect param should call exception
     if result is None:
         error = False
         try:
-            bool_from_request(params, 'test', 0)
+            bool_from_request(params, 'test', 0)  # type: ignore[no-untyped-call]
         except:
             error = True
 
@@ -38,7 +38,7 @@ def test_core_bool_from_request(param, result):
 
     # everything ok
     else:
-        assert bool_from_request(params, 'test', 0) == result
+        assert bool_from_request(params, 'test', 0) == result  # type: ignore[no-untyped-call]
 
 
 @pytest.mark.parametrize('param, result', [
@@ -50,14 +50,14 @@ def test_core_bool_from_request(param, result):
     (None, None)
 ])
 @pytest.mark.django_db
-def test_core_int_from_request(param, result):
+def test_core_int_from_request(param, result):  # type: ignore[no-untyped-def]
     params = {'test': param}
 
     # incorrect param should call exception
     if result is None:
         error = False
         try:
-            int_from_request(params, 'test', 0)
+            int_from_request(params, 'test', 0)  # type: ignore[no-untyped-call]
         except ValidationError:
             error = True
 
@@ -65,20 +65,20 @@ def test_core_int_from_request(param, result):
 
     # everything ok
     else:
-        assert int_from_request(params, 'test', 0) == result
+        assert int_from_request(params, 'test', 0) == result  # type: ignore[no-untyped-call]
 
 
 @pytest.mark.django_db
-def test_user_info(business_client):
+def test_user_info(business_client):  # type: ignore[no-untyped-def]
     if TYPE_CHECKING:
         from server import _get_user_info, _create_user
     else:
         from label_studio.server import _get_user_info, _create_user
 
-    user_data = _get_user_info(business_client.admin.email)
+    user_data = _get_user_info(business_client.admin.email)  # type: ignore[no-untyped-call]
     assert 'token' in user_data
 
-    user_data = _get_user_info(None)
+    user_data = _get_user_info(None)  # type: ignore[no-untyped-call]
     assert user_data is None
 
     class DummyArgs:
@@ -87,12 +87,12 @@ def test_user_info(business_client):
         user_token = 'token12345'
 
     args = DummyArgs()
-    _create_user(args, {})
-    user_data = _get_user_info('tester@x.com')
+    _create_user(args, {})  # type: ignore[no-untyped-call]
+    user_data = _get_user_info('tester@x.com')  # type: ignore[no-untyped-call]
     assert user_data['token'] == 'token12345'
 
     args.user_token, args.username = '123', 'tester2@x.com'
-    user = _create_user(args, {})
+    user = _create_user(args, {})  # type: ignore[no-untyped-call]
     assert user is not None
 
 
@@ -100,60 +100,60 @@ def test_user_info(business_client):
     (['label-studio', 'user', '--username', 'test@test.com', '--password', '12345678'], None),
 ])
 @pytest.mark.django_db
-def test_main(mocker, command_line, result):
+def test_main(mocker, command_line, result):  # type: ignore[no-untyped-def]
     from server import main
 
     mocker.patch(
         "sys.argv",
         command_line
     )
-    output = main()
+    output = main()  # type: ignore[no-untyped-call]
 
     assert output == result
 
 
-def test_string_is_url():
+def test_string_is_url():  # type: ignore[no-untyped-def]
     if TYPE_CHECKING:
         from core.utils.common import string_is_url
     else:
         from label_studio.core.utils.common import string_is_url
 
-    assert string_is_url('http://test.com') is True
-    assert string_is_url('https://test.com') is True
-    assert string_is_url('xyz') is False
+    assert string_is_url('http://test.com') is True  # type: ignore[no-untyped-call]
+    assert string_is_url('https://test.com') is True  # type: ignore[no-untyped-call]
+    assert string_is_url('xyz') is False  # type: ignore[no-untyped-call]
 
 
-def test_get_client_ip():
+def test_get_client_ip():  # type: ignore[no-untyped-def]
     if TYPE_CHECKING:
         from core.utils.common import get_client_ip
     else:
         from label_studio.core.utils.common import get_client_ip
 
-    ip = get_client_ip(types.SimpleNamespace(META={'HTTP_X_FORWARDED_FOR': '127.0.0.1'}))
+    ip = get_client_ip(types.SimpleNamespace(META={'HTTP_X_FORWARDED_FOR': '127.0.0.1'}))  # type: ignore[no-untyped-call]
     assert ip == '127.0.0.1'
 
-    ip = get_client_ip(types.SimpleNamespace(META={'REMOTE_ADDR': '127.0.0.2'}))
+    ip = get_client_ip(types.SimpleNamespace(META={'REMOTE_ADDR': '127.0.0.2'}))  # type: ignore[no-untyped-call]
     assert ip == '127.0.0.2'
 
 
-def test_timestamp_now():
+def test_timestamp_now():  # type: ignore[no-untyped-def]
     if TYPE_CHECKING:
         from core.utils.common import timestamp_now
     else:
         from label_studio.core.utils.common import timestamp_now
 
-    t = timestamp_now()
+    t = timestamp_now()  # type: ignore[no-untyped-call]
     assert t is not None
 
 
-def test_start_browser():
+def test_start_browser():  # type: ignore[no-untyped-def]
     if TYPE_CHECKING:
         from core.utils.common import start_browser
     else:
         from label_studio.core.utils.common import start_browser
 
-    assert start_browser('http://localhost:8080', True) is None
-    assert start_browser('http://localhost:8080', False) is None
+    assert start_browser('http://localhost:8080', True) is None  # type: ignore[no-untyped-call]
+    assert start_browser('http://localhost:8080', False) is None  # type: ignore[no-untyped-call]
 
 @pytest.mark.parametrize('url, block_local_urls, raises_exc', [
     ('http://0.0.0.0', True, InvalidUploadUrlError),
@@ -194,11 +194,11 @@ def test_start_browser():
     ('http://localhost', False, None),
  ])
 @pytest.mark.django_db
-def test_core_validate_upload_url(url, block_local_urls, raises_exc):
+def test_core_validate_upload_url(url, block_local_urls, raises_exc):  # type: ignore[no-untyped-def]
 
     if raises_exc is None:
-        assert validate_upload_url(url, block_local_urls=block_local_urls) is None
+        assert validate_upload_url(url, block_local_urls=block_local_urls) is None  # type: ignore[no-untyped-call]
         return
 
     with pytest.raises(raises_exc) as e:
-        validate_upload_url(url, block_local_urls=block_local_urls)
+        validate_upload_url(url, block_local_urls=block_local_urls)  # type: ignore[no-untyped-call]

--- a/label_studio/tests/test_data/gen_tasks_and_annotations.py
+++ b/label_studio/tests/test_data/gen_tasks_and_annotations.py
@@ -23,7 +23,7 @@ tc_template = """{"id": %s,"review_result":null,"ground_truth":false,"result":[{
 task_template_end = """],"data":{"text":"Но тут же раздался ужасный голос во мгле", "meta_info":"meta A"},"meta":{},"accuracy":1.0,"created_at":"2020-06-26T12:59:15.457035Z","updated_at":"2020-07-06T10:47:48.997310Z","is_labeled":true,"overlap":2,"project":2}"""
 
 
-def gen_tasks(user_id):
+def gen_tasks(user_id):  # type: ignore[no-untyped-def]
     i = 11
     tasks_n = 1000
 
@@ -48,4 +48,4 @@ def gen_tasks(user_id):
 
 
 if __name__ == '__main__':
-    gen_tasks(3)
+    gen_tasks(3)  # type: ignore[no-untyped-call]

--- a/label_studio/tests/test_endpoints.py
+++ b/label_studio/tests/test_endpoints.py
@@ -7,7 +7,7 @@ import os
 from unittest import mock
 
 from django.urls import get_resolver
-from django.shortcuts import reverse
+from django.shortcuts import reverse  # type: ignore[attr-defined]
 from django.core.management import call_command
 from tasks.models import Annotation
 from tasks.models import Task
@@ -286,7 +286,7 @@ group_annotator_statuses = {
     '/django-rq/': {'get': 302, 'post': 302, 'put': 302, 'delete': 302}}
 
 
-def build_urls(project_id, task_id, annotation_id):
+def build_urls(project_id, task_id, annotation_id):  # type: ignore[no-untyped-def]
     """ Get all the ulrs from django
     """
     urls = []
@@ -294,7 +294,7 @@ def build_urls(project_id, task_id, annotation_id):
     resolver = get_resolver(None).reverse_dict
     for url_name in resolver:
         if isinstance(url_name, str) and url_name not in exclude_urls:
-            keys = resolver[url_name][0][0][1]
+            keys = resolver[url_name][0][0][1]  # type: ignore[index]
             kwargs = {}
             for key in keys:
                 if 'pk' in key:
@@ -305,7 +305,7 @@ def build_urls(project_id, task_id, annotation_id):
                 elif key in ['token', 'uidb64']:
                     kwargs[key] = 1000
                 elif key in ['key']:
-                    kwargs[key] = '1000'
+                    kwargs[key] = '1000'  # type: ignore[assignment]
 
                 # we need to use really existing project/task/annotation ids from fixture
                 if key == 'project_id' or key == 'project_pk':
@@ -318,8 +318,8 @@ def build_urls(project_id, task_id, annotation_id):
                     kwargs[key] = 1
 
                 if url_name == 'password_reset_confirm':
-                    kwargs['token'] = '1000-1000'
-                    kwargs['uidb64'] = '1000'
+                    kwargs['token'] = '1000-1000'  # type: ignore[assignment]
+                    kwargs['uidb64'] = '1000'  # type: ignore[assignment]
             try:
                 url = reverse(url_name, kwargs=kwargs)
             except django.urls.exceptions.NoReverseMatch as e:
@@ -339,7 +339,7 @@ def build_urls(project_id, task_id, annotation_id):
     return urls
 
 
-def restore_objects(project):
+def restore_objects(project):  # type: ignore[no-untyped-def]
     """ Create task and annotation for URL tests
     """
     # task_db, annotation_db = None, None
@@ -371,12 +371,12 @@ def restore_objects(project):
     return task_db, annotation_db
 
 
-def check_urls(urls, runner, match_statuses, project):
+def check_urls(urls, runner, match_statuses, project):  # type: ignore[no-untyped-def]
     statuses = {}
     for url in urls:
         print('-->', url)
         status = {}
-        restore_objects(project)
+        restore_objects(project)  # type: ignore[no-untyped-call]
 
         r = runner.get(url)
         status['get'] = r.status_code
@@ -404,36 +404,36 @@ def check_urls(urls, runner, match_statuses, project):
     # print(statuses)  # use this to collect urls -> statuses dict
 
 
-def run(owner, runner):
+def run(owner, runner):  # type: ignore[no-untyped-def]
     """ Get all urls from Django and GET/POST/PUT/DELETE them
     """
-    owner.task_db, owner.annotation_db = restore_objects(owner.project)
-    urls = build_urls(owner.project.id, owner.task_db.id, owner.annotation_db.id)
+    owner.task_db, owner.annotation_db = restore_objects(owner.project)  # type: ignore[no-untyped-call]
+    urls = build_urls(owner.project.id, owner.task_db.id, owner.annotation_db.id)  # type: ignore[no-untyped-call]
 
-    check_urls(urls, runner, runner.statuses, owner.project)
+    check_urls(urls, runner, runner.statuses, owner.project)  # type: ignore[no-untyped-call]
 
 
 @pytest.mark.django_db
-def test_all_urls_owner(setup_project_choices):
+def test_all_urls_owner(setup_project_choices):  # type: ignore[no-untyped-def]
     runner = owner = setup_project_choices
     runner.statuses = owner_statuses
     runner.statuses_name = 'owner_statuses'
-    run(owner, runner)
+    run(owner, runner)  # type: ignore[no-untyped-call]
 
 
 @pytest.mark.django_db
-def test_all_urls_other_business(setup_project_choices, business_client):
+def test_all_urls_other_business(setup_project_choices, business_client):  # type: ignore[no-untyped-def]
     business_client.statuses = other_business_statuses
     business_client.statuses_name = 'other_business_statuses'
-    run(setup_project_choices, business_client)
+    run(setup_project_choices, business_client)  # type: ignore[no-untyped-call]
 
 
 @pytest.mark.django_db
-def test_urls_mismatch_with_registered(tmpdir):
+def test_urls_mismatch_with_registered(tmpdir):  # type: ignore[no-untyped-def]
     from core.utils.io import find_file
     from core.utils.params import get_bool_env
 
-    all_urls_file = find_file('all_urls.json')
+    all_urls_file = find_file('all_urls.json')  # type: ignore[no-untyped-call]
     with open(all_urls_file) as f:
         all_urls = json.load(f)
 
@@ -442,7 +442,7 @@ def test_urls_mismatch_with_registered(tmpdir):
 
     f = tmpdir.mkdir("subdir").join('show_urls.json')
     call_command('show_urls', format='pretty-json', stdout=f)
-    filename = os.path.join(f.dirname, f.basename)
+    filename = os.path.join(f.dirname, f.basename)  # type: ignore[attr-defined, attr-defined]
     with open(filename) as f1:
         all_current_urls = json.load(f1)
 

--- a/label_studio/tests/test_exception.py
+++ b/label_studio/tests/test_exception.py
@@ -8,7 +8,7 @@ from .utils import project_id
 
 
 @pytest.mark.django_db
-def test_custom_exception_handling(business_client, project_id):
+def test_custom_exception_handling(business_client, project_id):  # type: ignore[no-untyped-def]
     payload = dict(project=project_id, data={"test": 1})
     with mock.patch('data_manager.api.ViewAPI.create') as m:
         m.side_effect = Exception('Test')

--- a/label_studio/tests/test_export.py
+++ b/label_studio/tests/test_export.py
@@ -52,7 +52,7 @@ from django.apps import apps
     ('1', 'majority_vote', '1', 1)
 ])
 @pytest.mark.django_db
-def test_export(
+def test_export(  # type: ignore[no-untyped-def]
         business_client, configured_project, finished, aggregator_type, return_task, num_task_in_result,
         annotation_items, aggregated_class
 ):
@@ -86,11 +86,11 @@ def test_export(
 
     # test whether "id" or full task included in results
     if return_task == '0':
-        task_with_annotation = next((t for t in exports if t['id'] == task.id))
-        assert task_with_annotation['id'] == task.id
+        task_with_annotation = next((t for t in exports if t['id'] == task.id))  # type: ignore[union-attr]
+        assert task_with_annotation['id'] == task.id  # type: ignore[union-attr]
     elif return_task == '1':
-        task_with_annotation = next((t for t in exports if t['id'] == task.id))
-        assert task_with_annotation['data'] == task.data
+        task_with_annotation = next((t for t in exports if t['id'] == task.id))  # type: ignore[union-attr]
+        assert task_with_annotation['data'] == task.data  # type: ignore[union-attr]
     else:
         raise Exception('Incorrect return_task param in test: ' + str(return_task))
 
@@ -104,7 +104,7 @@ def test_export(
             # we expect to see all tasks in exports...
             assert len(exports) == task_query.count()
             # ...as well as task without annotations (with empty results)
-            assert all(len(t['annotations']) == 0 for t in exports if t['id'] != task.id)
+            assert all(len(t['annotations']) == 0 for t in exports if t['id'] != task.id)  # type: ignore[union-attr]
     else:
         assert task_with_annotation['annotations'][0]['result'][0]['value']['choices'][0] == aggregated_class
 
@@ -128,7 +128,7 @@ def test_export(
      ], None),
 ])
 @pytest.mark.django_db
-def test_export_with_predictions(
+def test_export_with_predictions(  # type: ignore[no-untyped-def]
         business_client, configured_project, finished, return_task, aggregator_type, annotation_results, predictions
 ):
     if aggregator_type == 'majority_vote' and not apps.is_installed('businesses'):

--- a/label_studio/tests/test_invites.py
+++ b/label_studio/tests/test_invites.py
@@ -7,7 +7,7 @@ from .utils import project_id
 
 
 @pytest.mark.django_db
-def test_signup_setting(business_client, client, settings):
+def test_signup_setting(business_client, client, settings):  # type: ignore[no-untyped-def]
     settings.DISABLE_SIGNUP_WITHOUT_LINK = True
     response = client.post('/user/signup', data={'email': 'test_user@example.com', 'password': 'test_password'})
     assert response.status_code == 403
@@ -21,7 +21,7 @@ def test_signup_setting(business_client, client, settings):
 
 
 @pytest.mark.django_db
-def test_reset_token(business_client, client, settings):
+def test_reset_token(business_client, client, settings):  # type: ignore[no-untyped-def]
     settings.DISABLE_SIGNUP_WITHOUT_LINK = True
 
     # get invite_url link and check it works
@@ -43,7 +43,7 @@ def test_reset_token(business_client, client, settings):
     assert response.status_code == 302
 
 @pytest.mark.django_db
-def test_reset_token_not_valid(business_client, client, settings):
+def test_reset_token_not_valid(business_client, client, settings):  # type: ignore[no-untyped-def]
     settings.DISABLE_SIGNUP_WITHOUT_LINK = False
 
     # disallow if token and does not match
@@ -53,7 +53,7 @@ def test_reset_token_not_valid(business_client, client, settings):
     assert response.status_code == 403, response.content
 
 @pytest.mark.django_db
-def test_token_get_not_post_shows_form(business_client, client, settings):
+def test_token_get_not_post_shows_form(business_client, client, settings):  # type: ignore[no-untyped-def]
     settings.DISABLE_SIGNUP_WITHOUT_LINK = True
 
     # can't bypass post

--- a/label_studio/tests/test_io_storages.py
+++ b/label_studio/tests/test_io_storages.py
@@ -5,8 +5,8 @@ from tests.utils import make_project
 
 
 @pytest.mark.django_db
-def test_gcs_storage_credentials_validation(business_client):
-    project = make_project({}, business_client.user, use_ml_backend=False)
+def test_gcs_storage_credentials_validation(business_client):  # type: ignore[no-untyped-def]
+    project = make_project({}, business_client.user, use_ml_backend=False)  # type: ignore[no-untyped-call]
 
     data = {
         "project": project.id,

--- a/label_studio/tests/test_next_task.py
+++ b/label_studio/tests/test_next_task.py
@@ -94,12 +94,12 @@ _project_for_text_choices_onto_A_B_classes = dict(
     )
 ])
 @pytest.mark.django_db
-def test_next_task(
+def test_next_task(  # type: ignore[no-untyped-def]
         business_client, any_client, project_config, tasks, status_code, expected_response_value_set
 ):
-    project = make_project(project_config, business_client.user)
-    if _client_is_annotator(any_client):
-        invite_client_to_project(any_client, project)
+    project = make_project(project_config, business_client.user)  # type: ignore[no-untyped-call]
+    if _client_is_annotator(any_client):  # type: ignore[no-untyped-call]
+        invite_client_to_project(any_client, project)  # type: ignore[no-untyped-call]
 
     # upload tasks with annotations
     r = business_client.post(
@@ -429,26 +429,26 @@ def test_next_task(
     'when some of the tasks are partially labeled, regardless scores sampling operates on depth-first (try to complete all tasks asap)',
 ])
 @pytest.mark.django_db
-def test_next_task_with_active_learning(mocker,
+def test_next_task_with_active_learning(mocker,  # type: ignore[no-untyped-def]
                                         business_client, any_client, annotator2_client, project_config, tasks,
                                         predictions, annotations, num_annotators,
                                         status_code, prelabeling_result
                                         ):
 
-    project = make_project(project_config, business_client.user, use_ml_backend=False)
-    if _client_is_annotator(any_client):
-        invite_client_to_project(any_client, project)
-    if _client_is_annotator(annotator2_client):
-        invite_client_to_project(annotator2_client, project)
+    project = make_project(project_config, business_client.user, use_ml_backend=False)  # type: ignore[no-untyped-call]
+    if _client_is_annotator(any_client):  # type: ignore[no-untyped-call]
+        invite_client_to_project(any_client, project)  # type: ignore[no-untyped-call]
+    if _client_is_annotator(annotator2_client):  # type: ignore[no-untyped-call]
+        invite_client_to_project(annotator2_client, project)  # type: ignore[no-untyped-call]
 
     class MockAnnotatorCount:
-        def count(self):
+        def count(self):  # type: ignore[no-untyped-def]
             return num_annotators
 
     mocker.patch.object(Project, 'annotators', return_value=MockAnnotatorCount())
 
     for task, prediction, annotation in zip(tasks, predictions, annotations):
-        task = make_task(task, project)
+        task = make_task(task, project)  # type: ignore[no-untyped-call]
         Prediction.objects.create(task=task, model_version=project.model_version, **prediction)
         if annotation is not None:
             completed_by = any_client.annotator if num_annotators == 1 else annotator2_client.annotator
@@ -461,7 +461,7 @@ def test_next_task_with_active_learning(mocker,
 
 
 @pytest.mark.django_db
-def test_active_learning_with_uploaded_predictions(business_client):
+def test_active_learning_with_uploaded_predictions(business_client):  # type: ignore[no-untyped-def]
     config = dict(
         title='Test',
         is_published=True,
@@ -475,7 +475,7 @@ def test_active_learning_with_uploaded_predictions(business_client):
               </Choices>
             </View>'''
     )
-    project = make_project(config, business_client.user, use_ml_backend=False)
+    project = make_project(config, business_client.user, use_ml_backend=False)  # type: ignore[no-untyped-call]
     result = [{
         'from_name': 'text_class',
         'to_name': 'text',
@@ -493,7 +493,7 @@ def test_active_learning_with_uploaded_predictions(business_client):
     r = business_client.post(f'/api/projects/{project.id}/tasks/bulk/', data=json.dumps(tasks), content_type="application/json")
     assert r.status_code == 201
 
-    def get_next_task_id_and_complete_it():
+    def get_next_task_id_and_complete_it():  # type: ignore[no-untyped-def]
         r = business_client.get(f'/api/projects/{project.id}/next')
         assert r.status_code == 200
         task = json.loads(r.content)
@@ -507,17 +507,17 @@ def test_active_learning_with_uploaded_predictions(business_client):
     assert project.model_version == ''
 
     # tasks will be shown according to the uploaded scores
-    assert get_next_task_id_and_complete_it() == 'score = 0.1'
-    assert get_next_task_id_and_complete_it() == 'score = 0.2'
-    assert get_next_task_id_and_complete_it() == 'score = 0.3'
-    assert get_next_task_id_and_complete_it() == 'score = 0.4'
-    assert get_next_task_id_and_complete_it() == 'score = 0.5'
+    assert get_next_task_id_and_complete_it() == 'score = 0.1'  # type: ignore[no-untyped-call]
+    assert get_next_task_id_and_complete_it() == 'score = 0.2'  # type: ignore[no-untyped-call]
+    assert get_next_task_id_and_complete_it() == 'score = 0.3'  # type: ignore[no-untyped-call]
+    assert get_next_task_id_and_complete_it() == 'score = 0.4'  # type: ignore[no-untyped-call]
+    assert get_next_task_id_and_complete_it() == 'score = 0.5'  # type: ignore[no-untyped-call]
 
 
-@pytest.mark.skipif(not redis_healthcheck(), reason='Multi user locks only supported with redis enabled')
+@pytest.mark.skipif(not redis_healthcheck(), reason='Multi user locks only supported with redis enabled')  # type: ignore[no-untyped-call]
 @pytest.mark.parametrize('sampling', (Project.UNIFORM, Project.UNCERTAINTY, Project.SEQUENCE))
 @pytest.mark.django_db
-def test_label_races(configured_project, business_client, sampling):
+def test_label_races(configured_project, business_client, sampling):  # type: ignore[no-untyped-def]
     config = dict(
         title='test_label_races',
         is_published=True,
@@ -530,13 +530,13 @@ def test_label_races(configured_project, business_client, sampling):
               </Choices>
             </View>'''
     )
-    project = make_project(config, business_client.user)
+    project = make_project(config, business_client.user)  # type: ignore[no-untyped-call]
     project.sampling = sampling
     project.save()
-    id1 = make_task({'data': {'text': 'aaa'}}, project).id
-    id2 = make_task({'data': {'text': 'bbb'}}, project).id
-    ann1 = make_annotator({'email': 'ann1@testlabelraces.com'}, project, True)
-    ann2 = make_annotator({'email': 'ann2@testlabelraces.com'}, project, True)
+    id1 = make_task({'data': {'text': 'aaa'}}, project).id  # type: ignore[no-untyped-call]
+    id2 = make_task({'data': {'text': 'bbb'}}, project).id  # type: ignore[no-untyped-call]
+    ann1 = make_annotator({'email': 'ann1@testlabelraces.com'}, project, True)  # type: ignore[no-untyped-call]
+    ann2 = make_annotator({'email': 'ann2@testlabelraces.com'}, project, True)  # type: ignore[no-untyped-call]
 
     # ann1 takes task id1
     r = ann1.get(f'/api/projects/{project.id}/next')
@@ -554,10 +554,10 @@ def test_label_races(configured_project, business_client, sampling):
     assert json.loads(r.content)['id'] == id2
 
 
-@pytest.mark.skipif(not redis_healthcheck(), reason='Multi user locks only supported with redis enabled')
+@pytest.mark.skipif(not redis_healthcheck(), reason='Multi user locks only supported with redis enabled')  # type: ignore[no-untyped-call]
 @pytest.mark.parametrize('sampling', (Project.UNIFORM, Project.UNCERTAINTY, Project.SEQUENCE))
 @pytest.mark.django_db
-def test_label_races_after_all_taken(configured_project, business_client, sampling):
+def test_label_races_after_all_taken(configured_project, business_client, sampling):  # type: ignore[no-untyped-def]
     config = dict(
         title='test_label_races',
         is_published=True,
@@ -570,13 +570,13 @@ def test_label_races_after_all_taken(configured_project, business_client, sampli
               </Choices>
             </View>'''
     )
-    project = make_project(config, business_client.user)
+    project = make_project(config, business_client.user)  # type: ignore[no-untyped-call]
     project.sampling = sampling
     project.save()
-    id1 = make_task({'data': {'text': 'aaa'}}, project).id
-    id2 = make_task({'data': {'text': 'bbb'}}, project).id
-    ann1 = make_annotator({'email': 'ann1@testlabelracesalltaken.com'}, project, True)
-    ann2 = make_annotator({'email': 'ann2@testlabelracesalltaken.com'}, project, True)
+    id1 = make_task({'data': {'text': 'aaa'}}, project).id  # type: ignore[no-untyped-call]
+    id2 = make_task({'data': {'text': 'bbb'}}, project).id  # type: ignore[no-untyped-call]
+    ann1 = make_annotator({'email': 'ann1@testlabelracesalltaken.com'}, project, True)  # type: ignore[no-untyped-call]
+    ann2 = make_annotator({'email': 'ann2@testlabelracesalltaken.com'}, project, True)  # type: ignore[no-untyped-call]
 
     # ann1 takes task id1
     r = ann1.get(f'/api/projects/{project.id}/next')
@@ -606,7 +606,7 @@ def test_label_races_after_all_taken(configured_project, business_client, sampli
 
 
 @pytest.mark.django_db
-def test_breadth_first_simple(business_client):
+def test_breadth_first_simple(business_client):  # type: ignore[no-untyped-def]
     config = dict(
         title='test_label_races',
         is_published=True,
@@ -626,13 +626,13 @@ def test_breadth_first_simple(business_client):
         'type': 'choices',
         'value': {'choices': ['class_A']}
     }])
-    project = make_project(config, business_client.user)
+    project = make_project(config, business_client.user)  # type: ignore[no-untyped-call]
     project.sampling = Project.SEQUENCE
     project.save()
-    id1 = make_task({'data': {'text': 'aaa'}}, project).id
-    id2 = make_task({'data': {'text': 'bbb'}}, project).id
-    ann1 = make_annotator({'email': 'ann1@testbreadthfirst.com'}, project, True)
-    ann2 = make_annotator({'email': 'ann2@testbreadthfirst.com'}, project, True)
+    id1 = make_task({'data': {'text': 'aaa'}}, project).id  # type: ignore[no-untyped-call]
+    id2 = make_task({'data': {'text': 'bbb'}}, project).id  # type: ignore[no-untyped-call]
+    ann1 = make_annotator({'email': 'ann1@testbreadthfirst.com'}, project, True)  # type: ignore[no-untyped-call]
+    ann2 = make_annotator({'email': 'ann2@testbreadthfirst.com'}, project, True)  # type: ignore[no-untyped-call]
 
     # ann1 takes first task
     r = ann1.get(f'/api/projects/{project.id}/next')
@@ -664,7 +664,7 @@ def test_breadth_first_simple(business_client):
 
 
 @pytest.mark.django_db
-def test_breadth_first_overlap_3(business_client):
+def test_breadth_first_overlap_3(business_client):  # type: ignore[no-untyped-def]
     config = dict(
         title='test_label_races',
         is_published=True,
@@ -684,41 +684,41 @@ def test_breadth_first_overlap_3(business_client):
         'type': 'choices',
         'value': {'choices': ['class_A']}
     }])
-    project = make_project(config, business_client.user)
+    project = make_project(config, business_client.user)  # type: ignore[no-untyped-call]
     project.sampling = Project.UNIFORM
     project.save()
 
-    def complete_task(annotator):
+    def complete_task(annotator):  # type: ignore[no-untyped-def]
         _r = annotator.get(f'/api/projects/{project.id}/next')
         assert _r.status_code == 200
         task_id = json.loads(_r.content)['id']
         annotator.post(f'/api/tasks/{task_id}/annotations/', data={'task': task_id, 'result': annotation_result})
         return task_id
 
-    id1 = make_task({'data': {'text': 'aaa'}}, project).id
-    id2 = make_task({'data': {'text': 'bbb'}}, project).id
-    id3 = make_task({'data': {'text': 'ccc'}}, project).id
+    id1 = make_task({'data': {'text': 'aaa'}}, project).id  # type: ignore[no-untyped-call]
+    id2 = make_task({'data': {'text': 'bbb'}}, project).id  # type: ignore[no-untyped-call]
+    id3 = make_task({'data': {'text': 'ccc'}}, project).id  # type: ignore[no-untyped-call]
 
-    ann1 = make_annotator({'email': 'ann1@testbreadthfirstoverlap3.com'}, project, True)
-    ann2 = make_annotator({'email': 'ann2@testbreadthfirstoverlap3.com'}, project, True)
-    ann3 = make_annotator({'email': 'ann3@testbreadthfirstoverlap3.com'}, project, True)
+    ann1 = make_annotator({'email': 'ann1@testbreadthfirstoverlap3.com'}, project, True)  # type: ignore[no-untyped-call]
+    ann2 = make_annotator({'email': 'ann2@testbreadthfirstoverlap3.com'}, project, True)  # type: ignore[no-untyped-call]
+    ann3 = make_annotator({'email': 'ann3@testbreadthfirstoverlap3.com'}, project, True)  # type: ignore[no-untyped-call]
 
     # ann1, ann2, ann3 should follow breadth-first scheme: trying to complete the tasks as fast as possible
-    task_id_ann1 = complete_task(ann1)
-    task_id_ann2 = complete_task(ann2)
+    task_id_ann1 = complete_task(ann1)  # type: ignore[no-untyped-call]
+    task_id_ann2 = complete_task(ann2)  # type: ignore[no-untyped-call]
     assert task_id_ann2 == task_id_ann1
-    complete_task(ann1)
-    complete_task(ann1)
-    task_id_ann3 = complete_task(ann3)
+    complete_task(ann1)  # type: ignore[no-untyped-call]
+    complete_task(ann1)  # type: ignore[no-untyped-call]
+    task_id_ann3 = complete_task(ann3)  # type: ignore[no-untyped-call]
     assert task_id_ann2 == task_id_ann3
-    task_id_ann2 = complete_task(ann2)
-    task_id_ann3 = complete_task(ann3)
+    task_id_ann2 = complete_task(ann2)  # type: ignore[no-untyped-call]
+    task_id_ann3 = complete_task(ann3)  # type: ignore[no-untyped-call]
     assert task_id_ann2 == task_id_ann3
 
 
-@pytest.mark.skipif(not redis_healthcheck(), reason='Multi user locks only supported with redis enabled')
+@pytest.mark.skipif(not redis_healthcheck(), reason='Multi user locks only supported with redis enabled')  # type: ignore[no-untyped-call]
 @pytest.mark.django_db
-def test_try_take_last_task_at_the_same_time(business_client):
+def test_try_take_last_task_at_the_same_time(business_client):  # type: ignore[no-untyped-def]
     config = dict(
         title='test_try_take_last_task_at_the_same_time',
         is_published=True,
@@ -738,28 +738,28 @@ def test_try_take_last_task_at_the_same_time(business_client):
         'type': 'choices',
         'value': {'choices': ['class_A']}
     }])
-    project = make_project(config, business_client.user)
+    project = make_project(config, business_client.user)  # type: ignore[no-untyped-call]
     project.sampling = Project.SEQUENCE
     project.save()
 
-    def complete_task(annotator):
+    def complete_task(annotator):  # type: ignore[no-untyped-def]
         _r = annotator.get(f'/api/projects/{project.id}/next')
         assert _r.status_code == 200
         task_id = json.loads(_r.content)['id']
         annotator.post(f'/api/tasks/{task_id}/annotations/', data={'task': task_id, 'result': annotation_result})
         return task_id
 
-    make_task({'data': {'text': 'aaa'}}, project)
-    make_task({'data': {'text': 'bbb'}}, project)
+    make_task({'data': {'text': 'aaa'}}, project)  # type: ignore[no-untyped-call]
+    make_task({'data': {'text': 'bbb'}}, project)  # type: ignore[no-untyped-call]
 
-    ann1 = make_annotator({'email': 'ann1@lasttask.com'}, project, True)
-    ann2 = make_annotator({'email': 'ann2@lasttask.com'}, project, True)
-    ann3 = make_annotator({'email': 'ann3@lasttask.com'}, project, True)
+    ann1 = make_annotator({'email': 'ann1@lasttask.com'}, project, True)  # type: ignore[no-untyped-call]
+    ann2 = make_annotator({'email': 'ann2@lasttask.com'}, project, True)  # type: ignore[no-untyped-call]
+    ann3 = make_annotator({'email': 'ann3@lasttask.com'}, project, True)  # type: ignore[no-untyped-call]
 
     # ann1, ann2 complete first task, then ann3 completes last task
-    complete_task(ann1)
-    complete_task(ann2)
-    complete_task(ann3)
+    complete_task(ann1)  # type: ignore[no-untyped-call]
+    complete_task(ann2)  # type: ignore[no-untyped-call]
+    complete_task(ann3)  # type: ignore[no-untyped-call]
 
     # only one annotator can take the last task
     _r = ann1.get(f'/api/projects/{project.id}/next')
@@ -772,9 +772,9 @@ def test_try_take_last_task_at_the_same_time(business_client):
     assert _r.status_code == 404
 
 
-@pytest.mark.skipif(not redis_healthcheck(), reason='Multi user locks only supported with redis enabled')
+@pytest.mark.skipif(not redis_healthcheck(), reason='Multi user locks only supported with redis enabled')  # type: ignore[no-untyped-call]
 @pytest.mark.django_db
-def test_breadth_first_with_label_race(configured_project, business_client):
+def test_breadth_first_with_label_race(configured_project, business_client):  # type: ignore[no-untyped-def]
     config = dict(
         title='test_label_races',
         is_published=True,
@@ -794,13 +794,13 @@ def test_breadth_first_with_label_race(configured_project, business_client):
         'type': 'choices',
         'value': {'choices': ['class_A']}
     }])
-    project = make_project(config, business_client.user)
+    project = make_project(config, business_client.user)  # type: ignore[no-untyped-call]
     project.sampling = Project.SEQUENCE
     project.save()
-    id1 = make_task({'data': {'text': 'aaa'}}, project).id
-    id2 = make_task({'data': {'text': 'bbb'}}, project).id
-    ann1 = make_annotator({'email': 'ann1@testbreadthlabelraces.com'}, project, True)
-    ann2 = make_annotator({'email': 'ann2@testbreadthlabelraces.com'}, project, True)
+    id1 = make_task({'data': {'text': 'aaa'}}, project).id  # type: ignore[no-untyped-call]
+    id2 = make_task({'data': {'text': 'bbb'}}, project).id  # type: ignore[no-untyped-call]
+    ann1 = make_annotator({'email': 'ann1@testbreadthlabelraces.com'}, project, True)  # type: ignore[no-untyped-call]
+    ann2 = make_annotator({'email': 'ann2@testbreadthlabelraces.com'}, project, True)  # type: ignore[no-untyped-call]
 
     # ann1 takes first task
     r = ann1.get(f'/api/projects/{project.id}/next')
@@ -840,9 +840,9 @@ def test_breadth_first_with_label_race(configured_project, business_client):
     assert json.loads(r.content)['id'] == id2
 
 
-@pytest.mark.skipif(not redis_healthcheck(), reason='Multi user locks only supported with redis enabled')
+@pytest.mark.skipif(not redis_healthcheck(), reason='Multi user locks only supported with redis enabled')  # type: ignore[no-untyped-call]
 @pytest.mark.django_db
-def test_label_race_with_overlap(configured_project, business_client):
+def test_label_race_with_overlap(configured_project, business_client):  # type: ignore[no-untyped-def]
     """
         2 annotators takes and finish annotations one by one
         depending on project settings overlap
@@ -875,12 +875,12 @@ def test_label_race_with_overlap(configured_project, business_client):
         'type': 'choices',
         'value': {'choices': ['class_A']}
     }])
-    project = make_project(config, business_client.user)
+    project = make_project(config, business_client.user)  # type: ignore[no-untyped-call]
     project.sampling = Project.SEQUENCE
     project.save()
 
-    ann1 = make_annotator({'email': 'ann1@testlabelracewithoverlap.com'}, project, True)
-    ann2 = make_annotator({'email': 'ann2@testlabelracewithoverlap.com'}, project, True)
+    ann1 = make_annotator({'email': 'ann1@testlabelracewithoverlap.com'}, project, True)  # type: ignore[no-untyped-call]
+    ann2 = make_annotator({'email': 'ann2@testlabelracewithoverlap.com'}, project, True)  # type: ignore[no-untyped-call]
 
     # create tasks
     tasks = []
@@ -903,8 +903,8 @@ def test_label_race_with_overlap(configured_project, business_client):
     assert t.count() == 1
     t1 = Task.objects.filter(project=project.id).filter(overlap=1)
     assert t1.count() == 1
-    overlap_id = t.first().id
-    other_id = t1.first().id
+    overlap_id = t.first().id  # type: ignore[union-attr]
+    other_id = t1.first().id  # type: ignore[union-attr]
 
     # ann1 takes first task
     r = ann1.get(f'/api/projects/{project.id}/next')
@@ -941,9 +941,9 @@ def test_label_race_with_overlap(configured_project, business_client):
     assert json.loads(r.content)['id'] == other_id
 
 
-@pytest.mark.skipif(not redis_healthcheck(), reason='Multi user locks only supported with redis enabled')
+@pytest.mark.skipif(not redis_healthcheck(), reason='Multi user locks only supported with redis enabled')  # type: ignore[no-untyped-call]
 @pytest.mark.django_db
-def test_label_w_drafts_race_with_overlap(configured_project, business_client):
+def test_label_w_drafts_race_with_overlap(configured_project, business_client):  # type: ignore[no-untyped-def]
     """
         2 annotators takes and leaves with draft annotations one by one
         depending on project settings overlap
@@ -977,12 +977,12 @@ def test_label_w_drafts_race_with_overlap(configured_project, business_client):
         'value': {'choices': ['class_A']}
     }])
 
-    project = make_project(config, business_client.user)
+    project = make_project(config, business_client.user)  # type: ignore[no-untyped-call]
     project.sampling = Project.SEQUENCE
     project.save()
 
-    ann1 = make_annotator({'email': 'ann1@testlabelracewdrafts.com'}, project, True)
-    ann2 = make_annotator({'email': 'ann2@testlabelracewdrafts.com'}, project, True)
+    ann1 = make_annotator({'email': 'ann1@testlabelracewdrafts.com'}, project, True)  # type: ignore[no-untyped-call]
+    ann2 = make_annotator({'email': 'ann2@testlabelracewdrafts.com'}, project, True)  # type: ignore[no-untyped-call]
 
     # create tasks
     tasks = []
@@ -1005,8 +1005,8 @@ def test_label_w_drafts_race_with_overlap(configured_project, business_client):
     assert t.count() == 1
     t1 = Task.objects.filter(project=project.id).filter(overlap=1)
     assert t1.count() == 1
-    overlap_id = t.first().id
-    other_id = t1.first().id
+    overlap_id = t.first().id  # type: ignore[union-attr]
+    other_id = t1.first().id  # type: ignore[union-attr]
 
     annotation_draft_result = {
         'task': overlap_id,
@@ -1062,7 +1062,7 @@ def test_label_w_drafts_race_with_overlap(configured_project, business_client):
 
 
 @pytest.mark.django_db
-def test_fetch_final_taken_task(business_client):
+def test_fetch_final_taken_task(business_client):  # type: ignore[no-untyped-def]
     config = dict(
         title='test_label_races',
         is_published=True,
@@ -1081,12 +1081,12 @@ def test_fetch_final_taken_task(business_client):
         'type': 'choices',
         'value': {'choices': ['class_A']}
     }])
-    project = make_project(config, business_client.user)
+    project = make_project(config, business_client.user)  # type: ignore[no-untyped-call]
     project.sampling = Project.SEQUENCE
     project.save()
 
-    ann1 = make_annotator({'email': 'ann1@testfetchfinal.com'}, project, True)
-    ann2 = make_annotator({'email': 'ann2@testfetchfinal.com'}, project, True)
+    ann1 = make_annotator({'email': 'ann1@testfetchfinal.com'}, project, True)  # type: ignore[no-untyped-call]
+    ann2 = make_annotator({'email': 'ann2@testfetchfinal.com'}, project, True)  # type: ignore[no-untyped-call]
 
     # create tasks
     tasks = []
@@ -1125,9 +1125,9 @@ def test_fetch_final_taken_task(business_client):
         assert json.loads(r.content)['id'] == another_task_id
 
 
-@pytest.mark.skipif(not redis_healthcheck(), reason='Multi user locks only supported with redis enabled')
+@pytest.mark.skipif(not redis_healthcheck(), reason='Multi user locks only supported with redis enabled')  # type: ignore[no-untyped-call]
 @pytest.mark.django_db
-def test_with_bad_annotation_result(business_client):
+def test_with_bad_annotation_result(business_client):  # type: ignore[no-untyped-def]
     config = dict(
         title='test_with_failed_matching_score',
         is_published=True,
@@ -1147,7 +1147,7 @@ def test_with_bad_annotation_result(business_client):
               </View>
             </View>''',
     )
-    project = make_project(config, business_client.user, use_ml_backend=False)
+    project = make_project(config, business_client.user, use_ml_backend=False)  # type: ignore[no-untyped-call]
 
     bad_result = {
         'id': 'Yv_lLEp_8I', 'type': 'polygonlabels', 'value': {'points': [[65.99824119670821, 73.11598603746282]], 'polygonlabels': ['t11']}, 'source': '$image', 'to_name': 'img', 'from_name': 'tag', 'parent_id': None, 'image_rotation': 0, 'original_width': 4032, 'original_height': 3024}
@@ -1249,28 +1249,28 @@ def test_with_bad_annotation_result(business_client):
     num_annotators = 30
     anns = []
     for i in range(num_annotators):
-        anns.append(make_annotator({'email': f'ann{i}@testwithbadannotationresult.com'}, project, True))
+        anns.append(make_annotator({'email': f'ann{i}@testwithbadannotationresult.com'}, project, True))  # type: ignore[no-untyped-call]
 
     # create one heavy task with many annotations - it's statistic recalculation should not be done after completing another task  # noqa
     # turn off statistics calculations for now
     with mock.patch('tasks.models.update_project_summary_annotations_and_is_labeled'):
         for i in range(10):
-            task = make_task({'data': {'image': f'https://data.s3.amazonaws.com/image/{i}.jpg'}}, project)
+            task = make_task({'data': {'image': f'https://data.s3.amazonaws.com/image/{i}.jpg'}}, project)  # type: ignore[no-untyped-call]
             for i in range(num_annotators):
-                make_annotation({'result': [bad_result] * 10 + [good_result] * 10, 'completed_by': anns[i].annotator}, task.id)
+                make_annotation({'result': [bad_result] * 10 + [good_result] * 10, 'completed_by': anns[i].annotator}, task.id)  # type: ignore[no-untyped-call]
 
     # create uncompleted task
-    uncompleted_task = make_task({'data': {'image': f'https://data.s3.amazonaws.com/image/uncompleted.jpg'}}, project)
+    uncompleted_task = make_task({'data': {'image': f'https://data.s3.amazonaws.com/image/uncompleted.jpg'}}, project)  # type: ignore[no-untyped-call]
 
     print('ann1 takes any task with bad annotation and complete it')
     r = anns[0].get(f'/api/projects/{project.id}/next')
     task_id = json.loads(r.content)['id']
     assert task_id == uncompleted_task.id
 
-    def make_async_annotation_submit(new_ann=None):
+    def make_async_annotation_submit(new_ann=None):  # type: ignore[no-untyped-def]
         print('Async annotation submit')
         if new_ann is None:
-            new_ann = make_annotator({'email': f'new_ann@testwithbadannotationresult.com'}, project, True)
+            new_ann = make_annotator({'email': f'new_ann@testwithbadannotationresult.com'}, project, True)  # type: ignore[no-untyped-call]
         new_ann.post(
             f'/api/tasks/{task_id}/annotations/',
             data={'task': task_id, 'result': json.dumps([good_result])},
@@ -1281,7 +1281,7 @@ def test_with_bad_annotation_result(business_client):
     # there is no any additional computational costs implied by statistics
     # recalculation over the entire project
     t = time.time()
-    make_async_annotation_submit(anns[0])
+    make_async_annotation_submit(anns[0])  # type: ignore[no-untyped-call]
     # TODO: measuring response time is not a good way to do that,
     #  but dunno how to emulate async requests or timeouts for Django test client
     assert (time.time() - t) < 1, 'Time of annotation.submit() increases - that might be caused by redundant computations over the rest of the tasks - check that only a single task is affected by /api/tasks/<task_id>/annotations'  # noqa
@@ -1292,7 +1292,7 @@ def test_with_bad_annotation_result(business_client):
 @pytest.mark.parametrize('setup_before_upload', (False, True))
 @pytest.mark.parametrize('show_overlap_first', (False, True))
 @pytest.mark.django_db
-def test_overlap_first(business_client, setup_before_upload, show_overlap_first):
+def test_overlap_first(business_client, setup_before_upload, show_overlap_first):  # type: ignore[no-untyped-def]
     c = business_client
     config = dict(
         title='test_overlap_first',
@@ -1310,7 +1310,7 @@ def test_overlap_first(business_client, setup_before_upload, show_overlap_first)
             </View>'''
     )
 
-    project = make_project(config, business_client.user)
+    project = make_project(config, business_client.user)  # type: ignore[no-untyped-call]
 
     annotation_result = json.dumps([{
         'from_name': 'text_class',
@@ -1353,17 +1353,17 @@ def test_overlap_first(business_client, setup_before_upload, show_overlap_first)
 
     assert Task.objects.filter(Q(project_id=project.id) & Q(overlap__gt=1)).count() == expected_tasks_with_overlap
 
-    def complete_task(annotator):
+    def complete_task(annotator):  # type: ignore[no-untyped-def]
         _r = annotator.get(f'/api/projects/{project.id}/next')
         assert _r.status_code == 200
         task_id = json.loads(_r.content)['id']
         annotator.post(f'/api/tasks/{task_id}/annotations/', data={'task': task_id, 'result': annotation_result})
 
-    ann1 = make_annotator({'email': 'ann1@testoverlapfirst.com'}, project, True)
-    ann2 = make_annotator({'email': 'ann2@testoverlapfirst.com'}, project, True)
+    ann1 = make_annotator({'email': 'ann1@testoverlapfirst.com'}, project, True)  # type: ignore[no-untyped-call]
+    ann2 = make_annotator({'email': 'ann2@testoverlapfirst.com'}, project, True)  # type: ignore[no-untyped-call]
 
     for i in range(expected_tasks_with_overlap):
-        complete_task(ann1), complete_task(ann2)
+        complete_task(ann1), complete_task(ann2)  # type: ignore[no-untyped-call]
 
     all_tasks_with_overlap_are_labeled = all(t.is_labeled for t in Task.objects.filter(Q(project_id=project.id) & Q(overlap__gt=1)))  # noqa
     all_tasks_without_overlap_are_not_labeled = all(not t.is_labeled for t in Task.objects.filter(Q(project_id=project.id) & Q(overlap=1)))  # noqa

--- a/label_studio/tests/test_organizations.py
+++ b/label_studio/tests/test_organizations.py
@@ -4,14 +4,14 @@ import pytest
 
 
 @pytest.mark.django_db
-def test_active_organization_filled(business_client):
+def test_active_organization_filled(business_client):  # type: ignore[no-untyped-def]
     response = business_client.get('/api/users/')
     response_data = response.json()
     assert response_data[0]['active_organization'] == business_client.organization.id
 
 
 @pytest.mark.django_db
-def test_api_list_organizations(business_client):
+def test_api_list_organizations(business_client):  # type: ignore[no-untyped-def]
     response = business_client.get('/api/organizations/')
     response_data = response.json()
     assert len(response_data) == 1

--- a/label_studio/tests/test_predictions.py
+++ b/label_studio/tests/test_predictions.py
@@ -1,7 +1,7 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
 import pytest
-import requests_mock
+import requests_mock  # type: ignore[import]
 import json
 
 from projects.models import Project
@@ -55,16 +55,16 @@ _2_prediction_results_for_textA_textB = [
 ]
 
 
-def run_task_predictions(client, project, mocker):
+def run_task_predictions(client, project, mocker):  # type: ignore[no-untyped-def]
     class TestJob:
-        def __init__(self, job_id):
+        def __init__(self, job_id):  # type: ignore[no-untyped-def]
             self.id = job_id
 
     m = MLBackend.objects.filter(project=project.id).filter(url='http://localhost:8999').first()
-    return client.post(f'/api/ml/{m.id}/predict')
+    return client.post(f'/api/ml/{m.id}/predict')  # type: ignore[union-attr]
 
 
-@pytest.mark.skipif(not redis_healthcheck(), reason='Starting predictions requires Redis server enabled')
+@pytest.mark.skipif(not redis_healthcheck(), reason='Starting predictions requires Redis server enabled')  # type: ignore[no-untyped-call]
 @pytest.mark.parametrize(
     'project_config, tasks, annotations, prediction_results, log_messages, model_version_in_request, use_ground_truth',
     [
@@ -147,7 +147,7 @@ def run_task_predictions(client, project, mocker):
     ],
 )
 @pytest.mark.django_db
-def test_predictions(
+def test_predictions(  # type: ignore[no-untyped-def]
     business_client,
     project_config,
     tasks,
@@ -160,7 +160,7 @@ def test_predictions(
 ):
 
     # create project with predefined task set
-    project = make_project(project_config, business_client.user)
+    project = make_project(project_config, business_client.user)  # type: ignore[no-untyped-call]
 
     for task, annotation in zip(tasks, annotations):
         t = Task.objects.create(data=task, project=project)
@@ -174,7 +174,7 @@ def test_predictions(
             'http://localhost:8999/predict',
             text=json.dumps({'results': prediction_results[:1], 'model_version': model_version_in_request}),
         )
-        r = run_task_predictions(business_client, project, mocker)
+        r = run_task_predictions(business_client, project, mocker)  # type: ignore[no-untyped-call]
         assert r.status_code == 200
         assert m.called
 
@@ -191,7 +191,7 @@ def test_predictions(
         assert ml_backend.model_version == actual_prediction.model_version
 
 
-@pytest.mark.skipif(not redis_healthcheck(), reason='Starting predictions requires Redis server enabled')
+@pytest.mark.skipif(not redis_healthcheck(), reason='Starting predictions requires Redis server enabled')  # type: ignore[no-untyped-call]
 @pytest.mark.parametrize(
     'test_name, project_config, setup_returns_model_version, tasks, annotations, '
     'input_predictions, prediction_call_count, num_project_stats, num_ground_truth_in_stats, '
@@ -630,7 +630,7 @@ def test_predictions(
     ],
 )
 @pytest.mark.django_db
-def test_predictions_with_partially_predicted_tasks(
+def test_predictions_with_partially_predicted_tasks(  # type: ignore[no-untyped-def]
     business_client,
     test_name,
     setup_returns_model_version,
@@ -644,7 +644,7 @@ def test_predictions_with_partially_predicted_tasks(
     num_ground_truth_fit_predictions,
     mocker,
 ):
-    project = make_project(project_config, business_client.user)
+    project = make_project(project_config, business_client.user)  # type: ignore[no-untyped-call]
     ml_backend = MLBackend.objects.get(url='http://localhost:8999')
     ml_backend.model_version = project_config['model_version']
     ml_backend.save()
@@ -683,7 +683,7 @@ def test_predictions_with_partially_predicted_tasks(
             ),
         )
 
-        r = run_task_predictions(business_client, project, mocker)
+        r = run_task_predictions(business_client, project, mocker)  # type: ignore[no-untyped-call]
         assert r.status_code == 200
         assert len(list(filter(lambda h: h.url.endswith('predict'), m.request_history))) == prediction_call_count
 
@@ -694,7 +694,7 @@ def test_predictions_with_partially_predicted_tasks(
 
 
 @pytest.mark.django_db
-def test_interactive_annotating(business_client, configured_project):
+def test_interactive_annotating(business_client, configured_project):  # type: ignore[no-untyped-def]
     # create project with predefined task set
     ml_backend = configured_project.ml_backends.first()
     ml_backend.is_interactive = True
@@ -725,7 +725,7 @@ def test_interactive_annotating(business_client, configured_project):
 
 
 @pytest.mark.django_db
-def test_interactive_annotating_failing(business_client, configured_project):
+def test_interactive_annotating_failing(business_client, configured_project):  # type: ignore[no-untyped-def]
     # create project with predefined task set
     ml_backend = configured_project.ml_backends.first()
     ml_backend.is_interactive = True
@@ -772,7 +772,7 @@ def test_interactive_annotating_failing(business_client, configured_project):
 
 
 @pytest.mark.django_db
-def test_interactive_annotating_with_drafts(business_client, configured_project):
+def test_interactive_annotating_with_drafts(business_client, configured_project):  # type: ignore[no-untyped-def]
     """
     Test interactive annotating with drafts
     :param business_client:

--- a/label_studio/tests/test_project.py
+++ b/label_studio/tests/test_project.py
@@ -5,11 +5,11 @@ from tests.utils import make_project
 
 
 @pytest.mark.django_db
-def test_update_tasks_counters_and_task_states(business_client):
-    project = make_project({}, business_client.user, use_ml_backend=False)
+def test_update_tasks_counters_and_task_states(business_client):  # type: ignore[no-untyped-def]
+    project = make_project({}, business_client.user, use_ml_backend=False)  # type: ignore[no-untyped-call]
 
     # CHECK EMPTY LIST
-    ids = []
+    ids = []  # type: ignore[var-annotated]
     obj = project._update_tasks_counters_and_task_states(ids, True, True, True)
     assert obj == 0
 
@@ -28,6 +28,6 @@ def test_update_tasks_counters_and_task_states(business_client):
     assert obj == 0
 
     # CHECK SET with IDS
-    ids = set(project.tasks.all().values_list('id', flat=True))
+    ids = set(project.tasks.all().values_list('id', flat=True))  # type: ignore[assignment]
     obj = project._update_tasks_counters_and_task_states(ids, True, True, True)
     assert obj == 0

--- a/label_studio/tests/test_project_validation.py
+++ b/label_studio/tests/test_project_validation.py
@@ -108,7 +108,7 @@ from django.urls import reverse
     ''', 204)
 ])
 @pytest.mark.django_db
-def test_validate_label_config(business_client, label_config, status_code):
+def test_validate_label_config(business_client, label_config, status_code):  # type: ignore[no-untyped-def]
     r = business_client.post(
         reverse('projects:api:label-config-validate'), data={'label_config': label_config}, content_type='application/json')
     assert r.status_code == status_code

--- a/label_studio/tests/test_suites/converter.py
+++ b/label_studio/tests/test_suites/converter.py
@@ -4,7 +4,7 @@ import yaml
 from collections import OrderedDict
 
 
-def represent_ordereddict(dumper, data):
+def represent_ordereddict(dumper, data):  # type: ignore[no-untyped-def]
     value = []
 
     for item_key, item_value in data.items():
@@ -20,7 +20,7 @@ yaml.add_representer(OrderedDict, represent_ordereddict)
 
 class Regexp(yaml.YAMLObject):
     yaml_tag = u'!re_match'
-    def __init__(self, regexp):
+    def __init__(self, regexp):  # type: ignore[no-untyped-def]
         self.regexp = regexp
     # def __repr__(self):
     #     return "" % (
@@ -87,8 +87,8 @@ with open(old_test) as f:
                     new_stages.append(
                         {
                             'name': 'stage',
-                            'request': request_data,
-                            'response': response_data,
+                            'request': request_data,  # type: ignore[dict-item]
+                            'response': response_data,  # type: ignore[dict-item]
                         }
                     )
 

--- a/label_studio/tests/test_tasks_upload.py
+++ b/label_studio/tests/test_tasks_upload.py
@@ -5,7 +5,7 @@ import copy
 import pytest
 import zipfile
 import ujson as json
-import requests_mock
+import requests_mock  # type: ignore[import]
 
 from rest_framework.authtoken.models import Token
 
@@ -13,7 +13,7 @@ from tasks.models import Task, Annotation, Prediction
 from projects.models import Project
 
 
-def post_data_as_format(setup, format_type, body, archive, multiply_files):
+def post_data_as_format(setup, format_type, body, archive, multiply_files):  # type: ignore[no-untyped-def]
     # post as data
     if format_type == 'json_data':
         return setup.post(setup.urls.task_bulk, data=body, content_type="application/json")
@@ -34,15 +34,15 @@ def post_data_as_format(setup, format_type, body, archive, multiply_files):
     if 'zip' in archive:
         file = io.BytesIO()
         ref = zipfile.ZipFile(file, mode='w', compression=zipfile.ZIP_DEFLATED)
-        [ref.writestr(name, body.read()) for name, body in files.items()]
+        [ref.writestr(name, body.read()) for name, body in files.items()]  # type: ignore[func-returns-value]
 
         ref.close()
         file.seek(0, 0)
-        files = {'upload_file.zip': file}
+        files = {'upload_file.zip': file}  # type: ignore[dict-item]
 
         # replicate zip file x2
         if 'zip_x2' == archive:
-            files.update({'upload_file2.zip': copy.deepcopy(file)})
+            files.update({'upload_file2.zip': copy.deepcopy(file)})  # type: ignore[dict-item]
 
     return setup.post(setup.urls.task_bulk, files)
 
@@ -71,14 +71,14 @@ def post_data_as_format(setup, format_type, body, archive, multiply_files):
     ([{'none': 'some', 'second_field': 123}]*10, 400, 0),
 ])
 @pytest.mark.django_db
-def test_json_task_upload(setup_project_dialog, format_type, tasks, status_code, task_count, multiply_files):
+def test_json_task_upload(setup_project_dialog, format_type, tasks, status_code, task_count, multiply_files):  # type: ignore[no-untyped-def]
     """ Upload JSON as file and data with one task to project.
         Decorator pytest.mark.django_db means it will be clean DB setup_project_dialog for this test.
     """
     if format_type == 'json_data' and multiply_files > 1:
         pytest.skip('Senseless parameter combination')
 
-    r = post_data_as_format(setup_project_dialog, format_type, json.dumps(tasks), 'none', multiply_files)
+    r = post_data_as_format(setup_project_dialog, format_type, json.dumps(tasks), 'none', multiply_files)  # type: ignore[no-untyped-call]
     print(f'Create json {format_type} tasks result:', r.content)
     assert r.status_code == status_code, f'Upload tasks failed. Response data: {r.data}'
     assert Task.objects.filter(project=setup_project_dialog.project.id).count() == task_count * multiply_files
@@ -94,13 +94,13 @@ def test_json_task_upload(setup_project_dialog, format_type, tasks, status_code,
     ([{'data': {'dialog': 'Test'}, 'annotations': [{'trash': '123'}]}] * 10, 400, 0, 0),
 ])
 @pytest.mark.django_db
-def test_json_task_annotation_and_meta_upload(setup_project_dialog, tasks, status_code, task_count, annotation_count):
+def test_json_task_annotation_and_meta_upload(setup_project_dialog, tasks, status_code, task_count, annotation_count):  # type: ignore[no-untyped-def]
     """ Upload JSON task with annotation to project
     """
     format_type = 'json_file'
     multiply_files = 1
 
-    r = post_data_as_format(setup_project_dialog, format_type, json.dumps(tasks), 'none', multiply_files)
+    r = post_data_as_format(setup_project_dialog, format_type, json.dumps(tasks), 'none', multiply_files)  # type: ignore[no-untyped-call]
     print('Create json tasks with annotations result:', r.content)
     assert r.status_code == status_code, 'Upload one task with annotation failed'
 
@@ -122,17 +122,17 @@ def test_json_task_annotation_and_meta_upload(setup_project_dialog, tasks, statu
     ([{'data': {'dialog': 'Test'}, 'predictions': [{'WRONG_FIELD': '123'}]}], 400, 0, 0),
 ])
 @pytest.mark.django_db
-def test_json_task_predictions(setup_project_dialog, tasks, status_code, task_count, prediction_count):
+def test_json_task_predictions(setup_project_dialog, tasks, status_code, task_count, prediction_count):  # type: ignore[no-untyped-def]
     """ Upload JSON task with predictions to project
     """
-    r = post_data_as_format(setup_project_dialog, 'json_file', json.dumps(tasks), 'none', 1)
+    r = post_data_as_format(setup_project_dialog, 'json_file', json.dumps(tasks), 'none', 1)  # type: ignore[no-untyped-call]
     assert r.status_code == status_code, 'Upload one task with prediction failed'
 
     # predictions
     predictions = Prediction.objects.filter(task__project=setup_project_dialog.project.id)
     assert predictions.count() == prediction_count
-    for i, predictions in enumerate(predictions):
-        assert predictions.model_version == 'test'
+    for i, predictions in enumerate(predictions):  # type: ignore[assignment]
+        assert predictions.model_version == 'test'  # type: ignore[attr-defined]
 
 
 @pytest.mark.parametrize('multiply_files', [1, 5])
@@ -143,13 +143,13 @@ def test_json_task_predictions(setup_project_dialog, tasks, status_code, task_co
     ([{'data': {'dialog': 'Test'}, 'annotations': [{'trash': '123'}]}]*10, 400, 0, 0),
 ])
 @pytest.mark.django_db
-def test_archives(setup_project_dialog, format_type, tasks, status_code, task_count,
+def test_archives(setup_project_dialog, format_type, tasks, status_code, task_count,  # type: ignore[no-untyped-def]
                   annotation_count, archive, multiply_files):
     """ Upload JSON task with annotation to project
     """
     multiplier = (2 if 'zip_x2' == archive else 1) * multiply_files
 
-    r = post_data_as_format(setup_project_dialog, format_type, json.dumps(tasks), archive, multiply_files)
+    r = post_data_as_format(setup_project_dialog, format_type, json.dumps(tasks), archive, multiply_files)  # type: ignore[no-untyped-call]
     print('Create json tasks with annotations result:', r.content)
     assert r.status_code == status_code, 'Upload one task with annotation failed'
 
@@ -177,14 +177,14 @@ def test_archives(setup_project_dialog, format_type, tasks, status_code, task_co
     ('', 400, 0)
 ])
 @pytest.mark.django_db
-def test_csv_tsv_task_upload(setup_project_dialog, format_type, tasks, status_code, task_count,
+def test_csv_tsv_task_upload(setup_project_dialog, format_type, tasks, status_code, task_count,  # type: ignore[no-untyped-def]
                              archive, multiply_files):
     """ Upload CSV/TSV with one task to project
     """
     multiplier = (2 if 'zip_x2' == archive else 1) * multiply_files
 
     tasks = tasks if format_type == 'csv_file' else tasks.replace(',', '\t')  # prepare tsv file from csv
-    r = post_data_as_format(setup_project_dialog, format_type, tasks, archive, multiply_files)
+    r = post_data_as_format(setup_project_dialog, format_type, tasks, archive, multiply_files)  # type: ignore[no-untyped-call]
     print(f'Create {format_type} tasks result:', r.content)
 
     assert r.status_code == status_code, f'Upload one task {format_type} failed. Response data: {r.data}'
@@ -198,12 +198,12 @@ def test_csv_tsv_task_upload(setup_project_dialog, format_type, tasks, status_co
     ('', 400, 0)
 ])
 @pytest.mark.django_db
-def test_txt_task_upload(setup_project_dialog, format_type, tasks, status_code, task_count, multiply_files):
+def test_txt_task_upload(setup_project_dialog, format_type, tasks, status_code, task_count, multiply_files):  # type: ignore[no-untyped-def]
     """ Upload CSV/TSV with one task to project
     """
     multiplier = multiply_files
 
-    r = post_data_as_format(setup_project_dialog, format_type, tasks, 'none', multiply_files)
+    r = post_data_as_format(setup_project_dialog, format_type, tasks, 'none', multiply_files)  # type: ignore[no-untyped-call]
     print(f'Create {format_type} tasks result:', r.content)
 
     assert r.status_code == status_code, f'Upload one task {format_type} failed. Response data: {r.data}'
@@ -214,10 +214,10 @@ def test_txt_task_upload(setup_project_dialog, format_type, tasks, status_code, 
     ([{'data': {'dialog': 'Test'}, 'annotations': [{'result': [{'id': '123'}]}]}] * 1000, 201, 1000, 30)
 ])
 @pytest.mark.django_db
-def test_upload_duration(setup_project_dialog, tasks, status_code, task_count, max_duration):
+def test_upload_duration(setup_project_dialog, tasks, status_code, task_count, max_duration):  # type: ignore[no-untyped-def]
     """ Upload JSON task with annotation to project
     """
-    r = post_data_as_format(setup_project_dialog, 'json_data', json.dumps(tasks), 'none', 1)
+    r = post_data_as_format(setup_project_dialog, 'json_data', json.dumps(tasks), 'none', 1)  # type: ignore[no-untyped-call]
     print('Create json tasks with annotations result:', r.content)
     assert r.status_code == status_code, ('Upload one task with annotation failed', r.content)
 
@@ -236,7 +236,7 @@ def test_upload_duration(setup_project_dialog, tasks, status_code, task_count, m
     ([{'data': {'dialog': 'Test'}, 'annotations': [{'result': [{'id': '123'}]}]}] * 100, 201, 100)
 ])
 @pytest.mark.django_db
-def test_url_upload(mocker, setup_project_dialog, tasks, status_code, task_count):
+def test_url_upload(mocker, setup_project_dialog, tasks, status_code, task_count):  # type: ignore[no-untyped-def]
     """ Upload tasks from URL
     """
     with requests_mock.Mocker(real_http=True) as m:
@@ -258,12 +258,12 @@ def test_url_upload(mocker, setup_project_dialog, tasks, status_code, task_count
     ([{'dialog': 'Test'}] * 1, 401, 0, True)
 ])
 @pytest.mark.django_db
-def test_upload_with_token(setup_project_for_token, tasks, status_code, task_count, bad_token):
+def test_upload_with_token(setup_project_for_token, tasks, status_code, task_count, bad_token):  # type: ignore[no-untyped-def]
     """ Upload with Django Token
     """
     setup = setup_project_for_token
     token = Token.objects.get(user=setup.user)
-    token = 'Token ' + str(token)
+    token = 'Token ' + str(token)  # type: ignore[assignment]
     broken_token = 'Token broken'
     data = setup.project_config
     data['organization_pk'] = setup.org.pk
@@ -272,13 +272,13 @@ def test_upload_with_token(setup_project_for_token, tasks, status_code, task_cou
     assert r.status_code == 201, 'Create project result should be redirect to the next page: ' + str(r.content)
 
     project = Project.objects.filter(title=setup.project_config['title']).first()
-    setup.urls.set_project(project.pk)
+    setup.urls.set_project(project.pk)  # type: ignore[union-attr]
 
     r = setup.post(setup.urls.task_bulk, data=json.dumps(tasks), content_type="application/json",
                    HTTP_AUTHORIZATION=broken_token if bad_token else token)
     assert r.status_code == status_code, 'Create json tasks result: ' + str(r.content)
 
     # tasks
-    tasks = Task.objects.filter(project=project.id)
+    tasks = Task.objects.filter(project=project.id)  # type: ignore[union-attr]
     assert tasks.count() == task_count
 

--- a/label_studio/tests/test_upload_svg.py
+++ b/label_studio/tests/test_upload_svg.py
@@ -6,7 +6,7 @@ from data_import.models import FileUpload
 from django.conf import settings
 
 @pytest.mark.django_db
-def test_svg_upload_sanitize(setup_project_dialog):
+def test_svg_upload_sanitize(setup_project_dialog):  # type: ignore[no-untyped-def]
     """ Upload malicious SVG file - remove harmful content"""
     settings.SVG_SECURITY_CLEANUP = True
 
@@ -28,7 +28,7 @@ def test_svg_upload_sanitize(setup_project_dialog):
     <polygon id="triangle" points="0,0 0,50 50,0" fill="#009900" stroke="#004400"></polygon>\n
     </svg>\n'''
 
-    actual = FileUpload.objects.filter(
+    actual = FileUpload.objects.filter(  # type: ignore[union-attr, union-attr]
             id=r.data['file_upload_ids'][0]).last().file.read()
 
     assert len("".join(actual.decode('UTF-8').split())) > 100 # confirm not empty
@@ -37,7 +37,7 @@ def test_svg_upload_sanitize(setup_project_dialog):
 
 
 @pytest.mark.django_db
-def test_svg_upload_invalid_format(setup_project_dialog):
+def test_svg_upload_invalid_format(setup_project_dialog):  # type: ignore[no-untyped-def]
     """ Upload invalid SVG file - still accepted"""
     settings.SVG_SECURITY_CLEANUP = True
 
@@ -55,14 +55,14 @@ def test_svg_upload_invalid_format(setup_project_dialog):
     <svgversion="1.1"baseprofile="full"xmlns="http://www.w3.org/2000/svg">gibberish</svg>
     '''
 
-    actual = FileUpload.objects.filter(
+    actual = FileUpload.objects.filter(  # type: ignore[union-attr, union-attr]
             id=r.data['file_upload_ids'][0]).last().file.read()
 
     assert "".join(expected.split()) == "".join(actual.decode('UTF-8').split())
 
 
 @pytest.mark.django_db
-def test_svg_upload_do_not_sanitize(setup_project_dialog):
+def test_svg_upload_do_not_sanitize(setup_project_dialog):  # type: ignore[no-untyped-def]
     """ Upload SVG file - do not sanitize file content"""
     settings.SVG_SECURITY_CLEANUP = False
 
@@ -80,7 +80,7 @@ def test_svg_upload_do_not_sanitize(setup_project_dialog):
 
     assert r.status_code == 201
 
-    actual = FileUpload.objects.filter(
+    actual = FileUpload.objects.filter(  # type: ignore[union-attr, union-attr]
             id=r.data['file_upload_ids'][0]).last().file.read()
 
     assert "".join(xml_dirty.split()) == "".join(actual.decode('UTF-8').replace("\n", "").split())

--- a/label_studio/tests/utils.py
+++ b/label_studio/tests/utils.py
@@ -2,11 +2,11 @@
 """
 import ujson as json
 
-import json
+import json  # type: ignore[no-redef]
 import re
 import io
 import pytest
-import requests_mock
+import requests_mock  # type: ignore[import]
 import requests
 import tempfile
 import os.path
@@ -28,18 +28,18 @@ from data_export.models import Export, ConvertedFormat
 from django.conf import settings
 
 try:
-    from businesses.models import Business, BillingPlan
+    from businesses.models import Business, BillingPlan  # type: ignore[import]
 except ImportError:
     BillingPlan = Business = None
 
 
 @contextmanager
-def ml_backend_mock(**kwargs):
+def ml_backend_mock(**kwargs):  # type: ignore[no-untyped-def]
     with requests_mock.Mocker(real_http=True) as m:
-        yield register_ml_backend_mock(m, **kwargs)
+        yield register_ml_backend_mock(m, **kwargs)  # type: ignore[no-untyped-call]
 
 
-def register_ml_backend_mock(m, url='http://localhost:9090', predictions=None, health_connect_timeout=False, train_job_id='123', setup_model_version='abc'):
+def register_ml_backend_mock(m, url='http://localhost:9090', predictions=None, health_connect_timeout=False, train_job_id='123', setup_model_version='abc'):  # type: ignore[no-untyped-def]
     m.post(f'{url}/setup', text=json.dumps({'status': 'ok', 'model_version': setup_model_version}))
     if health_connect_timeout:
         m.get(f'{url}/health', exc=requests.exceptions.ConnectTimeout)
@@ -53,7 +53,7 @@ def register_ml_backend_mock(m, url='http://localhost:9090', predictions=None, h
 
 
 @contextmanager
-def import_from_url_mock(**kwargs):
+def import_from_url_mock(**kwargs):  # type: ignore[no-untyped-def]
     with mock.patch('data_import.uploader.validate_upload_url'):
         with requests_mock.Mocker(real_http=True) as m:
             url='https://data.heartextest.net'
@@ -66,95 +66,95 @@ def import_from_url_mock(**kwargs):
 
 
 class _TestJob(object):
-    def __init__(self, job_id):
+    def __init__(self, job_id):  # type: ignore[no-untyped-def]
         self.id = job_id
 
 
 @contextmanager
-def email_mock():
+def email_mock():  # type: ignore[no-untyped-def]
     from django.core.mail import EmailMultiAlternatives
     with mock.patch.object(EmailMultiAlternatives, 'send'):
         yield
 
 
 @contextmanager
-def gcs_client_mock():
+def gcs_client_mock():  # type: ignore[no-untyped-def]
     from google.cloud import storage as google_storage
     from collections import namedtuple
 
     File = namedtuple('File', ['name'])
 
     class DummyGCSBlob:
-        def __init__(self, bucket_name, key, is_json):
+        def __init__(self, bucket_name, key, is_json):  # type: ignore[no-untyped-def]
             self.key = key
             self.bucket_name = bucket_name
             self.name = f"{bucket_name}/{key}"
             self.is_json = is_json
-        def download_as_string(self):
+        def download_as_string(self):  # type: ignore[no-untyped-def]
             data = f'test_blob_{self.key}'
             if self.is_json:
                 return json.dumps({'str_field': data, 'int_field': 123, 'dict_field': {'one': 'wow', 'two': 456}})
             return data
-        def upload_from_string(self, string):
+        def upload_from_string(self, string):  # type: ignore[no-untyped-def]
             print(f'String {string} uploaded to bucket {self.bucket_name}')
-        def generate_signed_url(self, **kwargs):
+        def generate_signed_url(self, **kwargs):  # type: ignore[no-untyped-def]
             return f'https://storage.googleapis.com/{self.bucket_name}/{self.key}'
-        def download_as_bytes(self):
+        def download_as_bytes(self):  # type: ignore[no-untyped-def]
             data = f'test_blob_{self.key}'
             if self.is_json:
                 return json.dumps({'str_field': data, 'int_field': 123, 'dict_field': {'one': 'wow', 'two': 456}})
             return data
 
     class DummyGCSBucket:
-        def __init__(self, bucket_name, is_json, **kwargs):
+        def __init__(self, bucket_name, is_json, **kwargs):  # type: ignore[no-untyped-def]
             self.name = bucket_name
             self.is_json = is_json
-        def list_blobs(self, prefix):
+        def list_blobs(self, prefix):  # type: ignore[no-untyped-def]
             return [File('abc'), File('def'), File('ghi')]
-        def blob(self, key):
-            return DummyGCSBlob(self.name, key, self.is_json)
+        def blob(self, key):  # type: ignore[no-untyped-def]
+            return DummyGCSBlob(self.name, key, self.is_json)  # type: ignore[no-untyped-call]
 
     class DummyGCSClient():
-        def get_bucket(self, bucket_name):
+        def get_bucket(self, bucket_name):  # type: ignore[no-untyped-def]
             is_json = bucket_name.endswith('_JSON')
-            return DummyGCSBucket(bucket_name, is_json)
+            return DummyGCSBucket(bucket_name, is_json)  # type: ignore[no-untyped-call]
 
-        def list_blobs(self, bucket_name, prefix):
+        def list_blobs(self, bucket_name, prefix):  # type: ignore[no-untyped-def]
             is_json = bucket_name.endswith('_JSON')
-            return [DummyGCSBlob(bucket_name, 'abc', is_json),
-                    DummyGCSBlob(bucket_name, 'def', is_json),
-                    DummyGCSBlob(bucket_name, 'ghi', is_json)]
+            return [DummyGCSBlob(bucket_name, 'abc', is_json),  # type: ignore[no-untyped-call]
+                    DummyGCSBlob(bucket_name, 'def', is_json),  # type: ignore[no-untyped-call]
+                    DummyGCSBlob(bucket_name, 'ghi', is_json)]  # type: ignore[no-untyped-call]
 
     with mock.patch.object(google_storage, 'Client', return_value=DummyGCSClient()):
         yield
 
 
 @contextmanager
-def azure_client_mock():
+def azure_client_mock():  # type: ignore[no-untyped-def]
     from io_storages.azure_blob import models 
     from collections import namedtuple
 
     File = namedtuple('File', ['name'])
 
     class DummyAzureBlob:
-        def __init__(self, container_name, key):
+        def __init__(self, container_name, key):  # type: ignore[no-untyped-def]
             self.key = key
             self.container_name = container_name
-        def download_as_string(self):
+        def download_as_string(self):  # type: ignore[no-untyped-def]
             return f'test_blob_{self.key}'
-        def upload_blob(self, string, overwrite):
+        def upload_blob(self, string, overwrite):  # type: ignore[no-untyped-def]
             print(f'String {string} uploaded to bucket {self.container_name}')
-        def generate_signed_url(self, **kwargs):
+        def generate_signed_url(self, **kwargs):  # type: ignore[no-untyped-def]
             return f'https://storage.googleapis.com/{self.container_name}/{self.key}'
 
     class DummyAzureContainer:
-        def __init__(self, container_name, **kwargs):
+        def __init__(self, container_name, **kwargs):  # type: ignore[no-untyped-def]
             self.name = container_name
-        def list_blobs(self, name_starts_with):
+        def list_blobs(self, name_starts_with):  # type: ignore[no-untyped-def]
             return [File('abc'), File('def'), File('ghi')]
-        def get_blob_client(self, key):
-            return DummyAzureBlob(self.name, key)
-        def get_container_properties(self, **kwargs):
+        def get_blob_client(self, key):  # type: ignore[no-untyped-def]
+            return DummyAzureBlob(self.name, key)  # type: ignore[no-untyped-call]
+        def get_container_properties(self, **kwargs):  # type: ignore[no-untyped-def]
             return SimpleNamespace(
                 name='test-container',
                 last_modified='2022-01-01 01:01:01',
@@ -172,20 +172,20 @@ def azure_client_mock():
 
 
     class DummyAzureClient():
-        def get_container_client(self, container_name):
-            return DummyAzureContainer(container_name)
+        def get_container_client(self, container_name):  # type: ignore[no-untyped-def]
+            return DummyAzureContainer(container_name)  # type: ignore[no-untyped-call]
 
     # def dummy_generate_blob_sas(*args, **kwargs):
     #     return 'token'
 
-    with mock.patch.object(models.BlobServiceClient, 'from_connection_string', return_value=DummyAzureClient()):
+    with mock.patch.object(models.BlobServiceClient, 'from_connection_string', return_value=DummyAzureClient()):  # type: ignore[attr-defined]
         with mock.patch.object(models, 'generate_blob_sas', return_value='token'):
             yield
 
 
 @contextmanager
-def redis_client_mock():
-    from fakeredis import FakeRedis
+def redis_client_mock():  # type: ignore[no-untyped-def]
+    from fakeredis import FakeRedis  # type: ignore[import]
     from io_storages.redis.models import RedisStorageMixin
 
     redis = FakeRedis()
@@ -195,13 +195,13 @@ def redis_client_mock():
         yield
 
 
-def upload_data(client, project, tasks):
-    tasks = TaskWithAnnotationsSerializer(tasks, many=True).data
+def upload_data(client, project, tasks):  # type: ignore[no-untyped-def]
+    tasks = TaskWithAnnotationsSerializer(tasks, many=True).data  # type: ignore[no-untyped-call]
     data = [{'data': task['data'], 'annotations': task['annotations']} for task in tasks]
     return client.post(f'/api/projects/{project.id}/tasks/bulk', data=data, content_type='application/json')
 
 
-def make_project(config, user, use_ml_backend=True, team_id=None, org=None):
+def make_project(config, user, use_ml_backend=True, team_id=None, org=None):  # type: ignore[no-untyped-def]
     if org is None:
         org = Organization.objects.filter(created_by=user).first()
     project = Project.objects.create(created_by=user, organization=org, **config)
@@ -213,7 +213,7 @@ def make_project(config, user, use_ml_backend=True, team_id=None, org=None):
 
 @pytest.fixture
 @pytest.mark.django_db
-def project_id(business_client):
+def project_id(business_client):  # type: ignore[no-untyped-def]
     payload = dict(title="test_project")
     response = business_client.post(
         "/api/projects/",
@@ -223,44 +223,44 @@ def project_id(business_client):
     return response.json()["id"]
 
 
-def make_task(config, project):
+def make_task(config, project):  # type: ignore[no-untyped-def]
     from tasks.models import Task
 
     return Task.objects.create(project=project, overlap=project.maximum_annotations, **config)
 
 
-def create_business(user):
+def create_business(user):  # type: ignore[no-untyped-def]
     return None
 
 
-def make_annotation(config, task_id):
+def make_annotation(config, task_id):  # type: ignore[no-untyped-def]
     from tasks.models import Annotation, Task
     task = Task.objects.get(pk=task_id)
 
     return Annotation.objects.create(project_id=task.project_id, task_id=task_id, **config)
 
 
-def make_prediction(config, task_id):
+def make_prediction(config, task_id):  # type: ignore[no-untyped-def]
     from tasks.models import Prediction
 
     return Prediction.objects.create(task_id=task_id, **config)
 
 
-def make_annotator(config, project, login=False, client=None):
+def make_annotator(config, project, login=False, client=None):  # type: ignore[no-untyped-def]
     from users.models import User
 
     user = User.objects.create(**config)
     user.set_password('12345')
     user.save()
 
-    create_business(user)
+    create_business(user)  # type: ignore[no-untyped-call]
 
     if login:
-        Organization.create_organization(created_by=user, title=user.first_name)
+        Organization.create_organization(created_by=user, title=user.first_name)  # type: ignore[no-untyped-call]
 
         if client is None:
             client = Client()
-        signin_status_code = signin(client, config['email'], '12345').status_code
+        signin_status_code = signin(client, config['email'], '12345').status_code  # type: ignore[no-untyped-call]
         assert signin_status_code == 302, f'Sign-in status code: {signin_status_code}'
 
     project.add_collaborator(user)
@@ -270,14 +270,14 @@ def make_annotator(config, project, login=False, client=None):
     return user
 
 
-def invite_client_to_project(client, project):
+def invite_client_to_project(client, project):  # type: ignore[no-untyped-def]
     if apps.is_installed('annotators'):
         return client.get(f'/annotator/invites/{project.token}/')
     else:
         return SimpleNamespace(status_code=200)
 
 
-def login(client, email, password):
+def login(client, email, password):  # type: ignore[no-untyped-def]
     if User.objects.filter(email=email).exists():
         r = client.post(f'/user/login/', data={'email': email, 'password': password})
         assert r.status_code == 302, r.status_code
@@ -286,21 +286,21 @@ def login(client, email, password):
         assert r.status_code == 302, r.status_code
 
 
-def signin(client, email, password):
+def signin(client, email, password):  # type: ignore[no-untyped-def]
     return client.post(f'/user/login/', data={'email': email, 'password': password})
 
 
-def _client_is_annotator(client):
+def _client_is_annotator(client):  # type: ignore[no-untyped-def]
     return 'annotator' in client.user.email
 
 
-def save_response(response):
+def save_response(response):  # type: ignore[no-untyped-def]
     fp = os.path.join(settings.TEST_DATA_ROOT, 'tavern-output.json')
     with open(fp, 'w') as f:
         json.dump(response.json(), f)
 
 
-def os_independent_path(_, path, add_tempdir=False):
+def os_independent_path(_, path, add_tempdir=False):  # type: ignore[no-untyped-def]
     os_independent_path = Path(path)
     if add_tempdir:
         tempdir = Path(tempfile.gettempdir())
@@ -316,7 +316,7 @@ def os_independent_path(_, path, add_tempdir=False):
     )
 
 
-def verify_docs(response):
+def verify_docs(response):  # type: ignore[no-untyped-def]
     for _, path in response.json()['paths'].items():
         print(path)
         for _, method in path.items():
@@ -325,18 +325,18 @@ def verify_docs(response):
                 assert 'api' not in method['tags'], f'Need docs for API method {method}'
 
 
-def empty_list(response):
+def empty_list(response):  # type: ignore[no-untyped-def]
     assert len(response.json()) == 0, f'Response should be empty, but is {response.json()}'
 
 
-def save_export_file_path(response):
+def save_export_file_path(response):  # type: ignore[no-untyped-def]
     export_id = response.json().get('id')
     export = Export.objects.get(id=export_id)
     file_path = export.file.path
     return Box({'file_path': file_path})
 
 
-def save_convert_file_path(response, export_id=None):
+def save_convert_file_path(response, export_id=None):  # type: ignore[no-untyped-def]
     export = response.json()[0]
     convert = export['converted_formats'][0]
 
@@ -352,7 +352,7 @@ def save_convert_file_path(response, export_id=None):
         return Box({'convert_file_path': None})
 
 
-def file_exists_in_storage(response, exists=True, file_path=None):
+def file_exists_in_storage(response, exists=True, file_path=None):  # type: ignore[no-untyped-def]
     if not file_path:
         export_id = response.json().get('id')
         export = Export.objects.get(id=export_id)

--- a/label_studio/tests/webhooks/test_webhooks.py
+++ b/label_studio/tests/webhooks/test_webhooks.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 import pytest
 import json
-import requests_mock
+import requests_mock  # type: ignore[import]
 import requests
 from django.urls import reverse
 from organizations.models import Organization
@@ -15,7 +15,7 @@ from webhooks.utils import emit_webhooks, emit_webhooks_for_instance, run_webhoo
 
 
 @pytest.fixture
-def organization_webhook(configured_project):
+def organization_webhook(configured_project):  # type: ignore[no-untyped-def]
     organization = configured_project.organization
     uri = 'http://127.0.0.1:8000/api/organization/'
     return Webhook.objects.create(
@@ -26,7 +26,7 @@ def organization_webhook(configured_project):
 
 
 @pytest.fixture
-def project_webhook(configured_project):
+def project_webhook(configured_project):  # type: ignore[no-untyped-def]
     organization = configured_project.organization
     uri = 'http://127.0.0.1:8000/api/project/'
     return Webhook.objects.create(
@@ -37,11 +37,11 @@ def project_webhook(configured_project):
 
 
 @pytest.mark.django_db
-def test_run_webhook(setup_project_dialog, organization_webhook):
+def test_run_webhook(setup_project_dialog, organization_webhook):  # type: ignore[no-untyped-def]
     webhook = organization_webhook
     with requests_mock.Mocker(real_http=True) as m:
         m.register_uri('POST', webhook.url)
-        run_webhook(organization_webhook, WebhookAction.PROJECT_CREATED, {'data': 'test'})
+        run_webhook(organization_webhook, WebhookAction.PROJECT_CREATED, {'data': 'test'})  # type: ignore[no-untyped-call]
 
     request_history = m.request_history
     assert len(request_history) == 1
@@ -51,11 +51,11 @@ def test_run_webhook(setup_project_dialog, organization_webhook):
 
 
 @pytest.mark.django_db
-def test_emit_webhooks(setup_project_dialog, organization_webhook):
+def test_emit_webhooks(setup_project_dialog, organization_webhook):  # type: ignore[no-untyped-def]
     webhook = organization_webhook
     with requests_mock.Mocker(real_http=True) as m:
         m.register_uri('POST', webhook.url)
-        emit_webhooks(webhook.organization, webhook.project, WebhookAction.PROJECT_CREATED, {'data': 'test'})
+        emit_webhooks(webhook.organization, webhook.project, WebhookAction.PROJECT_CREATED, {'data': 'test'})  # type: ignore[no-untyped-call]
 
     request_history = m.request_history
     assert len(request_history) == 1
@@ -65,13 +65,13 @@ def test_emit_webhooks(setup_project_dialog, organization_webhook):
 
 
 @pytest.mark.django_db
-def test_emit_webhooks_for_instance(setup_project_dialog, organization_webhook):
+def test_emit_webhooks_for_instance(setup_project_dialog, organization_webhook):  # type: ignore[no-untyped-def]
     webhook = organization_webhook
     project_title = f'Projects 1'
     project = Project.objects.create(title=project_title)
     with requests_mock.Mocker(real_http=True) as m:
         m.register_uri('POST', webhook.url)
-        emit_webhooks_for_instance(
+        emit_webhooks_for_instance(  # type: ignore[no-untyped-call]
             webhook.organization, webhook.project, WebhookAction.PROJECT_CREATED, instance=project
         )
     assert len(m.request_history) == 1
@@ -83,17 +83,17 @@ def test_emit_webhooks_for_instance(setup_project_dialog, organization_webhook):
 
 
 @pytest.mark.django_db
-def test_exception_catch(organization_webhook):
+def test_exception_catch(organization_webhook):  # type: ignore[no-untyped-def]
     webhook = organization_webhook
     with requests_mock.Mocker(real_http=True) as m:
         m.register_uri('POST', webhook.url, exc=requests.exceptions.ConnectTimeout)
-        result = run_webhook(webhook, WebhookAction.PROJECT_CREATED)
+        result = run_webhook(webhook, WebhookAction.PROJECT_CREATED)  # type: ignore[no-untyped-call]
     assert result is None
 
 
 # PROJECT CREATE/UPDATE/DELETE API
 @pytest.mark.django_db
-def test_webhooks_for_projects(configured_project, business_client, organization_webhook):
+def test_webhooks_for_projects(configured_project, business_client, organization_webhook):  # type: ignore[no-untyped-def]
     webhook = organization_webhook
 
     # create/update/delete project through API
@@ -142,7 +142,7 @@ def test_webhooks_for_projects(configured_project, business_client, organization
 # TASK CREATE/DELETE API
 # WE DON'T SUPPORT UPDATE FOR TASK
 @pytest.mark.django_db
-def test_webhooks_for_tasks(configured_project, business_client, organization_webhook):
+def test_webhooks_for_tasks(configured_project, business_client, organization_webhook):  # type: ignore[no-untyped-def]
     webhook = organization_webhook
     # CREATE
     with requests_mock.Mocker(real_http=True) as m:
@@ -183,7 +183,7 @@ def test_webhooks_for_tasks(configured_project, business_client, organization_we
 
 # TASK CREATE on IMPORT
 @pytest.mark.django_db
-def test_webhooks_for_tasks_import(configured_project, business_client, organization_webhook):
+def test_webhooks_for_tasks_import(configured_project, business_client, organization_webhook):  # type: ignore[no-untyped-def]
     from django.core.files.uploadedfile import SimpleUploadedFile
 
     webhook = organization_webhook
@@ -213,7 +213,7 @@ def test_webhooks_for_tasks_import(configured_project, business_client, organiza
 
 # ANNOTATION CREATE/UPDATE/DELETE
 @pytest.mark.django_db
-def test_webhooks_for_annotation(configured_project, business_client, organization_webhook):
+def test_webhooks_for_annotation(configured_project, business_client, organization_webhook):  # type: ignore[no-untyped-def]
 
     webhook = organization_webhook
     task = configured_project.tasks.all().first()
@@ -344,7 +344,7 @@ def test_webhooks_for_action_delete_tasks_annotations(configured_project, busine
 
 
 # ACTION: DELETE TASKS
-@pytest.mark.django_db
+@pytest.mark.django_db  # type: ignore[no-redef]
 def test_webhooks_for_action_delete_tasks_annotations(configured_project, business_client, organization_webhook):
     webhook = organization_webhook
     with requests_mock.Mocker(real_http=True) as m:

--- a/label_studio/users/admin.py
+++ b/label_studio/users/admin.py
@@ -19,7 +19,7 @@ class UserAdminShort(UserAdmin):
         (None, {'fields': ('email', 'password1', 'password2')}),
     )
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         super(UserAdminShort, self).__init__(*args, **kwargs)
 
         self.list_display = ('email', 'username', 'active_organization', 'organization', 'is_staff', 'is_superuser')
@@ -34,8 +34,8 @@ class UserAdminShort(UserAdmin):
                           ('Important dates', {'fields': ('last_login', 'date_joined')}))
 
 
-class AsyncMigrationStatusAdmin(admin.ModelAdmin):
-    def __init__(self, *args, **kwargs):
+class AsyncMigrationStatusAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
+    def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         super(AsyncMigrationStatusAdmin, self).__init__(*args, **kwargs)
 
         self.list_display = ('id', 'name', 'project', 'status', 'created_at', 'updated_at', 'meta')
@@ -44,8 +44,8 @@ class AsyncMigrationStatusAdmin(admin.ModelAdmin):
         self.ordering = ('id',)
 
 
-class OrganizationMemberAdmin(admin.ModelAdmin):
-    def __init__(self, *args, **kwargs):
+class OrganizationMemberAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
+    def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         super(OrganizationMemberAdmin, self).__init__(*args, **kwargs)
 
         self.list_display = ('id', 'user', 'organization', 'created_at', 'updated_at')

--- a/label_studio/users/api.py
+++ b/label_studio/users/api.py
@@ -1,9 +1,9 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
 import logging
-import drf_yasg.openapi as openapi
+import drf_yasg.openapi as openapi  # type: ignore[import, import]
 
-from drf_yasg.utils import swagger_auto_schema
+from drf_yasg.utils import swagger_auto_schema  # type: ignore[import]
 from django.utils.decorators import method_decorator
 
 from rest_framework.views import APIView
@@ -90,7 +90,7 @@ logger = logging.getLogger(__name__)
                 description='User ID'),
         ],
     ))
-class UserAPI(viewsets.ModelViewSet):
+class UserAPI(viewsets.ModelViewSet):  # type: ignore[type-arg]
     serializer_class = UserSerializer
     permission_required = ViewClassPermission(
         GET=all_permissions.organizations_change,
@@ -101,14 +101,14 @@ class UserAPI(viewsets.ModelViewSet):
     )
     http_method_names = ['get', 'post', 'head', 'patch', 'delete']
 
-    def get_queryset(self):
-        return User.objects.filter(organizations=self.request.user.active_organization)
+    def get_queryset(self):  # type: ignore[no-untyped-def]
+        return User.objects.filter(organizations=self.request.user.active_organization)  # type: ignore[misc, union-attr]
 
     @swagger_auto_schema(auto_schema=None, methods=['delete', 'post'])
     @action(detail=True, methods=['delete', 'post'], permission_required=all_permissions.avatar_any)
-    def avatar(self, request, pk):
+    def avatar(self, request, pk):  # type: ignore[no-untyped-def]
         if request.method == 'POST':
-            avatar = check_avatar(request.FILES)
+            avatar = check_avatar(request.FILES)  # type: ignore[no-untyped-call]
             request.user.avatar = avatar
             request.user.save()
             return Response({'detail': 'avatar saved'}, status=200)
@@ -118,32 +118,32 @@ class UserAPI(viewsets.ModelViewSet):
             request.user.save()
             return Response(status=204)
 
-    def get_serializer_class(self):
+    def get_serializer_class(self):  # type: ignore[no-untyped-def]
         if self.request.method in {'PUT', 'PATCH'}:
             return UserSerializerUpdate
         return super().get_serializer_class()
 
-    def update(self, request, *args, **kwargs):
+    def update(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         return super(UserAPI, self).update(request, *args, **kwargs)
 
-    def list(self, request, *args, **kwargs):
+    def list(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         return super(UserAPI, self).list(request, *args, **kwargs)
 
-    def create(self, request, *args, **kwargs):
+    def create(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         return super(UserAPI, self).create(request, *args, **kwargs)
 
-    def perform_create(self, serializer):
+    def perform_create(self, serializer):  # type: ignore[no-untyped-def]
         instance = serializer.save()
-        self.request.user.active_organization.add_user(instance)
+        self.request.user.active_organization.add_user(instance)  # type: ignore[union-attr, union-attr]
 
-    def retrieve(self, request, *args, **kwargs):
+    def retrieve(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         return super(UserAPI, self).retrieve(request, *args, **kwargs)
 
-    def partial_update(self, request, *args, **kwargs):
+    def partial_update(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         result = super(UserAPI, self).partial_update(request, *args, **kwargs)
 
         # throw MethodNotAllowed if read-only fields are attempted to be updated
-        read_only_fields = self.get_serializer_class().Meta.read_only_fields
+        read_only_fields = self.get_serializer_class().Meta.read_only_fields  # type: ignore[no-untyped-call]
         for field in read_only_fields:
             if field in request.data:
                 raise MethodNotAllowed(
@@ -159,7 +159,7 @@ class UserAPI(viewsets.ModelViewSet):
             }
         return result
 
-    def destroy(self, request, *args, **kwargs):
+    def destroy(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         return super(UserAPI, self).destroy(request, *args, **kwargs)
 
 
@@ -186,7 +186,7 @@ class UserResetTokenAPI(APIView):
     queryset = User.objects.all()
     permission_classes = (IsAuthenticated,)
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         user = request.user
         token = user.reset_token()
         logger.debug(f'New token for user {user.pk} is {token.key}')
@@ -213,7 +213,7 @@ class UserGetTokenAPI(APIView):
     parser_classes = (JSONParser,)
     permission_classes = (IsAuthenticated,)
     
-    def get(self, request, *args, **kwargs):
+    def get(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         user = request.user
         token = Token.objects.get(user=user)
         return Response({'token': str(token)}, status=200)
@@ -224,14 +224,14 @@ class UserGetTokenAPI(APIView):
         operation_summary='Retrieve my user',
         operation_description='Retrieve details of the account that you are using to access the API.'
     ))
-class UserWhoAmIAPI(generics.RetrieveAPIView):
+class UserWhoAmIAPI(generics.RetrieveAPIView):  # type: ignore[type-arg]
     parser_classes = (JSONParser, FormParser, MultiPartParser)
     queryset = User.objects.all()
     permission_classes = (IsAuthenticated, )
     serializer_class = UserSerializer
 
-    def get_object(self):
+    def get_object(self):  # type: ignore[no-untyped-def]
         return self.request.user
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         return super(UserWhoAmIAPI, self).get(request, *args, **kwargs)

--- a/label_studio/users/forms.py
+++ b/label_studio/users/forms.py
@@ -33,22 +33,22 @@ class LoginForm(forms.Form):
     password = forms.CharField(widget=forms.PasswordInput())
     persist_session = forms.BooleanField(widget=forms.CheckboxInput(), required=False)
 
-    def clean(self, *args, **kwargs):
+    def clean(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         cleaned = super(LoginForm, self).clean()
-        email = cleaned.get('email', '').lower()
-        password = cleaned.get('password', '')
+        email = cleaned.get('email', '').lower()  # type: ignore[union-attr]
+        password = cleaned.get('password', '')  # type: ignore[union-attr]
         if len(email) >= EMAIL_MAX_LENGTH:
             raise forms.ValidationError('Email is too long')
 
         # advanced way for user auth
-        user = settings.USER_AUTH(User, email, password)
+        user = settings.USER_AUTH(User, email, password)  # type: ignore[no-untyped-call]
 
         # regular access
         if user is None:
             user = auth.authenticate(email=email, password=password)
 
         if user and user.is_active:
-            persist_session = cleaned.get('persist_session', False)
+            persist_session = cleaned.get('persist_session', False)  # type: ignore[union-attr]
             return {'user': user, 'persist_session': persist_session}
         else:
             raise forms.ValidationError(INVALID_USER_ERROR)
@@ -61,20 +61,20 @@ class UserSignupForm(forms.Form):
                                widget=forms.TextInput(attrs={'type': 'password'}))
     allow_newsletters = forms.BooleanField(required=False)
 
-    def clean_password(self):
+    def clean_password(self):  # type: ignore[no-untyped-def]
         password = self.cleaned_data['password']
         if len(password) < PASS_MIN_LENGTH:
             raise forms.ValidationError(PASS_LENGTH_ERR)
         return password
 
-    def clean_username(self):
+    def clean_username(self):  # type: ignore[no-untyped-def]
         username = self.cleaned_data.get('username')
         if username and User.objects.filter(username=username.lower()).exists():
             raise forms.ValidationError('User with username already exists')
         return username
 
-    def clean_email(self):
-        email = self.cleaned_data.get('email').lower()
+    def clean_email(self):  # type: ignore[no-untyped-def]
+        email = self.cleaned_data.get('email').lower()  # type: ignore[union-attr]
         if len(email) >= EMAIL_MAX_LENGTH:
             raise forms.ValidationError('Email is too long')
 
@@ -83,18 +83,18 @@ class UserSignupForm(forms.Form):
 
         return email
 
-    def save(self):
+    def save(self):  # type: ignore[no-untyped-def]
         cleaned = self.cleaned_data
         password = cleaned['password']
         email = cleaned['email'].lower()
         allow_newsletters = None
         if 'allow_newsletters' in cleaned:
             allow_newsletters = cleaned['allow_newsletters']
-        user = User.objects.create_user(email, password, allow_newsletters=allow_newsletters)
+        user = User.objects.create_user(email, password, allow_newsletters=allow_newsletters)  # type: ignore[no-untyped-call]
         return user
 
 
-class UserProfileForm(forms.ModelForm):
+class UserProfileForm(forms.ModelForm):  # type: ignore[type-arg]
     """ This form is used in profile account pages
     """
     class Meta:

--- a/label_studio/users/functions.py
+++ b/label_studio/users/functions.py
@@ -15,12 +15,12 @@ from core.utils.contextlog import ContextLog
 from core.utils.common import load_func
 
 
-def hash_upload(instance, filename):
+def hash_upload(instance, filename):  # type: ignore[no-untyped-def]
     filename = str(uuid.uuid4())[0:8] + '-' + filename
     return settings.AVATAR_PATH + '/' + filename
 
 
-def check_avatar(files):
+def check_avatar(files):  # type: ignore[no-untyped-def]
     images = list(files.items())
     if not images:
         return None
@@ -49,7 +49,7 @@ def check_avatar(files):
     return avatar
 
 
-def save_user(request, next_page, user_form):
+def save_user(request, next_page, user_form):  # type: ignore[no-untyped-def]
     """ Save user instance to DB
     """
     user = user_form.save()
@@ -58,9 +58,9 @@ def save_user(request, next_page, user_form):
 
     if Organization.objects.exists():
         org = Organization.objects.first()
-        org.add_user(user)
+        org.add_user(user)  # type: ignore[union-attr]
     else:
-        org = Organization.create_organization(created_by=user, title='Label Studio')
+        org = Organization.create_organization(created_by=user, title='Label Studio')  # type: ignore[no-untyped-call]
     user.active_organization = org
     user.save(update_fields=['active_organization'])
 
@@ -69,20 +69,20 @@ def save_user(request, next_page, user_form):
         'update-notifications': 1, 'new-user': 1
     }
     redirect_url = next_page if next_page else reverse('projects:project-index')
-    login(request, user, backend='django.contrib.auth.backends.ModelBackend')
+    login(request, user, backend='django.contrib.auth.backends.ModelBackend')  # type: ignore[no-untyped-call]
     return redirect(redirect_url)
 
 
-def proceed_registration(request, user_form, organization_form, next_page):
+def proceed_registration(request, user_form, organization_form, next_page):  # type: ignore[no-untyped-def]
     """ Register a new user for POST user_signup
     """
     # save user to db
-    save_user = load_func(settings.SAVE_USER)
+    save_user = load_func(settings.SAVE_USER)  # type: ignore[no-untyped-call]
     response = save_user(request, next_page, user_form)
 
     return response
 
 
-def login(request, *args, **kwargs):
+def login(request, *args, **kwargs):  # type: ignore[no-untyped-def]
     request.session['last_login'] = time()
     return auth.login(request, *args, **kwargs)

--- a/label_studio/users/mixins.py
+++ b/label_studio/users/mixins.py
@@ -1,9 +1,9 @@
 class UserMixin:
     @property
-    def is_annotator(self):
+    def is_annotator(self):  # type: ignore[no-untyped-def]
         return False
 
-    def has_permission(self, user):
-        if user.active_organization in self.organizations.all():
+    def has_permission(self, user):  # type: ignore[no-untyped-def]
+        if user.active_organization in self.organizations.all():  # type: ignore[attr-defined]
             return True
         return False

--- a/label_studio/users/models.py
+++ b/label_studio/users/models.py
@@ -22,13 +22,13 @@ YEAR_CHOICES = []
 for r in range(YEAR_START, (datetime.datetime.now().year+1)):
     YEAR_CHOICES.append((r, r))
 
-year = models.IntegerField(_('year'), choices=YEAR_CHOICES, default=datetime.datetime.now().year)
+year = models.IntegerField(_('year'), choices=YEAR_CHOICES, default=datetime.datetime.now().year)  # type: ignore[var-annotated]
 
 
-class UserManager(BaseUserManager):
+class UserManager(BaseUserManager):  # type: ignore[type-arg]
     use_in_migrations = True
 
-    def _create_user(self, email, password, **extra_fields):
+    def _create_user(self, email, password, **extra_fields):  # type: ignore[no-untyped-def]
         """
         Create and save a user with the given email and password.
         """
@@ -43,12 +43,12 @@ class UserManager(BaseUserManager):
 
         return user
 
-    def create_user(self, email, password=None, **extra_fields):
+    def create_user(self, email, password=None, **extra_fields):  # type: ignore[no-untyped-def]
         extra_fields.setdefault('is_staff', False)
         extra_fields.setdefault('is_superuser', False)
-        return self._create_user(email, password, **extra_fields)
+        return self._create_user(email, password, **extra_fields)  # type: ignore[no-untyped-call]
 
-    def create_superuser(self, email, password, **extra_fields):
+    def create_superuser(self, email, password, **extra_fields):  # type: ignore[no-untyped-def]
         extra_fields.setdefault('is_staff', True)
         extra_fields.setdefault('is_superuser', True)
 
@@ -57,14 +57,14 @@ class UserManager(BaseUserManager):
         if extra_fields.get('is_superuser') is not True:
             raise ValueError('Superuser must have is_superuser=True.')
 
-        return self._create_user(email, password, **extra_fields)
+        return self._create_user(email, password, **extra_fields)  # type: ignore[no-untyped-call]
 
 
 class UserLastActivityMixin(models.Model):
     last_activity = models.DateTimeField(
         _('last activity'), default=timezone.now, editable=False)
 
-    def update_last_activity(self):
+    def update_last_activity(self):  # type: ignore[no-untyped-def]
         self.last_activity = timezone.now()
         self.save(update_fields=["last_activity"])
 
@@ -72,10 +72,10 @@ class UserLastActivityMixin(models.Model):
         abstract = True
 
 
-UserMixin = load_func(settings.USER_MIXIN)
+UserMixin = load_func(settings.USER_MIXIN)  # type: ignore[no-untyped-call]
 
 
-class User(UserMixin, AbstractBaseUser, PermissionsMixin, UserLastActivityMixin):
+class User(UserMixin, AbstractBaseUser, PermissionsMixin, UserLastActivityMixin):  # type: ignore[misc, valid-type]
     """
     An abstract base class implementing a fully featured User model with
     admin-compliant permissions.
@@ -119,7 +119,7 @@ class User(UserMixin, AbstractBaseUser, PermissionsMixin, UserLastActivityMixin)
 
     EMAIL_FIELD = 'email'
     USERNAME_FIELD = 'email'
-    REQUIRED_FIELDS = ()
+    REQUIRED_FIELDS = ()  # type: ignore[assignment]
 
     class Meta:
         db_table = 'htx_user'
@@ -134,60 +134,60 @@ class User(UserMixin, AbstractBaseUser, PermissionsMixin, UserLastActivityMixin)
         ]
 
     @property
-    def avatar_url(self):
+    def avatar_url(self):  # type: ignore[no-untyped-def]
         if self.avatar:
             if settings.CLOUD_FILE_STORAGE_ENABLED:
                 return self.avatar.url
             else:
                 return settings.HOSTNAME + self.avatar.url
 
-    def is_organization_admin(self, org_pk):
+    def is_organization_admin(self, org_pk):  # type: ignore[no-untyped-def]
         return True
 
-    def active_organization_annotations(self):
+    def active_organization_annotations(self):  # type: ignore[no-untyped-def]
         return self.annotations.filter(project__organization=self.active_organization)
 
-    def active_organization_contributed_project_number(self):
-        annotations = self.active_organization_annotations()
+    def active_organization_contributed_project_number(self):  # type: ignore[no-untyped-def]
+        annotations = self.active_organization_annotations()  # type: ignore[no-untyped-call]
         return annotations.values_list('project').distinct().count()
 
     @property
-    def own_organization(self):
+    def own_organization(self):  # type: ignore[no-untyped-def]
         return Organization.objects.get(created_by=self)
 
     @property
-    def has_organization(self):
+    def has_organization(self):  # type: ignore[no-untyped-def]
         return Organization.objects.filter(created_by=self).exists()
 
-    def clean(self):
+    def clean(self):  # type: ignore[no-untyped-def]
         super().clean()
         self.email = self.__class__.objects.normalize_email(self.email)
 
-    def name_or_email(self):
-        name = self.get_full_name()
+    def name_or_email(self):  # type: ignore[no-untyped-def]
+        name = self.get_full_name()  # type: ignore[no-untyped-call]
         if len(name) == 0:
             name = self.email
 
         return name
         
-    def get_full_name(self):
+    def get_full_name(self):  # type: ignore[no-untyped-def]
         """
         Return the first_name and the last_name for a given user with a space in between.
         """
         full_name = '%s %s' % (self.first_name, self.last_name)
         return full_name.strip()
 
-    def get_short_name(self):
+    def get_short_name(self):  # type: ignore[no-untyped-def]
         """Return the short name for the user."""
         return self.first_name
 
-    def reset_token(self):
+    def reset_token(self):  # type: ignore[no-untyped-def]
         token = Token.objects.filter(user=self)
         if token.exists():
             token.delete()
         return Token.objects.create(user=self)
     
-    def get_initials(self):
+    def get_initials(self):  # type: ignore[no-untyped-def]
         initials = '?'
         if not self.first_name and not self.last_name:
             initials = self.email[0:2]
@@ -201,7 +201,7 @@ class User(UserMixin, AbstractBaseUser, PermissionsMixin, UserLastActivityMixin)
 
 
 @receiver(post_save, sender=User)
-def init_user(sender, instance=None, created=False, **kwargs):
+def init_user(sender, instance=None, created=False, **kwargs):  # type: ignore[no-untyped-def]
     if created:
         # create token for user
         Token.objects.create(user=instance)

--- a/label_studio/users/serializers.py
+++ b/label_studio/users/serializers.py
@@ -1,25 +1,25 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
 from rest_framework import serializers
-from rest_flex_fields import FlexFieldsModelSerializer
+from rest_flex_fields import FlexFieldsModelSerializer  # type: ignore[import]
 from django.conf import settings
 
 from .models import User
 from core.utils.common import load_func
 
 
-class BaseUserSerializer(FlexFieldsModelSerializer):
+class BaseUserSerializer(FlexFieldsModelSerializer):  # type: ignore[misc]
     # short form for user presentation
     initials = serializers.SerializerMethodField(default='?', read_only=True)
     avatar = serializers.SerializerMethodField(read_only=True)
 
-    def get_avatar(self, user):
+    def get_avatar(self, user):  # type: ignore[no-untyped-def]
         return user.avatar_url
 
-    def get_initials(self, user):
+    def get_initials(self, user):  # type: ignore[no-untyped-def]
         return user.get_initials()
 
-    def to_representation(self, instance):
+    def to_representation(self, instance):  # type: ignore[no-untyped-def]
         """ Returns user with cache, this helps to avoid multiple s3/gcs links resolving for avatars """
 
         uid = instance.id
@@ -60,5 +60,5 @@ class UserSimpleSerializer(BaseUserSerializer):
         fields = ('id', 'first_name', 'last_name', 'email', 'avatar')
 
 
-UserSerializer = load_func(settings.USER_SERIALIZER)
-UserSerializerUpdate = load_func(settings.USER_SERIALIZER_UPDATE)
+UserSerializer = load_func(settings.USER_SERIALIZER)  # type: ignore[no-untyped-call]
+UserSerializerUpdate = load_func(settings.USER_SERIALIZER_UPDATE)  # type: ignore[no-untyped-call]

--- a/label_studio/users/views.py
+++ b/label_studio/users/views.py
@@ -4,11 +4,11 @@ import logging
 from time import time
 
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import render, redirect, reverse
+from django.shortcuts import render, redirect, reverse  # type: ignore[attr-defined]
 from django.contrib import auth
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from django.utils.http import is_safe_url
+from django.utils.http import is_safe_url  # type: ignore[attr-defined]
 
 from rest_framework.authtoken.models import Token
 
@@ -25,7 +25,7 @@ logger = logging.getLogger()
 
 
 @login_required
-def logout(request):
+def logout(request):  # type: ignore[no-untyped-def]
     auth.logout(request)
     if settings.HOSTNAME:
         redirect_url = settings.HOSTNAME
@@ -36,7 +36,7 @@ def logout(request):
 
 
 @enforce_csrf_checks
-def user_signup(request):
+def user_signup(request):  # type: ignore[no-untyped-def]
     """ Sign up page
     """
     user = request.user
@@ -67,7 +67,7 @@ def user_signup(request):
         organization_form = OrganizationSignupForm(request.POST)
 
         if user_form.is_valid():
-            redirect_response = proceed_registration(request, user_form, organization_form, next_page)
+            redirect_response = proceed_registration(request, user_form, organization_form, next_page)  # type: ignore[no-untyped-call]
             if redirect_response:
                 return redirect_response
 
@@ -80,7 +80,7 @@ def user_signup(request):
 
 
 @enforce_csrf_checks
-def user_login(request):
+def user_login(request):  # type: ignore[no-untyped-def]
     """ Login page
     """
     user = request.user
@@ -90,7 +90,7 @@ def user_login(request):
     if not next_page or not is_safe_url(url=next_page, allowed_hosts=request.get_host()):
         next_page = reverse('projects:project-index')
 
-    login_form = load_func(settings.USER_LOGIN_FORM)
+    login_form = load_func(settings.USER_LOGIN_FORM)  # type: ignore[no-untyped-call]
     form = login_form()
 
     if user.is_authenticated:
@@ -100,14 +100,14 @@ def user_login(request):
         form = login_form(request.POST)
         if form.is_valid():
             user = form.cleaned_data['user']
-            login(request, user, backend='django.contrib.auth.backends.ModelBackend')
+            login(request, user, backend='django.contrib.auth.backends.ModelBackend')  # type: ignore[no-untyped-call]
             if form.cleaned_data['persist_session'] is not True:
                 # Set the session to expire when the browser is closed
                 request.session['keep_me_logged_in'] = False
                 request.session.set_expiry(0)
 
             # user is organization member
-            org_pk = Organization.find_by_user(user).pk
+            org_pk = Organization.find_by_user(user).pk  # type: ignore[no-untyped-call]
             user.active_organization_id = org_pk
             user.save(update_fields=['active_organization'])
             return redirect(next_page)
@@ -119,7 +119,7 @@ def user_login(request):
 
 
 @login_required
-def user_account(request):
+def user_account(request):  # type: ignore[no-untyped-def]
     user = request.user
 
     if user.active_organization is None and 'organization_pk' not in request.session:

--- a/label_studio/webhooks/api.py
+++ b/label_studio/webhooks/api.py
@@ -1,10 +1,10 @@
 import logging
 
 from django.utils.decorators import method_decorator
-from django_filters.rest_framework import DjangoFilterBackend
-import django_filters
-from drf_yasg.utils import swagger_auto_schema
-from drf_yasg import openapi
+from django_filters.rest_framework import DjangoFilterBackend  # type: ignore[import]
+import django_filters  # type: ignore[import]
+from drf_yasg.utils import swagger_auto_schema  # type: ignore[import]
+from drf_yasg import openapi  # type: ignore[import]
 from rest_framework import generics
 from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -16,7 +16,7 @@ from .serializers import WebhookSerializer, WebhookSerializerForUpdate
 from projects import models as project_models
 
 
-class WebhookFilterSet(django_filters.FilterSet):
+class WebhookFilterSet(django_filters.FilterSet):  # type: ignore[misc]
     project = django_filters.ModelChoiceFilter(
         field_name='project', queryset=project_models.Project.objects.all(), null_label='isnull'
     )
@@ -46,18 +46,18 @@ class WebhookFilterSet(django_filters.FilterSet):
         operation_description="Create a webhook for your organization.",
     ),
 )
-class WebhookListAPI(generics.ListCreateAPIView):
+class WebhookListAPI(generics.ListCreateAPIView):  # type: ignore[type-arg]
     queryset = Webhook.objects.all()
     serializer_class = WebhookSerializer
     permission_classes = [IsAuthenticated]
     filter_backends = [DjangoFilterBackend]
     filterset_class = WebhookFilterSet
 
-    def get_queryset(self):
-        return Webhook.objects.filter(organization=self.request.user.active_organization)
+    def get_queryset(self):  # type: ignore[no-untyped-def]
+        return Webhook.objects.filter(organization=self.request.user.active_organization)  # type: ignore[misc, union-attr]
 
-    def perform_create(self, serializer):
-        serializer.save(organization=self.request.user.active_organization)
+    def perform_create(self, serializer):  # type: ignore[no-untyped-def]
+        serializer.save(organization=self.request.user.active_organization)  # type: ignore[union-attr]
 
 
 @method_decorator(name='get', decorator=swagger_auto_schema(tags=['Webhooks'], operation_summary='Get webhook info'))
@@ -76,18 +76,18 @@ class WebhookListAPI(generics.ListCreateAPIView):
 @method_decorator(
     name='delete', decorator=swagger_auto_schema(tags=['Webhooks'], operation_summary='Delete webhook info')
 )
-class WebhookAPI(generics.RetrieveUpdateDestroyAPIView):
+class WebhookAPI(generics.RetrieveUpdateDestroyAPIView):  # type: ignore[type-arg]
     queryset = Webhook.objects.all()
     serializer_class = WebhookSerializer
     permission_classes = [IsAuthenticated]
 
-    def get_serializer_class(self):
+    def get_serializer_class(self):  # type: ignore[no-untyped-def]
         if self.request.method in ['PUT', 'PATCH']:
             return WebhookSerializerForUpdate
         return super().get_serializer_class()
 
-    def get_queryset(self):
-        return Webhook.objects.filter(organization=self.request.user.active_organization)
+    def get_queryset(self):  # type: ignore[no-untyped-def]
+        return Webhook.objects.filter(organization=self.request.user.active_organization)  # type: ignore[misc, union-attr]
 
 
 @method_decorator(
@@ -110,7 +110,7 @@ class WebhookAPI(generics.RetrieveUpdateDestroyAPIView):
 class WebhookInfoAPI(APIView):
     permission_classes = [AllowAny]
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         result = {
             key: {
                 'name': value['name'],

--- a/label_studio/webhooks/models.py
+++ b/label_studio/webhooks/models.py
@@ -67,29 +67,29 @@ class Webhook(models.Model):
     created_at = models.DateTimeField(_('created at'), auto_now_add=True, help_text=_('Creation time'), db_index=True)
     updated_at = models.DateTimeField(_('updated at'), auto_now=True, help_text=_('Last update time'), db_index=True)
 
-    def get_actions(self):
+    def get_actions(self):  # type: ignore[no-untyped-def]
         return WebhookAction.objects.filter(webhook=self).values_list('action', flat=True)
 
-    def validate_actions(self, actions):
+    def validate_actions(self, actions):  # type: ignore[no-untyped-def]
         actions_meta = [WebhookAction.ACTIONS[action] for action in actions]
         if self.project and any((meta.get('organization-only') for meta in actions_meta)):
             raise ValidationError("Project webhook can't contain organization-only action.")
         return actions
 
-    def set_actions(self, actions):
+    def set_actions(self, actions):  # type: ignore[no-untyped-def]
         if not actions:
             actions = set()
         actions = set(actions)
-        old_actions = set(self.get_actions())
+        old_actions = set(self.get_actions())  # type: ignore[no-untyped-call]
 
         for new_action in list(actions - old_actions):
             WebhookAction.objects.create(webhook=self, action=new_action)
 
         WebhookAction.objects.filter(webhook=self, action__in=(old_actions - actions)).delete()
 
-    def has_permission(self, user):
+    def has_permission(self, user):  # type: ignore[no-untyped-def]
         user.project = self.project  # link for activity log
-        return self.organization.has_user(user)
+        return self.organization.has_user(user)  # type: ignore[no-untyped-call]
 
     class Meta:
         db_table = 'webhook'
@@ -120,7 +120,7 @@ class WebhookAction(models.Model):
             'key': 'project',
             'many': False,
             'model': Project,
-            'serializer': load_func(settings.WEBHOOK_SERIALIZERS['project']),
+            'serializer': load_func(settings.WEBHOOK_SERIALIZERS['project']),  # type: ignore[no-untyped-call]
             'organization-only': True,
         },
         PROJECT_UPDATED: {
@@ -129,7 +129,7 @@ class WebhookAction(models.Model):
             'key': 'project',
             'many': False,
             'model': Project,
-            'serializer': load_func(settings.WEBHOOK_SERIALIZERS['project']),
+            'serializer': load_func(settings.WEBHOOK_SERIALIZERS['project']),  # type: ignore[no-untyped-call]
             'project-field': '__self__',
         },
         PROJECT_DELETED: {
@@ -147,7 +147,7 @@ class WebhookAction(models.Model):
             'key': 'tasks',
             'many': True,
             'model': Task,
-            'serializer': load_func(settings.WEBHOOK_SERIALIZERS['task']),
+            'serializer': load_func(settings.WEBHOOK_SERIALIZERS['task']),  # type: ignore[no-untyped-call]
             'project-field': 'project',
         },
         TASKS_DELETED: {
@@ -165,11 +165,11 @@ class WebhookAction(models.Model):
             'key': 'annotation',
             'many': False,
             'model': Annotation,
-            'serializer': load_func(settings.WEBHOOK_SERIALIZERS['annotation']),
+            'serializer': load_func(settings.WEBHOOK_SERIALIZERS['annotation']),  # type: ignore[no-untyped-call]
             'project-field': 'project',
             'nested-fields': {
                 'task': {
-                    'serializer': load_func(settings.WEBHOOK_SERIALIZERS['task']),
+                    'serializer': load_func(settings.WEBHOOK_SERIALIZERS['task']),  # type: ignore[no-untyped-call]
                     'many': False,
                     'field': 'task',
                 },
@@ -181,11 +181,11 @@ class WebhookAction(models.Model):
             'key': 'annotation',
             'many': True,
             'model': Annotation,
-            'serializer': load_func(settings.WEBHOOK_SERIALIZERS['annotation']),
+            'serializer': load_func(settings.WEBHOOK_SERIALIZERS['annotation']),  # type: ignore[no-untyped-call]
             'project-field': 'project',
             'nested-fields': {
                 'task': {
-                    'serializer': load_func(settings.WEBHOOK_SERIALIZERS['task']),
+                    'serializer': load_func(settings.WEBHOOK_SERIALIZERS['task']),  # type: ignore[no-untyped-call]
                     'many': True,
                     'field': 'task',
                 },
@@ -197,11 +197,11 @@ class WebhookAction(models.Model):
             'key': 'annotation',
             'many': False,
             'model': Annotation,
-            'serializer': load_func(settings.WEBHOOK_SERIALIZERS['annotation']),
+            'serializer': load_func(settings.WEBHOOK_SERIALIZERS['annotation']),  # type: ignore[no-untyped-call]
             'project-field': 'project',
             'nested-fields': {
                 'task': {
-                    'serializer': load_func(settings.WEBHOOK_SERIALIZERS['task']),
+                    'serializer': load_func(settings.WEBHOOK_SERIALIZERS['task']),  # type: ignore[no-untyped-call]
                     'many': False,
                     'field': 'task',
                 },
@@ -222,7 +222,7 @@ class WebhookAction(models.Model):
             'key': 'label_link',
             'many': True,
             'model': LabelLink,
-            'serializer': load_func(settings.WEBHOOK_SERIALIZERS['label_link']),
+            'serializer': load_func(settings.WEBHOOK_SERIALIZERS['label_link']),  # type: ignore[no-untyped-call]
             'project-field': 'project',
         },
         LABEL_LINK_UPDATED: {
@@ -231,13 +231,13 @@ class WebhookAction(models.Model):
             'key': 'label_link',
             'many': False,
             'model': LabelLink,
-            'serializer': load_func(settings.WEBHOOK_SERIALIZERS['label_link']),
+            'serializer': load_func(settings.WEBHOOK_SERIALIZERS['label_link']),  # type: ignore[no-untyped-call]
             'project-field': 'project',
             'nested-fields': {
                 'label': {
                     'many': False,
                     'field': 'label',
-                    'serializer': load_func(settings.WEBHOOK_SERIALIZERS['label']),
+                    'serializer': load_func(settings.WEBHOOK_SERIALIZERS['label']),  # type: ignore[no-untyped-call]
                 },
             }
         },
@@ -257,7 +257,7 @@ class WebhookAction(models.Model):
 
     action = models.CharField(
         _('action of webhook'),
-        choices=[[key, value['name']] for key, value in ACTIONS.items()],
+        choices=[[key, value['name']] for key, value in ACTIONS.items()],  # type: ignore[misc]
         max_length=128,
         db_index=True,
         help_text=_('Action value'),

--- a/label_studio/webhooks/serializers.py
+++ b/label_studio/webhooks/serializers.py
@@ -4,7 +4,7 @@ from rest_framework import serializers
 from .models import Webhook, WebhookAction
 
 
-class WebhookSerializer(serializers.ModelSerializer):
+class WebhookSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
 
     actions = serializers.ListField(
         child=serializers.ChoiceField(choices=WebhookAction.ACTIONS), default=[], source='_actions'
@@ -27,26 +27,26 @@ class WebhookSerializer(serializers.ModelSerializer):
         )
         read_only_fields = ('id', 'organization', 'created_at', 'updated_at')
 
-    def validate(self, attrs):
+    def validate(self, attrs):  # type: ignore[no-untyped-def]
         actions = attrs.pop('_actions', [])
         instance = Webhook(**attrs)
-        instance.validate_actions(actions)
+        instance.validate_actions(actions)  # type: ignore[no-untyped-call]
         attrs['_actions'] = actions
         return attrs
 
-    def create(self, validated_data):
+    def create(self, validated_data):  # type: ignore[no-untyped-def]
         actions = validated_data.pop('_actions', [])
         instance = Webhook.objects.create(**validated_data)
-        instance.set_actions(actions)
+        instance.set_actions(actions)  # type: ignore[no-untyped-call]
         return instance
 
-    def update(self, instance, validated_data):
+    def update(self, instance, validated_data):  # type: ignore[no-untyped-def]
         actions = validated_data.pop('_actions', [])
         instance = super().update(instance, validated_data)
         instance.set_actions(actions)
         return instance
 
-    def to_representation(self, instance):
+    def to_representation(self, instance):  # type: ignore[no-untyped-def]
         instance._actions = instance.get_actions()
         return super().to_representation(instance)
 
@@ -57,4 +57,4 @@ class WebhookSerializerForUpdate(WebhookSerializer):
     Used to forbid updating project field."""
 
     class Meta(WebhookSerializer.Meta):
-        read_only_fields = WebhookSerializer.Meta.read_only_fields + ('project',)
+        read_only_fields = WebhookSerializer.Meta.read_only_fields + ('project',)  # type: ignore[assignment]

--- a/label_studio/webhooks/serializers_for_hooks.py
+++ b/label_studio/webhooks/serializers_for_hooks.py
@@ -5,14 +5,14 @@ from tasks.models import Task, Annotation
 from core.label_config import replace_task_data_undefined_with_config_field
 
 
-class OnlyIDWebhookSerializer(serializers.Serializer):
+class OnlyIDWebhookSerializer(serializers.Serializer):  # type: ignore[type-arg]
     id = serializers.IntegerField()
 
     class Meta:
-        fields: ('id',)
+        fields: ('id',)  # type: ignore[syntax]
 
 
-class ProjectWebhookSerializer(serializers.ModelSerializer):
+class ProjectWebhookSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
 
     task_number = serializers.IntegerField(read_only=True)
     finished_task_number = serializers.IntegerField(read_only=True)
@@ -23,8 +23,8 @@ class ProjectWebhookSerializer(serializers.ModelSerializer):
     ground_truth_number = serializers.IntegerField(read_only=True)
     skipped_annotations_number = serializers.IntegerField(read_only=True)
 
-    def to_representation(self, instance):
-        instance = Project.objects.with_counts().filter(id=instance.id)[0]
+    def to_representation(self, instance):  # type: ignore[no-untyped-def]
+        instance = Project.objects.with_counts().filter(id=instance.id)[0]  # type: ignore[no-untyped-call]
         return super().to_representation(instance)
 
     class Meta:
@@ -32,13 +32,13 @@ class ProjectWebhookSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
-class TaskWebhookSerializer(serializers.ModelSerializer):
+class TaskWebhookSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
     # resolve $undefined$ key in task data, if any
-    def to_representation(self, task):
+    def to_representation(self, task):  # type: ignore[no-untyped-def]
         project = task.project
         data = task.data
 
-        replace_task_data_undefined_with_config_field(data, project)
+        replace_task_data_undefined_with_config_field(data, project)  # type: ignore[no-untyped-call]
         return super().to_representation(task)
 
     class Meta:
@@ -46,7 +46,7 @@ class TaskWebhookSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
-class AnnotationWebhookSerializer(serializers.ModelSerializer):
+class AnnotationWebhookSerializer(serializers.ModelSerializer):  # type: ignore[type-arg]
     class Meta:
         model = Annotation
         fields = '__all__'


### PR DESCRIPTION
### PR fulfills these requirements
- [ ] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [ ] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [ ] Frontend

Backend developer experience. Mypy succeeds when run in strict mode with these changes:

```
$ docker exec -it label-studio-app-1 bash
I have no name!@119335b2c025:~$ cd label_studio
I have no name!@119335b2c025:~/label_studio$ time mypy .
=> Database and media directory: /label-studio/data
=> Static URL is set to: /static/
[Tracing] Create new propagation context: {'trace_id': '84cc2a19587942c78aacbb689bd5b156', 'span_id': '838edd34748d0833', 'parent_span_id': None, 'dynamic_sampling_context': None}
Starting new HTTPS connection (1): pypi.org:443
https://pypi.org:443 "GET /pypi/label-studio/json HTTP/1.1" 200 57379
Can't read version file: ls-version_.py. Fall back to: version_.py
Can't read version file: version_.py
Read flags from file /label-studio/label_studio/feature_flags.json
Initializing LaunchDarkly Client 7.5.0
Using user-specified update processor: <function Files.new_data_source.<locals>.<lambda> at 0x7fc6e3741510>
Initialized 'segments' store with 0 items
Initialized 'features' store with 167 items
Waiting up to 5 seconds for LaunchDarkly client to initialize...
Started LaunchDarkly Client: OK
=> Redis is not connected.
Can't read version file: ls-version_.py. Fall back to: version_.py
Can't read version file: version_.py
Success: no issues found in 230 source files

real	0m14.130s
user	0m14.149s
sys	0m2.412s
I have no name!@119335b2c025:~/label_studio$ time mypy .
=> Database and media directory: /label-studio/data
=> Static URL is set to: /static/
[Tracing] Create new propagation context: {'trace_id': '368731a619fd45018dda423b49823d02', 'span_id': '909028bf04abf946', 'parent_span_id': None, 'dynamic_sampling_context': None}
Starting new HTTPS connection (1): pypi.org:443
https://pypi.org:443 "GET /pypi/label-studio/json HTTP/1.1" 200 57379
Can't read version file: ls-version_.py. Fall back to: version_.py
Can't read version file: version_.py
Read flags from file /label-studio/label_studio/feature_flags.json
Initializing LaunchDarkly Client 7.5.0
Using user-specified update processor: <function Files.new_data_source.<locals>.<lambda> at 0x7f855b541510>
Initialized 'segments' store with 0 items
Initialized 'features' store with 167 items
Waiting up to 5 seconds for LaunchDarkly client to initialize...
Started LaunchDarkly Client: OK
=> Redis is not connected.
Can't read version file: ls-version_.py. Fall back to: version_.py
Can't read version file: version_.py
Success: no issues found in 230 source files

real	0m1.617s
user	0m1.916s
sys	0m2.064s
I have no name!@119335b2c025:~/label_studio$
```

Note that incremental mode / caching allows mypy to run very quickly.

### Describe the reason for change
_(link to issue, supportive screenshots etc.)_

Static typing will allow us to develop more quickly and with a reduced likelihood of bugs.

In order to have mypy run correctly, it was necessary to avoid having multiple module paths resolve to the same file. For this reason, where we had imports at the level of `label_studio.foo.bar.baz` as opposed to `foo.bar.baz`, I use `typing.TYPE_CHECKING` to replace the import with the `foo.bar.baz` version for mypy; this, plus `explicit_package_bases` allowed mypy to run successfully on our codebase, despite our design of having `label-studio` be both an importable library and a django project on its own.

To generate the (many) necessary type:ignore comments, I used https://pypi.org/project/mypy-clean-slate/. We should remove these ignores as we work on the files in this project; as ignores become unnecessary mypy will report errors for them.

TODOs:
- [ ] it looks like a few ignore comments were generated like `# type: ignore[import, import]`. purely cosmetic, but we should fix all of these.
- [x] check whether a relative path can be used for `.mypy_cache` in the .ini file
- [ ] consider whether we want to suppress the `no_untyped_calls` error in general; it seems a bit redundant with `no_untyped_defs` for our purposes.

#### What libraries were added/updated?
_(list all with version changes)_

mypy==1.4.1
django-stubs==4.2.3
pyre-check==0.9.18
lxml-stubs==0.4.0
types-psutil==5.9.5.16
types-mock==5.1.0.1
types-bleach==6.0.0.4
pandas-stubs==2.0.2.230605
types-urllib3==1.26.25.14
types-redis==4.6.0.3
types-google-cloud-ndb==2.1.0.8
types-colorama==0.4.15.12
types-ujson==5.8.0.1
types-setuptools==68.0.0.3
types-requests==2.31.0.2
types-jsonschema==4.17.0.10
appdirs-stubs==0.1.0
djangorestframework-stubs[compatible-mypy]==3.14.2

#### Does this change affect performance?
_(if so describe the impacts positive or negative)_



#### Does this change affect security?
_(if so describe the impacts positive or negative)_



#### What alternative approaches were there?
_(briefly list any if applicable)_



#### What feature flags were used to cover this change?
_(briefly list any if applicable)_



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [ ] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
_(for bug fixes/features, be as precise as possible. ex. Authentication, Annotation History, Review Stream etc.)_

