### PR TITLE
fix: LEAP-508: Add `rel=noopener` to external links

### DIFF
--- a/web/apps/labelstudio/src/components/Menubar/Menubar.js
+++ b/web/apps/labelstudio/src/components/Menubar/Menubar.js
@@ -227,18 +227,21 @@ export const Menubar = ({
                   href="https://labelstud.io/guide"
                   icon={<IconBook/>}
                   target="_blank"
+                  rel="noopener"
                 />
                 <Menu.Item
                   label="GitHub"
                   href="https://github.com/heartexlabs/label-studio"
                   icon={<LsGitHub/>}
                   target="_blank"
+                  rel="noopener"
                 />
                 <Menu.Item
                   label="Slack Community"
                   href="https://slack.labelstud.io/?source=product-menu"
                   icon={<LsSlack/>}
                   target="_blank"
+                  rel="noopener"
                 />
 
                 <VersionNotifier showCurrentVersion/>

--- a/web/apps/labelstudio/src/components/VersionNotifier/VersionNotifier.js
+++ b/web/apps/labelstudio/src/components/VersionNotifier/VersionNotifier.js
@@ -52,7 +52,7 @@ export const VersionNotifier = ({ showNewVersion, showCurrentVersion }) => {
 
   return (newVersion && showNewVersion) ? (
     <Block tag="li" name="version-notifier">
-      <a href={url} target="_blank">
+      <a href={url} target="_blank" rel="noopener">
         <Elem name="icon">
           <IconBell/>
         </Elem>

--- a/web/apps/labelstudio/src/pages/CreateProject/Config/Config.js
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/Config.js
@@ -29,7 +29,7 @@ const EmptyConfigPlaceholder = () => (
     <p>Your labeling configuration is empty. It is required to label your data.</p>
     <p>
       Start from one of our predefined templates or create your own config on the Code panel.
-      The labeling config is XML-based and you can <a href="https://labelstud.io/tags/" target="_blank">read about the available tags in our documentation</a>.
+      The labeling config is XML-based and you can <a href="https://labelstud.io/tags/" target="_blank" rel="noopener">read about the available tags in our documentation</a>.
     </p>
   </div>
 );
@@ -408,7 +408,7 @@ const Configurator = ({ columns, config, project, template, setTemplate, onBrows
     <p className={configClass.elem('tags-link')}>
       Configure the labeling interface with tags.
       <br/>
-      <a href="https://labelstud.io/tags/" target="_blank">See all available tags</a>
+      <a href="https://labelstud.io/tags/" target="_blank" rel="noopener">See all available tags</a>
       .
     </p>
   );

--- a/web/apps/labelstudio/src/pages/CreateProject/Config/TemplatesList.js
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/TemplatesList.js
@@ -79,7 +79,7 @@ export const TemplatesList = ({ selectedGroup, selectedRecipe, onCustomTemplate,
       </main>
       <footer>
         <IconInfo className={listClass.elem("info-icon")} width="20" height="20" />
-        See the documentation to <a href="https://labelstud.io/guide" target="_blank">contribute a template</a>.
+        See the documentation to <a href="https://labelstud.io/guide" target="_blank" rel="noopener">contribute a template</a>.
       </footer>
     </div>
   );

--- a/web/apps/labelstudio/src/pages/CreateProject/CreateProject.js
+++ b/web/apps/labelstudio/src/pages/CreateProject/CreateProject.js
@@ -45,10 +45,13 @@ const ProjectName = ({ name, setName, onSaveName, onSubmit, error, description, 
         <Select placeholder="Select an option" disabled options={[]} />
         <Caption>
           Simplify project management by organizing projects into workspaces.
-          <a href={createURL('https://docs.humansignal.com/guide/manage_projects#Create-workspaces-to-organize-projects', {
-          experiment: "project_creation_dropdown",
-          treatment: "simplify_project_management",
-        })} target="_blank">Learn more</a>
+          <a href={createURL(
+            'https://docs.humansignal.com/guide/manage_projects#Create-workspaces-to-organize-projects',
+            {
+              experiment: "project_creation_dropdown",
+              treatment: "simplify_project_management",
+            },
+          )} target="_blank" rel="noopener">Learn more</a>
         </Caption>
         <HeidiTips collection="projectCreation" />
       </div>

--- a/web/apps/labelstudio/src/pages/CreateProject/Import/Import.js
+++ b/web/apps/labelstudio/src/pages/CreateProject/Import/Import.js
@@ -75,8 +75,8 @@ const Footer = () => {
   return (
     <Modal.Footer>
       <IconInfo className={importClass.elem("info-icon")} width="20" height="20" />
-      See the&nbsp;documentation to <a target="_blank" href="https://labelstud.io/guide/predictions.html">import preannotated data</a>{" "}
-      or&nbsp;to <a target="_blank" href="https://labelstud.io/guide/storage.html">sync data from a&nbsp;database or&nbsp;cloud storage</a>.
+      See the&nbsp;documentation to <a target="_blank" href="https://labelstud.io/guide/predictions.html" rel="noopener">import preannotated data</a>{" "}
+      or&nbsp;to <a target="_blank" href="https://labelstud.io/guide/storage.html" rel="noopener">sync data from a&nbsp;database or&nbsp;cloud storage</a>.
     </Modal.Footer>
   );
 };
@@ -343,7 +343,7 @@ export const ImportPage = ({
                 </dl>
                 <b>
                    * – Support depends on the browser<br/>
-                   * – Use <a href="https://labelstud.io/guide/storage.html" target="_blank">
+                   * – Use <a href="https://labelstud.io/guide/storage.html" target="_blank" rel="noopener">
                   Cloud Storages</a> if you want to import a large number of files
                 </b>
               </div>

--- a/web/apps/labelstudio/src/pages/ExportPage/ExportPage.js
+++ b/web/apps/labelstudio/src/pages/ExportPage/ExportPage.js
@@ -235,7 +235,7 @@ const FormatInfo = ({ availableFormats, selected, onClick }) => {
       <Elem name="feedback">
         Can't find an export format?
         <br/>
-        Please let us know in <a className="no-go" href="https://slack.labelstud.io/?source=product-export">Slack</a> or submit an issue to the <a className="no-go" href="https://github.com/heartexlabs/label-studio-converter/issues">Repository</a>
+        Please let us know in <a className="no-go" href="https://slack.labelstud.io/?source=product-export" rel="noopener">Slack</a> or submit an issue to the <a className="no-go" href="https://github.com/heartexlabs/label-studio-converter/issues" rel="noopener">Repository</a>
       </Elem>
     </Block>
   );

--- a/web/apps/labelstudio/src/pages/Organization/PeoplePage/PeoplePage.js
+++ b/web/apps/labelstudio/src/pages/Organization/PeoplePage/PeoplePage.js
@@ -26,7 +26,7 @@ const InvitationModal = ({ link }) => {
       />
 
       <Description style={{ width: '70%', marginTop: 16 }}>
-        Invite people to join your Label Studio instance. People that you invite have full access to all of your projects. <a href="https://labelstud.io/guide/signup.html">Learn more</a>.
+        Invite people to join your Label Studio instance. People that you invite have full access to all of your projects. <a href="https://labelstud.io/guide/signup.html" target="_blank" rel="noopener">Learn more</a>.
       </Description>
     </Block>
   );

--- a/web/apps/labelstudio/src/pages/Settings/GeneralSettings.js
+++ b/web/apps/labelstudio/src/pages/Settings/GeneralSettings.js
@@ -64,10 +64,15 @@ export const GeneralSettings = () => {
                 </Elem>
                 <Select placeholder="Select an option" disabled options={[]} />
                 <Caption>
-                  Simplify project management by organizing projects into workspaces. <a target="_blank" href={createURL("https://docs.humansignal.com/guide/manage_projects#Create-workspaces-to-organize-projects", {
-                  experiment: 'project_settings_tip',
-                  treatment: 'simplify_project_management',
-                })}>Learn more</a>
+                  Simplify project management by organizing projects into workspaces.
+                  {" "}
+                  <a target="_blank" rel="noopener" href={createURL(
+                    "https://docs.humansignal.com/guide/manage_projects#Create-workspaces-to-organize-projects",
+                    {
+                      experiment: 'project_settings_tip',
+                      treatment: 'simplify_project_management',
+                    },
+                  )}>Learn more</a>
                 </Caption>
               </Block>
             )}
@@ -96,10 +101,15 @@ export const GeneralSettings = () => {
                   disabled
                   description={(
                     <>
-                      Tasks are chosen according to model uncertainty score (active learning mode). <a target="_blank" href={createURL("https://docs.humansignal.com/guide/active_learning", {
-                      experiment: 'project_settings_workspace',
-                      treatment: 'workspaces',
-                    })}>Learn more</a>
+                      Tasks are chosen according to model uncertainty score (active learning mode).
+                      {" "}
+                      <a target="_blank" rel="noopener" href={createURL(
+                        "https://docs.humansignal.com/guide/active_learning",
+                        {
+                          experiment: 'project_settings_workspace',
+                          treatment: 'workspaces',
+                        },
+                      )}>Learn more</a>
                     </>
                   )}
                 />

--- a/web/apps/labelstudio/src/pages/Settings/MachineLearningSettings/MachineLearningSettings.js
+++ b/web/apps/labelstudio/src/pages/Settings/MachineLearningSettings/MachineLearningSettings.js
@@ -129,9 +129,10 @@ export const MachineLearningSettings = () => {
         Add one or more machine learning models to predict labels for your data.
         To import predictions without connecting a model,
         {" "}
-        <a href="https://labelstud.io/guide/predictions.html" target="_blank">
+        <a href="https://labelstud.io/guide/predictions.html" target="_blank" rel="noopener">
           see the documentation
-        </a>.
+        </a>
+        .
       </Description>
       <Button onClick={() => showMLFormModal()}>
         Add Model

--- a/web/apps/labelstudio/src/pages/Settings/StorageSettings/StorageSet.js
+++ b/web/apps/labelstudio/src/pages/Settings/StorageSettings/StorageSet.js
@@ -81,7 +81,10 @@ export const StorageSet = ({title, target, rootClass, buttonLabel}) => {
         <>
           Save completed annotations to Amazon S3, Google Cloud, Microsoft Azure, or Redis.
           <br/>
-          <a href="https://labelstud.io/guide/storage.html">See more in the documentation</a>.
+          <a href="https://labelstud.io/guide/storage.html" target="_blank" rel="noopener">
+            See more in the documentation
+          </a>
+          .
         </>
       ),
     });

--- a/web/apps/labelstudio/src/pages/Settings/StorageSettings/StorageSummary.js
+++ b/web/apps/labelstudio/src/pages/Settings/StorageSettings/StorageSummary.js
@@ -42,11 +42,21 @@ export const StorageSummary = ({ target, storage, className, storageTypes = [] }
             navigator.clipboard.writeText(msg);
           }}>Copy</Button>
           {(target === 'export' ? (
-            <a style={{ float: "right" }} target="_blank" href="https://labelstud.io/guide/storage.html#Target-storage-permissions">
+            <a
+              style={{ float: "right" }}
+              target="_blank"
+              href="https://labelstud.io/guide/storage.html#Target-storage-permissions"
+              rel="noopener"
+            >
               Check Target Storage documentation
             </a>
           ) : (
-            <a style={{ float: "right" }} target="_blank" href="https://labelstud.io/guide/storage.html#Source-storage-permissions">
+            <a
+              style={{ float: "right" }}
+              target="_blank"
+              href="https://labelstud.io/guide/storage.html#Source-storage-permissions"
+              rel="noopener"
+            >
               Check Source Storage documentation
             </a>
           ))}

--- a/web/apps/labelstudio/src/pages/WebhookPage/WebhookPage.js
+++ b/web/apps/labelstudio/src/pages/WebhookPage/WebhookPage.js
@@ -126,7 +126,10 @@ const Webhook = () => {
         When the specified events occur, a POST request is sent to each of the URLs you provide.
           </p>
           <p>
-            <a href="https://labelstud.io/guide/webhooks.html">Read more in the documentation</a>.
+            <a href="https://labelstud.io/guide/webhooks.html" target="_blank" rel="noopener">
+              Read more in the documentation
+            </a>
+            .
           </p>
         </Elem>
       </Elem>

--- a/web/libs/editor/src/tags/object/TimeSeries.js
+++ b/web/libs/editor/src/tags/object/TimeSeries.js
@@ -192,7 +192,7 @@ const Model = types
             throw new Error([
               `<b>timeColumn</b> (${self.timecolumn}) must be incremental and sequentially ordered.`,
               `First wrong values: ${nonSeqValues.join(', ')}`,
-              `<br/><a href="${getEnv(self).messages.URL_TAGS_DOCS}/timeseries.html" target="_blank">Read Documentation</a> for details.`,
+              `<br/><a href="${getEnv(self).messages.URL_TAGS_DOCS}/timeseries.html" target="_blank" rel="noopener">Read Documentation</a> for details.`,
             ].join('<br/>'));
           }
 
@@ -211,7 +211,7 @@ const Model = types
             message.push('You have to use <b>timeFormat</b> parameter if your values are datetimes.');
           }
           message.push(
-            `<br/><a href="${getEnv(self).messages.URL_TAGS_DOCS}/timeseries.html#Parameters" target="_blank">Read Documentation</a> for details.`,
+            `<br/><a href="${getEnv(self).messages.URL_TAGS_DOCS}/timeseries.html#Parameters" target="_blank" rel="noopener">Read Documentation</a> for details.`,
           );
           throw new Error(message.join('<br/>'));
         }

--- a/web/libs/editor/src/utils/messages.js
+++ b/web/libs/editor/src/utils/messages.js
@@ -71,7 +71,7 @@ export default {
         The request parameters are invalid.
         If you are using S3, make sure you’ve specified the right bucket region name.
       </p>
-      <p>URL: <code><a href="${encodeURI(url)}" target="_blank">${htmlEscape(url)}</a></code></p>
+      <p>URL: <code><a href="${encodeURI(url)}" target="_blank" rel="noopener">${htmlEscape(url)}</a></code></p>
     </div>`;
   },
 
@@ -81,7 +81,7 @@ export default {
       <p>
         There was an issue loading URL from <code>${attr}</code> value.
         Most likely that's because static server has wide-open CORS.
-        <a href="${this.URL_CORS_DOCS}" target="_blank">Read more on that here.</a>
+        <a href="${this.URL_CORS_DOCS}" target="_blank" rel="noopener">Read more on that here.</a>
       </p>
       <p>
         Also check that:
@@ -90,7 +90,7 @@ export default {
           <li>Network is reachable</li>
         </ul>
       </p>
-      <p>URL: <code><a href="${encodeURI(url)}" target="_blank">${htmlEscape(url)}</a></code></p>
+      <p>URL: <code><a href="${encodeURI(url)}" target="_blank" rel="noopener">${htmlEscape(url)}</a></code></p>
     </div>`;
   },
 
@@ -107,14 +107,14 @@ export default {
           <li>URL scheme matches the service scheme, i.e. https and https</li>
           <li>
             The static server has wide-open CORS,
-            <a href=${this.URL_CORS_DOCS} target="_blank">more on that here</a>
+            <a href=${this.URL_CORS_DOCS} target="_blank" rel="noopener">more on that here</a>
           </li>
         </ul>
       </p>
       <p>
         Technical description: <code>${error}</code>
         <br />
-        URL: <code><a href="${encodeURI(url)}" target="_blank">${htmlEscape(url)}</a></code>
+        URL: <code><a href="${encodeURI(url)}" target="_blank" rel="noopener">${htmlEscape(url)}</a></code>
       </p>
     </div>`;
   },


### PR DESCRIPTION
HTML links that open in a new tab or window allow the target page to access the DOM of the origin page using window.opener unless link type noopener or noreferrer is specified. This is a potential security risk. Our links lead to slack, github or our docs, but that's a good practice to use `noopener` anyway. We need referrer for analytics in some places, so `noreferrer` is not a choice.

This fixes https://github.com/HumanSignal/label-studio/security/code-scanning/769 and possible similar security issues.


### PR fulfills these requirements
- [ ] Tests for the changes have been added/updated
- [ ] Docs have been added/updated
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance

### This change affects (describe how if yes)
- [ ] Performance
- [x] Security
- [x] UX — some external links are opened in new tab now

### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)
