### PR TITLE
fix: OPTIC-574: Inconsistent behavior on Create Annotations From Predictions

### DIFF
--- a/label_studio/data_manager/actions/predictions_to_annotations.py
+++ b/label_studio/data_manager/actions/predictions_to_annotations.py
@@ -65,8 +65,9 @@ def predictions_to_annotations_form(user, project):
     versions = project.get_model_versions()
 
     # put the current model version on the top of the list
+    # if it exists
     first = project.model_version
-    if first is not None:
+    if first:
         try:
             versions.remove(first)
         except ValueError:

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -931,7 +931,7 @@ class Project(ProjectMixin, models.Model):
             output = {r['model_version']: r['count'] for r in model_versions}
 
             # Ensure that self.model_version exists in output
-            if self.model_version is not None and self.model_version not in output:
+            if self.model_version and self.model_version not in output:
                 output[self.model_version] = 0
 
             # Return as per requirement

--- a/label_studio/tests/data_manager/actions/test_predictions_to_annotations.py
+++ b/label_studio/tests/data_manager/actions/test_predictions_to_annotations.py
@@ -1,0 +1,34 @@
+import mock
+from data_manager.actions.predictions_to_annotations import predictions_to_annotations_form
+from users.models import User
+from projects.models import Project
+
+
+def test_predictions_to_annotations_form():
+    project = Project()
+    user = User()
+
+    with mock.patch('projects.models.Project.get_model_versions') as mock_get_model_versions:
+        project.model_version = ''
+        mock_get_model_versions.return_value = ['undefined']
+        assert predictions_to_annotations_form(user, project)[0]['fields'][0]['options'] == ['undefined']
+
+        project.model_version = None
+        mock_get_model_versions.return_value = ['undefined']
+        assert predictions_to_annotations_form(user, project)[0]['fields'][0]['options'] == ['undefined']
+
+        project.model_version = 'undefined'
+        mock_get_model_versions.return_value = ['undefined']
+        assert predictions_to_annotations_form(user, project)[0]['fields'][0]['options'] == ['undefined']
+
+        project.model_version = ''
+        mock_get_model_versions.return_value = []
+        assert predictions_to_annotations_form(user, project)[0]['fields'][0]['options'] == []
+
+        project.model_version = None
+        mock_get_model_versions.return_value = []
+        assert predictions_to_annotations_form(user, project)[0]['fields'][0]['options'] == []
+
+        project.model_version = 'undefined'
+        mock_get_model_versions.return_value = []
+        assert predictions_to_annotations_form(user, project)[0]['fields'][0]['options'] == ['undefined']

--- a/label_studio/tests/data_manager/actions/test_predictions_to_annotations.py
+++ b/label_studio/tests/data_manager/actions/test_predictions_to_annotations.py
@@ -1,7 +1,7 @@
 import mock
 from data_manager.actions.predictions_to_annotations import predictions_to_annotations_form
-from users.models import User
 from projects.models import Project
+from users.models import User
 
 
 def test_predictions_to_annotations_form():


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [X] Backend (API)
- [ ] Frontend



### Describe the reason for change
With the changes to ML Backends, the logic in the retrieval of model versions caused a workflow regression in DataManager. The reason was because the default value of a project model version is an empty string, and all subsequent checks on retrieval of the model versions were considering strictly None to represent the absence. This fix loosens the checks to look for falsey/truthy instead which fixes the observed regressions.



### Which logical domain(s) does this change affect?
Predictions, ModelVersions, DataManager

