### PR TITLE
docs: DOCS-128: Fix role descriptions to include appropriate API access

### DIFF
--- a/docs/source/guide/manage_users.md
+++ b/docs/source/guide/manage_users.md
@@ -209,8 +209,8 @@ A Label Studio administrator sees all projects and workspaces that exist in the 
   </tr>
   <tr>
     <td>API access to equivalent Label Studio functionality</td>
-    <td></td>
-    <td></td>
+    <td style="text-align:center">✔️</td>
+    <td style="text-align:center">✔️</td>
     <td style="text-align:center">✔️ for own or workspace projects</td>
     <td style="text-align:center">✔️</td>
     <td style="text-align:center">✔️</td>


### PR DESCRIPTION
Update API permissions for certain roles in the Permissions in Label Studio table. 