### PR TITLE
docs: DOC-153: Adjust order in page front matter

### DIFF
--- a/docs/scripts/release-notes.js
+++ b/docs/scripts/release-notes.js
@@ -43,8 +43,8 @@ title: On-Premises Release Notes for Label Studio Enterprise
 short: On-Prem Release Notes
 type: guide
 tier: enterprise
-order: 221
-order_enterprise: 142
+order: 0
+order_enterprise: 999
 section: "Reference"
 meta_title: On-premises release notes for Label Studio Enterprise
 meta_description: Review new features, enhancements, and bug fixes for on-premises Label Studio Enterprise installations. 

--- a/docs/source/guide/FAQ.md
+++ b/docs/source/guide/FAQ.md
@@ -3,8 +3,8 @@ title: Troubleshoot Label Studio
 short: Troubleshooting
 type: guide
 tier: all
-order: 100
-order_enterprise: 100
+order: 15
+order_enterprise: 10
 section: "Get started"
 meta_title: Troubleshoot Label Studio
 meta_description: Troubleshoot common issuesTroubleshoot machine learning with Label Studio configuration and performance so that you can return to your machine learning and data science projects.

--- a/docs/source/guide/active_learning.md
+++ b/docs/source/guide/active_learning.md
@@ -3,8 +3,8 @@ title: Set up active learning with Label Studio
 short: Active learning loop
 tier: enterprise
 type: guide
-order: 304
-order_enterprise: 117
+order: 0
+order_enterprise: 315
 meta_title: Set up an active learning loop with Label Studio
 meta_description: Set up an end-to-end active learning loop with Label Studio using the ML backend SDK and webhooks to perform model training and predictions and labeling.
 section: "Machine learning"

--- a/docs/source/guide/api.md
+++ b/docs/source/guide/api.md
@@ -1,10 +1,10 @@
 ---
 title: API Reference for Label Studio
-short: Backend API
+short: API usage
 type: guide
 tier: all
-order: 214
-order_enterprise: 120
+order: 405
+order_enterprise: 505
 meta_title: API Endpoints
 meta_description: API documentation for authenticating, listing data science projects, importing predictions and raw data and exporting annotated data, and user management.
 section: "Integration and Development"

--- a/docs/source/guide/auth_setup.md
+++ b/docs/source/guide/auth_setup.md
@@ -3,8 +3,8 @@ title: Set up authentication for Label Studio
 short: Set up authentication
 tier: enterprise
 type: guide
-order: 113
-order_enterprise: 139
+order: 0
+order_enterprise: 485
 meta_title: Authentication for Label Studio Enterprise
 meta_description: Label Studio Enterprise documentation for setting up SSO and LDAP authentication for your data labeling, machine learning, and data science projects.
 section: "Install"

--- a/docs/source/guide/billing.md
+++ b/docs/source/guide/billing.md
@@ -2,8 +2,8 @@
 title: Manage billing 
 type: guide
 tier: enterprise
-order: 102
-order_enterprise: 129
+order: 0
+order_enterprise: 355
 meta_title: Manage billing
 meta_description: Manage billing for the plans for Label Studio Enterprise and Teams, monitor your license usage, and explore the small business options with Label Studio Teams and the larger organization options with Label Studio Enterprise.  
 section: "Billing and Usage"

--- a/docs/source/guide/comments_notifications.md
+++ b/docs/source/guide/comments_notifications.md
@@ -4,8 +4,8 @@ short: Comments and notifications
 type: guide
 tier: enterprise
 section: "Labeling"
-order: 410
-order_enterprise: 113
+order: 0
+order_enterprise: 115
 meta_title: Comment and notification systems in Label Studio
 meta_description: The Comments and Notifications feature defines how annotators, reviewers and administrators communicate and receive updates on projects and tasks.
 ---

--- a/docs/source/guide/custom_metric.md
+++ b/docs/source/guide/custom_metric.md
@@ -3,8 +3,8 @@ title: Add a custom agreement metric to Label Studio
 short: Custom agreement metric
 tier: enterprise
 type: guide
-order: 301
-order_enterprise: 115
+order: 0
+order_enterprise: 265
 meta_title: Add a Custom Agreement Metric for Labeling
 meta_description: Label Studio Enterprise documentation about how to add a custom agreement metric to use for assessing annotator agreement or the quality of your annotation and prediction results for data labeling and machine learning projects.
 section: "Quality control"

--- a/docs/source/guide/dashboards.md
+++ b/docs/source/guide/dashboards.md
@@ -3,7 +3,8 @@ title: Project Performance Dashboards
 short: Performance Dashboards
 tier: enterprise
 type: guide
-order_enterprise: 103
+order: 0
+order_enterprise: 65
 meta_title: Manage Role-Based Access Control in Label Studio
 meta_description: Manage access and set up permissions with user roles, organizations, and project workspaces for your projects in Label Studio Enterprise.
 section: "Project & Team Management"

--- a/docs/source/guide/dataset_create.md
+++ b/docs/source/guide/dataset_create.md
@@ -4,7 +4,7 @@ short: Create a dataset
 date: 2023-08-16 11:52:38
 tier: enterprise
 order: 0
-order_enterprise: 405
+order_enterprise: 205
 meta_title: Create a Dataset to use with data discovery in Label Studio Enterprise
 meta_description: How to create a Dataset in Label Studio Enterprise using Google Cloud, Azure, or AWS.
 hide_sidebar: true

--- a/docs/source/guide/dataset_manage.md
+++ b/docs/source/guide/dataset_manage.md
@@ -3,7 +3,7 @@ title: Manage datasets
 short: Manage datasets
 tier: enterprise
 order: 0
-order_enterprise: 408
+order_enterprise: 210
 meta_title: Manage a dataset in Label Studio Enterprise
 meta_description: How to manage your datasets in Label Studio Enterprise 
 date: 2023-08-23 12:07:13

--- a/docs/source/guide/dataset_search.md
+++ b/docs/source/guide/dataset_search.md
@@ -3,7 +3,7 @@ title: Semantic search with datasets
 short: Semantic search
 tier: enterprise
 order: 0
-order_enterprise: 412
+order_enterprise: 215
 meta_title: Semantic search with datasets
 meta_description: Use semantic search to refine your datasets. 
 date: 2023-08-23 12:18:50

--- a/docs/source/guide/email_setup.md
+++ b/docs/source/guide/email_setup.md
@@ -3,8 +3,8 @@ title: Set up email backend for Label Studio Enterprise
 short: Set up email backend
 tier: enterprise
 type: guide
-order: 113
-order_enterprise: 139
+order: 0
+order_enterprise: 480
 meta_title: Email backends in Label Studio 
 section: "Install"
 

--- a/docs/source/guide/export.md
+++ b/docs/source/guide/export.md
@@ -3,8 +3,8 @@ title: Export annotations and data from Label Studio
 short: Export annotations
 type: guide
 tier: all
-order: 206
-order_enterprise: 109
+order: 270
+order_enterprise: 170
 meta_title: Export Annotations
 meta_description: Label Studio documentation for exporting data labeling annotations to use in machine learning models and data science projects.
 section: "Import and Export"

--- a/docs/source/guide/frontend.md
+++ b/docs/source/guide/frontend.md
@@ -3,8 +3,8 @@ title: Frontend builds
 short: Frontend builds
 type: guide
 tier: all
-order: 219
-order_enterprise: 126
+order: 430
+order_enterprise: 530
 meta_title: Customize User Interface
 meta_description: Label Studio documentation for integrating the Label Studio frontend interface into your own machine learning or data labeling application workflow.
 section: "Integration and Development"

--- a/docs/source/guide/frontend_reference.md
+++ b/docs/source/guide/frontend_reference.md
@@ -3,11 +3,13 @@ title: Frontend reference
 short: Frontend reference
 type: guide
 tier: all
-order: 220
-order_enterprise: 127
+order: 435
+order_enterprise: 535
 meta_title: Frontend Library Reference
 meta_description: Reference documentation for implementing the Label Studio Frontend into your own machine learning or data science application workflows.
 section: "Integration and Development"
+parent: "frontend"
+parent_enterprise: "frontend"
 ---
 
 Label Studio Frontend (LSF) includes several UI options and callbacks that you can use when implementing the frontend with a custom labeling backend, or when customizing the Label Studio interface.

--- a/docs/source/guide/get_started.md
+++ b/docs/source/guide/get_started.md
@@ -3,8 +3,8 @@ title: Label Studio
 short: Overview
 type: guide
 tier: all
-order: 99
-order_enterprise: 99
+order: 5
+order_enterprise: 5
 section: "Get started"
 meta_title: Overview of Label Studio
 meta_description: Get started with Label Studio by creating projects to label and annotate data for machine learning and data science models.

--- a/docs/source/guide/helm_values.md
+++ b/docs/source/guide/helm_values.md
@@ -3,8 +3,8 @@ title: Available Helm values for Label Studio Helm Chart
 short: Available Helm values
 tier: all
 type: guide
-order: 114
-order_enterprise: 141
+order: 75
+order_enterprise: 463
 meta_title: Available Helm values for Label Studio Helm Chart
 meta_description: For cases when you want to customize your Label Studio Kubernetes deployment, review these available Helm values that you can set in your Helm chart.
 section: "Install"

--- a/docs/source/guide/index.md
+++ b/docs/source/guide/index.md
@@ -2,6 +2,6 @@
 type: guide
 tier: all
 layout: home
-order: 999
-order_enterprise: 999
+order: 9999
+order_enterprise: 9999
 ---

--- a/docs/source/guide/ingress_config.md
+++ b/docs/source/guide/ingress_config.md
@@ -3,8 +3,8 @@ title: Set up an ingress controller for Label Studio Kubernetes deployments
 short: Set up an ingress controller
 type: guide
 tier: all
-order: 111
-order_enterprise: 137
+order: 65
+order_enterprise: 457
 meta_title: Set up an ingress controller for Label Studio Kubernetes Deployments
 meta_description: Set up an ingress controller to manage load balancing and access to Label Studio Kubernetes deployments for your data science and machine learning projects.
 section: "Install"

--- a/docs/source/guide/install.md
+++ b/docs/source/guide/install.md
@@ -2,7 +2,8 @@
 title: Install and upgrade
 type: guide
 tier: opensource
-order: 103
+order: 55
+order_enterprise: 0
 meta_title: Install and Upgrade Label Studio
 meta_description: "Label Studio documentation: install and upgrade Label Studio with Docker, pip, and anaconda for your machine learning and data science projects."
 section: "Install"

--- a/docs/source/guide/install_enterprise.md
+++ b/docs/source/guide/install_enterprise.md
@@ -3,8 +3,8 @@ title: Installation overview
 short: Overview
 tier: enterprise
 type: guide
-order: 133
-order_enterprise: 133
+order: 0
+order_enterprise: 452
 meta_title: Set up an active learning loop with Label Studio
 meta_description: Set up an end-to-end active learning loop with Label Studio using the ML backend SDK and webhooks to perform model training and predictions and labeling.
 section: "Install"

--- a/docs/source/guide/install_enterprise_docker.md
+++ b/docs/source/guide/install_enterprise_docker.md
@@ -3,8 +3,8 @@ title: Install Label Studio Enterprise On-premises using Docker Compose
 short: Docker Compose
 type: guide
 tier: enterprise
-order: 109
-order_enterprise: 134
+order: 0
+order_enterprise: 465
 meta_title: Install Label Studio Enterprise on-premises using Docker
 meta_description: Install, back up, and upgrade Label Studio Enterprise with Docker to create machine learning and data science projects on-premises.
 section: "Install"

--- a/docs/source/guide/install_enterprise_k8s.md
+++ b/docs/source/guide/install_enterprise_k8s.md
@@ -3,8 +3,8 @@ title: Deploy Label Studio Enterprise on Kubernetes
 short: Kubernetes
 tier: enterprise
 type: guide
-order: 108
-order_enterprise: 133
+order: 0
+order_enterprise: 455
 meta_title: Deploy Label Studio Enterprise on Kubernetes
 meta_description: Deploy Label Studio Enterprise on Kubernetes, such as on Amazon Elastic Container Service for Kubernetes, to create machine learning and data science projects in a scalable containerized environment. 
 section: "Install"

--- a/docs/source/guide/install_k8s.md
+++ b/docs/source/guide/install_k8s.md
@@ -3,8 +3,8 @@ title: Deploy Label Studio on Kubernetes
 short: Kubernetes
 tier: opensource
 type: guide
-order: 106
-order_enterprise: 132
+order: 60
+order_enterprise: 0
 meta_title: Deploy Label Studio on Kubernetes
 meta_description: Deploy Label Studio on Kubernetes, such as on Amazon Elastic Container Service for Kubernetes, to create machine learning and data science projects in a scalable containerized environment.
 section: "Install"

--- a/docs/source/guide/install_k8s_airgapped.md
+++ b/docs/source/guide/install_k8s_airgapped.md
@@ -3,8 +3,8 @@ title: Install Label Studio without public internet access
 short: Airgapped Server
 tier: all
 type: guide
-order: 112
-order_enterprise: 135
+order: 70
+order_enterprise: 460
 meta_title: Install Label Studio without public internet access
 meta_description: Install Label Studio without public internet access to create machine learning and data science projects in an airgapped environment. 
 section: "Install"

--- a/docs/source/guide/label_studio_compare.md
+++ b/docs/source/guide/label_studio_compare.md
@@ -3,7 +3,8 @@ title: Compare Community and Enterprise Features
 short: Enterprise vs Community
 type: guide
 tier: all
-order: 100
+order: 20
+order_enterprise: 15
 section: "Get started"
 meta_title: Label Studio Community and Enterprise Features
 meta_description: Compare the features of Label Studio Community Edition with the paid Label Studio Enterprise Edition so that you can choose the best option for your data labeling and annotation projects.

--- a/docs/source/guide/labeling.md
+++ b/docs/source/guide/labeling.md
@@ -2,8 +2,8 @@
 title: Label and annotate data
 tier: all 
 type: guide
-order: 208
-order_enterprise: 112
+order: 210
+order_enterprise: 110
 meta_title: Label and annotate data
 meta_description: Label and annotate data to create bounding boxes, label text spans, set up relations. Filter and sort project data for machine learning dataset creation.
 section: "Labeling"

--- a/docs/source/guide/manage_data.md
+++ b/docs/source/guide/manage_data.md
@@ -3,8 +3,8 @@ title: Manage data for your labeling project
 short: Data manager
 type: guide
 tier: all
-order: 207
-order_enterprise: 111
+order: 205
+order_enterprise: 105 
 meta_title: Manage data for your labeling project
 meta_description: Manage, filter, and sort project data for your machine learning data science labeling project.
 section: "Labeling"

--- a/docs/source/guide/manage_projects.md
+++ b/docs/source/guide/manage_projects.md
@@ -3,8 +3,8 @@ title: Manage projects in Label Studio Enterprise
 short: Project management
 tier: enterprise
 type: guide
-order: 115
-order_enterprise: 103
+order: 0
+order_enterprise: 60
 meta_title: Manage Role-Based Access Control in Label Studio
 meta_description: Manage access and set up permissions with user roles, organizations, and project workspaces for your projects in Label Studio Enterprise.
 section: "Project & Team Management"

--- a/docs/source/guide/manage_users.md
+++ b/docs/source/guide/manage_users.md
@@ -3,8 +3,8 @@ title: Manage users to Label Studio Enterprise
 short: User management
 tier: enterprise
 type: guide
-order: 115
-order_enterprise: 102
+order: 0
+order_enterprise: 70
 meta_title: Manage Role-Based Access Control in Label Studio
 meta_description: Manage access and set up permissions with user roles, organizations, and project workspaces for your projects in Label Studio Enterprise.
 section: "Project & Team Management"

--- a/docs/source/guide/ml.md
+++ b/docs/source/guide/ml.md
@@ -3,8 +3,8 @@ title: Integrate Label Studio into your machine learning pipeline
 short: Machine learning integration
 type: guide
 tier: all
-order: 209
-order_enterprise: 116
+order: 355
+order_enterprise: 305
 meta_title: Integrate Label Studio into your machine learning pipeline
 meta_description: Machine learning frameworks for integrating your model development pipeline seamlessly with your data labeling workflow.
 section: "Machine learning"

--- a/docs/source/guide/ml_create.md
+++ b/docs/source/guide/ml_create.md
@@ -3,8 +3,8 @@ title: Write your own ML backend
 short: Write your own ML backend
 type: guide
 tier: all
-order: 210
-order_enterprise: 117
+order: 360
+order_enterprise: 310
 meta_title: Machine Learning SDK
 meta_description: Set up your machine learning model to output and consume predictions in your data science and data labeling projects. 
 section: "Machine learning"

--- a/docs/source/guide/ml_troubleshooting.md
+++ b/docs/source/guide/ml_troubleshooting.md
@@ -3,8 +3,8 @@ title: Troubleshoot machine learning
 short: Troubleshooting
 type: guide
 tier: all
-order: 213
-order_enterprise: 119
+order: 370
+order_enterprise: 325
 meta_title: Troubleshoot Machine Learning
 meta_description: Troubleshoot Label Studio connections with machine learning frameworks using the Label Studio ML backend SDK.
 section: "Machine learning"

--- a/docs/source/guide/ml_tutorials.html
+++ b/docs/source/guide/ml_tutorials.html
@@ -2,8 +2,8 @@
 title: ML Examples and Tutorials
 type: guide
 tier: all
-order: 211
-order_enterprise: 118
+order: 365
+order_enterprise: 320
 section: "Machine learning"
 meta_title: Machine Learning Example Tutorials
 meta_description: Tutorial documentation for setting up a machine learning model with predictions using PyTorch, GPT2, Sci-kit learn, and other popular frameworks.

--- a/docs/source/guide/persistent_storage.md
+++ b/docs/source/guide/persistent_storage.md
@@ -2,8 +2,8 @@
 title: Set up persistent storage
 type: guide
 tier: all
-order: 112
-order_enterprise: 138
+order: 85
+order_enterprise: 475
 meta_title: Set up persistent storage with Label Studio
 meta_description: Configure persistent storage with Label Studio hosted in the cloud to store uploaded data such as task data, user images, and more.
 section: "Install"

--- a/docs/source/guide/predictions.md
+++ b/docs/source/guide/predictions.md
@@ -88,23 +88,11 @@ If the "Show predictions to annotators in the Label Stream and Quick View" toggl
 ### Specific examples for pre-annotations
 
 Refer to the following examples for sample pre-annotation formats:
-- [Prepare pre-annotations for Label Studio](#prepare-pre-annotations-for-label-studio)
-  - [JSON format for pre-annotations](#json-format-for-pre-annotations)
-    - [Specify the data object](#specify-the-data-object)
-    - [Add results to the predictions array](#add-results-to-the-predictions-array)
-  - [Predictions are read-only](#predictions-are-read-only)
-  - [Specific examples for pre-annotations](#specific-examples-for-pre-annotations)
-- [Import bbox and choice pre-annotations for images](#import-bbox-and-choice-pre-annotations-for-images)
-- [Import pre-annotated rectangle, polygon, ellipse \& keypoint regions without labels for images](#import-pre-annotated-rectangle-polygon-ellipse--keypoint-regions-without-labels-for-images)
-- [Import span pre-annotations for text](#import-span-pre-annotations-for-text)
-- [Import brush segmentation pre-annotations in RLE format](#import-brush-segmentation-pre-annotations-in-rle-format)
-- [Import OCR pre-annotations](#import-ocr-pre-annotations)
-- [Troubleshoot pre-annotations](#troubleshoot-pre-annotations)
-  - [Make sure the predictions are visible to annotators](#make-sure-the-predictions-are-visible-to-annotators)
-  - [Check the configuration values of the labeling configuration and tasks](#check-the-configuration-values-of-the-labeling-configuration-and-tasks)
-  - [Check the labels in your configuration and your tasks](#check-the-labels-in-your-configuration-and-your-tasks)
-  - [Check the IDs and toName values](#check-the-ids-and-toname-values)
-  - [Read only and hidden regions](#read-only-and-hidden-regions)
+- [Import bbox and choice pre-annotations for images](#Import-bbox-and-choice-pre-annotations-for-images)
+- [Import pre-annotated rectangle, polygon, ellipse & keypoint regions without labels for images](#Import-pre-annotated-rectangle-polygon-ellipse-amp-keypoint-regions-without-labels-for-images)
+- [Text pre-annotations with NER spans](#Import-span-pre-annotations-for-text)
+- [Brush pre-annotations for segmentation with masks](#Import-brush-segmentation-pre-annotations-in-RLE-format)
+- [OCR pre-annotations with bounding boxes, labels, and text transcriptions](#Import-OCR-pre-annotations)
 
 To format pre-annotations for Label Studio not represented in these examples, refer to the sample results JSON for the relevant object and control tags for your labeling configuration, such as the [Audio tag](/tags/audio.html) for audio classification tasks. Each tag must be represented in the JSON pre-annotations format to render predictions in the Label Studio UI. Not all object and control tags list sample results JSON. 
 

--- a/docs/source/guide/predictions.md
+++ b/docs/source/guide/predictions.md
@@ -3,8 +3,8 @@ title: Import pre-annotated data into Label Studio
 short: Import pre-annotations
 type: guide
 tier: all
-order: 122
-order_enterprise: 107
+order: 260
+order_enterprise: 160
 meta_title: Import pre-annotated data into Label Studio
 meta_description: Import predicted labels, predictions, pre-annotations, or pre-labels into Label Studio for your data labeling, machine learning, and data science projects.
 section: "Import and Export"
@@ -88,11 +88,23 @@ If the "Show predictions to annotators in the Label Stream and Quick View" toggl
 ### Specific examples for pre-annotations
 
 Refer to the following examples for sample pre-annotation formats:
-- [Import bbox and choice pre-annotations for images](#Import-bbox-and-choice-pre-annotations-for-images)
-- [Import pre-annotated rectangle, polygon, ellipse & keypoint regions without labels for images](#Import-pre-annotated-rectangle-polygon-ellipse-amp-keypoint-regions-without-labels-for-images)
-- [Text pre-annotations with NER spans](#Import-span-pre-annotations-for-text)
-- [Brush pre-annotations for segmentation with masks](#Import-brush-segmentation-pre-annotations-in-RLE-format)
-- [OCR pre-annotations with bounding boxes, labels, and text transcriptions](#Import-OCR-pre-annotations)
+- [Prepare pre-annotations for Label Studio](#prepare-pre-annotations-for-label-studio)
+  - [JSON format for pre-annotations](#json-format-for-pre-annotations)
+    - [Specify the data object](#specify-the-data-object)
+    - [Add results to the predictions array](#add-results-to-the-predictions-array)
+  - [Predictions are read-only](#predictions-are-read-only)
+  - [Specific examples for pre-annotations](#specific-examples-for-pre-annotations)
+- [Import bbox and choice pre-annotations for images](#import-bbox-and-choice-pre-annotations-for-images)
+- [Import pre-annotated rectangle, polygon, ellipse \& keypoint regions without labels for images](#import-pre-annotated-rectangle-polygon-ellipse--keypoint-regions-without-labels-for-images)
+- [Import span pre-annotations for text](#import-span-pre-annotations-for-text)
+- [Import brush segmentation pre-annotations in RLE format](#import-brush-segmentation-pre-annotations-in-rle-format)
+- [Import OCR pre-annotations](#import-ocr-pre-annotations)
+- [Troubleshoot pre-annotations](#troubleshoot-pre-annotations)
+  - [Make sure the predictions are visible to annotators](#make-sure-the-predictions-are-visible-to-annotators)
+  - [Check the configuration values of the labeling configuration and tasks](#check-the-configuration-values-of-the-labeling-configuration-and-tasks)
+  - [Check the labels in your configuration and your tasks](#check-the-labels-in-your-configuration-and-your-tasks)
+  - [Check the IDs and toName values](#check-the-ids-and-toname-values)
+  - [Read only and hidden regions](#read-only-and-hidden-regions)
 
 To format pre-annotations for Label Studio not represented in these examples, refer to the sample results JSON for the relevant object and control tags for your labeling configuration, such as the [Audio tag](/tags/audio.html) for audio classification tasks. Each tag must be represented in the JSON pre-annotations format to render predictions in the Label Studio UI. Not all object and control tags list sample results JSON. 
 

--- a/docs/source/guide/quality.md
+++ b/docs/source/guide/quality.md
@@ -3,8 +3,8 @@ title: Review annotations in Label Studio
 short: Review annotations
 tier: enterprise
 type: guide
-order: 300
-order_enterprise: 113
+order: 0
+order_enterprise: 255
 meta_title: Review annotation quality in Label Studio
 meta_description: In data labeling projects, start evaluating annotator performance against ground truth annotations, predictions, and other annotator's annotations.
 section: "Quality control"

--- a/docs/source/guide/saas.md
+++ b/docs/source/guide/saas.md
@@ -2,8 +2,8 @@
 title: Configuration details of SaaS
 type: guide
 tier: enterprise
-order: 102
-order_enterprise: 128
+order: 0
+order_enterprise: 410
 meta_title: app.humansignal.com Settings
 meta_description: This page contains information about the settings that are used on app.humansignal.com, available to HumanSignal SaaS customers.
 section: "Security and Privacy"

--- a/docs/source/guide/scim_setup.md
+++ b/docs/source/guide/scim_setup.md
@@ -3,8 +3,8 @@ title: Set up SCIM2 for Label Studio
 short: Set up SCIM2
 tier: enterprise
 type: guide
-order: 113
-order_enterprise: 140
+order: 0
+order_enterprise: 490
 meta_title: System for Cross-domain Identity Management (SCIM) for Label Studio Enterprise
 meta_description: Label Studio Enterprise documentation for setting up SCIM2
 section: "Install"

--- a/docs/source/guide/sdk.md
+++ b/docs/source/guide/sdk.md
@@ -1,10 +1,10 @@
 ---
 title: Python SDK Tutorial for Label Studio
-short: Backend SDK Python Tutorial 
+short: SDK usage 
 type: guide
 tier: all
-order: 215
-order_enterprise: 121
+order: 410
+order_enterprise: 510
 meta_title: Label Studio Python SDK Tutorial
 meta_description: Tutorial documentation for the Label Studio Python SDK. How and why to use the SDK for data labeling project creation and annotated task parsing.
 section: "Integration and Development"

--- a/docs/source/guide/security.md
+++ b/docs/source/guide/security.md
@@ -2,8 +2,8 @@
 title: Secure Label Studio
 type: guide
 tier: all
-order: 101
-order_enterprise: 128
+order: 105
+order_enterprise: 405
 meta_title: Secure Label Studio
 meta_description: About the security and hardening processes used by various Label Studio editions, and how you can configure a more secure data labeling project.
 section: "Security and Privacy"

--- a/docs/source/guide/setup.md
+++ b/docs/source/guide/setup.md
@@ -2,8 +2,8 @@
 title: Labeling configuration
 type: guide
 tier: all
-order: 119
-order_enterprise: 104
+order: 160
+order_enterprise: 57
 meta_title: Set up labeling configuration interface
 meta_description: Customize your data labeling and annotation interface with templates or custom tag combinations for your machine learning and data science projects.
 section: "Project & Team Management"

--- a/docs/source/guide/setup_project.md
+++ b/docs/source/guide/setup_project.md
@@ -3,8 +3,8 @@ title: Project setup
 short: Project setup
 type: guide
 tier: all
-order: 116
-order_enterprise: 103
+order: 155
+order_enterprise: 55
 section: "Project & Team Management"
 meta_title: Set up your labeling project
 meta_description: Set up data labeling and annotation projects in Label Studio to produce high-quality data for your machine learning and data science projects.

--- a/docs/source/guide/signup.md
+++ b/docs/source/guide/signup.md
@@ -2,8 +2,8 @@
 title: User management
 type: guide
 tier: opensource
-order: 114
-order_enterprise: 101
+order: 165
+order_enterprise: 0
 meta_title: User Management
 meta_description: Sign up for Label Studio and invite users to collaborate on your data labeling, machine learning, and data science projects.
 section: "Project & Team Management"

--- a/docs/source/guide/start.md
+++ b/docs/source/guide/start.md
@@ -2,8 +2,8 @@
 title: Start Label Studio
 type: guide
 tier: opensource
-order: 99
-order_enterprise: 99
+order: 10
+order_enterprise: 0
 meta_title: Start Commands for Label Studio
 meta_description: Documentation for starting Label Studio and configuring the environment to use Label Studio with your machine learning or data science project. 
 section: "Get started"

--- a/docs/source/guide/stats.md
+++ b/docs/source/guide/stats.md
@@ -3,8 +3,8 @@ title: Annotation agreement and how it is calculated
 short: Annotation agreement
 tier: enterprise
 type: guide
-order: 300
-order_enterprise: 114
+order: 0
+order_enterprise: 260
 meta_title: Data Labeling Statistics
 meta_description: Label Studio Enterprise documentation about task agreement, annotator consensus, and other data annotation statistics for data labeling and machine learning projects.
 section: "Quality control"

--- a/docs/source/guide/storage.md
+++ b/docs/source/guide/storage.md
@@ -3,8 +3,8 @@ title: Sync data from external storage
 short: Cloud storage setup 
 type: guide
 tier: all
-order: 125
-order_enterprise: 108
+order: 265
+order_enterprise: 165
 meta_title: Cloud and External Storage Integration
 meta_description: "Label Studio Documentation for integrating Amazon AWS S3, Google Cloud Storage, Microsoft Azure, Redis, and local file directories with Label Studio."
 section: "Import and Export"

--- a/docs/source/guide/storedata.md
+++ b/docs/source/guide/storedata.md
@@ -2,7 +2,8 @@
 title: Database setup 
 type: guide
 tier: opensource
-order: 104
+order: 80
+order_enterprise: 0
 meta_title: Database Storage Setup
 meta_description: Configure the database storage used by Label Studio to ensure performant and scalable data and configuration storage.
 section: "Install"

--- a/docs/source/guide/task_format.md
+++ b/docs/source/guide/task_format.md
@@ -3,8 +3,8 @@ title: Label Studio Task Format
 short: Task format 
 type: guide
 tier: all
-order: 120
-order_enterprise: 105
+order: 275
+order_enterprise: 175
 meta_title: Label Studio Task Format
 meta_description: Label Studio documentation for exporting data labeling annotations to use in machine learning models and data science projects.
 section: "Import and Export"

--- a/docs/source/guide/tasks.md
+++ b/docs/source/guide/tasks.md
@@ -3,8 +3,8 @@ title: Get data into Label Studio
 short: Import data
 type: guide
 tier: all
-order: 120
-order_enterprise: 105
+order: 255
+order_enterprise: 155
 meta_title: Import Data into Label Studio
 meta_description: Label and annotate data for your machine learning and data science projects using common file formats or the Label Studio JSON format.
 section: "Import and Export"

--- a/docs/source/guide/upgrade_enterprise.md
+++ b/docs/source/guide/upgrade_enterprise.md
@@ -4,7 +4,7 @@ short: Upgrade Label Studio
 tier: enterprise
 type: guide
 order: 0
-order_enterprise: 141
+order_enterprise: 470
 meta_title: Upgrade Label Studio Enterprise
 meta_description: Steps you should take when upgrading Label Studio Enterprise.
 section: "Install"

--- a/docs/source/guide/webhook_create.md
+++ b/docs/source/guide/webhook_create.md
@@ -3,11 +3,13 @@ title: Create custom events for webhooks in Label Studio
 short: Webhook development
 type: guide
 tier: all
-order: 217
-order_enterprise: 124
+order: 420
+order_enterprise: 520
 meta_title: Create Custom Webhooks in Label Studio
 meta_description: Label Studio documentation for creating custom webhook event triggers to create custom integrations between Label Studio and your machine learning pipeline
 section: "Integration and Development"
+parent: "webhooks"
+parent_enterprise: "webhooks"
 
 ---
 

--- a/docs/source/guide/webhook_reference.md
+++ b/docs/source/guide/webhook_reference.md
@@ -3,11 +3,13 @@ title: Webhook event format reference
 short: Webhook event reference
 type: guide
 tier: all
-order: 218
-order_enterprise: 125
+order: 425
+order_enterprise: 525
 meta_title: Label Studio Webhook Event Reference 
 meta_description: Label Studio reference documentation for webhook event fields and payloads sent from Label Studio for integration with your machine learning pipeline. 
 section: "Integration and Development"
+parent: "webhooks"
+parent_enterprise: "webhooks"
 
 ---
 

--- a/docs/source/guide/webhooks.md
+++ b/docs/source/guide/webhooks.md
@@ -3,8 +3,8 @@ title: Set up webhooks in Label Studio
 short: Webhook setup
 type: guide
 tier: all
-order: 216
-order_enterprise: 123
+order: 415
+order_enterprise: 515
 meta_title: Configure Webhooks in Label Studio
 meta_description: Label Studio documentation for setting up and configuring webhooks to integrate Label Studio with your machine learning pipeline.
 section: "Integration and Development"


### PR DESCRIPTION
For every page in the TOC, modified the `order` and `order_enterprise` values in the front matter to allow more flexibility when inserting and reordering pages. 

Tier: 
[X] enterprise 
[X] open source 
[_] not applicable