### PR TITLE
docs: DOC-132: Include analytics collection setting in Enterprise docs

### DIFF
--- a/docs/source/guide/security.md
+++ b/docs/source/guide/security.md
@@ -126,6 +126,12 @@ You can disable data collection by setting the environment variable `COLLECT_AN
 
 </div>
 
+<div class="enterprise-only">
+
+For on-prem installations, you can disable data collection by setting the environment variable `COLLECT_ANALYTICS` to `False`. 
+
+</div>
+
 ## Add self-signed certificate to trusted root store
 
 <div class="code-tabs">


### PR DESCRIPTION
The line about the COLLECT_ANALYTICS environment variable was hidden from the Enterprise docs. This PR exposes. 

Affects:
- [ ] Community docs
- [X] Enterprise docs


