### PR TITLE
fix: DIA-1116: Deleting predictions timing out

### DIFF
--- a/label_studio/ml_models/models.py
+++ b/label_studio/ml_models/models.py
@@ -2,7 +2,7 @@
 """
 
 from django.conf import settings
-from django.db import connection, models
+from django.db import models
 from django.utils.translation import gettext_lazy as _
 from ml_model_providers.models import ModelProviderConnection
 from projects.models import Project

--- a/label_studio/ml_models/models.py
+++ b/label_studio/ml_models/models.py
@@ -2,12 +2,12 @@
 """
 
 from django.conf import settings
-from django.db import models
+from django.db import connection, models
 from django.utils.translation import gettext_lazy as _
 from ml_model_providers.models import ModelProviderConnection
 from projects.models import Project
 from rest_framework.exceptions import ValidationError
-from tasks.models import Prediction
+from tasks.models import Annotation, Prediction
 
 
 def validate_string_list(value):
@@ -173,9 +173,16 @@ class ModelRun(models.Model):
     def delete_predictions(self):
         """
         Deletes any predictions that have originated from a ModelRun
-        """
 
-        Prediction.objects.filter(model_run=self.id).delete()
+        Executing a raw SQL query here for speed. This ignores any foreign key relationships
+        so if another model has a Prediction fk and set to on_delete=CASCADE for example,
+        it will not take affect. The only relationship like this that currently exists
+        is in Annotation.parent_prediction, which we are handling here
+        """
+        predictions = Prediction.objects.filter(model_run=self.id)
+        prediction_ids = [p.id for p in predictions]
+        Annotation.objects.filter(parent_prediction__in=prediction_ids).update(parent_prediction=None)
+        predictions._raw_delete(predictions.db)
 
     def delete(self, *args, **kwargs):
         """


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Backend (Database)
- [ ] Backend (API)
- [ ] Frontend



### Describe the reason for change
After evaluating a model on all tasks, and running a second time, we first delete all predictions before starting thew new job. However, this was taking a super long time for projects with a lot of tasks - causing a timeout in some cases. Now we are performing a _raw_delete() on these predictions, which bypasses the ORM. So we need to manually handle any foreign key relationships - which in this case we have one. When we create an annotation from a prediction, the parent_prediction field is set. When deleting through ORM, we are setting that field to null - so doing the same thing here. Operation is much much faster almost instant now.



#### What does this fix?
_(if this is a bug fix)_



#### What is the new behavior?
_(if this is a breaking or feature change)_



#### What is the current behavior?
_(if this is a breaking or feature change)_



#### What libraries were added/updated?
_(list all with version changes)_



#### Does this change affect performance?
_(if so describe the impacts positive or negative)_



#### Does this change affect security?
_(if so describe the impacts positive or negative)_



#### What alternative approaches were there?
_(briefly list any if applicable)_



#### What feature flags were used to cover this change?
_(briefly list any if applicable)_



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [ ] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
_(for bug fixes/features, be as precise as possible. ex. Authentication, Annotation History, Review Stream etc.)_

