### PR TITLE
docs: Fix <details> plugin

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -37,14 +37,12 @@
     "hexo-renderer-marked": "^6.1.0",
     "hexo-renderer-stylus": "^0.3.3",
     "hexo-server": "^3.0.0",
-    "hexo-tag-details": "^0.1.7",
     "node-html-parser": "^6.1.4",
     "notion-to-md": "https://github.com/huguestennier/notion-to-md",
     "save": "^2.4.0"
   },
   "resolutions": {
     "hexo-footnote/hexo-util": "3.0.1",
-    "hexo-tag-details/hexo-util": "3.0.1",
     "markdown-it": "13.0.1"
   },
   "scripts": {

--- a/docs/scripts/details.js
+++ b/docs/scripts/details.js
@@ -1,0 +1,37 @@
+/**
+ * hexo-tag-details
+ * https://github.com/hinastory/hexo-tag-details.git
+ * Copyright (c) 2019, hinastory
+ * Licensed under the MIT license.
+ * Syntax:
+ *   {% details [mode:open/close] summary text %}
+ *   detail text
+ *   {% enddetails %}
+ **/
+
+"use strict";
+const util = require("hexo-util");
+const config = hexo.config.tag_details;
+const className = config && config.className ? config.className : false;
+const openSetting = config && config.open ? config.open : false;
+
+hexo.extend.tag.register("details", tagDetails, { ends: true });
+
+function tagDetails(args, content) {
+  let isOpen = (e) => e === "mode:open";
+  let isClose = (e) => e === "mode:close";
+  let isMode = (e) => isOpen(e) || isClose(e);
+
+  let filtered = args.filter((e) => !isMode(e));
+  let modeFlag = isOpen(args.find((e) => isMode(e)));
+
+  let openMode = filtered.length < args.length ? modeFlag : openSetting;
+  let summary = util.htmlTag("summary", {}, filtered.join(" "), false);
+  let rendered = hexo.render.renderSync({ text: content, engine: "markdown" });
+  let attrs = {};
+
+  if (openMode) attrs.open = "open";
+  if (className) attrs.class = className;
+
+  return util.htmlTag("details", attrs, summary + rendered, false);
+}

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2374,13 +2374,6 @@ hexo-server@^3.0.0:
     picocolors "^1.0.0"
     serve-static "^1.14.1"
 
-hexo-tag-details@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/hexo-tag-details/-/hexo-tag-details-0.1.7.tgz#dcc2ff00157abc07f1a9421db89853271fdc6080"
-  integrity sha512-wjt5OLJKvhaqnjj3HaOWVRrRaAlLeV/YWq5CpyRzIqZ+K7lvuWXf4dTjzzb46NrENaiRLE4saENyDVK0jOWUbw==
-  dependencies:
-    hexo-util "^0.6.3"
-
 hexo-util@3.0.1, hexo-util@^0.6.3:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/hexo-util/-/hexo-util-3.0.1.tgz#9dc20a9ceac971e512e69bdab3d60800d76fad97"
@@ -3261,9 +3254,9 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-"notion-to-md@https://github.com/huguestennier/notion-to-md":
+"notion-to-md@https://github.com/huguestennier/notion-to-md.git":
   version "2.5.5"
-  resolved "https://github.com/huguestennier/notion-to-md#28f2b7c827e783316cb588636314ce3a251c7edf"
+  resolved "https://github.com/huguestennier/notion-to-md.git#28f2b7c827e783316cb588636314ce3a251c7edf"
   dependencies:
     markdown-table "^2.0.0"
 

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -3254,9 +3254,9 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-"notion-to-md@https://github.com/huguestennier/notion-to-md.git":
+"notion-to-md@https://github.com/huguestennier/notion-to-md":
   version "2.5.5"
-  resolved "https://github.com/huguestennier/notion-to-md.git#28f2b7c827e783316cb588636314ce3a251c7edf"
+  resolved "https://github.com/huguestennier/notion-to-md#28f2b7c827e783316cb588636314ce3a251c7edf"
   dependencies:
     markdown-table "^2.0.0"
 


### PR DESCRIPTION
### Describe the reason for change
The [hexo-tag-details](https://github.com/hinastory/hexo-tag-details/tree/master) plugin we are using was depending on an older version of [hexo-util](https://github.com/hexojs/hexo-util).


#### What does this fix?
This moves the plugin directly into the our codebase with the fixes applied to support the latest version of hexo-util

#### How to test

The `<details>` tag here should work as expected: https://deploy-preview-4723--label-studio-docs-new-theme.netlify.app/guide/tasks#How-to-import-your-data


