### PR TITLE
docs: DOC-181: Moved new helm chart section to LSE 2.3.1 section

### DIFF
--- a/docs/scripts/release-notes.js
+++ b/docs/scripts/release-notes.js
@@ -3,35 +3,20 @@ const concatMd = require("concat-md");
 
 hexo.extend.filter.register("after_init", async function () {
     const compareVersions = (a, b) => {
-        const [aMain, aSub] = a.split('-').map((part) => part.split('.').map(Number));
-        const [bMain, bSub] = b.split('-').map((part) => part.split('.').map(Number));
-
-        // Compare main version
-        for (let i = 0; i < Math.max(aMain.length, bMain.length); i++) {
-            const aVal = aMain[i] || 0;
-            const bVal = bMain[i] || 0;
-
-            if (aVal > bVal) return -1;
-            if (aVal < bVal) return 1;
+        const versionRegExp = /(?<x>\d+)?\.(?<y>\d+)?\.(?<z>\d+)?(\.dev|dev-|-)?(?<n>\d+)?/;
+        const aMatch = a.match(versionRegExp);
+        const bMatch = b.match(versionRegExp);
+        const toInt = (a, d) => a.groups[d]? a.groups[d] * 1 : 0;
+        for (let d of ['x', 'y', 'z', 'n']) {
+            const aMatchInt = toInt(aMatch, d);
+            const bMatchInt = toInt(bMatch, d);
+            if (aMatchInt === bMatchInt)
+                continue;
+            return bMatchInt - aMatchInt;
         }
-
-        // If main versions are equal, compare sub-versions
-        if (aSub && bSub) {
-            for (let i = 0; i < Math.max(aSub.length, bSub.length); i++) {
-                const aVal = aSub[i] || 0;
-                const bVal = bSub[i] || 0;
-
-                if (aVal > bVal) return -1;
-                if (aVal < bVal) return 1;
-            }
-        } else if (aSub) {
-            return -1;
-        } else if (bSub) {
-            return 1;
-        }
-
-        return 0;
+        return 0
     };
+
     const markdownFiles = await concatMd.default(
         "source/guide/release_notes/onprem", {sorter: compareVersions}
     );

--- a/docs/scripts/release-notes.js
+++ b/docs/scripts/release-notes.js
@@ -3,20 +3,35 @@ const concatMd = require("concat-md");
 
 hexo.extend.filter.register("after_init", async function () {
     const compareVersions = (a, b) => {
-        const versionRegExp = /(?<x>\d+)?\.(?<y>\d+)?\.(?<z>\d+)?(\.dev|dev-|-)?(?<n>\d+)?/;
-        const aMatch = a.match(versionRegExp);
-        const bMatch = b.match(versionRegExp);
-        const toInt = (a, d) => a.groups[d]? a.groups[d] * 1 : 0;
-        for (let d of ['x', 'y', 'z', 'n']) {
-            const aMatchInt = toInt(aMatch, d);
-            const bMatchInt = toInt(bMatch, d);
-            if (aMatchInt === bMatchInt)
-                continue;
-            return bMatchInt - aMatchInt;
-        }
-        return 0
-    };
+        const [aMain, aSub] = a.split('-').map((part) => part.split('.').map(Number));
+        const [bMain, bSub] = b.split('-').map((part) => part.split('.').map(Number));
 
+        // Compare main version
+        for (let i = 0; i < Math.max(aMain.length, bMain.length); i++) {
+            const aVal = aMain[i] || 0;
+            const bVal = bMain[i] || 0;
+
+            if (aVal > bVal) return -1;
+            if (aVal < bVal) return 1;
+        }
+
+        // If main versions are equal, compare sub-versions
+        if (aSub && bSub) {
+            for (let i = 0; i < Math.max(aSub.length, bSub.length); i++) {
+                const aVal = aSub[i] || 0;
+                const bVal = bSub[i] || 0;
+
+                if (aVal > bVal) return -1;
+                if (aVal < bVal) return 1;
+            }
+        } else if (aSub) {
+            return -1;
+        } else if (bSub) {
+            return 1;
+        }
+
+        return 0;
+    };
     const markdownFiles = await concatMd.default(
         "source/guide/release_notes/onprem", {sorter: compareVersions}
     );
@@ -40,14 +55,6 @@ meta_description: Review new features, enhancements, and bug fixes for on-premis
 
 !!! note 
     Before upgrading, review the steps outlined in [Upgrade Label Studio Enterprise](upgrade_enterprise) and ensure that you complete the recommended tests after each upgrade. 
-
-## New helm chart
-
-A common chart for LS and LSE has been released and is available as of LSE version 2.3.x. The chart can be accessed at the following repository: https://github.com/HumanSignal/charts/tree/master/heartex/label-studio.
-
-### Migration Process
-
-The migration process can be performed without any downtime. The steps required to carry out the migration are documented in the migration guide, available at: https://github.com/HumanSignal/charts/blob/master/heartex/label-studio/FAQs.md#label-studio-enterprise-upgrade-from-decommissioned-label-studio-enterprise-helm-chart.
 
 `;
 

--- a/docs/source/guide/release_notes/onprem/2.3.1.md
+++ b/docs/source/guide/release_notes/onprem/2.3.1.md
@@ -4,9 +4,17 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.3.1
 
-<div class="onprem-highlight">Multiple usability enhancements, including new Data Manager columns and the ability to duplicate projects</div>
+<div class="onprem-highlight">New helm chart, multiple usability enhancements, including new Data Manager columns and the ability to duplicate projects</div>
 
 This section highlights the breaking changes, new features and enhancements, and bug fixes in Label Studio Enterprise 2.3.1.
+
+### New helm chart
+
+A common chart for LS and LSE has been released and is available as of LSE version 2.3.x. The chart can be accessed at the following repository: https://github.com/HumanSignal/charts/tree/master/heartex/label-studio.
+
+#### Migration Process
+
+The migration process can be performed without any downtime. The steps required to carry out the migration are documented in the migration guide, available at: https://github.com/HumanSignal/charts/blob/master/heartex/label-studio/FAQs.md#label-studio-enterprise-upgrade-from-decommissioned-label-studio-enterprise-helm-chart.
 
 ### Breaking changes
 Label Studio Enterprise 2.3.1 includes the following breaking change:


### PR DESCRIPTION
The "New helm chart" section has been stickied to the top of the on-prem release notes. This PR moves it to the 2.3.1 release notes section. 

We are now adding the helm chart version and link in each new release note, so this no longer needs to be stickied to the top. 


- [ ] Community docs
- [X] Enterprise docs



