### PR TITLE
docs: Remove tier-specific content from the table of content

### DIFF
--- a/docs/scripts/index.js
+++ b/docs/scripts/index.js
@@ -1,3 +1,5 @@
-var breadcrumb = require('./breadcrumb')(hexo);
+var breadcrumb = require("./breadcrumb")(hexo);
+var removeContent = require("./removeContent")(hexo);
 
-hexo.extend.helper.register('breadcrumb', breadcrumb, {async: true});
+hexo.extend.helper.register("breadcrumb", breadcrumb, { async: true });
+hexo.extend.helper.register("removeContent", removeContent, { async: true });

--- a/docs/scripts/removeContent.js
+++ b/docs/scripts/removeContent.js
@@ -1,17 +1,21 @@
-var HTMLParser = require('node-html-parser');
+var HTMLParser = require("node-html-parser");
 
-hexo.extend.filter.register('after_render:html', function(data) {
+module.exports = function (ctx) {
+  return function includeTag(content) {
+    const { config } = ctx;
 
-  const { config } = this;
+    /* If you’re on the OSS site, remove every `.enterprise-only` element. Opposite for the ENT site */
+    const classToRemove =
+      config.theme_config.tier === "opensource"
+        ? ".enterprise-only"
+        : ".opensource-only";
 
-  /* If you’re on the OSS site, remove every `.enterprise-only` element. Opposite for the ENT site */
-  const classToRemove = config.theme_config.tier === "opensource" ? ".enterprise-only" : ".opensource-only";
+    const template = HTMLParser.parse(content);
 
-  const template = HTMLParser.parse(data);
+    template.querySelectorAll(classToRemove).forEach((x) => x.remove());
 
-  template.querySelectorAll(classToRemove).forEach(x=> x.remove()); 
+    content = template.toString();
 
-  data = template.toString();
-
-  return data;
-})
+    return content;
+  };
+};

--- a/docs/themes/v2/layout/page.ejs
+++ b/docs/themes/v2/layout/page.ejs
@@ -3,6 +3,8 @@
 
 <% const showToc = pageContainsHeadings && tocPageTypes %>
 
+<% const formattedContent = removeContent(page.content) %>
+
 <div class="content-grid">
   <div class="content-markdown">
     <% if(page.type && page.parent !== undefined) { %>
@@ -11,13 +13,13 @@
     <% if (page.title.trim()) { %>
       <%- partial("component/heading", {text: page.title, size: "XLarge", tag: "h1", customClass: "home-page-title"}) %>
     <% } %>
-    <%- page.content %>
+    <%- formattedContent %>
   </div>
   <div class="page-rightsidebar">
     <% if (showToc) { %>
       <div class="toc">
         <%- partial("component/text", {text: "In this article", tag: "h3", size: "Eyebrow"}) %>
-        <%- toc(page.content, {max_depth: 2, list_number: false, class: "toc-list"}) %>
+        <%- toc(formattedContent, {max_depth: 2, list_number: false, class: "toc-list"}) %>
       </div>
     <% } %>
     <div class="toc-enterprise-cta">


### PR DESCRIPTION
Before, `removeContent` was a filter after the page was generated to remove tier-specific content.

The problem was that, since the table of content was generated based on `page.content` it would still show all the `<h2>`s on the page.

This PR move `removeContent` from a filter to a function, so we can call it anywhere in the site. Simplified, it means we can save the formatted content in a variable and reuse it on the page:

`<% const content = removeContent(page.content) %>` 

Render the page:

`<%- formattedContent %>`

Use it in the TOC

`<%- toc(formattedContent) %>`

### Test plan

https://deploy-preview-4873--label-studio-docs-new-theme.netlify.app/guide/security shouldn’t show "Audit logging" either in the content nor the table of content since it’s enterprise only

https://deploy-preview-4873--heartex-docs.netlify.app/guide/security.html should show "Audit logging"