### PR TITLE
feat: LEAP-818: Add X-Api-Key support

### DIFF
--- a/label_studio/core/middleware.py
+++ b/label_studio/core/middleware.py
@@ -159,23 +159,6 @@ class DatabaseIsLockedRetryMiddleware(CommonMiddleware):
         return response
 
 
-class SimpleMiddleware:
-    def __init__(self, get_response):
-        self.get_response = get_response
-        # One-time configuration and initialization.
-
-    def __call__(self, request):
-        # Code to be executed for each request before
-        # the view (and later middleware) are called.
-
-        response = self.get_response(request)
-
-        # Code to be executed for each request/response after
-        # the view is called.
-
-        return response
-
-
 class XApiKeySupportMiddleware:
     """Middleware that adds support for the X-Api-Key header, by having its value supersede
     anything that's set in the Authorization header."""

--- a/label_studio/core/middleware.py
+++ b/label_studio/core/middleware.py
@@ -159,7 +159,7 @@ class DatabaseIsLockedRetryMiddleware(CommonMiddleware):
         return response
 
 
-class XApiKeySupportMiddleware(CommonMiddleware):
+class XApiKeySupportMiddleware(MiddlewareMixin):
     """Middleware that adds support for the X-Api-Key header, by having its value supersede
     anything that's set in the Authorization header."""
 

--- a/label_studio/core/middleware.py
+++ b/label_studio/core/middleware.py
@@ -159,15 +159,36 @@ class DatabaseIsLockedRetryMiddleware(CommonMiddleware):
         return response
 
 
-class XApiKeySupportMiddleware(MiddlewareMixin):
+class SimpleMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+        # One-time configuration and initialization.
+
+    def __call__(self, request):
+        # Code to be executed for each request before
+        # the view (and later middleware) are called.
+
+        response = self.get_response(request)
+
+        # Code to be executed for each request/response after
+        # the view is called.
+
+        return response
+
+
+class XApiKeySupportMiddleware:
     """Middleware that adds support for the X-Api-Key header, by having its value supersede
     anything that's set in the Authorization header."""
 
-    def process_request(self, request):
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
         if 'HTTP_X_API_KEY' in request.META:
             request.META['HTTP_AUTHORIZATION'] = f'Token {request.META["HTTP_X_API_KEY"]}'
             del request.META['HTTP_X_API_KEY']
-        return super().process_request(request)
+
+        return self.get_response(request)
 
 
 class UpdateLastActivityMiddleware(CommonMiddleware):

--- a/label_studio/core/middleware.py
+++ b/label_studio/core/middleware.py
@@ -159,6 +159,17 @@ class DatabaseIsLockedRetryMiddleware(CommonMiddleware):
         return response
 
 
+class XApiKeySupportMiddleware(CommonMiddleware):
+    """Middleware that adds support for the X-Api-Key header, by having its value supersede
+    anything that's set in the Authorization header."""
+
+    def process_request(self, request):
+        if 'HTTP_X_API_KEY' in request.META:
+            request.META['HTTP_AUTHORIZATION'] = f'Token {request.META["HTTP_X_API_KEY"]}'
+            del request.META['HTTP_X_API_KEY']
+        return super().process_request(request)
+
+
 class UpdateLastActivityMiddleware(CommonMiddleware):
     def process_view(self, request, view_func, view_args, view_kwargs):
         if hasattr(request, 'user') and request.method not in SAFE_METHODS:

--- a/label_studio/core/settings/base.py
+++ b/label_studio/core/settings/base.py
@@ -232,6 +232,7 @@ MIDDLEWARE = [
     'django.middleware.locale.LocaleMiddleware',
     'core.middleware.DisableCSRF',
     'django.middleware.csrf.CsrfViewMiddleware',
+    'core.middleware.XApiKeySupportMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'core.middleware.CommonMiddlewareAppendSlashWithoutRedirect',  # instead of 'CommonMiddleware'

--- a/label_studio/tests/test_api.py
+++ b/label_studio/tests/test_api.py
@@ -33,6 +33,7 @@ def any_api_client(request, client_and_token, business_client):
     return result
 
 
+@pytest.mark.parametrize('use_x_api_key', [True, False])
 @pytest.mark.parametrize(
     'payload, response, status_code',
     [
@@ -68,8 +69,12 @@ def any_api_client(request, client_and_token, business_client):
     ],
 )
 @pytest.mark.django_db
-def test_create_project(client_and_token, payload, response, status_code):
+def test_create_project(client_and_token, payload, response, status_code, use_x_api_key):
     client, token = client_and_token
+
+    if use_x_api_key:
+        client.credentials(HTTP_X_API_KEY=token.key)
+
     payload['organization_pk'] = client.organization_pk
     with ml_backend_mock():
         r = client.post(


### PR DESCRIPTION
If X-API-Key header is specified with `<token>`, overwrite the `Authorization` header with `Token <token>`.

Resolves https://github.com/HumanSignal/label-studio/issues/3349

```
~/Repos/label-studio on  fb-LEAP-818/x-api-key [$?]
❯ curl -X GET http://localhost:8080/api/projects/ -H 'X-API-Key: [redacted]'
{"count":27,"next":null,"previous":null,"results":[...]}
```

`HttpRequest.META` documentation for reference: https://docs.djangoproject.com/en/5.0/ref/request-response/#django.http.HttpRequest.META