### PR TITLE
fix: LEAP-1019: Validation with Table tag fails on List values in task.data

### DIFF
--- a/label_studio/tasks/validation.py
+++ b/label_studio/tasks/validation.py
@@ -20,7 +20,7 @@ _DATA_TYPES = {
     'HyperText': [str],
     'Image': [str, list],
     'Paragraphs': [list, str],
-    'Table': [dict, str],
+    'Table': [dict, list, str],
     'TimeSeries': [dict, list, str],
     'TimeSeriesChannel': [dict, list, str],
     'List': [list, str],

--- a/label_studio/tests/config_validation.tavern.yml
+++ b/label_studio/tests/config_validation.tavern.yml
@@ -1363,3 +1363,43 @@ stages:
         taxonomy_other: null
   response:
     status_code: 201
+
+
+---
+test_name: Validate Table tag with task data on import
+strict: false
+marks:
+- usefixtures:
+  - django_live_url
+
+stages:
+- # Signup to the system
+  id: signup
+  type: ref
+
+- # Create a project with Table labeling configuration
+  name: create project
+  request:
+    data:
+      label_config: ' <View><Table name="table" value="$table"/><Choices name="sentiment" toName="table" choice="single" showInLine="true"> <Choice value="1"/></Choices></View>'
+    method: POST
+    url: '{django_live_url}/api/projects'
+  response:
+    save:
+      json:
+        pk: id
+    status_code: 201
+
+- # Import a task with List to the project
+  name: import task
+  request:
+    headers:
+      content-type: application/json
+    json:
+      - table:
+        - "test1"
+        - "test2"
+    method: POST
+    url: '{django_live_url}/api/projects/{pk}/import'
+  response:
+    status_code: 201


### PR DESCRIPTION
#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [x] Backend (API)
- [ ] Frontend



### Describe the reason for change
Import fails with values like task.data['table'] = ["test", "test2"] (list) when Table is used in label config. However, Table supports it. 



#### What does this fix?
Just add 1 line to supported types. 

