### PR TITLE
fix: LEAP-930: Set model as prelabeler

### DIFF
--- a/label_studio/ml/api.py
+++ b/label_studio/ml/api.py
@@ -90,11 +90,10 @@ class MLBackendListAPI(generics.ListCreateAPIView):
 
         project = ml_backend.project
 
-        # In case we are adding the model, let's set it as the default 
-        # to obtain predictions. This approach is consistent with uploading 
+        # In case we are adding the model, let's set it as the default
+        # to obtain predictions. This approach is consistent with uploading
         # offline predictions, which would be set automatically.
-        if project.show_collab_predictions and \
-           (project.model_version is None or project.model_version == ""):
+        if project.show_collab_predictions and (project.model_version is None or project.model_version == ''):
             project.model_version = ml_backend.title
             project.save(update_fields=['model_version'])
 

--- a/label_studio/ml/api.py
+++ b/label_studio/ml/api.py
@@ -93,7 +93,7 @@ class MLBackendListAPI(generics.ListCreateAPIView):
         # In case we are adding the model, let's set it as the default
         # to obtain predictions. This approach is consistent with uploading
         # offline predictions, which would be set automatically.
-        if project.show_collab_predictions and (project.model_version is None or project.model_version == ''):
+        if project.show_collab_predictions and not project.model_version:
             project.model_version = ml_backend.title
             project.save(update_fields=['model_version'])
 

--- a/label_studio/ml/api.py
+++ b/label_studio/ml/api.py
@@ -88,6 +88,16 @@ class MLBackendListAPI(generics.ListCreateAPIView):
         ml_backend = serializer.save()
         ml_backend.update_state()
 
+        project = ml_backend.project
+
+        # In case we are adding the model, let's set it as the default 
+        # to obtain predictions. This approach is consistent with uploading 
+        # offline predictions, which would be set automatically.
+        if project.show_collab_predictions and \
+           (project.model_version is None or project.model_version == ""):
+            project.model_version = ml_backend.title
+            project.save(update_fields=['model_version'])
+
 
 @method_decorator(
     name='patch',

--- a/label_studio/projects/serializers.py
+++ b/label_studio/projects/serializers.py
@@ -102,7 +102,7 @@ class ProjectSerializer(FlexFieldsModelSerializer):
             data['expert_instruction'] = bleach.clean(
                 initial_data['expert_instruction'], tags=SAFE_HTML_TAGS, attributes=SAFE_HTML_ATTRIBUTES
             )
-            
+
         return data
 
     class Meta:
@@ -187,8 +187,8 @@ class ProjectSerializer(FlexFieldsModelSerializer):
         return value
 
     def update(self, instance, validated_data):
-        if validated_data.get("show_collab_predictions") is False:
-            instance.model_version = ""
+        if validated_data.get('show_collab_predictions') is False:
+            instance.model_version = ''
 
         return super().update(instance, validated_data)
 

--- a/label_studio/projects/serializers.py
+++ b/label_studio/projects/serializers.py
@@ -94,6 +94,7 @@ class ProjectSerializer(FlexFieldsModelSerializer):
         # FIXME: remake this logic with start_training_on_annotation_update
         initial_data = data
         data = super().to_internal_value(data)
+
         if 'start_training_on_annotation_update' in initial_data:
             data['min_annotations_to_start_training'] = int(initial_data['start_training_on_annotation_update'])
 
@@ -101,7 +102,7 @@ class ProjectSerializer(FlexFieldsModelSerializer):
             data['expert_instruction'] = bleach.clean(
                 initial_data['expert_instruction'], tags=SAFE_HTML_TAGS, attributes=SAFE_HTML_ATTRIBUTES
             )
-
+            
         return data
 
     class Meta:
@@ -186,8 +187,8 @@ class ProjectSerializer(FlexFieldsModelSerializer):
         return value
 
     def update(self, instance, validated_data):
-        if not validated_data.get('show_collab_predictions'):
-            instance.model_version = ''
+        if validated_data.get("show_collab_predictions") is False:
+            instance.model_version = ""
 
         return super().update(instance, validated_data)
 

--- a/label_studio/tests/ml/test_api.py
+++ b/label_studio/tests/ml/test_api.py
@@ -6,6 +6,9 @@ from rest_framework import status
 
 from label_studio.tests.utils import make_project, register_ml_backend_mock
 
+ORIG_MODEL_NAME="basic_ml_backend"
+PROJECT_CONFIG="""<View><Image name="image" value="$image_url"/><Choices name="label"
+          toName="image"><Choice value="pos"/><Choice value="neg"/></Choices></View>"""
 
 @pytest.fixture
 def ml_backend_for_test_api(ml_backend):
@@ -23,12 +26,71 @@ def mock_gethostbyname(mocker):
 
 
 @pytest.mark.django_db
+def test_ml_backend_set_for_prelabeling(business_client, ml_backend_for_test_api, mock_gethostbyname):
+    project = make_project(
+        config=dict(
+            is_published=True,
+            label_config=PROJECT_CONFIG,
+            title='test_ml_backend_creation',
+        ),
+        user=business_client.user,
+    )
+
+    assert project.model_version == ''
+
+    # create ML backend
+    response = business_client.post(
+        '/api/ml/',
+        data={
+            'project': project.id,
+            'title': 'ml_backend_title',
+            'url': 'https://ml_backend_for_test_api',
+        },
+    )
+    assert response.status_code == 201
+    
+    project.refresh_from_db()
+    assert project.model_version == 'ml_backend_title'
+
+
+@pytest.mark.django_db
+def test_ml_backend_not_set_for_prelabeling(business_client, ml_backend_for_test_api, mock_gethostbyname):
+    """We are not setting it when its already set for another name,
+    for example when predictions were uploaded before"""
+
+    project = make_project(
+        config=dict(
+            is_published=True,
+            label_config=PROJECT_CONFIG,
+            title='test_ml_backend_creation',
+        ),
+        user=business_client.user,
+    )
+
+    project.model_version = ORIG_MODEL_NAME
+    project.save()
+    
+    # create ML backend
+    response = business_client.post(
+        '/api/ml/',
+        data={
+            'project': project.id,
+            'title': 'ml_backend_title',
+            'url': 'https://ml_backend_for_test_api',
+        },
+    )
+    assert response.status_code == 201
+    
+    project.refresh_from_db()
+    assert project.model_version == ORIG_MODEL_NAME
+    
+
+@pytest.mark.django_db
 def test_model_version_on_save(business_client, ml_backend_for_test_api, mock_gethostbyname):
     project = make_project(
         config=dict(
             is_published=True,
-            label_config="""<View><Image name="image" value="$image_url"/><Choices name="label"
-          toName="image"><Choice value="pos"/><Choice value="neg"/></Choices></View>""",
+            label_config=PROJECT_CONFIG,
             title='test_ml_backend_creation',
         ),
         user=business_client.user,
@@ -86,8 +148,7 @@ def test_model_version_on_delete(business_client, ml_backend_for_test_api, mock_
     project = make_project(
         config=dict(
             is_published=True,
-            label_config="""<View><Image name="image" value="$image_url"/><Choices name="label"
-          toName="image"><Choice value="pos"/><Choice value="neg"/></Choices></View>""",
+            label_config=PROJECT_CONFIG,
             title='test_ml_backend_creation',
         ),
         user=business_client.user,
@@ -135,8 +196,7 @@ def test_security_write_only_payload(business_client, ml_backend_for_test_api, m
     project = make_project(
         config=dict(
             is_published=True,
-            label_config="""<View><Image name="image" value="$image_url"/><Choices name="label"
-          toName="image"><Choice value="pos"/><Choice value="neg"/></Choices></View>""",
+            label_config=PROJECT_CONFIG,
             title='test_ml_backend_creation',
         ),
         user=business_client.user,
@@ -226,8 +286,7 @@ def test_ml_backend_predict_test_api_post_random_true(business_client):
     project = make_project(
         config=dict(
             is_published=True,
-            label_config="""<View><Image name="image" value="$image_url"/><Choices name="label"
-          toName="image"><Choice value="pos"/><Choice value="neg"/></Choices></View>""",
+            label_config=PROJECT_CONFIG,
             title='test_ml_backend_creation',
         ),
         user=business_client.user,
@@ -245,3 +304,5 @@ def test_ml_backend_predict_test_api_post_random_true(business_client):
     r = response.json()
     assert r['url'] == 'http://localhost:8999/predict'
     assert r['status'] == 200
+
+

--- a/label_studio/tests/ml/test_api.py
+++ b/label_studio/tests/ml/test_api.py
@@ -6,9 +6,10 @@ from rest_framework import status
 
 from label_studio.tests.utils import make_project, register_ml_backend_mock
 
-ORIG_MODEL_NAME="basic_ml_backend"
-PROJECT_CONFIG="""<View><Image name="image" value="$image_url"/><Choices name="label"
+ORIG_MODEL_NAME = 'basic_ml_backend'
+PROJECT_CONFIG = """<View><Image name="image" value="$image_url"/><Choices name="label"
           toName="image"><Choice value="pos"/><Choice value="neg"/></Choices></View>"""
+
 
 @pytest.fixture
 def ml_backend_for_test_api(ml_backend):
@@ -48,7 +49,7 @@ def test_ml_backend_set_for_prelabeling(business_client, ml_backend_for_test_api
         },
     )
     assert response.status_code == 201
-    
+
     project.refresh_from_db()
     assert project.model_version == 'ml_backend_title'
 
@@ -69,7 +70,7 @@ def test_ml_backend_not_set_for_prelabeling(business_client, ml_backend_for_test
 
     project.model_version = ORIG_MODEL_NAME
     project.save()
-    
+
     # create ML backend
     response = business_client.post(
         '/api/ml/',
@@ -80,10 +81,10 @@ def test_ml_backend_not_set_for_prelabeling(business_client, ml_backend_for_test
         },
     )
     assert response.status_code == 201
-    
+
     project.refresh_from_db()
     assert project.model_version == ORIG_MODEL_NAME
-    
+
 
 @pytest.mark.django_db
 def test_model_version_on_save(business_client, ml_backend_for_test_api, mock_gethostbyname):
@@ -304,5 +305,3 @@ def test_ml_backend_predict_test_api_post_random_true(business_client):
     r = response.json()
     assert r['url'] == 'http://localhost:8999/predict'
     assert r['status'] == 200
-
-

--- a/label_studio/tests/predictions.model.tavern.yml
+++ b/label_studio/tests/predictions.model.tavern.yml
@@ -287,15 +287,15 @@ stages:
   request:
     data:
       project: '{project_pk}'
-      title: My Testing ML backend
+      title: "ml_backend"
       url: https://test.heartex.mlbackend.com:9090
     method: POST
     url: '{django_live_url}/api/ml'
-- name: check_project_model_not_change_after_ml_added_to_empty
+- name: check_project_model_change_after_ml_added_to_empty
   request:
     method: GET
     url: '{django_live_url}/api/projects/{project_pk}'
   response:
     status_code: 200
     json:
-      model_version: ""
+      model_version: "ml_backend"

--- a/label_studio/tests/predictions.model.tavern.yml
+++ b/label_studio/tests/predictions.model.tavern.yml
@@ -136,7 +136,7 @@ stages:
   request:
     data:
       project: '{project_pk}'
-      title: My Testing ML backend
+      title: "ml_backend"
       url: https://test.heartex.mlbackend.com:9090
     method: POST
     url: '{django_live_url}/api/ml'
@@ -147,25 +147,7 @@ stages:
   response:
     status_code: 200
     json:
-      model_version: ''
-- name: change_project_model_to_ml_backend
-  request:
-    method: PATCH
-    url: '{django_live_url}/api/projects/{project_pk}'
-    data:
-      model_version: "My Testing ML backend"
-  response:
-    status_code: 200
-    json:
-      model_version: "My Testing ML backend"
-- name: check_project_model_after_project_change
-  request:
-    method: GET
-    url: '{django_live_url}/api/projects/{project_pk}'
-  response:
-    status_code: 200
-    json:
-      model_version: "My Testing ML backend"
+      model_version: "ml_backend"
 
 ---
 test_name: model_change_before_ML_added

--- a/scripts/update_ml_tutorials.py
+++ b/scripts/update_ml_tutorials.py
@@ -25,10 +25,10 @@ The script does the following:
 
 import os
 import re
-import yaml
 from pathlib import Path
 from typing import List
 
+import yaml
 
 ML_REPO_PATH = os.getenv('ML_REPO_PATH', 'label-studio-ml-backend/')
 
@@ -45,10 +45,7 @@ def parse_readme_file(file_path: str) -> dict:
     header = re.findall(r'---\n(.*?)\n---', content, re.DOTALL)
     body = re.sub(r'---\n(.*?)\n---', '', content, flags=re.DOTALL)
 
-    return {
-        'header': header[0].strip() if header else '',
-        'body': body.strip()
-    }
+    return {'header': header[0].strip() if header else '', 'body': body.strip()}
 
 
 def create_tutorial_files():
@@ -68,10 +65,9 @@ def create_tutorial_files():
                 f.write(parsed_content['header'])
                 f.write('\n---\n\n')
             f.write(parsed_content['body'])
-        files_and_headers.append({
-            'model_name': model_name,
-            'header': yaml.load(parsed_content['header'], Loader=yaml.FullLoader)
-        })
+        files_and_headers.append(
+            {'model_name': model_name, 'header': yaml.load(parsed_content['header'], Loader=yaml.FullLoader)}
+        )
 
     update_ml_tutorials_index(files_and_headers)
 
@@ -91,10 +87,7 @@ def update_ml_tutorials_index(files_and_headers: List):
     for f in files_and_headers:
         print('Processing', f['model_name'])
         h = f['header'] or {}
-        card = {
-            'title': h.get('title') or f['model_name'],
-            'url': f'/tutorials/{f["model_name"]}.html'
-        }
+        card = {'title': h.get('title') or f['model_name'], 'url': f'/tutorials/{f["model_name"]}.html'}
         card.update(f['header'] or {})
         data['cards'].append(card)
 


### PR DESCRIPTION
This code sets a model as a default prelabeler in case no other option was selected. This is done to keep it consistent with how offline predictions are used when uploaded (they get selected).

That's basically a #5695 fixed for Follow Merge


### PR fulfills these requirements
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)


#### Change has impacts in these area(s)
- [ ] Product design
- [x] Backend (Database)
- [x] Backend (API)
- [ ] Frontend


### Describe the reason for change
Label Stream and other flows have some issues when model is added but not selected because of discrepancies in logic.


#### What alternative approaches were there?
We could change the way model is added and handled in settings, but autoselect is small and precise fix.


### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)


### What level of testing was included in the change?
- [ ] e2e
- [x] integration
- [ ] unit
