### PR TITLE
fix: OPTIC-572: The Retrieve Predictions modal is not formatted properly

### DIFF
--- a/label_studio/data_manager/actions/basic.py
+++ b/label_studio/data_manager/actions/basic.py
@@ -142,7 +142,6 @@ actions = [
             'text': 'Send the selected tasks to all ML backends connected to the project.'
             'This operation might be abruptly interrupted due to a timeout. '
             'The recommended way to get predictions is to update tasks using the Label Studio API.'
-            '<a href="https://labelstud.io/guide/ml.html">See more in the documentation</a>.'
             'Please confirm your action.',
             'type': 'confirm',
         },


### PR DESCRIPTION
The current model does not support HTML code. 
Also, the link seems tailored to LSO.

@niklub 