### PR TITLE
docs: Fix playground condition issue

### DIFF
--- a/docs/themes/v2/layout/partials/header.ejs
+++ b/docs/themes/v2/layout/partials/header.ejs
@@ -173,11 +173,12 @@
       }
     ];
       const currentQuickLink = quickLinks.find(link => link.href.includes(page.type));
+
     %>
     <% if(quickLinks && quickLinks.length > 0) {%>
       <ul class="page-header-content-switcher">
       <% quickLinks.forEach(function(link) { %>
-        <li><a href="<%- link.href %>" class="<%- link.href === (currentQuickLink.href || quickLinks[0].href) ? 'active' : '' %>"><%- link.label %></a></li>
+        <li><a href="<%- link.href %>" class="<%- link.href === currentQuickLink?.href ? 'active' : '' %>"><%- link.label %></a></li>
       <% }); %>
       <li>
         <a href="https://app.heartex.com/docs/api" target="_blank">


### PR DESCRIPTION
Currently, the playground cannot render because of a template error in the header.

Update the condition to check if `currentQuickLink.href` exists.