### PR TITLE
fix: OPTIC-391: Tasks rendered incomplete by low agreement should not count on project cards

### DIFF
--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -59,9 +59,6 @@ logger = logging.getLogger(__name__)
 
 
 class ProjectManager(models.Manager):
-    def for_user(self, user):
-        return self.filter(organization=user.active_organization)
-
     COUNTER_FIELDS = [
         'task_number',
         'finished_task_number',
@@ -73,21 +70,26 @@ class ProjectManager(models.Manager):
         'skipped_annotations_number',
     ]
 
+    ANNOTATED_FIELDS = {
+        'task_number': annotate_task_number,
+        'finished_task_number': annotate_finished_task_number,
+        'total_predictions_number': annotate_total_predictions_number,
+        'total_annotations_number': annotate_total_annotations_number,
+        'num_tasks_with_annotations': annotate_num_tasks_with_annotations,
+        'useful_annotation_number': annotate_useful_annotation_number,
+        'ground_truth_number': annotate_ground_truth_number,
+        'skipped_annotations_number': annotate_skipped_annotations_number,
+    }
+
+    def for_user(self, user):
+        return self.filter(organization=user.active_organization)
+
     def with_counts(self, fields=None):
         return self.with_counts_annotate(self, fields=fields)
 
     @staticmethod
     def with_counts_annotate(queryset, fields=None):
-        available_fields = {
-            'task_number': annotate_task_number,
-            'finished_task_number': annotate_finished_task_number,
-            'total_predictions_number': annotate_total_predictions_number,
-            'total_annotations_number': annotate_total_annotations_number,
-            'num_tasks_with_annotations': annotate_num_tasks_with_annotations,
-            'useful_annotation_number': annotate_useful_annotation_number,
-            'ground_truth_number': annotate_ground_truth_number,
-            'skipped_annotations_number': annotate_skipped_annotations_number,
-        }
+        available_fields = ProjectManager.ANNOTATED_FIELDS
         if fields is None:
             to_annotate = available_fields
         else:


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [X] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [X] Backend (API)
- [ ] Frontend


### Describe the reason for change
#### What
Given an enterprise user is utilizing the Low Agreement strategy to assign tasks to annotators, this was not correctly reflecting in the project cards for Admin/Manager/Owner often having a higher number reported than it should be. 

#### Why
The total completed tasks were not accounting for the low agreement aspect, and reporting just the base raw `is_labeled` of the project based tasks.

#### How
By refactoring the ProjectManager to be extensible, this allowed the annotated fields to be replaced at a granular level. In this case only `finished_task_number` required a differing calculation. The implementation of which can be seen in the parent PR to this one, along with tests.
