### PR TITLE
docs: DOC-210: Add information about ML backend data access

### DIFF
--- a/docs/source/guide/ml_create.md
+++ b/docs/source/guide/ml_create.md
@@ -149,6 +149,9 @@ Other methods and parameters are available within the `LabelStudioMLBase` class:
 - `self.label_interface` - Returns the Label Studio Label Interface object that contains all information about the labeling task.
 - `self.model_version` - Returns the current model version.
 
+## 4. Ensure the ML backend can access Label Studio data
+
+Depending on how you are getting data into Label Studio, you may need to set `LABEL_STUDIO_URL`. See [Allow the ML backend to access Label Studio data](ml#Allow-the-ML-backend-to-access-Label-Studio-data). 
 
 ## 5. Run the ML backend server
 
@@ -179,6 +182,7 @@ To modify the host and port, use the following command line parameters:
 
 ```bash
 label-studio-ml start my_ml_backend -p 9091 --host 0.0.0.0
+```
 
 ### Test your ML backend
 

--- a/docs/source/guide/ml_create.md
+++ b/docs/source/guide/ml_create.md
@@ -151,7 +151,9 @@ Other methods and parameters are available within the `LabelStudioMLBase` class:
 
 ## 4. Ensure the ML backend can access Label Studio data
 
-Depending on how you are getting data into Label Studio, you may need to set `LABEL_STUDIO_URL`. See [Allow the ML backend to access Label Studio data](ml#Allow-the-ML-backend-to-access-Label-Studio-data). 
+If your data is stored in a cloud, local directory, or has been imported into Label Studio, you will need to set the `LABEL_STUDIO_URL` and `LABEL_STUDIO_API_KEY` environment variables. 
+
+For more information, see [Allow the ML backend to access Label Studio data](ml#Allow-the-ML-backend-to-access-Label-Studio-data). 
 
 ## 5. Run the ML backend server
 


### PR DESCRIPTION
Added a section entitled "Allow the ML backend to access Label Studio data" to the docs


Affects:
- [X] Enterprise docs
- [X] Community docs


