### PR TITLE
docs: DOC-132: Release notes date fix

### DIFF
--- a/docs/source/guide/release_notes/onprem/2.7.0-1.md
+++ b/docs/source/guide/release_notes/onprem/2.7.0-1.md
@@ -5,7 +5,7 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.7.0-1
 
-*Oct 06, 2023*
+*Dec 06, 2023*
 
 ### Bug fixes
-- Fix uwsgi config to support ipv4 only host networks.
+- Fix UWSGI config to support IPv4 only host networks.


### PR DESCRIPTION
2.7.0-1 list "Oct 06" for their date when it should be "Dec 06"