### PR TITLE
fix: LEAP-1023: Fix misspelled LocalFilesImportStorageLink in remove_duplicates

### DIFF
--- a/label_studio/data_manager/actions/remove_duplicates.py
+++ b/label_studio/data_manager/actions/remove_duplicates.py
@@ -13,6 +13,7 @@ from io_storages.azure_blob.models import AzureBlobImportStorageLink
 from io_storages.gcs.models import GCSImportStorageLink
 from io_storages.localfiles.models import LocalFilesImportStorageLink
 from io_storages.s3.models import S3ImportStorageLink
+from io_storages.redis.models import RedisImportStorageLink
 from tasks.models import Task
 
 logger = logging.getLogger(__name__)
@@ -136,7 +137,7 @@ def restore_storage_links_for_duplicated_tasks(duplicates) -> None:
         'io_storages_gcsimportstoragelink': GCSImportStorageLink,
         'io_storages_azureblobimportstoragelink': AzureBlobImportStorageLink,
         'io_storages_localfilesimportstoragelink': LocalFilesImportStorageLink,
-        # 'io_storages_redisimportstoragelink',
+        'io_storages_redisimportstoragelink': RedisImportStorageLink,
         # 'lse_io_storages_lses3importstoragelink'  # not supported yet
     }
 

--- a/label_studio/data_manager/actions/remove_duplicates.py
+++ b/label_studio/data_manager/actions/remove_duplicates.py
@@ -11,7 +11,7 @@ from core.redis import start_job_async_or_sync
 from data_manager.actions.basic import delete_tasks
 from io_storages.azure_blob.models import AzureBlobImportStorageLink
 from io_storages.gcs.models import GCSImportStorageLink
-from io_storages.localfiles.models import LocalFilesImportStorage
+from io_storages.localfiles.models import LocalFilesImportStorageLink
 from io_storages.s3.models import S3ImportStorageLink
 from tasks.models import Task
 
@@ -135,7 +135,7 @@ def restore_storage_links_for_duplicated_tasks(duplicates) -> None:
         'io_storages_s3importstoragelink': S3ImportStorageLink,
         'io_storages_gcsimportstoragelink': GCSImportStorageLink,
         'io_storages_azureblobimportstoragelink': AzureBlobImportStorageLink,
-        'io_storages_localfilesimportstoragelink': LocalFilesImportStorage,
+        'io_storages_localfilesimportstoragelink': LocalFilesImportStorageLink,
         # 'io_storages_redisimportstoragelink',
         # 'lse_io_storages_lses3importstoragelink'  # not supported yet
     }

--- a/label_studio/data_manager/actions/remove_duplicates.py
+++ b/label_studio/data_manager/actions/remove_duplicates.py
@@ -12,8 +12,8 @@ from data_manager.actions.basic import delete_tasks
 from io_storages.azure_blob.models import AzureBlobImportStorageLink
 from io_storages.gcs.models import GCSImportStorageLink
 from io_storages.localfiles.models import LocalFilesImportStorageLink
-from io_storages.s3.models import S3ImportStorageLink
 from io_storages.redis.models import RedisImportStorageLink
+from io_storages.s3.models import S3ImportStorageLink
 from tasks.models import Task
 
 logger = logging.getLogger(__name__)

--- a/label_studio/tests/data_manager/test_api_actions.py
+++ b/label_studio/tests/data_manager/test_api_actions.py
@@ -7,9 +7,9 @@ import pytest
 from django.db import transaction
 from io_storages.azure_blob.models import AzureBlobImportStorage, AzureBlobImportStorageLink
 from io_storages.gcs.models import GCSImportStorage, GCSImportStorageLink
-from io_storages.s3.models import S3ImportStorage, S3ImportStorageLink
 from io_storages.localfiles.models import LocalFilesImportStorage, LocalFilesImportStorageLink
 from io_storages.redis.models import RedisImportStorage, RedisImportStorageLink
+from io_storages.s3.models import S3ImportStorage, S3ImportStorageLink
 from projects.models import Project
 
 from ..utils import make_annotation, make_prediction, make_task, project_id  # noqa
@@ -100,13 +100,16 @@ def test_action_delete_all_annotations(tasks_count, annotations_count, predictio
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("storage_model, link_model", [
-    (AzureBlobImportStorage, AzureBlobImportStorageLink),
-    (GCSImportStorage, GCSImportStorageLink),
-    (S3ImportStorage, S3ImportStorageLink),
-    (LocalFilesImportStorage, LocalFilesImportStorageLink),
-    (RedisImportStorage, RedisImportStorageLink),
-])
+@pytest.mark.parametrize(
+    'storage_model, link_model',
+    [
+        (AzureBlobImportStorage, AzureBlobImportStorageLink),
+        (GCSImportStorage, GCSImportStorageLink),
+        (S3ImportStorage, S3ImportStorageLink),
+        (LocalFilesImportStorage, LocalFilesImportStorageLink),
+        (RedisImportStorage, RedisImportStorageLink),
+    ],
+)
 def test_action_remove_duplicates(business_client, project_id, storage_model, link_model):
     # Setup
     project = Project.objects.get(pk=project_id)

--- a/label_studio/tests/data_manager/test_api_actions.py
+++ b/label_studio/tests/data_manager/test_api_actions.py
@@ -5,7 +5,11 @@ import json
 
 import pytest
 from django.db import transaction
+from io_storages.azure_blob.models import AzureBlobImportStorage, AzureBlobImportStorageLink
+from io_storages.gcs.models import GCSImportStorage, GCSImportStorageLink
 from io_storages.s3.models import S3ImportStorage, S3ImportStorageLink
+from io_storages.localfiles.models import LocalFilesImportStorage, LocalFilesImportStorageLink
+from io_storages.redis.models import RedisImportStorage, RedisImportStorageLink
 from projects.models import Project
 
 from ..utils import make_annotation, make_prediction, make_task, project_id  # noqa
@@ -96,10 +100,17 @@ def test_action_delete_all_annotations(tasks_count, annotations_count, predictio
 
 
 @pytest.mark.django_db
-def test_action_remove_duplicates(business_client, project_id):
+@pytest.mark.parametrize("storage_model, link_model", [
+    (AzureBlobImportStorage, AzureBlobImportStorageLink),
+    (GCSImportStorage, GCSImportStorageLink),
+    (S3ImportStorage, S3ImportStorageLink),
+    (LocalFilesImportStorage, LocalFilesImportStorageLink),
+    (RedisImportStorage, RedisImportStorageLink),
+])
+def test_action_remove_duplicates(business_client, project_id, storage_model, link_model):
     # Setup
     project = Project.objects.get(pk=project_id)
-    storage = S3ImportStorage.objects.create(project=project)
+    storage = storage_model.objects.create(project=project)
 
     # task 1: add not a duplicated task
     task_data = {'data': {'image': 'normal.jpg'}}
@@ -117,7 +128,7 @@ def test_action_remove_duplicates(business_client, project_id):
     # task 4: add duplicated task, with storage link and one annotation
     task4 = make_task(task_data, project)
     make_annotation({'result': []}, task4.id)
-    S3ImportStorageLink.objects.create(task=task4, key='duplicated.jpg', storage=storage)
+    link_model.objects.create(task=task4, key='duplicated.jpg', storage=storage)
 
     # call the "remove duplicated tasks" action
     status = business_client.post(
@@ -125,14 +136,14 @@ def test_action_remove_duplicates(business_client, project_id):
         json={'selectedItems': {'all': True, 'excluded': []}},
     )
 
-    # as the result, we should have only 2 tasks left:
+    # As the result, we should have only 2 tasks left:
     # task 1 and task 3 with storage link copied from task 4
     assert list(project.tasks.order_by('id').values_list('id', flat=True)) == [
         task1.id,
         task3.id,
     ]
     assert status.status_code == 200
-    assert S3ImportStorageLink.objects.count() == 1
+    assert link_model.objects.count() == 1
     assert project.annotations.count() == 4
     assert project.tasks.count() == 2
 


### PR DESCRIPTION
#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [x] Backend (API)
- [ ] Frontend



### Describe the reason for change
Right now remove duplicates from Local Storages raises error because there is a misspell in code:

`LocalFilesImportStorageLink` => `LocalFilesImportStorageLink`


#### What does this fix?
Just rename import model. 


#### What is the current behavior?
Remove duplicates from DM actions fails when applied to files from Local Storage. 


### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [x] unit



