### PR TITLE
feat: feature/Labels subgroups

### DIFF
--- a/web/libs/editor/src/tags/control/Label.js
+++ b/web/libs/editor/src/tags/control/Label.js
@@ -229,10 +229,9 @@ const Model = types.model({
           }
           break;
         case 'subgroup':
-          const labels_without_groups = labels.selectedLabels.filter((label)=>!label.subgroup)
-          const labels_in_same_group = labels.selectedLabels.filter((label)=>label.subgroup==self.subgroup)
+          const other_in_same_group = labels.selectedLabels.filter((label)=>label.subgroup==self.subgroup && label.alias!=self.alias)
           /** We unselect labels in the same group */
-          labels_in_same_group.map((l)=>l.setSelected(false))
+          other_in_same_group.map((l)=>l.setSelected(false))
           self.setSelected(!self.selected)
       }
     }

--- a/web/libs/editor/src/tags/control/Label.js
+++ b/web/libs/editor/src/tags/control/Label.js
@@ -219,6 +219,7 @@ const Model = types.model({
       switch (labels.choice) {
         case 'multiple':
           self.setSelected(!self.selected);
+          break;
         case 'single':
           if (!self.selected) {
             labels.unselectAll();
@@ -226,6 +227,7 @@ const Model = types.model({
           } else {
             labels.unselectAll();
           }
+          break;
         case 'subgroup':
           const labels_without_groups = labels.selectedLabels.filter((label)=>!label.subgroup)
           const labels_in_same_group = labels.selectedLabels.filter((label)=>label.subgroup==self.subgroup)

--- a/web/libs/editor/src/tags/control/Label.js
+++ b/web/libs/editor/src/tags/control/Label.js
@@ -229,10 +229,17 @@ const Model = types.model({
           }
           break;
         case 'subgroup':
-          const other_in_same_group = labels.selectedLabels.filter((label)=>label.subgroup==self.subgroup && label.alias!=self.alias)
+          const was_already_selected = self.selected
+          const label_in_samegroup = labels.selectedLabels.filter((label)=>label.subgroup==self.subgroup)
           /** We unselect labels in the same group */
-          other_in_same_group.map((l)=>l.setSelected(false))
+          label_in_samegroup.map((l)=>l.setSelected(false))
+          if (was_already_selected && self.subgroup!=null){
+            // Allow Unselect in subgroup
+            self.setSelected(false)
+          } else
+          {
           self.setSelected(!self.selected)
+          }
       }
     }
 

--- a/web/libs/editor/src/tags/control/Labels/Labels.js
+++ b/web/libs/editor/src/tags/control/Labels/Labels.js
@@ -185,6 +185,7 @@ const HtxLabelGroup = observer(({item}) => {
 
               }}
           >
+            <Option key={group_name} value={'-'}/>
             {elements.map((el)=>{
               return (
                 <Option key={el._value} value={el._value}>


### PR DESCRIPTION
### PR fulfills these requirements
- [ x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
Often, we need more than one class when we annotate image. There can also be some group of labels that have a meaning.

For example, let's take the example of the plane image :
![image](https://github.com/HumanSignal/label-studio/assets/26071804/f694305c-ee16-4447-b776-453e2f8e9c54)

The plane can be white/red, Boeing/Airbus.
It can have only one color and only one manufacturer.

#### What does this fix?
With this fix, we are able to group labels in subgroups.
In this case, we will group labels in combo-boxes.
![image](https://github.com/HumanSignal/label-studio/assets/26071804/9dde23cb-6e60-4d11-9acf-3e410425f25f)


#### What is the new behavior?
The UI will automatically group labels in subgroup.
If we activate mode "multiple" : 
- It will allow multiple labels in the main group (without subgroup)
- It will allow only one label per subgroup
If we activate mode "subgroup":
- it will allow only one label in the main group
- It will allow only one label per subgroup

https://github.com/HumanSignal/label-studio/assets/26071804/b04d6259-a259-418d-b7f3-8f9b8ff20f56



#### What is the current behavior?
It will unpack all options and it will be complicate to identify main and subgroups.



#### What libraries were added/updated?
None


#### Does this change affect performance?
No


#### Does this change affect security?
No



#### What alternative approaches were there?
It would have been possible to create a complex taxonomy but it's much more impactful.


#### What feature flags were used to cover this change?
???



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [ ] No
- [x ] Not sure (briefly explain the situation below)

For me it's not a major change because the old behavior is not impacted.


### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
It will allow to annotate more precisely when we have "nested" classes on an object.