### PR TITLE
docs: DOC-177: Add CVE links to on-prem release notes

### DIFF
--- a/docs/source/guide/release_notes/onprem/2.7.0.md
+++ b/docs/source/guide/release_notes/onprem/2.7.0.md
@@ -9,6 +9,8 @@ hide_sidebar: true
 
 *Nov 21, 2023*
 
+**[Helm chart](https://github.com/HumanSignal/charts/tree/master/heartex/label-studio) version:** 1.2.9
+
 ### New Features
 
 #### External taxonomy
@@ -60,6 +62,7 @@ For more information, see [Introducing Label Distribution Charts for Label Group
 
 - Fixed an SSRF DNS rebinding issue.
 - Fixed an XSS vulnerability on certain error pages.
+- Fixed an XSS vulnerability related to file extensions for avatars. This change addresses [`CVE-2023-47115`](https://github.com/HumanSignal/label-studio/security/advisories/GHSA-q68h-xwq5-mm7x).
 
 ### Bug fixes
 

--- a/docs/source/guide/release_notes/onprem/2.9.0.md
+++ b/docs/source/guide/release_notes/onprem/2.9.0.md
@@ -24,7 +24,7 @@ hide_sidebar: true
 ### Security
 
 - Fixed an issue with HTML sanitization to address a vulnerability identified by CodeQL.
-
+- Addressed [`CVE-2024-23633`](https://github.com/HumanSignal/label-studio/security/advisories/GHSA-fq23-g58m-799r) by setting a `sandbox` CSP header on the `/data/upload/` endpoint. 
 
 ### Bug fixes
 


### PR DESCRIPTION
Updated 2.7.0 and 2.9.0 release notes with links to published CVEs. 

- [ ] Community docs
- [X] Enterprise docs
