### PR TITLE
Add react-app, editor, and DM to wheel build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,9 @@ packages = [
 ]
 include = [
     "deploy/requirements.txt",
+    "web/dist/libs/datamanager/**/*",
+    "web/dist/libs/editor/**/*",
+    "web/dist/apps/labelstudio/**/*",
     "label_studio/frontend/dist/react-app/*",
     "label_studio/frontend/dist/lsf/**/*",
     "label_studio/frontend/dist/dm/**/*",


### PR DESCRIPTION
Currently we get a whitescreen from the wheel that results when LSO is built using `poetry build`. This fixes that issue.