### PR TITLE
docs: DOC-166: Add helm chart version to 2.8.0 release notes 

### DIFF
--- a/docs/source/guide/release_notes/onprem/2.8.0.md
+++ b/docs/source/guide/release_notes/onprem/2.8.0.md
@@ -6,7 +6,7 @@ hide_sidebar: true
 
 *Dec 19, 2023*
 
-**Helm chart version**: [1.3.2](https://github.com/HumanSignal/charts/tree/master/heartex/label-studio)
+**[Helm chart]((https://github.com/HumanSignal/charts/tree/master/heartex/label-studio) version:** 1.3.2
 
 ### Enhancements
 

--- a/docs/source/guide/release_notes/onprem/2.8.0.md
+++ b/docs/source/guide/release_notes/onprem/2.8.0.md
@@ -6,7 +6,7 @@ hide_sidebar: true
 
 *Dec 19, 2023*
 
-**[Helm chart]((https://github.com/HumanSignal/charts/tree/master/heartex/label-studio) version:** 1.3.2
+**[Helm chart](https://github.com/HumanSignal/charts/tree/master/heartex/label-studio) version:** 1.3.2
 
 ### Enhancements
 

--- a/docs/source/guide/release_notes/onprem/2.8.0.md
+++ b/docs/source/guide/release_notes/onprem/2.8.0.md
@@ -6,6 +6,8 @@ hide_sidebar: true
 
 *Dec 19, 2023*
 
+**Helm chart version**: [1.3.2](https://github.com/HumanSignal/charts/tree/master/heartex/label-studio)
+
 ### Enhancements
 
 - The members list on the Organization page now allows you to filter by one or more roles. By default, Deactivated and Not Activated users are hidden. This makes it easier to locate users within the member list.


### PR DESCRIPTION
Added a helm chart version to the 2.8.0 release notes

Will create a separate PR to add the same to previous release notes.

Enterprise-only change