### PR TITLE
Return predictions even in next_task even with empty model_version

### DIFF
--- a/label_studio/tasks/models.py
+++ b/label_studio/tasks/models.py
@@ -219,21 +219,24 @@ class Task(TaskMixin, models.Model):
         predictions = self.predictions
 
         # TODO if we use live_model on project then we will need to check for it here
-        if project.show_collab_predictions and project.model_version is not None:
-            if project.ml_backend_in_model_version:
-                new_predictions = evaluate_predictions([self])
-                # TODO this is not as clean as I'd want it to
-                # be. Effectively retrieve_predictions will work only for
-                # tasks where there is no predictions matching current
-                # model version. In case it will return a model_version
-                # and we can grab predictions explicitly
-                if isinstance(new_predictions, str):
-                    model_version = new_predictions
-                    return predictions.filter(model_version=model_version)
+        if project.show_collab_predictions:
+            if project.model_version:
+                if project.ml_backend_in_model_version:
+                    new_predictions = evaluate_predictions([self])
+                    # TODO this is not as clean as I'd want it to
+                    # be. Effectively retrieve_predictions will work only for
+                    # tasks where there is no predictions matching current
+                    # model version. In case it will return a model_version
+                    # and we can grab predictions explicitly
+                    if isinstance(new_predictions, str):
+                        model_version = new_predictions
+                        return predictions.filter(model_version=model_version)
+                    else:
+                        return new_predictions
                 else:
-                    return new_predictions
+                    return predictions.filter(model_version=project.model_version)
             else:
-                return predictions.filter(model_version=project.model_version)
+                return predictions
         else:
             return []
 


### PR DESCRIPTION
Fixes two things:
- any empty version (`""` or `None`) considered falsy
- if there are no `model_version` selected we return all predictions to be consistent with old version and `GET /task/:id`

Connected to LEAP-930 investigations