### PR TITLE
fix: LEAP-660: Fix prefixed external CSS

### DIFF
--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -145,7 +145,7 @@ module.exports = composePlugins(withNx({
       });
     }
 
-    if (rule.test.toString().match(/css|scss|sass|styl/)) {
+    if (rule.test.toString().match(/scss|sass|styl/)) {
       const r = rule.oneOf.filter((r) => r.use && r.use.find((u) => u.loader && u.loader.includes('css-loader')));
 
       r.forEach((_r) => {


### PR DESCRIPTION
All external CSS files got prefixed because of change to loaders. Remove `css` from filter.
