### PR TITLE
fix: pre-commit when --all-files is use on manual, for example in 'make fmt-al'

### DIFF
--- a/.pre-commit-dev.yaml
+++ b/.pre-commit-dev.yaml
@@ -15,3 +15,4 @@ repos:
     -   id: biome-check
         args: [--config-path, ./web]
         additional_dependencies: ["@biomejs/biome@1.7.0"]
+        files: ^web/.*


### PR DESCRIPTION
When you execute 
`pre-commit run --hook-stage manual "biome-check" --config .pre-commit-dev.yaml --all-files`
for example using  'make fmt-al' biome hangs because files outside the main configuration are being pass. 

