### PR TITLE
fix: build-pypi workflow / twine call

### DIFF
--- a/.github/workflows/build_pypi.yml
+++ b/.github/workflows/build_pypi.yml
@@ -122,7 +122,7 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_APIKEY }}
-        run: twine upload dist/*
+        run: poetry run twine upload dist/*
 
       - name: Get PyPI package details
         id: pypi-package-details


### PR DESCRIPTION
Our pypi build failed because twine is installed within poetry's venv, not globally https://github.com/HumanSignal/label-studio/actions/runs/7049696162/job/19188758524