### PR TITLE
docs: DOC-167: Add highlight description for on-prem release notes

### DIFF
--- a/docs/source/guide/release_notes/onprem/2.2.10.md
+++ b/docs/source/guide/release_notes/onprem/2.2.10.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.2.10
 
+<div class="onprem-highlight">Bug fixes</div>
+
 This section highlights the bug fixes in Label Studio Enterprise 2.2.10.
 
 ### Bug fixes

--- a/docs/source/guide/release_notes/onprem/2.2.8.md
+++ b/docs/source/guide/release_notes/onprem/2.2.8.md
@@ -4,7 +4,7 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.2.8
 
-<div class="onprem-highlight">Comment visibility, SCIM enhancements, Redis SSL support, notification center, drafts in Annotation History</div>
+<div class="onprem-highlight">Comment visibility, SCIM enhancements, Redis SSL support, notification center, drafts in Annotation History, new history types</div>
 
 This section highlights the breaking changes, new features and enhancements, and bug fixes in Label Studio Enterprise 2.2.8. 
 

--- a/docs/source/guide/release_notes/onprem/2.2.8.md
+++ b/docs/source/guide/release_notes/onprem/2.2.8.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.2.8
 
+<div class="onprem-highlight">Comment visibility, SCIM enhancements, Redis SSL support, notification center, drafts in Annotation History</div>
+
 This section highlights the breaking changes, new features and enhancements, and bug fixes in Label Studio Enterprise 2.2.8. 
 
 ### New features and enhancements

--- a/docs/source/guide/release_notes/onprem/2.2.9.md
+++ b/docs/source/guide/release_notes/onprem/2.2.9.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.2.9
 
+<div class="onprem-highlight">Dynamic Labels template, Comments column in the Data Manager, decommissioning MinIO</div>
+
 This section highlights the breaking changes, new features and enhancements, and bug fixes in Label Studio Enterprise 2.2.9. 
 
 ### Breaking changes

--- a/docs/source/guide/release_notes/onprem/2.2.md
+++ b/docs/source/guide/release_notes/onprem/2.2.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.2.0
 
+<div class="onprem-highlight">SCIM 2.0 support, rotating bounding boxes, 'Last updated by' column in the Data Manager, ability to navigate to the previous task </div>
+
 This section highlights the new features and enhancements in Label Studio Enterprise 2.2.0.
 
 ### New features and enhancements 

--- a/docs/source/guide/release_notes/onprem/2.3.1.md
+++ b/docs/source/guide/release_notes/onprem/2.3.1.md
@@ -3,6 +3,9 @@ hide_sidebar: true
 ---
 
 ## Label Studio Enterprise 2.3.1
+
+<div class="onprem-highlight">Multiple usability enhancements, including new Data Manager columns and the ability to duplicate projects</div>
+
 This section highlights the breaking changes, new features and enhancements, and bug fixes in Label Studio Enterprise 2.3.1.
 
 ### Breaking changes

--- a/docs/source/guide/release_notes/onprem/2.4.0.md
+++ b/docs/source/guide/release_notes/onprem/2.4.0.md
@@ -3,6 +3,9 @@ hide_sidebar: true
 ---
 
 ## Label Studio Enterprise 2.4.0
+
+<div class="onprem-highlight">Audio player enhancements, comments and notifications improvements, support for numpad hotkeys</div>
+
 This section highlights the new features and enhancements, and bug fixes in Label Studio Enterprise 2.4.
 
 ### New features and enhancements 

--- a/docs/source/guide/release_notes/onprem/2.4.1.md
+++ b/docs/source/guide/release_notes/onprem/2.4.1.md
@@ -3,6 +3,7 @@ hide_sidebar: true
 ---
 
 ## Label Studio Enterprise 2.4.1
+<div class="onprem-highlight">Improved logging, API for project annotation history</div>
 
 ### New features and enhancements 
 - Add project annotation history API

--- a/docs/source/guide/release_notes/onprem/2.4.10.md
+++ b/docs/source/guide/release_notes/onprem/2.4.10.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.4.10
 
+<div class="onprem-highlight">Contextual scrolling for audio and video, search field on the Projects page, autocomplete prompt when editing the labeling configuration</div>
+
 *Sep 13, 2023*
 
 

--- a/docs/source/guide/release_notes/onprem/2.4.2.md
+++ b/docs/source/guide/release_notes/onprem/2.4.2.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.4.2
 
+<div class="onprem-highlight">Label placement change for regions, YOLO support for PolygonLabels</div>
+
 ### New features
 - Labels are not displayed inside the regions
 - Add YOLO support for PolygonLabels in export options

--- a/docs/source/guide/release_notes/onprem/2.4.3.md
+++ b/docs/source/guide/release_notes/onprem/2.4.3.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.4.3
 
+<div class="onprem-highlight">New <code>splitchannels</code> option on audio configs, keyboard shortcuts for the Data Manager, restore locked annotations</div>
+
 ### Enhancements
 - Support simultaneous render of multi-channel audio with added splitchannels="true" option on Audio config (larger memory requirement)
 - Allow selecting task automatically on Data Manager page whenever the user presses shift+up/down

--- a/docs/source/guide/release_notes/onprem/2.4.4.md
+++ b/docs/source/guide/release_notes/onprem/2.4.4.md
@@ -4,13 +4,14 @@ hide_sidebar: true
   
 
 ## Label Studio Enterprise 2.4.4
+<div class="onprem-highlight"><code>skipDuplicates</code> parameter for TextArea, audio v3 Web Audio alternative decoder option, S3 custom endpoint for persistent storage </div>
 
 ### New features
 - New parameter skipDuplicates of TextArea allows to keep submissions unique.
 
 ### Enhancements
 - Audio v3 webaudio alternative decoder option
-- s3 custom endpoint support for persistent storage
+- S3 custom endpoint support for persistent storage
 - Table tag ordering items alphabetically
 
 ### Bug fixes

--- a/docs/source/guide/release_notes/onprem/2.4.5.md
+++ b/docs/source/guide/release_notes/onprem/2.4.5.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.4.5
 
+<div class="onprem-highlight">Performance optimization for projects API, storage link resolver for nested task data fields</div>
+
 *Apr 10, 2023*
 
 ### Enhancements

--- a/docs/source/guide/release_notes/onprem/2.4.6-1.md
+++ b/docs/source/guide/release_notes/onprem/2.4.6-1.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.4.6-1
 
+<div class="onprem-highlight">Bug fix</div>
+
 *May 09, 2023*
 
 ### Bug fixes

--- a/docs/source/guide/release_notes/onprem/2.4.6.md
+++ b/docs/source/guide/release_notes/onprem/2.4.6.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.4.6
 
+<div class="onprem-highlight">Data Manager actions for reviewers, better placement for annotation instructions, allow email lists when inviting users</div>
+
 *Apr 27, 2023*
 
 ### Enhancements

--- a/docs/source/guide/release_notes/onprem/2.4.7.md
+++ b/docs/source/guide/release_notes/onprem/2.4.7.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.4.7
 
+<div class="onprem-highlight">Updated content for empty project pages, UI changes for async export conversion</div>
+
 *May 18, 2023*
 
 ### New features

--- a/docs/source/guide/release_notes/onprem/2.4.8-1.md
+++ b/docs/source/guide/release_notes/onprem/2.4.8-1.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.4.8-1
 
+<div class="onprem-highlight">Bug fix</div>
+
 *Jun 26, 2023*
 
 ### Bug fixes

--- a/docs/source/guide/release_notes/onprem/2.4.8.md
+++ b/docs/source/guide/release_notes/onprem/2.4.8.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.4.8
 
+<div class="onprem-highlight">Enhanced UI for panels and tabs, new Ranker tag, new Outliner filter, async imports</div>
+
 *Jun 16, 2023*
 
 ### New features

--- a/docs/source/guide/release_notes/onprem/2.4.9-2.md
+++ b/docs/source/guide/release_notes/onprem/2.4.9-2.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.4.9-2
 
+<div class="onprem-highlight">New workspace actions, per-image classifications</div>
+
 *July 26, 2023*
 
 ### New features

--- a/docs/source/guide/release_notes/onprem/2.4.9-4.md
+++ b/docs/source/guide/release_notes/onprem/2.4.9-4.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.4.9-4
 
+<div class="onprem-highlight">Draft column in the Data Manager</div>
+
 *Aug 04, 2023*
 <!-- Release notes generated using configuration in .github/release.yml at lse-release/2.4.9 -->
 

--- a/docs/source/guide/release_notes/onprem/2.4.9-5.md
+++ b/docs/source/guide/release_notes/onprem/2.4.9-5.md
@@ -6,6 +6,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.4.9-5
 
+<div class="onprem-highlight">Bug fix</div>
+
 *Aug 11, 2023*
 
 ### Bug fixes

--- a/docs/source/guide/release_notes/onprem/2.4.9-6.md
+++ b/docs/source/guide/release_notes/onprem/2.4.9-6.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.4.9-6
 
+<div class="onprem-highlight">Bug fixes</div>
+
 *Aug 21, 2023*
 
 ### Bug fixes

--- a/docs/source/guide/release_notes/onprem/2.4.9-7.md
+++ b/docs/source/guide/release_notes/onprem/2.4.9-7.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.4.9-7
 
+<div class="onprem-highlight">Bug fixes</div>
+
 *Aug 22, 2023*
 
 ### Bug fixes

--- a/docs/source/guide/release_notes/onprem/2.5.0-1.md
+++ b/docs/source/guide/release_notes/onprem/2.5.0-1.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.5.0-1
 
+<div class="onprem-highlight">Security fix</div>
+
 *Sep 30, 2023*
 
 ### Security

--- a/docs/source/guide/release_notes/onprem/2.5.0.md
+++ b/docs/source/guide/release_notes/onprem/2.5.0.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.5.0
 
+<div class="onprem-highlight">Project-level roles for SAML/SCIM, ability to pause annotation sessions</div>
+
 *Sep 28, 2023*
 
 ### New features

--- a/docs/source/guide/release_notes/onprem/2.6.0-1.md
+++ b/docs/source/guide/release_notes/onprem/2.6.0-1.md
@@ -6,6 +6,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.6.0-1
 
+<div class="onprem-highlight">Bug fix</div>
+
 *Oct 26, 2023*
 
 ### Bug fixes

--- a/docs/source/guide/release_notes/onprem/2.6.0-2.md
+++ b/docs/source/guide/release_notes/onprem/2.6.0-2.md
@@ -5,6 +5,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.6.0-2
 
+<div class="onprem-highlight">Improved label and review stream counter</div>
+
 *Oct 27, 2023*
 
 ### Enhancements

--- a/docs/source/guide/release_notes/onprem/2.6.0.md
+++ b/docs/source/guide/release_notes/onprem/2.6.0.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.6.0
 
+<div class="onprem-highlight">New <code>snap</code> parameter for KeyPoint, KeyPointLabels, Polygon, and PolygonLabels tags, improved usability when reviewing video in Outliner </div>
+
 *Oct 24, 2023*
 
 ### Enhancements

--- a/docs/source/guide/release_notes/onprem/2.7.0-1.md
+++ b/docs/source/guide/release_notes/onprem/2.7.0-1.md
@@ -5,6 +5,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.7.0-1
 
+<div class="onprem-highlight">Bug fix</div>
+
 *Dec 06, 2023*
 
 ### Bug fixes

--- a/docs/source/guide/release_notes/onprem/2.7.0.md
+++ b/docs/source/guide/release_notes/onprem/2.7.0.md
@@ -5,6 +5,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.7.0
 
+<div class="onprem-highlight">External taxonomy, group visibility in label distribution charts, soft delete users</div>
+
 *Nov 21, 2023*
 
 ### New Features

--- a/docs/source/guide/release_notes/onprem/2.8.0.md
+++ b/docs/source/guide/release_notes/onprem/2.8.0.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.8.0
 
+<div class="onprem-highlight">Improved member list filtering from the Organization page, collapsible Ranker items, various UI improvements</div>
+
 *Dec 19, 2023*
 
 **[Helm chart](https://github.com/HumanSignal/charts/tree/master/heartex/label-studio) version:** 1.3.2

--- a/docs/source/guide/release_notes/onprem/2.9.0.md
+++ b/docs/source/guide/release_notes/onprem/2.9.0.md
@@ -4,6 +4,8 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.9.0
 
+<div class="onprem-highlight">Improved webhook performance and various UI improvements</div>
+
 *Jan 16, 2024*
 
 **[Helm chart](https://github.com/HumanSignal/charts/tree/master/heartex/label-studio) version:** 1.3.3

--- a/docs/themes/v2/source/js/collapse.js
+++ b/docs/themes/v2/source/js/collapse.js
@@ -38,6 +38,11 @@ style.textContent = `
 .toc button:hover {
   color: var(--color-yellow-120);
 }
+.onprem-highlight {
+  display: block!important;
+  font-weight: bold;
+  margin: 1em 0 0 0;
+}
 `;
 
 document.head.appendChild(style);


### PR DESCRIPTION
To improve the release notes page usability, added a brief highlight description for each release

- [ ] Community docs
- [X] Enterprise docs



