### PR TITLE
fix: OPTIC-514: Dashboards page crashes when opened on project with no imported tasks

### DIFF
--- a/label_studio/data_manager/managers.py
+++ b/label_studio/data_manager/managers.py
@@ -517,7 +517,7 @@ def newest_annotation_subquery():
 
 def base_annotate_completed_at(queryset):
     newest = newest_annotation_subquery()
-    return queryset.annotate(completed_at=Subquery(newest.values('created_at')))
+    return queryset.annotate(completed_at=Case(When(is_labeled=True, then=Subquery(newest.values('created_at')))))
 
 
 def annotate_completed_at(queryset):
@@ -538,9 +538,7 @@ def annotated_completed_at_considering_agreement_threshold(queryset):
     LseProject = load_func(settings.LSE_PROJECT)
     get_tasks_agreement_queryset = load_func(settings.GET_TASKS_AGREEMENT_QUERYSET)
 
-    project_id = None
-    if queryset.project is not None:
-        project_id = queryset.project.id
+    project_id = queryset[0].project_id
 
     lse_project = LseProject.objects.filter(project_id=project_id).first() if LseProject and project_id else None
     agreement_threshold = lse_project.agreement_threshold if lse_project else None

--- a/label_studio/data_manager/managers.py
+++ b/label_studio/data_manager/managers.py
@@ -509,45 +509,47 @@ class GroupConcat(Aggregate):
         super().__init__(expression, distinct='DISTINCT ' if distinct else '', output_field=output_field, **extra)
 
 
+def newest_annotation_subquery():
+    from tasks.models import Annotation
+
+    return Annotation.objects.filter(task=OuterRef('pk')).order_by('-id')[:1]
+
+
+def base_annotate_completed_at(queryset):
+    newest = newest_annotation_subquery()
+    return queryset.annotate(completed_at=Subquery(newest.values('created_at')))
+
+
 def annotate_completed_at(queryset):
-    if flag_set('fflag_feat_optic_161_project_settings_for_low_agreement_threshold_score_short', user='auto'):
-        return annotated_completed_at_considering_agreement_threshold(queryset)
-
-    from tasks.models import Annotation
-
-    newest = Annotation.objects.filter(task=OuterRef('pk')).order_by('-id')[:1]
-    return queryset.annotate(completed_at=Case(When(is_labeled=True, then=Subquery(newest.values('created_at')))))
-
-
-def annotated_completed_at_considering_agreement_threshold(queryset):
-    from tasks.models import Annotation
-
     LseProject = load_func(settings.LSE_PROJECT)
     get_tasks_agreement_queryset = load_func(settings.GET_TASKS_AGREEMENT_QUERYSET)
 
-    if not queryset.exists():
-        # No tasks to annotate. Quit early
-        return queryset
+    if (
+        get_tasks_agreement_queryset
+        and LseProject
+        and flag_set('fflag_feat_optic_161_project_settings_for_low_agreement_threshold_score_short', user='auto')
+    ):
+        return annotated_completed_at_considering_agreement_threshold(queryset)
 
-    project_id = queryset[0].project_id
+    return base_annotate_completed_at(queryset)
 
-    newest_annotation = Annotation.objects.filter(task=OuterRef('pk')).order_by('-id')[:1]
 
-    if not LseProject:
-        # Not LSE so there will not be agreement_threshold-based task completeness
-        return queryset.annotate(
-            completed_at=Case(When(is_labeled=True, then=Subquery(newest_annotation.values('created_at'))))
-        )
+def annotated_completed_at_considering_agreement_threshold(queryset):
+    LseProject = load_func(settings.LSE_PROJECT)
+    get_tasks_agreement_queryset = load_func(settings.GET_TASKS_AGREEMENT_QUERYSET)
 
-    lse_project = LseProject.objects.filter(project_id=project_id).first()
+    project_id = None
+    if queryset.project is not None:
+        project_id = queryset.project.id
+
+    lse_project = LseProject.objects.filter(project_id=project_id).first() if LseProject and project_id else None
     agreement_threshold = lse_project.agreement_threshold if lse_project else None
-    if not (get_tasks_agreement_queryset and agreement_threshold):
+    if not lse_project or not agreement_threshold:
         # This project doesn't use task_agreement so don't consider it when determining completed_at
-        return queryset.annotate(
-            completed_at=Case(When(is_labeled=True, then=Subquery(newest_annotation.values('created_at'))))
-        )
+        return base_annotate_completed_at(queryset)
 
-    queryset = get_tasks_agreement_queryset(queryset)
+    newest_annotation = newest_annotation_subquery()
+    queryset = get_tasks_agreement_queryset(queryset) if get_tasks_agreement_queryset else queryset
     max_additional_annotators_assignable = lse_project.max_additional_annotators_assignable
 
     completed_at_case = Case(

--- a/label_studio/data_manager/managers.py
+++ b/label_studio/data_manager/managers.py
@@ -563,7 +563,7 @@ def annotated_completed_at_considering_agreement_threshold(queryset):
         # This project doesn't use task_agreement so don't consider it when determining completed_at
         return base_annotate_completed_at(queryset)
 
-    queryset = get_tasks_agreement_queryset(queryset) if has_custom_agreement_queryset else queryset
+    queryset = get_tasks_agreement_queryset(queryset)
     max_additional_annotators_assignable = lse_project['max_additional_annotators_assignable']
 
     completed_at_case = Case(

--- a/label_studio/data_manager/managers.py
+++ b/label_studio/data_manager/managers.py
@@ -525,10 +525,13 @@ def annotate_completed_at(queryset: TaskQuerySet) -> TaskQuerySet:
     LseProject = load_func(settings.LSE_PROJECT)
     get_tasks_agreement_queryset = load_func(settings.GET_TASKS_AGREEMENT_QUERYSET)
 
-    is_lse_project = bool(LseProject and get_tasks_agreement_queryset)
+    is_lse_project = bool(LseProject)
+    has_custom_agreement_queryset = bool(get_tasks_agreement_queryset)
 
-    if is_lse_project and flag_set(
-        'fflag_feat_optic_161_project_settings_for_low_agreement_threshold_score_short', user='auto'
+    if (
+        is_lse_project
+        and has_custom_agreement_queryset
+        and flag_set('fflag_feat_optic_161_project_settings_for_low_agreement_threshold_score_short', user='auto')
     ):
         return annotated_completed_at_considering_agreement_threshold(queryset)
 
@@ -539,7 +542,9 @@ def annotated_completed_at_considering_agreement_threshold(queryset):
     LseProject = load_func(settings.LSE_PROJECT)
     get_tasks_agreement_queryset = load_func(settings.GET_TASKS_AGREEMENT_QUERYSET)
 
-    is_lse_project = bool(LseProject and get_tasks_agreement_queryset)
+    is_lse_project = bool(LseProject)
+    has_custom_agreement_queryset = bool(get_tasks_agreement_queryset)
+
     project_exists = is_lse_project and hasattr(queryset, 'project') and queryset.project is not None
 
     project_id = queryset.project.id if project_exists else None
@@ -553,7 +558,7 @@ def annotated_completed_at_considering_agreement_threshold(queryset):
                 'agreement_threshold', 'max_additional_annotators_assignable'
             )
         )
-        if LseProject and project_id
+        if is_lse_project
         else None
     )
     agreement_threshold = lse_project['agreement_threshold'] if lse_project else None
@@ -561,7 +566,7 @@ def annotated_completed_at_considering_agreement_threshold(queryset):
         # This project doesn't use task_agreement so don't consider it when determining completed_at
         return base_annotate_completed_at(queryset)
 
-    queryset = get_tasks_agreement_queryset(queryset) if get_tasks_agreement_queryset else queryset
+    queryset = get_tasks_agreement_queryset(queryset) if has_custom_agreement_queryset else queryset
     max_additional_annotators_assignable = lse_project['max_additional_annotators_assignable']
 
     completed_at_case = Case(

--- a/label_studio/data_manager/managers.py
+++ b/label_studio/data_manager/managers.py
@@ -525,7 +525,7 @@ def annotate_completed_at(queryset: TaskQuerySet) -> TaskQuerySet:
     LseProject = load_func(settings.LSE_PROJECT)
     get_tasks_agreement_queryset = load_func(settings.GET_TASKS_AGREEMENT_QUERYSET)
 
-    is_lse_project = LseProject and get_tasks_agreement_queryset
+    is_lse_project = bool(LseProject and get_tasks_agreement_queryset)
 
     if is_lse_project and flag_set(
         'fflag_feat_optic_161_project_settings_for_low_agreement_threshold_score_short', user='auto'
@@ -539,7 +539,7 @@ def annotated_completed_at_considering_agreement_threshold(queryset):
     LseProject = load_func(settings.LSE_PROJECT)
     get_tasks_agreement_queryset = load_func(settings.GET_TASKS_AGREEMENT_QUERYSET)
 
-    is_lse_project = LseProject and get_tasks_agreement_queryset
+    is_lse_project = bool(LseProject and get_tasks_agreement_queryset)
     project_exists = is_lse_project and hasattr(queryset, 'project') and queryset.project is not None
 
     project_id = queryset.project.id if project_exists else None

--- a/label_studio/data_manager/managers.py
+++ b/label_studio/data_manager/managers.py
@@ -550,14 +550,14 @@ def annotated_completed_at_considering_agreement_threshold(queryset):
         if LseProject and project_id
         else None
     )
-    agreement_threshold = lse_project.agreement_threshold if lse_project else None
+    agreement_threshold = lse_project['agreement_threshold'] if lse_project else None
     if not lse_project or not agreement_threshold:
         # This project doesn't use task_agreement so don't consider it when determining completed_at
         return base_annotate_completed_at(queryset)
 
     newest_annotation = newest_annotation_subquery()
     queryset = get_tasks_agreement_queryset(queryset) if get_tasks_agreement_queryset else queryset
-    max_additional_annotators_assignable = lse_project.max_additional_annotators_assignable
+    max_additional_annotators_assignable = lse_project['max_additional_annotators_assignable']
 
     completed_at_case = Case(
         When(

--- a/label_studio/data_manager/managers.py
+++ b/label_studio/data_manager/managers.py
@@ -549,18 +549,15 @@ def annotated_completed_at_considering_agreement_threshold(queryset):
 
     project_id = queryset.project.id if project_exists else None
 
-    if project_id is None:
+    if project_id is None or not is_lse_project or not has_custom_agreement_queryset:
         return base_annotate_completed_at(queryset)
 
-    lse_project = (
-        fast_first(
-            LseProject.objects.filter(project_id=project_id).values(
-                'agreement_threshold', 'max_additional_annotators_assignable'
-            )
+    lse_project = fast_first(
+        LseProject.objects.filter(project_id=project_id).values(
+            'agreement_threshold', 'max_additional_annotators_assignable'
         )
-        if is_lse_project
-        else None
     )
+
     agreement_threshold = lse_project['agreement_threshold'] if lse_project else None
     if not lse_project or not agreement_threshold:
         # This project doesn't use task_agreement so don't consider it when determining completed_at


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [X] Backend (API)
- [ ] Frontend



### Describe the reason for change
When no tasks were imported for a project, the absence of the completed_at annotation used in DataManager filters would cause errors to be thrown. This properly annotates the None result to ensure there is always a completed_at annotated field so that the filters do not break.
