### PR TITLE
chore: LEAP-608: bump label-studio-converter version

### DIFF
--- a/label_studio/data_manager/views.py
+++ b/label_studio/data_manager/views.py
@@ -5,6 +5,8 @@ from core.version import get_short_version
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
 
+### todo(jo): delete this comment, just triggering follow merge
+
 
 @login_required
 def task_page(request, pk):

--- a/poetry.lock
+++ b/poetry.lock
@@ -1446,13 +1446,13 @@ testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)",
 
 [[package]]
 name = "label-studio-converter"
-version = "0.0.57"
+version = "0.0.58"
 description = "Format converter add-on for Label Studio"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "label-studio-converter-0.0.57.tar.gz", hash = "sha256:dee5dc1e75b9fc92b87747b05eaf843057e739391309d538fe91e0decacec698"},
-    {file = "label_studio_converter-0.0.57-py3-none-any.whl", hash = "sha256:375a9d299c81540df1ff0393d20295c87fd8c0d3fe1a5679e9991dab89e9e77c"},
+    {file = "label-studio-converter-0.0.58.tar.gz", hash = "sha256:027101d949c42daa630a1900b08185433b3fb45d36217e7b2c25267126c53ee4"},
+    {file = "label_studio_converter-0.0.58-py3-none-any.whl", hash = "sha256:c6f55ebe19498c4634da261675eca516e6089e4503fe36127393e60ee55ba525"},
 ]
 
 [package.dependencies]
@@ -2728,6 +2728,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -3609,4 +3610,4 @@ mysql = ["mysqlclient"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "d558e36c7b3d9359591d0a84d2d5d049419808e3b9792d633a8c98ce3d652ef5"
+content-hash = "5425d1a7fb8897a3409c85bdd797fdb8bb45fdf1e035f815d09aafb199b7a701"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,7 +195,7 @@ redis = "~=3.5"
 sentry-sdk = ">=1.1.0"
 launchdarkly-server-sdk = "7.5.0"
 python-json-logger = "2.0.4"
-label-studio-converter = "0.0.57"
+label-studio-converter = "0.0.58"
 google-cloud-storage = "^2.13.0"
 mysqlclient = {version = "*", optional = true}
 django-csp = "3.7"


### PR DESCRIPTION
Supersedes #5394. Adds a new version of LSC that will support JSON-MIN exports from projects that use Repeater