### PR TITLE
fix: Add missing ending quotation mark in href

### DIFF
--- a/label_studio/data_manager/actions/basic.py
+++ b/label_studio/data_manager/actions/basic.py
@@ -141,7 +141,7 @@ actions = [
             'text': 'Send the selected tasks to all ML backends connected to the project.'
             'This operation might be abruptly interrupted due to a timeout. '
             'The recommended way to get predictions is to update tasks using the Label Studio API.'
-            '<a href="https://labelstud.io/guide/ml.html>See more in the documentation</a>.'
+            '<a href="https://labelstud.io/guide/ml.html">See more in the documentation</a>.'
             'Please confirm your action.',
             'type': 'confirm',
         },

--- a/label_studio/ml/serializers.py
+++ b/label_studio/ml/serializers.py
@@ -20,7 +20,7 @@ class MLBackendSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(
                 f"Can't connect to ML backend {url}, health check failed. "
                 f'Make sure it is up and your firewall is properly configured. '
-                f'<a href="https://labelstud.io/guide/ml.html>Learn more</a>'
+                f'<a href="https://labelstud.io/guide/ml.html">Learn more</a>'
                 f' about how to set up an ML backend. Additional info:' + healthcheck_response.error_message
             )
         project = attrs['project']


### PR DESCRIPTION
#### Change has impacts in these area(s)
- [x] Frontend

### Describe the reason for change
Missing ending quotation mark caused misrendering of messages in user interface.
![image](https://github.com/HumanSignal/label-studio/assets/8211411/5e7a78af-28a2-4759-8ea0-2c0b1c36a2b5)

#### Does this change affect performance?
No

#### Does this change affect security?
No

### Does this PR introduce a breaking change?
- [x] No