### PR TITLE
docs: DOC-211: Note Data Discovery search result limits

### DIFF
--- a/docs/source/guide/dataset_overview.md
+++ b/docs/source/guide/dataset_overview.md
@@ -57,6 +57,7 @@ This targeted approach to data gathering not only saves valuable time but also c
 | **Supported storage for import** | Google Cloud storage <br><br>AWS S3 <br><br>Azure blob storage |
 | **Number of storage sources per dataset** | One |
 | **Maximum number of records per dataset** | 1 million |
+| **Maximum number of records returned per search** | 16,384 |
 | **Number of datasets per org** | 10 |
 | **Supported search types** | Natural language search <br><br>Similarity search |
 | **Supported filter types** | Similarity score |

--- a/docs/source/guide/dataset_search.md
+++ b/docs/source/guide/dataset_search.md
@@ -22,6 +22,9 @@ Label studio provides several search mechanisms:
 * **Combined searches** - Combine similarity searching and natural language searching. 
 * **Filtering** - Reduce your dataset to only show records that have a certain threshold of similarity to your searches.
 
+!!! attention
+    Search results are limited to 16,384 records at a time. All records with the dataset are stored, but the Label Studio interface is limited to returning a smaller subset per search. As you change your search query, you’ll see different sets of records (all with a max of 16,384 at a time).
+
 ## How searches work
 
 ### Embeddings 


### PR DESCRIPTION
The frontend limits how many records can be returned per search. The docs should include this. 



Affects: 
- [ ] Community docs
- [X] Enterprise docs

