### PR TITLE
docs: DOC-162: Fix LSE and LSO divisions in Setup project page

### DIFF
--- a/docs/source/guide/setup_project.md
+++ b/docs/source/guide/setup_project.md
@@ -44,40 +44,63 @@ You can also create a project from a template by clicking **Use Template**. See 
 
 After you save a project, any other collaborator with access to the Label Studio instance can view your project, perform labeling, and make changes. To use role-based access control, you need to use Label Studio Enterprise Edition.
 
+<div class="opensource-only">
+
+## Set up instructions for data labelers
+
+In the project settings, you can add instructions and choose whether to show the instructions to annotators before they perform labeling.
+
+1. Within a project on the Label Studio UI, click **Settings**.
+2. Click **Instructions**.
+3. Enter your instructions and choose whether to show the instructions to annotators before labeling. If you want to provide additional details or links for reference, instructions support HTML markup.
+4. Click **Save**. 
+
+Annotators can view instructions at any time  by clicking the information icon in the labeling interface.
+
+## Set up task sampling
+
+You can set up task sampling from the command line when you start Label Studio or from the Label Studio UI.
+
+- To start a project with specific task sampling, see [Set up task sampling for your project](start.html#Set-up-task-sampling-for-your-project).
+- To change task sampling settings from the Label Studio UI, do the following:
+  - Within a project on the Label Studio UI, click **Settings**.
+  - On the **General** settings tab, under **Task Sampling**, choose between `Sequential sampling` and `Random sampling`.
+  - Click **Save**.
+
+## Where Label Studio stores your project data and configurations
+
+All labeling activities in Label Studio occur in the context of a project.
+
+Starting in version 1.0.0, Label Studio stores your project data and configurations in a SQLite database. You can choose to use PostgreSQL instead. See [Set up database storage](storedata.html).
+
+In versions of Label Studio earlier than 1.0.0, when you start Label Studio for the first time, it launches from a project directory that Label Studio creates, called `./my_project` by default.
+
+`label-studio start ./my_project --init`
+
+
+</div>
+
+<div class="enterprise-only">
+
 ## Set up annotation settings for your project
 
 Set up annotation settings to configure how you want annotators to perform labeling for your project.
 
-<div class="enterprise-only">
 
 Some annotation settings are only available in Label Studio Enterprise Edition. If you're using Label Studio Community Edition, see <a href="https://labelstud.io/guide/label_studio_compare.html">Label Studio Features</a> to learn more.
 
-</div>
+
 
 ### Set up instructions for data labelers
 
 In the project settings, you can add instructions and choose whether to show the instructions to annotators before they perform labeling.
 
 1. Within a project on the Label Studio UI, click **Settings**.
-
-<div class="enterprise-only">
-
 2. Click **Annotation Settings**.
+3. Enter your instructions and choose whether to show the instructions to annotators before labeling. If you want to provide additional details or links for reference, instructions support HTML markup.
+4. Click **Save**. 
 
-</div>
-
-<div class="opensource-only">
-
-2. Click **Instructions**.
-
-</div>
-
-3. Type instructions and choose whether to show the instructions to annotators before labeling. If you want to provide additional details or links for reference, instructions support HTML markup.
-4. Click **Save**. <br/>Click the project name to return to the data manager view.
-
-Annotators can view instructions at any time when labeling by clicking the (i) button from the labeling interface.
-
-<div class="enterprise-only">
+Annotators can view instructions at any time when labeling by clicking the information icon from the labeling interface.
 
 ### Set up task distribution for labeling
 
@@ -94,10 +117,6 @@ Your changes save automatically.
 !!! note
     You can't assign annotators to tasks unless you select the **Manual** option.
 
-</div>
-
-<div class="enterprise-only">
-
 ### Set minimum annotations per task
 
 By default, each task only needs to be annotated by one annotator. If you want multiple annotators to be able to annotate tasks, set the Overlap of Annotations for a project in the project settings.
@@ -108,8 +127,6 @@ By default, each task only needs to be annotated by one annotator. If you want m
 4. Choose whether to enforce the overlap for the default of 100% of tasks, or a smaller percentage.
 5. Choose whether to show tasks that require multiple annotations, **tasks with overlap**, before other tasks that need to be annotated.
 6. Your changes save automatically. Return to the **Data Manager** and assign annotators to the tasks so that they can annotate the tasks.
-
-</div>
 
 #### How task overlap works
 
@@ -135,17 +152,7 @@ If you want, you can allow empty annotations.
 
 ### Set up task sampling
 
-In Label Studio Community Edition, you can set up task sampling from the command line when you start Label Studio or from the Label Studio UI.
-
-- To start a project with specific task sampling, see [Set up task sampling for your project](start.html#Set-up-task-sampling-for-your-project).
-- To change task sampling settings from the Label Studio UI, do the following:
-  - Within a project on the Label Studio UI, click **Settings**.
-  - On the **General** settings tab, under **Task Sampling**, choose between `Sequential sampling` and `Random sampling`.
-  - Click **Save**.
-
-<div class="enterprise-only">
-
-In Label Studio Enterprise, you can set up task sampling in the annotation settings for a project.
+You can set up task sampling in the annotation settings for a project.
 
 1. Within a project on the Label Studio UI, click **Settings**.
 2. Click **Annotation Settings**.
@@ -155,10 +162,6 @@ In Label Studio Enterprise, you can set up task sampling in the annotation setti
    - Uniform sampling, where tasks are shown to annotators in a random order.
 4. You can also choose whether to show tasks with ground truth labels first.
    Your changes save automatically.
-
-</div>
-
-<div class="enterprise-only">
 
 ### Define the agreement metrics for annotation statistics
 
@@ -171,17 +174,12 @@ Annotation statistics such as annotator consensus are calculated using an agreem
 
 Your changes save automatically.
 
-</div>
-
-<div class="enterprise-only">
 
 ## Set up review settings for your project
 
 Set up review settings to guide reviewers when they review annotated tasks. For more about reviewing annotations, see [Review annotations in Label Studio](quality.html)
 
 Review settings and the review stream are only available in Label Studio Enterprise Edition. If you're using Label Studio Community Edition, see <a href="https://labelstud.io/guide/label_studio_compare.html">Label Studio Features</a> to learn more.
-
-</div>
 
 ### Set up instructions for task reviewers
 
@@ -201,9 +199,8 @@ Configure the reviewing settings for your project.
 2. Click **Review**.
 3. Under **Reviewing Options**, choose whether to mark a task as reviewed if at least one annotation has been reviewed, or only after all annotations for a task have been processed.
 4. Under **Reviewing Options**, choose whether to anonymize annotators when reviewing tasks.
-   Your changes save automatically.
 
-<div class="enterprise-only">
+Your changes save automatically.
 
 ## Add members to a project
 
@@ -217,10 +214,6 @@ To add members to a specific project, do the following:
 4. Click **Save**.
 
 After adding a member to a project, you can [assign them as a reviewer](quality.html#Assign-reviewers-to-tasks) or [assign them as an annotator](manage_data.html#Assign-annotators-to-tasks) to tasks in the project.
-
-</div>
-
-<div class="enterprise-only">
 
 ## Publish project to annotators
 
@@ -236,10 +229,6 @@ To publish a project, do the following:
 
 1. Open a project and navigate to the project **Dashboard**.
 2. Click **Publish**. <br/>After the project is published, annotators can view the project and start being assigned tasks according to the method that you use to [distribute tasks for labeling](#Set-up-task-distribution-for-labeling).
-
-</div>
-
-<div class="enterprise-only">
 
 ## Create a project template
 
@@ -258,19 +247,5 @@ After you create a project template, you can use the template when you create a 
 4. Click **Create**. The project is created and saved in your Sandbox.
    - Click **Import** to import data.
    - Click **Data Manager** to start annotating.
-
-</div>
-
-<div class="opensource-only">
-
-## Where Label Studio stores your project data and configurations
-
-All labeling activities in Label Studio occur in the context of a project.
-
-Starting in version 1.0.0, Label Studio stores your project data and configurations in a SQLite database. You can choose to use PostgreSQL instead. See [Set up database storage](storedata.html).
-
-In versions of Label Studio earlier than 1.0.0, when you start Label Studio for the first time, it launches from a project directory that Label Studio creates, called `./my_project` by default.
-
-`label-studio start ./my_project --init`
 
 </div>

--- a/docs/source/guide/setup_project.md
+++ b/docs/source/guide/setup_project.md
@@ -24,7 +24,6 @@ After you [start Label Studio](start.html) and [create an account](signup.html),
 4. (Optional) [Set up annotation settings for your project](#Set-up-annotation-settings-for-your-project).
 
 <div class="enterprise-only">
-
 5. (Optional) [Set up review settings for your project](#Set-up-review-settings-for-your-project).
 6. [Publish your project](#Publish-project-to-annotators).
 
@@ -46,7 +45,9 @@ After you save a project, any other collaborator with access to the Label Studio
 
 <div class="opensource-only">
 
-## Set up instructions for data labelers
+## Set up annotation settings for your project
+
+### Set up instructions for data labelers
 
 In the project settings, you can add instructions and choose whether to show the instructions to annotators before they perform labeling.
 
@@ -57,7 +58,7 @@ In the project settings, you can add instructions and choose whether to show the
 
 Annotators can view instructions at any time  by clicking the information icon in the labeling interface.
 
-## Set up task sampling
+### Set up task sampling
 
 You can set up task sampling from the command line when you start Label Studio or from the Label Studio UI.
 


### PR DESCRIPTION
The OSS version of the "Setup project" page includes Enterprise-only feature descriptions. This PR expands the tier `div`s to better separate the content by tier. 