### PR TITLE
fix: #5704 Fix DOMAIN_FROM_REQUEST validation for HOSTNAME

### DIFF
--- a/label_studio/core/settings/base.py
+++ b/label_studio/core/settings/base.py
@@ -84,8 +84,13 @@ SILENCED_SYSTEM_CHECKS = []
 
 # Hostname is used for proper path generation to the resources, pages, etc
 HOSTNAME = get_env('HOST', '')
+DOMAIN_FROM_REQUEST = get_bool_env('DOMAIN_FROM_REQUEST', False)
+
 if HOSTNAME:
-    if not HOSTNAME.startswith('http://') and not HOSTNAME.startswith('https://'):
+    if DOMAIN_FROM_REQUEST and not HOSTNAME.startswith('/'):
+        # in this mode HOSTNAME can be only subpath
+        raise ImproperlyConfigured('LABEL_STUDIO_HOST must be a subpath if DOMAIN_FROM_REQUEST is True')
+    else if not HOSTNAME.startswith('http://') and not HOSTNAME.startswith('https://'):
         logger.info(
             '! HOST variable found in environment, but it must start with http:// or https://, ignore it: %s', HOSTNAME
         )
@@ -103,13 +108,6 @@ if HOSTNAME:
             FORCE_SCRIPT_NAME = match.group(3)
             if FORCE_SCRIPT_NAME:
                 logger.info('=> Django URL prefix is set to: %s', FORCE_SCRIPT_NAME)
-
-DOMAIN_FROM_REQUEST = get_bool_env('DOMAIN_FROM_REQUEST', False)
-
-if DOMAIN_FROM_REQUEST:
-    # in this mode HOSTNAME can be only subpath
-    if HOSTNAME and not HOSTNAME.startswith('/'):
-        raise ImproperlyConfigured('LABEL_STUDIO_HOST must be a subpath if DOMAIN_FROM_REQUEST is True')
 
 INTERNAL_PORT = '8080'
 


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [x] Backend (API)
- [ ] Frontend



### Describe the reason for change
https://github.com/HumanSignal/label-studio/issues/5704


#### What does this fix?
When the `DOMAIN_FROM_REQUEST`  env variable is set, `HOSTNAME` is expected to start with `/` (so that the subpath is added to domain). However, that constraint validation happens *after* another validation for `HOSTNAME`, which is otherwise expected to start with `https?://`, and resets it to an empty string if that isn't the case - meaning that `DOMAIN_FROM_REQUEST` cannot be used successfully.



#### What is the new behavior?
The validation for a `HOSTNAME` subpath used with `DOMAIN_FROM_REQUEST` is moved above the check for a `https://?` `HOSTNAME`.



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
_(for bug fixes/features, be as precise as possible. ex. Authentication, Annotation History, Review Stream etc.)_

