### PR TITLE
feat: Fix MultiLayer Image display

### DIFF
--- a/web/libs/editor/src/components/App/App.styl
+++ b/web/libs/editor/src/components/App/App.styl
@@ -65,7 +65,8 @@
   justify-content space-between
 
   &__annotation
-    padding 1em
+    padding-left 1em
+    padding-right 1em
 
   &__infobar
     padding 6px 1em 7px

--- a/web/libs/editor/src/components/ImageView/ImageView.js
+++ b/web/libs/editor/src/components/ImageView/ImageView.js
@@ -1109,23 +1109,25 @@ export default observer(
               />
             ) : null}
           </div>
-
-          {toolsReady && imageIsLoaded && this.renderTools()}
-          {item.images.length > 1 && (
-            <div className={styles.gallery}>
-              {item.images.map((src, i) => (
-                <img
-                  {...imgDefaultProps}
-                  alt=""
-                  key={src}
-                  src={src}
-                  className={i === item.currentImage && styles.active}
-                  height="60"
-                  onClick={() => item.setCurrentImage(i)}
-                />
-              ))}
+          <div className={styles.toolContainer}>
+            {item.images.length > 1 && (
+              <div className={styles.gallery}>
+                {item.images.map((src, i) => (
+                  <img
+                    {...imgDefaultProps}
+                    alt=""
+                    key={src}
+                    src={src}
+                    className={i === item.currentImage && styles.active}
+                    height="60"
+                    onClick={() => item.setCurrentImage(i)}
+                  />
+                ))}
+                {toolsReady && imageIsLoaded && this.renderTools()}
+              </div>
+            )}
             </div>
-          )}
+          
         </ObjectTag>
       );
     }

--- a/web/libs/editor/src/components/ImageView/ImageView.module.scss
+++ b/web/libs/editor/src/components/ImageView/ImageView.module.scss
@@ -115,21 +115,29 @@
     top: 0;
   }
 }
-
-.withGallery {
-  margin-bottom: 80px;
-}
+// No longer necessary with fused toolbar
+// .withGallery {
+//   // margin-bottom: 80px;
+// }
 
 .withPagination {
   padding-top: 30px; // pagination height 24px + 6px offset
 }
 
+.toolContainer {
+  display:flex;
+  flex-direction: column;
+  position:sticky;
+  top:70px;
+}
+
 .gallery {
-  position: absolute;
-  bottom: -80px;
+  position: relative;
+  bottom: -20px;
   display: flex;
+  flex-direction: column;
   overflow-x: auto;
-  width: 100%;
+  width: 50px;
   padding-bottom: 8px; // for scroll
 
   img {

--- a/web/libs/editor/src/components/Toolbar/Toolbar.styl
+++ b/web/libs/editor/src/components/Toolbar/Toolbar.styl
@@ -3,9 +3,7 @@
   background #FFFFFF
   box-shadow 0px 0px 0px 1px rgba(0, 0, 0, 0.05), 0px 5px 10px rgba(0, 0, 0, 0.1)
   border-radius 7px
-  position sticky
-  top 70px
-  margin-top 50px
+  position relative
 
   &::before
     height 12px

--- a/web/libs/editor/src/tags/object/Image/Image.js
+++ b/web/libs/editor/src/tags/object/Image/Image.js
@@ -74,6 +74,8 @@ const IMAGE_PRELOAD_COUNT = 3;
  * @param {boolean} [smoothing]               - Enable smoothing, by default it uses user settings
  * @param {string=} [width=100%]              - Image width
  * @param {string=} [maxWidth=750px]          - Maximum image width
+ * @param {string=} [height=100%]             - Image height
+ * @param {string=} [maxheight=calc(100vh - 200px)]         - Maximum image height
  * @param {boolean=} [zoom=false]             - Enable zooming an image with the mouse wheel
  * @param {boolean=} [negativeZoom=false]     - Enable zooming out an image
  * @param {float=} [zoomBy=1.1]               - Scale factor
@@ -97,7 +99,7 @@ const TagAttrs = types.model({
   width: types.optional(types.string, '100%'),
   height: types.maybeNull(types.string),
   maxwidth: types.optional(types.string, '100%'),
-  maxheight: types.optional(types.string, 'calc(100vh - 194px)'),
+  maxheight: types.optional(types.string, 'calc(100vh - 200px)'),
   smoothing: types.maybeNull(types.boolean),
 
   // rulers: types.optional(types.boolean, true),


### PR DESCRIPTION
### PR fulfills these requirements
- [ x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x ] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [ x] Frontend



### Describe the reason for change
When using multilayered images. Often the gallery is not visible when dealing with large images.
<img src='https://github.com/HumanSignal/label-studio/assets/26071804/6ade399d-6b77-4bee-87c4-fa2219e4b1ea' width='600px'/>

#### What does this fix?
The fix moves toggle button near the toolbar in order it to be everytime visible.

New behavior :
<video src='https://github.com/HumanSignal/label-studio/assets/26071804/dd3b9376-64b0-4b20-8303-2cbe2f10d997'/>




#### What is the new behavior?
The new behavior is very similar to the old one. Just the buttons are in another place and sticky.


#### What is the current behavior?
In the current behavior, buttons can be hidden and we need to scroll up/down to access it.
By doing so, most of the time we lose buttons in order to select labels what is anoying.



#### What libraries were added/updated?
None


#### Does this change affect performance?
It improve labellers performance.


#### Does this change affect security?
No


#### What alternative approaches were there?
Display everytime buttons, but if doing so, we'll lose some place for the image.


#### What feature flags were used to cover this change?



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [ ] No
- [x ] Not sure (briefly explain the situation below)
For me it's not breaking changes.


### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Annotation of multilayer images.
