### PR TITLE
docs:  DOC-159: Reorganizing pages in Getting Started section

### DIFF
--- a/docs/source/guide/FAQ.md
+++ b/docs/source/guide/FAQ.md
@@ -1,5 +1,5 @@
 ---
-title: Troubleshoot Labeling Issues
+title: Troubleshoot labeling issues
 short: Troubleshooting
 type: guide
 tier: all

--- a/docs/source/guide/FAQ.md
+++ b/docs/source/guide/FAQ.md
@@ -6,7 +6,7 @@ tier: all
 order: 220
 order_enterprise: 120
 section: "Labeling"
-meta_title: Troubleshoot Label Studio
+meta_title: Troubleshoot labeling issues
 meta_description: Troubleshoot common issuesTroubleshoot machine learning with Label Studio configuration and performance so that you can return to your machine learning and data science projects.
 ---
 

--- a/docs/source/guide/FAQ.md
+++ b/docs/source/guide/FAQ.md
@@ -1,11 +1,11 @@
 ---
-title: Troubleshoot Label Studio
+title: Troubleshoot Labeling Issues
 short: Troubleshooting
 type: guide
 tier: all
-order: 15
-order_enterprise: 10
-section: "Get started"
+order: 220
+order_enterprise: 120
+section: "Labeling"
 meta_title: Troubleshoot Label Studio
 meta_description: Troubleshoot common issuesTroubleshoot machine learning with Label Studio configuration and performance so that you can return to your machine learning and data science projects.
 ---
@@ -134,58 +134,4 @@ See [Troubleshoot pre-annotations](predictions.html#Troubleshoot-pre-annotations
 
 Label Studio does not support labeling PDF files directly. However, you can convert files to HTML using your PDF viewer or another tool and label the PDF as part of the HTML. See an example labeling configuration in the [Label Studio playground](/playground/?config=%3CView%3E%3Cbr%3E%20%20%3CHyperText%20name%3D%22pdf%22%20value%3D%22%24pdf%22%2F%3E%3Cbr%3E%3Cbr%3E%20%20%3CHeader%20value%3D%22Rate%20this%20article%22%2F%3E%3Cbr%3E%20%20%3CRating%20name%3D%22rating%22%20toName%3D%22pdf%22%20maxRating%3D%2210%22%20icon%3D%22star%22%20size%3D%22medium%22%20%2F%3E%3Cbr%3E%3Cbr%3E%20%20%3CChoices%20name%3D%22choices%22%20choice%3D%22single-radio%22%20toName%3D%22pdf%22%20showInline%3D%22true%22%3E%3Cbr%3E%20%20%20%20%3CChoice%20value%3D%22Important%20article%22%2F%3E%3Cbr%3E%20%20%20%20%3CChoice%20value%3D%22Yellow%20press%22%2F%3E%3Cbr%3E%20%20%3C%2FChoices%3E%3Cbr%3E%3C%2FView%3E%3Cbr%3E).
 
-## Add self-signed certificate to trusted root store
 
-<div class="code-tabs">
-  <div data-name="Docker Compose">
-
-1. Mount your self-signed certificate as a volume into `app` container:
-
-```yaml
-volumes:
-  - ./my.cert:/tmp/my.cert:ro
-```
-2. Add environment variable with the name `CUSTOM_CA_CERTS` mentioning all certificates in comma-separated way that should be added into trust store:
-
-```yaml
-CUSTOM_CA_CERTS=/tmp/my.cert
-```
-  </div>
-
-  <div data-name="Kubernetes">
-
-1. Upload your self-signed certificate as a k8s secret.
-   Upload `my.cert` as a secrets with a name `test-my-root-cert`:
-```yaml
-kubectl create secret generic test-my-root-cert --from-file=file=my.cert
-```
-
-2. Add volumes into your values.yaml file and mention them in `.global.customCaCerts`:
-
-```yaml
-global:
-  customCaCerts:
-   - /opt/heartex/secrets/ca_certs/file/file
-
-app:
-  extraVolumes:
-    - name: foo
-      secret:
-        secretName: test-my-root-cert
-  extraVolumeMounts:
-    - name: foo
-      mountPath: "/opt/heartex/secrets/ca_certs/file"
-      readOnly: true
-
-rqworker:
-  extraVolumes:
-    - name: foo
-      secret:
-        secretName: test-my-root-cert
-  extraVolumeMounts:
-    - name: foo
-      mountPath: "/opt/heartex/secrets/ca_certs/file"
-      readOnly: true
-```
-  </div>
-</div>

--- a/docs/source/guide/get_started.md
+++ b/docs/source/guide/get_started.md
@@ -1,5 +1,5 @@
 ---
-title: Label Studio
+title: Label Studio overview
 short: Overview
 type: guide
 tier: all
@@ -12,51 +12,25 @@ meta_description: Get started with Label Studio by creating projects to label an
 
 ## What is Label Studio?
 
-Label Studio is an open source data labeling tool that supports multiple projects, users and data types in one platform. It allows you to do the following:
+Label Studio is an open source data labeling tool that supports multiple projects, users, and data types in one platform. It allows you to do the following:
 
 - Perform different types of labeling with many data formats.
 
+- Integrate Label Studio with machine learning models to supply predictions for labels (pre-labels), or perform continuous active learning. See [Set up machine learning with your labeling process](ml).
+
 <div class="enterprise-only">
 
-- Use [Label Studio Enterprise as a cloud offering](https://heartex.com/product).
+- Use [Label Studio Enterprise as a cloud offering](https://humansignal.com/platform/).
 
 </div>
-
-- Integrate Label Studio with machine learning models to supply predictions for labels (pre-labels), or perform continuous active learning. See [Set up machine learning with your labeling process](ml.html).
-
-Label Studio is also available an [Enterprise cloud service](https://heartex.com/) with enhanced security (SSO, RBAC, SOC2), team management features, analytics & reporting, and support SLAs. A [free trial is available](https://humansignal.com/free-trial) to get started quickly and explore the enterprise cloud product.
 
 <div class="opensource-only">
 
-## Quick start
-
-1. Install Label Studio:
-
-```bash
-pip install label-studio
-```
-
-2. Start Label Studio
-
-```bash
-label-studio start
-```
-
-3. Open the Label Studio UI at http://localhost:8080.
-4. Sign up with an email address and password that you create.
-5. Click **Create** to create a project and start labeling data.
-6. Name the project, and if you want, type a description and select a color.
-7. Click **Data Import** and upload the data files that you want to use. If you want to use data from a local directory, cloud storage bucket, or database, skip this step for now.
-8. Click **Labeling Setup** and choose a template and customize the label names for your use case.
-9. Click **Save** to save your project.
-
-You're ready to start [labeling and annotating your data](labeling.html)!
+Label Studio is also available an [Enterprise cloud service](https://humansignal.com/platform/) with enhanced security (SSO, RBAC, SOC2), team management features, data discovery, analytics and reporting, and support SLAs. A [free trial is available](https://humansignal.com/free-trial) to get started quickly and explore the enterprise cloud product.
 
 </div>
 
-## Terminology
-
-When you upload data to Label Studio, each item in the dataset becomes a labeling task. The following table describes some terms you might encounter as you use Label Studio.
+## Interface
 
 <div class="opensource-only">
 
@@ -86,193 +60,7 @@ When you upload data to Label Studio, each item in the dataset becomes a labelin
 
 </div>
 
-| Term                              | Description                                                                                                                                                                                |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Dataset                           | What you import into Label Studio, comprised of individual items, or labeling tasks.                                                                                                       |
-| Task                              | A distinct item from a dataset that is ready to be labeled, pre-annotated, or has already been annotated. For example: a sentence of text, an image, or a video clip.                      |
-| Region                            | The portion of the task identified for labeling. For images, an example region is a bounding box. For text, an example region is a span of text. Often has a label assigned to it.         |
-| Labels                            | What you add to each region while labeling a task in Label Studio.                                                                                                                         |
-| Relation                          | A defined relationship between two labeled regions.                                                                                                                                        |
-| Result                            | A label applied to a specific region as stored in an annotation or prediction. See [Label Studio JSON format of annotated tasks](export.html#Label-Studio-JSON-format-of-annotated-tasks). |
-| Annotations                       | The output of a labeling task. Previously called "completions".                                                                                                                            |
-| Predictions, <br> Pre-annotations | Annotations in Label Studio format that machine learning models create for an unlabeled dataset. See [import pre-annotations](predictions.html)                                            |
-| Templates                         | Example labeling configurations that you can use to specify the type of labeling that you're performing with your dataset. See [all available templates](/templates)                       |
-| Tags                              | Configuration options to customize the labeling interface. See [more about tags](/tags).                                                                                                   |
 
-<div class="opensource-only">
-
-## Features
-
-Label Studio is available as a <a href="https://labelstud.io">Community edition open source data labeling tool</a>. It is also available as a paid version with extended functionality and support. Smaller organizations might want to consider the SaaS option and larger teams with robust data labeling needs can get the Enterprise edition. To get started with Label Studio Enterprise edition, contact the [Heartex team](https://heartex.com/).
-
-<table>
-  <tr>
-    <th>Functionality</th>
-    <th>Community</th>
-    <th>Enterprise</th>
-  </tr>
-  <tr>
-    <td colspan="4"><b>User Management</b></td>
-  </tr>
-  <tr>
-    <td><a href="signup.html">User accounts to associate labeling activities to a specific user.</a></td>
-    <td style="text-align:center">✔️</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td><a href="https://docs.heartex.com/guide/manage_users.html#Set-up-role-based-access-control-RBAC-with-Label-Studio">Role-based access control for each user account.</a></td>
-    <td style="text-align:center">❌</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td><a href="https://docs.heartex.com/guide/manage_users.html">Organizations and workspaces to manage users and projects.</a></td>
-    <td style="text-align:center">❌</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td colspan="3"><b>Project Management</b></td>
-  </tr>
-  <tr>
-    <td><a href="setup_project.html">Projects to manage data labeling activities.</a></td>
-    <td style="text-align:center">✔️</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td><a href="setup.html">Templates to get started with specific data labeling tasks faster.</a></td>
-    <td style="text-align:center">✔️</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td colspan="3"><b>Data Management</b></td>
-  </tr>
-  <tr>
-    <td><a href="manage_data.html">Manage your data in a user interface.</a></td>
-    <td style="text-align:center">✔️</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td><a href="tasks.html">Import data from many sources.</a></td>
-    <td style="text-align:center">✔️</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td><a href="export.html">Export data into many formats.</a></td>
-    <td style="text-align:center">✔️</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td><a href="storage.html">Synchronize data from and to remote data storage.</a></td>
-    <td style="text-align:center">✔️</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td colspan="3"><b>Data Labeling Workflows</b></td>
-  </tr>
-  <tr>
-    <td><a href="manage_data.html#Assign-annotators-to-tasks">Assign specific annotators to specific tasks.</a></td>
-    <td style="text-align:center">❌</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td><a href="setup_project.html">Automatic queue management.</a></td>
-    <td style="text-align:center">❌</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td>Label text, images, audio data, HTML, and time series data.</td>
-    <td style="text-align:center">✔️</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td>Label mixed types of data.</td>
-    <td style="text-align:center">✔️</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td>Annotator-specific view.</td>
-    <td style="text-align:center">❌</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td colspan="3"><b>Annotator Performance</b></td>
-  </tr>
-  <tr>
-    <td><a href="https://docs.heartex.com/guide/quality.html#Review-annotator-agreement-matrix">Control label quality by monitoring annotator agreement.</a></td>
-    <td style="text-align:center">❌</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td><a href="https://docs.heartex.com/guide/quality.html#Review-annotator-activity-on-the-project-dashboard">Manage and review annotator performance.</a></td>
-    <td style="text-align:center">❌</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td><a href="https://docs.heartex.com/guide/quality.html">Verify model and annotator accuracy against ground truth annotations.</a></td>
-    <td style="text-align:center">❌</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td><a href="https://docs.heartex.com/guide/quality.html#Verify-model-and-annotator-performance">Verify annotation results.</a></td>
-    <td style="text-align:center">❌</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td><a href="https://docs.heartex.com/guide/quality.html#Review-annotator-performance">Assign reviewers to review annotation results.</a></td>
-    <td style="text-align:center">❌</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td colspan="3"><b>Machine Learning</b></td>
-  </tr>
-  <tr>
-    <td><a href="ml_create.html">Connect machine learning models to Label Studio with an SDK.</a></td>
-    <td style="text-align:center">✔️</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td><a href="active_learning.html">Accelerate labeling with active learning.</a></td>
-    <td style="text-align:center">✔️</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td><a href="ml.html">Automatically label dataset items with ML models.</a></td>
-    <td style="text-align:center">✔️</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td colspan="3"><b>Analytics and Reporting</b></td>
-  </tr>
-  <tr>
-    <td><a href="quality.html#Verify-model-and-annotator-performance">Reporting and analytics on labeling and annotation activity.</a></td>
-    <td style="text-align:center">❌</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td>Activity log to use to audit annotator activity.</td>
-    <td style="text-align:center">❌</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td colspan="3"><b>Advanced Functionality</b></td>
-  </tr>
-  <tr>
-    <td><a href="api.html">API access to manage Label Studio.</a></td>
-    <td style="text-align:center">✔️</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td>On-premises deployment of Label Studio.</td>
-    <td style="text-align:center">✔️</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-  <tr>
-    <td><a href="https://docs.heartex.com/guide/auth_setup.html">Support for single sign-on using LDAP or SAML. </a></td>
-    <td style="text-align:center">❌</td>
-    <td style="text-align:center">✔️</td>
-  </tr>
-</table>
-
-</div>
 
 ## Labeling workflow
 
@@ -321,6 +109,5 @@ The component parts of Label Studio are available as modular extensible packages
 <div style="margin:auto; text-align:center;"><img src="/images/ls-modules-scheme.png" style="opacity: 0.8"/></div>
 <!--update to include data manager-->
 
-## Information collected by Label Studio
 
-Label Studio collects anonymous usage statistics about the number of page visits and data types being used in labeling configurations that you set up. No sensitive information is included in the information we collect. The information we collect helps us improve the experience of labeling data in Label Studio and helps us plan future data types and labeling configurations to support.
+

--- a/docs/source/guide/glossary.md
+++ b/docs/source/guide/glossary.md
@@ -1,11 +1,11 @@
 ---
-title: Label Studio Terminology
+title: Label Studio terminology
 short: Terminology
 tier: all
 type: guide
 order: 15
 order_enterprise: 35
-meta_title: Label Studio Terminology
+meta_title: Label Studio terminology
 meta_description: A glossary of common terms seen throughout Label Studio. 
 section: "Get started"
 date: 2023-10-27 11:38:25

--- a/docs/source/guide/glossary.md
+++ b/docs/source/guide/glossary.md
@@ -1,0 +1,35 @@
+---
+title: Label Studio Terminology
+short: Terminology
+tier: all
+type: guide
+order: 15
+order_enterprise: 35
+meta_title: Label Studio Terminology
+meta_description: A glossary of common terms seen throughout Label Studio. 
+section: "Get started"
+date: 2023-10-27 11:38:25
+---
+
+ The following table describes some terms you might encounter as you use Label Studio:
+
+
+| Term   | Description   |
+|--|-----|
+| Annotations  | The output of a labeling task. Previously called "completions". The terms "annotations" and "labels" are frequently used interchangeably. |
+| Bounding box | Region within an image. |
+| Dataset | What you import into Label Studio, comprised of individual items, or labeling tasks. |
+| Labels | What you add to each region while labeling a task in Label Studio.  |
+| Label stream | When you click **Label All Tasks** from the Data Manager, you are working within the label stream. |
+| Labeling configuration | The labeling configuration determines what annotators and reviewers will see. It is configured in the project settings. |
+| Predictions, <br> Pre-annotations | Annotations in Label Studio format that machine learning models create for an unlabeled dataset. See [import pre-annotations](predictions.html)  |
+| Relation   | A defined relationship between two labeled regions.  |
+| Result | A label applied to a specific region as stored in an annotation or prediction. See [Label Studio JSON format of annotated tasks](export.html#Label-Studio-JSON-format-of-annotated-tasks). |
+| Quick view   | The "quick view" is what you see when you click an individual item in the Data Manager to open it (different than viewing it in the "label stream").   |
+| Record | Item in a dataset.   |
+| Region | The portion of the task identified for labeling. For example, when working with text, this might be a specific span of text or field. For images, an example region is a bounding box. For text, an example region is a span of text. Often has a label assigned to it.         |
+| Task  | When you upload data to Label Studio, each item in the dataset becomes a labeling *task*. A task is a distinct item from a dataset that is ready to be labeled, pre-annotated, or has already been annotated. For example: a text snippet, an image, or a video clip.  |
+| Tags   | Configuration options to customize the labeling interface. See [more about tags](/tags).  |
+| Templates | Example labeling configurations that you can use to specify the type of labeling that you're performing with your dataset. See [all available templates](/templates) |
+
+

--- a/docs/source/guide/quick_start.md
+++ b/docs/source/guide/quick_start.md
@@ -1,0 +1,42 @@
+---
+title: Quick Start
+short: Quick Start
+tier: opensource
+type: guide
+order: 7
+order_enterprise: 0
+meta_title: Quick Start
+meta_description: description
+section: "Get started"
+date: 2023-11-27 13:34:32
+---
+
+
+
+
+1. Install Label Studio:
+
+```bash
+pip install label-studio
+```
+
+2. Start Label Studio
+
+```bash
+label-studio start
+```
+
+1. Open Label Studio at `http://localhost:8080`.
+2. Sign up with an email address and password that you create.
+3. Click **Create** to create a project and start labeling data.
+4. Name the project and optionally enter a description and select a color.
+5. Click **Data Import** and upload the data files that you want to use. If you want to use data from a local directory, cloud storage bucket, or database, skip this step for now.
+6. Click **Labeling Setup** and choose a template and customize the label names for your use case.
+7. Click **Save** to save your project.
+
+You're ready to start [labeling and annotating your data](labeling.html)!
+
+!!! info Tip
+    For a quickstart tutorial that includes demo data, see [Zero to One: Getting Started with Label Studio](https://labelstud.io/blog/zero-to-one-getting-started-with-label-studio/). 
+
+

--- a/docs/source/guide/quick_start.md
+++ b/docs/source/guide/quick_start.md
@@ -1,18 +1,15 @@
 ---
-title: Quick Start
-short: Quick Start
+title: Quickstart
+short: Quickstart
 tier: opensource
 type: guide
 order: 7
 order_enterprise: 0
-meta_title: Quick Start
-meta_description: description
+meta_title: Quickstart guide for Label Studio
+meta_description: Quickstart guide for installing Label Studio and creating a new project. 
 section: "Get started"
 date: 2023-11-27 13:34:32
 ---
-
-
-
 
 1. Install Label Studio:
 

--- a/docs/source/guide/security.md
+++ b/docs/source/guide/security.md
@@ -111,3 +111,63 @@ If you use Redis as an external storage database for data and annotations, the s
 Label Studio Enterprise automatically logs all user activities so that you can monitor the activities being performed in the application.
 
 </div>
+
+## Information collected by Label Studio
+
+Label Studio collects anonymous usage statistics about the number of page visits and data types being used in labeling configurations that you set up. No sensitive information is included in the information we collect. The information we collect helps us improve the experience of labeling data in Label Studio and helps us plan future data types and labeling configurations to support.
+
+## Add self-signed certificate to trusted root store
+
+<div class="code-tabs">
+  <div data-name="Docker Compose">
+
+1. Mount your self-signed certificate as a volume into `app` container:
+
+```yaml
+volumes:
+  - ./my.cert:/tmp/my.cert:ro
+```
+2. Add environment variable with the name `CUSTOM_CA_CERTS` mentioning all certificates in comma-separated way that should be added into trust store:
+
+```yaml
+CUSTOM_CA_CERTS=/tmp/my.cert
+```
+  </div>
+
+  <div data-name="Kubernetes">
+
+1. Upload your self-signed certificate as a k8s secret.
+   Upload `my.cert` as a secrets with a name `test-my-root-cert`:
+```yaml
+kubectl create secret generic test-my-root-cert --from-file=file=my.cert
+```
+
+2. Add volumes into your values.yaml file and mention them in `.global.customCaCerts`:
+
+```yaml
+global:
+  customCaCerts:
+   - /opt/heartex/secrets/ca_certs/file/file
+
+app:
+  extraVolumes:
+    - name: foo
+      secret:
+        secretName: test-my-root-cert
+  extraVolumeMounts:
+    - name: foo
+      mountPath: "/opt/heartex/secrets/ca_certs/file"
+      readOnly: true
+
+rqworker:
+  extraVolumes:
+    - name: foo
+      secret:
+        secretName: test-my-root-cert
+  extraVolumeMounts:
+    - name: foo
+      mountPath: "/opt/heartex/secrets/ca_certs/file"
+      readOnly: true
+```
+  </div>
+</div>

--- a/docs/source/guide/start.md
+++ b/docs/source/guide/start.md
@@ -2,18 +2,18 @@
 title: Start Label Studio
 type: guide
 tier: opensource
-order: 10
+order: 78
 order_enterprise: 0
 meta_title: Start Commands for Label Studio
 meta_description: Documentation for starting Label Studio and configuring the environment to use Label Studio with your machine learning or data science project. 
-section: "Get started"
+section: "Install"
 ---
 
 After you install Label Studio, start the server to start using it. 
 
 ```bash
 label-studio start
-```
+``` 
 
 By default, Label Studio starts with an SQLite database to store labeling tasks and annotations. You can specify different sources and target storage for labeling tasks and annotations using Label Studio UI or the API. See [Database storage](storedata.html) for more.
 
@@ -69,7 +69,7 @@ export LABEL_STUDIO_LOCAL_FILES_SERVING_ENABLED=true
 ```
 
 !!! note
-    If you are using docker, you can write all your [environment variables into the `.env`](https://docs.docker.com/compose/env-file/) file.
+    If you are using Docker, you can write all your [environment variables into the `.env`](https://docs.docker.com/compose/env-file/) file.
     
     
     

--- a/docs/source/guide/start.md
+++ b/docs/source/guide/start.md
@@ -4,7 +4,7 @@ type: guide
 tier: opensource
 order: 78
 order_enterprise: 0
-meta_title: Start Commands for Label Studio
+meta_title: Start commands for Label Studio
 meta_description: Documentation for starting Label Studio and configuring the environment to use Label Studio with your machine learning or data science project. 
 section: "Install"
 ---

--- a/docs/themes/v2/layout/home.ejs
+++ b/docs/themes/v2/layout/home.ejs
@@ -194,7 +194,7 @@ meta_description: Get started with Label Studio by creating projects to label an
         <%- partial("component/link", { url: "https://github.com/heartexlabs/label-studio/releases", label: "Release Notes", size: "Full" }) %>
       </li>
       <li>
-        <%- partial("component/link", { url: "/guide/get_started.html#Terminology", label: "Glossary", size: "Full" }) %>
+        <%- partial("component/link", { url: "/guide/glossary.html", label: "Glossary", size: "Full" }) %>
       </li>
     </ul>
     </div>
@@ -343,7 +343,7 @@ meta_description: Get started with Label Studio by creating projects to label an
               <%- partial("component/link", { url: "/guide/release_notes.html", label: "Release Notes", size: "Full" }) %>
             </li>
             <li>
-              <%- partial("component/link", { url: "/guide/get_started.html#Terminology", label: "Glossary", size: "Full" }) %>
+              <%- partial("component/link", { url: "/guide/glossary.html", label: "Glossary", size: "Full" }) %>
             </li>
           </ul>
     </div>

--- a/docs/themes/v2/layout/partials/footer.ejs
+++ b/docs/themes/v2/layout/partials/footer.ejs
@@ -194,7 +194,7 @@
         </nav>
         <% if(!isEnterpriseTheme) { %>
           <div class="FooterCTA">
-            <a class="Button Secondary FooterCTAButton" href="/guide/get_started.html#Quick-start"><span class="Heading XXSmall ButtonText astro-EXBSDJPD">Quick Start</span></a>
+            <a class="Button Secondary FooterCTAButton" href="/guide/quick_start.html"><span class="Heading XXSmall ButtonText astro-EXBSDJPD">Quick Start</span></a>
             <svg class="FooterCTASquares" width="201" height="201" viewBox="0 0 201 201" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
               <rect x="0.504975" y="100.505" width="49.9901" height="49.9901" stroke="#505263" stroke-width="1.00995"></rect>
               <rect x="50.505" y="150.505" width="49.9901" height="49.9901" stroke="#505263" stroke-width="1.00995"></rect>

--- a/docs/themes/v2/layout/partials/header.ejs
+++ b/docs/themes/v2/layout/partials/header.ejs
@@ -107,7 +107,7 @@
           </button>
           <ul>
             <li>
-              <a href="/guide/get_started.html#Quick-start">Quickstart</a>
+              <a href="/guide/quick_start.html">Quickstart</a>
             </li>
             <li>
               <a href="/guide/install_enterprise.html">Install</a>
@@ -181,7 +181,7 @@
           </button>
           <ul>
             <li>
-              <a href="/guide/get_started.html#Quick-start">Quickstart</a>
+              <a href="/guide/quick_start.html">Quickstart</a>
             </li>
             <li>
               <a href="/guide/install.html">Install</a>
@@ -216,7 +216,7 @@
           </a>
         </li>
         <li>
-          <%- partial("component/button", { url: "/guide/get_started.html#Quick-start", label: "Quick start", }) %>
+          <%- partial("component/button", { url: "/guide/quick_start.html", label: "Quick start", }) %>
         </li>
         <% } %>
     </ul>


### PR DESCRIPTION
Restructuring docs, starting with Getting Started section:

- Moved Quick Start to separate page
- Moved Terminology section to a separate page
- Moved location of Troubleshooting page under Labeling
- Moved "Starting Label Studio" to the more technical Install section 
- Moved security-focused info from Overview page to the page about Security
- Removed duplicate section about LSE vs. LSO features
- Updated links where necessary