### PR TITLE
docs: DOC-176: Add blog link to API guide page

### DIFF
--- a/docs/source/guide/api.md
+++ b/docs/source/guide/api.md
@@ -15,6 +15,9 @@ You can use the Label Studio API to import data for labeling, export annotations
 
 See the [API reference documentation](/api) for further guidance and interactive examples. If you want to write Python scripts using the API, use the [Label Studio Python SDK](sdk.html). 
 
+!!! info Tip
+    For additional guidance on using our API, see [5 Tips and Tricks for Label Studio’s API and SDK](https://labelstud.io/blog/5-tips-and-tricks-for-label-studio-s-api-and-sdk/).
+
 <div class="enterprise-only">
 
 <p>

--- a/docs/source/guide/sdk.md
+++ b/docs/source/guide/sdk.md
@@ -23,6 +23,9 @@ With the Label Studio Python SDK, you can perform the following tasks in a Pytho
 
 See the [full SDK reference documentation for all available modules](https://labelstud.io/sdk/), or review the available [API endpoints](/api) for any tasks that the SDK does not cover. 
 
+!!! info Tip
+    For additional guidance on using our SDK, see [5 Tips and Tricks for Label Studio’s API and SDK](https://labelstud.io/blog/5-tips-and-tricks-for-label-studio-s-api-and-sdk/).
+
 ## Start using the Label Studio Python SDK
 
 1. Install the SDK:


### PR DESCRIPTION
Adding a link to the "API Reference for Label Studio" page


- [X] Community docs
- [X] Enterprise docs

