### PR TITLE
fix: OPTIC-553: Import fails when user.active_organization is None

### DIFF
--- a/label_studio/tasks/serializers.py
+++ b/label_studio/tasks/serializers.py
@@ -314,11 +314,7 @@ class BaseTaskSerializerBulk(serializers.ListSerializer):
         ff_user = self.project.organization.created_by
 
         # get members from project, we need them to restore annotation.completed_by etc
-        organization = (
-            user.active_organization
-            if not self.project.created_by.active_organization
-            else self.project.created_by.active_organization
-        )
+        organization = self.project.organization
         members_email_to_id = dict(organization.members.values_list('user__email', 'user__id'))
         members_ids = set(members_email_to_id.values())
         logger.debug(f'{len(members_email_to_id)} members found in organization {organization}')


### PR DESCRIPTION
This PR fixes a minor bug when 
1. project.created_by.active_organization is None (pretty rare case). 
2. request.user is None (in rq workers it's always None). 
3. the line in the code where this problem happens can **lead to very bad consequences - another organization might be taken instead of the real organization** where the project is created.

The PR makes code more clear and remove "bad-excess" lines of code. 