### PR TITLE
docs: Replace `Label Studio Enterprise` with `LSE` in the table of content

### DIFF
--- a/docs/scripts/index.js
+++ b/docs/scripts/index.js
@@ -1,5 +1,7 @@
 var breadcrumb = require("./breadcrumb")(hexo);
 var removeContent = require("./removeContent")(hexo);
+var replaceContent = require("./replaceContent")(hexo);
 
 hexo.extend.helper.register("breadcrumb", breadcrumb, { async: true });
 hexo.extend.helper.register("removeContent", removeContent, { async: true });
+hexo.extend.helper.register("replaceContent", replaceContent, { async: true });

--- a/docs/scripts/replaceContent.js
+++ b/docs/scripts/replaceContent.js
@@ -1,0 +1,10 @@
+module.exports = function () {
+  return function includeTag(content) {
+    const replacedContent = content.replaceAll(
+      "Label Studio Enterprise",
+      "LSE"
+    );
+
+    return replacedContent;
+  };
+};

--- a/docs/themes/v2/layout/page.ejs
+++ b/docs/themes/v2/layout/page.ejs
@@ -4,6 +4,7 @@
 <% const showToc = pageContainsHeadings && tocPageTypes %>
 
 <% const formattedContent = removeContent(page.content) %>
+<% const tocContent = replaceContent(formattedContent) %>
 
 <div class="content-grid">
   <div class="content-markdown">
@@ -19,7 +20,7 @@
     <% if (showToc) { %>
       <div class="toc">
         <%- partial("component/text", {text: "In this article", tag: "h3", size: "Eyebrow"}) %>
-        <%- toc(formattedContent, {max_depth: 2, list_number: false, class: "toc-list"}) %>
+        <%- toc(tocContent, {max_depth: 2, list_number: false, class: "toc-list"}) %>
       </div>
     <% } %>
     <div class="toc-enterprise-cta">


### PR DESCRIPTION
 Replace `Label Studio Enterprise` with `LSE` in the table of content to make it easier to scan

https://deploy-preview-5360--heartex-docs.netlify.app/guide/release_notes