### PR TITLE
fix: LEAP-245: make Number tag complain about missing to_name

### DIFF
--- a/label_studio/core/utils/schema/label_config_schema.json
+++ b/label_studio/core/utils/schema/label_config_schema.json
@@ -35,6 +35,28 @@
         }
       }
     },
+    "tag_with_name_and_toname": {
+      "type": "object",
+      "oneOf": [
+        {
+          "required": [
+            "@name",
+            "@toName"
+          ]
+        }
+      ],
+      "properties": {
+        "@name": {
+          "$ref": "#/definitions/@name"
+        },
+        "@toName": {
+          "$ref": "#/definitions/@toName"
+        },
+        "$": {
+          "$ref": "#/definitions/$"
+        }
+      }
+    },
     "tag_with_value_required_name": {
       "type": "object",
       "oneOf": [
@@ -80,6 +102,13 @@
         "items": {"$ref": "#/definitions/tag_with_value_required_name"}
       }, {"$ref": "#/definitions/tag_with_value_required_name"}]
     },
+    "tags_with_name_and_toname": {
+      "anyOf": [{"$ref": "#/definitions/tag_with_name_and_toname"},
+        {
+          "type": "array",
+          "items": {"$ref": "#/definitions/tag_with_name_and_toname"}
+        }]
+    },
     "View": {
       "type": "object",
       "additionalProperties": true,
@@ -92,7 +121,8 @@
         "Text": {"$ref": "#/definitions/tags_with_value_required_name"},
         "HyperText": {"$ref": "#/definitions/tags_with_value_required_name"},
         "View": {"$ref": "#/definitions/MaybeMultipleView"},
-        "TextArea": {"$ref": "#/definitions/MaybeMultipleTextAreas"}
+        "TextArea": {"$ref": "#/definitions/MaybeMultipleTextAreas"},
+        "Number": {"$ref": "#/definitions/tags_with_name_and_toname"}
       }
     },
     "MaybeMultipleView": {
@@ -219,7 +249,8 @@
         "Image": {"$ref": "#/definitions/tags_with_value_required_name"},
         "Text": {"$ref": "#/definitions/tags_with_value_required_name"},
         "HyperText": {"$ref": "#/definitions/tags_with_value_required_name"},
-        "TextArea": {"$ref": "#/definitions/MaybeMultipleTextAreas"}
+        "TextArea": {"$ref": "#/definitions/MaybeMultipleTextAreas"},
+        "Number": {"$ref": "#/definitions/tags_with_name_and_toname"}
       }
     }
   }

--- a/label_studio/tests/test_config_validation.py
+++ b/label_studio/tests/test_config_validation.py
@@ -161,6 +161,28 @@ def test_config_validation_for_choices_workaround(business_client, project_id):
 
 
 @pytest.mark.django_db
+def test_config_validation_for_missing_to_name_in_number_tag_fails(business_client, project_id):
+    """
+    Validate Choices tag for 1 choice with workaround
+    Example bug DEV-3635
+    """
+    payload = {
+        'label_config': (
+            '<View>'
+            '<Text name="question" value="$question" granularity="word"/>'
+            '<Number name="number" to="question" required="true" />'
+            '</View>'
+        )
+    }
+    response = business_client.patch(
+        f'/api/projects/{project_id}',
+        data=json.dumps(payload),
+        content_type='application/json',
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
 def test_parse_wrong_xml(business_client, project_id):
     # Change label config to Repeater
     payload = {

--- a/label_studio/tests/test_config_validation.py
+++ b/label_studio/tests/test_config_validation.py
@@ -180,7 +180,7 @@ def test_config_validation_for_missing_to_name_in_number_tag_fails(business_clie
     )
     assert response.status_code == 400
     response_data = response.json()
-    assert '!!! TODO: put correct error message for missing to_name here !!!' in response_data['detail']
+    assert "'toName' is a required property" in response_data['validation_errors']['label_config'][0]
 
 
 @pytest.mark.django_db

--- a/label_studio/tests/test_config_validation.py
+++ b/label_studio/tests/test_config_validation.py
@@ -163,15 +163,14 @@ def test_config_validation_for_choices_workaround(business_client, project_id):
 @pytest.mark.django_db
 def test_config_validation_for_missing_to_name_in_number_tag_fails(business_client, project_id):
     """
-    Validate Choices tag for 1 choice with workaround
-    Example bug DEV-3635
+    Validate Number tag with missing to_name fails (see LEAP-245)
     """
     payload = {
         'label_config': (
             '<View>'
             '<Text name="question" value="$question" granularity="word"/>'
             '<Number name="number" to="question" required="true" />'
-            '</View>'
+            '</Vii>'
         )
     }
     response = business_client.patch(
@@ -180,6 +179,8 @@ def test_config_validation_for_missing_to_name_in_number_tag_fails(business_clie
         content_type='application/json',
     )
     assert response.status_code == 400
+    response_data = response.json()
+    assert '!!! TODO: put correct error message for missing to_name here !!!' in response_data['detail']
 
 
 @pytest.mark.django_db

--- a/label_studio/tests/test_config_validation.py
+++ b/label_studio/tests/test_config_validation.py
@@ -170,7 +170,7 @@ def test_config_validation_for_missing_to_name_in_number_tag_fails(business_clie
             '<View>'
             '<Text name="question" value="$question" granularity="word"/>'
             '<Number name="number" to="question" required="true" />'
-            '</Vii>'
+            '</View>'
         )
     }
     response = business_client.patch(


### PR DESCRIPTION
`<Number/>` tag didn't throw validation error if there is missing property of `toName`.

### PR fulfills these requirements
- [x] Tests for the changes have been added/updated
- [ ] Docs have been added/updated
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance

### This change affects (describe how if yes)
- [ ] Performance
- [ ] Security
- [ ] UX

### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
- [ ] e2e (codecept)
- [ ] integration (cypress)
- [ ] unit (jest)
- [x] python!

### Which logical domain(s) does this change affect?
`Config Validation`, `Number`, `Labeling Interface`, `Creating Project`
