### PR TITLE
docs: Update `Try Cloud` link in header

### DIFF
--- a/docs/themes/v2/layout/partials/header.ejs
+++ b/docs/themes/v2/layout/partials/header.ejs
@@ -207,7 +207,7 @@
           <a href="/integrations">Integrations</a>
         </li>
         <li>
-          <a href="https://humansignal.com/goenterprise" target="_blank" rel="noopener noreferrer">Try Cloud</a>
+          <a href="https://humansignal.com/goenterprise" target="_blank" rel="noopener noreferrer">Enterprise</a>
         </li>
         <li>
           <a href="https://github.com/heartexlabs/label-studio/" class="github-stars" target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
Switch Try Cloud with Enterprise