### PR TITLE
docs: DOCS-132: Fix note formatting across files

### DIFF
--- a/docs/source/guide/comments_notifications.md
+++ b/docs/source/guide/comments_notifications.md
@@ -55,7 +55,7 @@ This approach is centered on the notification panel (see figure 1A). The entry p
 
 Annotators will see notifications from reviewers and other users when another user’s comment is added to the annotator draft or annotation
 
-!!! info
+!!! note
     An annotator must be added to the project or workspace to see associated comments.
 
 #### Reviewers and other higher roles
@@ -77,7 +77,7 @@ Reviewers (or other higher roles) can write comments during the review stream. I
 - The comment is the first one in a task draft or an annotation
 - There is a new comment in an annotation that were reviewed by this reviewer previously
 
-!!! info
+!!! note
     A reviewer must be added to the project or workspace to see associated comments.
 
 ### Submitted annotations vs postponed drafts
@@ -228,7 +228,7 @@ To see the notifications, navigate and click the user profile icon on the top-ri
 3. To mark an individual notification as an unread notification, click on the three dots (**...**) >> **Mark as Unread** option. 
 4. To mark all the notification as a read notification, click on the three dots (**...**) >> **Mark All as Read** option. 
 
-!!! info
+!!! note
     The read notification has a gray color background which means a user has already read this notification.
 
 

--- a/docs/source/guide/frontend.md
+++ b/docs/source/guide/frontend.md
@@ -276,7 +276,7 @@ All frontend-related files are stored under `label-studio/frontend` directory. Y
 
 Under `dist/` folder locate the `lsf/` folder and replace its contents with your custom LSF build.
 
-!!! info
+!!! note
     Inside every folder under `dist/` you will find a `version.json` file. Do not modify or remove it. Its presence is required for the Label Studio to operate.
 
 1. **Do not forget** to remove the old build from LSB:

--- a/docs/source/guide/frontend_reference.md
+++ b/docs/source/guide/frontend_reference.md
@@ -196,8 +196,8 @@ const callback = () => {
 labelStudio.off("event", callback);
 ```
 
-!!! info
-To be able to unsubscribe from an event, you must pass the same callback function reference to the `off` method.
+!!! note
+    To be able to unsubscribe from an event, you must pass the same callback function reference to the `off` method.
 
 ## Available events
 

--- a/docs/source/guide/install.md
+++ b/docs/source/guide/install.md
@@ -99,7 +99,7 @@ docker run -it -p 8080:8080 -v $(pwd)/mydata:/label-studio/data heartexlabs/labe
 ```
 
 !!! attention "important"
-As this is a non-root container, the mounted files and directories must have the proper permissions for the `UID 1001`.
+    As this is a non-root container, the mounted files and directories must have the proper permissions for the `UID 1001`.
 
 ### Install with Docker on Windows
 

--- a/docs/source/guide/labeling.md
+++ b/docs/source/guide/labeling.md
@@ -368,7 +368,7 @@ You can edit regions with a focus on labeling. You can zoom in and precise contr
 <div style="margin:auto; text-align:center;"><img src="/images/comments-box.png" style="opacity: 0.8" class="gif-border"/></div>
 <i>Figure 13: Comments box </i>
 
-!!! info 
+!!! note
     Use Outliner to work with larger annotation tasks (many bounding boxes in one image, larger videos, and so on).
 
 To add a region in the OCR transcription templates, draw a rectangle, and you can see a text box that appears in the **Outliner** panel to enter OCR text. The new functionality allows you to select a region and the **Details** panel changes. You can experience the following:

--- a/docs/source/guide/manage_projects.md
+++ b/docs/source/guide/manage_projects.md
@@ -121,7 +121,7 @@ As an **Organization Admin** and **Reviewer** in Label Studio UI, you can do the
 - View projects by workspace, including projects that you and other administrators have pinned.
 
 !!! note
-If there are no available pinned projects, all other projects will display.
+    If there are no available pinned projects, all other projects will display.
 
 As an **Annotator** in Label Studio UI, you can do the following:
 
@@ -142,7 +142,8 @@ To pin or unpin projects:
 
 3. Click **Pin project** to pin your projects.
 
-!!! note - When you pin a project, a message (for example, `New Project was pinned`) is displayed at the bottom of the page to confirm that your project is pinned. - Click **Undo** near the message to undo this action.
+!!! note
+    When you pin a project, a message (for example, `New Project was pinned`) is displayed at the bottom of the page to confirm that your project is pinned. - Click **Undo** near the message to undo this action.
 
 4. To filter and display only the pinned projects, click **Pinned projects** on the top-right side drop-down list.
 

--- a/docs/source/guide/manage_users.md
+++ b/docs/source/guide/manage_users.md
@@ -283,7 +283,7 @@ To activate a user account and assign a role, do the following:
 ### Statuses of user accounts
 
 !!! note
-`NOT_ACTIVATED` status is equal to `Pending` status.
+    `NOT_ACTIVATED` status is equal to `Pending` status.
 
 If a user is in `Pending` status then it means he was invited and signed up for the account, but his role is not defined by administrator.
 

--- a/docs/source/guide/quality.md
+++ b/docs/source/guide/quality.md
@@ -32,7 +32,7 @@ After you [assign reviewers to tasks](#Assign-reviewers-to-tasks), they can revi
 3. Continue reviewing annotated tasks until you've reviewed all annotated tasks. Click **Data Manager** to return to the list of tasks for the project.
 
 !!! note
-If there are multiple annotations, you can select the tab of each annotation by annotator and result ID to view them separately. The [annotation result ID](labeling.html#How-Label-Studio-saves-results-in-annotations) is different from the task ID visible in the left menu. To see annotations side-by-side, you can click the task in the Data Manager and view a grid of annotations in the task preview mode.
+    If there are multiple annotations, you can select the tab of each annotation by annotator and result ID to view them separately. The [annotation result ID](labeling.html#How-Label-Studio-saves-results-in-annotations) is different from the task ID visible in the left menu. To see annotations side-by-side, you can click the task in the Data Manager and view a grid of annotations in the task preview mode.
 
 ### Choose what to review
 
@@ -79,7 +79,7 @@ You can now navigate back through the review stream in the same path as moving f
 16. Navigate back through the Review Stream using the go back (`<`) button.
 
 !!! note
-Confirm that you are not taken through the same path that you have come through moving forward.
+    Confirm that you are not taken through the same path that you have come through moving forward.
 
 <br>
 <div style="margin:auto; text-align:center;"><img src="/images/go-back-reviewstream.png" style="opacity: 0.8"/></div>
@@ -153,7 +153,7 @@ Define ground truth annotations in a Label Studio project. Use ground truth anno
 Label Studio Enterprise compares annotations from annotators and model predictions against the ground truth annotations for a task to calculate an accuracy score between 0 and 1.
 
 !!! note
-Ground truth annotations are only available in Label Studio Enterprise Edition. If you're using Label Studio Community Edition, see [Label Studio Features](https://labelstud.io/guide/label_studio_compare.html) to learn more.
+    Ground truth annotations are only available in Label Studio Enterprise Edition. If you're using Label Studio Community Edition, see [Label Studio Features](https://labelstud.io/guide/label_studio_compare.html) to learn more.
 
 ## Define ground truth annotations for a project
 

--- a/docs/source/guide/setup_project.md
+++ b/docs/source/guide/setup_project.md
@@ -88,7 +88,7 @@ Select how you want to distribute tasks to annotators for labeling. Different fr
 Your changes save automatically.
 
 !!! note
-You can't assign annotators to tasks unless you select the **Manual** option.
+    You can't assign annotators to tasks unless you select the **Manual** option.
 
 </div>
 

--- a/docs/source/guide/signup.md
+++ b/docs/source/guide/signup.md
@@ -29,7 +29,7 @@ label-studio start --username <username> --password <password> [--user-token <to
 ```
 
 !!! note
-The `--user-token` argument is optional. If you don't set the user token, one is automatically generated for the user. Use the user token for API access. The minimum token length is 5 characters.
+    The `--user-token` argument is optional. If you don't set the user token, one is automatically generated for the user. Use the user token for API access. The minimum token length is 5 characters.
 
 ### Retrieve user info from the command line
 
@@ -87,8 +87,8 @@ Then, start Label Studio and log in with the username and password that you set 
 
 <img src="/images/invite-collaborators-ls-single-server.png" class="gif-border"/>
 
-!!! note
-To invite collaborators, you only need a single Label Studio instance, and all your team members should have access to it. If you want to build a simple solution that exposes Label Studio outside of your local network, you can [try ngrock](https://labelstud.io/guide/start.html#Expose-a-local-Label-Studio-instance-outside-using-ngrok).
+!!! info Tip
+    To invite collaborators, you only need a single Label Studio instance, and all your team members should have access to it. If you want to build a simple solution that exposes Label Studio outside of your local network, you can [try ngrock](https://labelstud.io/guide/start.html#Expose-a-local-Label-Studio-instance-outside-using-ngrok).
 
 After you [set up a labeling project](setup.html), invite annotators to the project to start collaborating on labeling tasks. Inviting people to your Label Studio instance with a link does not restrict access to the signup page unless you also set an environment variable. See how to [Restrict signup for local deployments](#Restrict-signup-for-local-deployments) and [Restrict signup for cloud deployments](#Restrict-signup-for-cloud-deployments) on this page.
 


### PR DESCRIPTION
- Fix note formatting where needed
- Make 'info' notes into 'note' due to recent style changes