### PR TITLE
fix: DEV-5327: Add the s3transfer version lock to the deployment requirements.txt

### DIFF
--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -63,5 +63,6 @@ redis~=3.5
 sentry-sdk>=1.1.0
 launchdarkly-server-sdk==7.5.0
 python-json-logger==2.0.4
+s3transfer==0.7.0
 
 label-studio-converter==0.0.57


### PR DESCRIPTION
fix: DEV-5327: Add the s3transfer version lock to the deployment requirements.txt.  s3transfer's newest version causes issues with Cloud Storage -> Sync Storage when syncing with S3.

### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [X] Tests for the changes have been added/updated (for bug fixes/features)
- [X] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [ ] Frontend



### Describe the reason for change
https://github.com/HumanSignal/label-studio/issues/5327



#### What does this fix?
S3 sync fails on newer versions due to s3transfer version issues. 



#### What is the new behavior?
Works as expected.  We just move back to version 0.7.0 instead of the newer 0.10.0, which requires a newer boto3 and botocore. 



#### What is the current behavior?
Does not sync and throws an exception. 



#### What libraries were added/updated?
None added.
S3transfer version set to 0.7.0, as already set in the requirements-test.txt



#### Does this change affect performance?
No



#### Does this change affect security?
No



#### What alternative approaches were there?
To upgrade boto, boto3, and botocore but that affects a lot more. 



#### What feature flags were used to cover this change?
None



### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Cloud Storage Sync

