### PR TITLE
docs: DOC-114: Add note about not opening the label stream in two tabs

### DIFF
--- a/docs/source/guide/labeling.md
+++ b/docs/source/guide/labeling.md
@@ -32,6 +32,9 @@ You can also label a specific task in the **Quick View** or **Preview** by click
 
 You can also select the checkboxes next to specific tasks and then click **Label $n Tasks** to label the selected number of tasks. For example, select the checkboxes for 5 different tasks, then click **Label 5 Tasks** to label only those 5 tasks. 
 
+!!! note
+    When labeling tasks, you should not open the label stream (click **Label All Tasks**) simultaneously in two tabs. This could result in you receiving the same task twice. 
+
 ### Label a region in the data
 Annotate a section of the data by adding a region. 
 

--- a/docs/source/guide/labeling.md
+++ b/docs/source/guide/labeling.md
@@ -33,7 +33,7 @@ You can also label a specific task in the **Quick View** or **Preview** by click
 You can also select the checkboxes next to specific tasks and then click **Label $n Tasks** to label the selected number of tasks. For example, select the checkboxes for 5 different tasks, then click **Label 5 Tasks** to label only those 5 tasks. 
 
 !!! note
-    When labeling tasks, you should not open the label stream (click **Label All Tasks**) simultaneously in two tabs. This could result in you receiving the same task twice. 
+    When labeling tasks, you should not open the label stream (meaning to click **Label All Tasks**) simultaneously in two tabs. This could result in you receiving the same task twice, which can circumvent project settings that address annotator overlap. 
 
 ### Label a region in the data
 Annotate a section of the data by adding a region. 


### PR DESCRIPTION
Added a note that labelers should not open the label stream in two separate tabs at once. 


- [X] Community docs
- [X] Enterprise docs




