### PR TITLE
feat: LEAP-1026: Add option for including annotation history

### DIFF
--- a/label_studio/data_export/mixins.py
+++ b/label_studio/data_export/mixins.py
@@ -135,10 +135,7 @@ class ExportMixin:
             options['context'] = {'interpolate_key_frames': settings.INTERPOLATE_KEY_FRAMES}
             if 'interpolate_key_frames' in serialization_options:
                 options['context']['interpolate_key_frames'] = serialization_options['interpolate_key_frames']
-            if (
-                'include_annotation_history' in serialization_options
-                and serialization_options['include_annotation_history'] is False
-            ):
+            if serialization_options.get('include_annotation_history') is False:
                 options['omit'] = ['annotations.history']
         return options
 

--- a/label_studio/data_export/serializers.py
+++ b/label_studio/data_export/serializers.py
@@ -155,6 +155,9 @@ class SerializationOptionsSerializer(serializers.Serializer):
 
     drafts = SerializationOption(required=False, help_text='JSON dict with parameters')
     predictions = SerializationOption(required=False, help_text='JSON dict with parameters')
+    include_annotation_history = serializers.BooleanField(
+        default=False, help_text='Include annotation history', required=False
+    )
     annotations__completed_by = SerializationOption(required=False, help_text='JSON dict with parameters')
     interpolate_key_frames = serializers.BooleanField(
         default=settings.INTERPOLATE_KEY_FRAMES, help_text='Interpolate video key frames', required=False


### PR DESCRIPTION
added parameter for including annotation history in export, it does not change the export format for LSO, because history does not exist here. Related methods will be overridden in LSE.

Mirroring https://github.com/HumanSignal/label-studio/pull/5843