### PR TITLE
ci: Keep biome version sync

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,4 +15,5 @@ repos:
     hooks:
     -   id: biome-check
         args: [--config-path, ./web]
-        additional_dependencies: ["@biomejs/biome@1.7.0"]
+        additional_dependencies: ["@biomejs/biome@1.7.1"]
+        files: ^web/.*

--- a/.pre-commit-dev.yaml
+++ b/.pre-commit-dev.yaml
@@ -14,5 +14,5 @@ repos:
     hooks:
     -   id: biome-check
         args: [--config-path, ./web]
-        additional_dependencies: ["@biomejs/biome@1.7.0"]
+        additional_dependencies: ["@biomejs/biome@1.7.1"]
         files: ^web/.*

--- a/web/biome.json
+++ b/web/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.7.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.7.1/schema.json",
   "organizeImports": {
     "enabled": false
   },

--- a/web/dist/apps/labelstudio/version.json
+++ b/web/dist/apps/labelstudio/version.json
@@ -1,6 +1,6 @@
 {
-  "message": "add comment",
-  "commit": "d14113cce25e4bd294a7c4a8c57917ab06a923e0",
-  "date": "2024-05-08T15:50:58.000Z",
-  "branch": "fb-optic-719/typeerror"
+  "message": "CI: Keep biome version sync",
+  "commit": "66eba02dd5b6a0ff08ebcf41c89cb056122ab404",
+  "date": "2024-05-17T22:07:44.000Z",
+  "branch": "ci/biome-version"
 }

--- a/web/dist/libs/datamanager/version.json
+++ b/web/dist/libs/datamanager/version.json
@@ -1,6 +1,6 @@
 {
-  "message": "add comment",
-  "commit": "d14113cce25e4bd294a7c4a8c57917ab06a923e0",
-  "date": "2024-05-08T15:50:58.000Z",
-  "branch": "fb-optic-719/typeerror"
+  "message": "CI: Keep biome version sync",
+  "commit": "66eba02dd5b6a0ff08ebcf41c89cb056122ab404",
+  "date": "2024-05-17T22:07:44.000Z",
+  "branch": "ci/biome-version"
 }

--- a/web/dist/libs/editor/version.json
+++ b/web/dist/libs/editor/version.json
@@ -1,6 +1,6 @@
 {
-  "message": "add comment",
-  "commit": "d14113cce25e4bd294a7c4a8c57917ab06a923e0",
-  "date": "2024-05-08T15:50:58.000Z",
-  "branch": "fb-optic-719/typeerror"
+  "message": "CI: Keep biome version sync",
+  "commit": "66eba02dd5b6a0ff08ebcf41c89cb056122ab404",
+  "date": "2024-05-17T22:07:44.000Z",
+  "branch": "ci/biome-version"
 }


### PR DESCRIPTION

Simply using the same version on the hooks that we have on package.json for biome