### PR TITLE
fix: LEAP-176: Remove unused styles to fix CSP

### DIFF
--- a/label_studio/templates/base.html
+++ b/label_studio/templates/base.html
@@ -59,13 +59,7 @@
 <div class="app-wrapper"></div>
 
 <template id="main-content">
-  <main class="main" style="background: transparent">
-
-      <div class="ui floating dropdown theme basic" style="float: right;">
-        {% block top-buttons %}
-        {% endblock %}
-      </div>
-    </div>
+  <main class="main">
 
     <!-- Space & Divider -->
     {% block divider %}


### PR DESCRIPTION
Strict CSP complains about those inline styles. Turned out we don't need this code at all.

This code block has broken html and is actually not used in the app. And transparent background is overriden in the app.

### PR fulfills these requirements
- [ ] Tests for the changes have been added/updated
- [ ] Docs have been added/updated
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [ ] Self-reviewed and ran all changes on a local instance

### This change affects (describe how if yes)
- [ ] Performance
- [x] Security — fixes CSP complains about inline styles
- [ ] UX

### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [ ] No
- [x] Not sure — html was broken but might've been fixed to some different structure; background might've stayed somewhere untouched — could not find evidences for those concerns
