### PR TITLE
feat: RND-70: Add experimental action to cache labels and search over cached data field

### DIFF
--- a/label_studio/data_manager/actions/cache_labels.py
+++ b/label_studio/data_manager/actions/cache_labels.py
@@ -5,27 +5,25 @@ import logging
 
 from core.permissions import AllPermissions
 from core.redis import start_job_async_or_sync
-from tasks.models import Task, Annotation
+from tasks.models import Annotation, Task
 
 logger = logging.getLogger(__name__)
 all_permissions = AllPermissions()
 
 
 def cache_labels_job(project, queryset, **kwargs):
-    request_data = kwargs["request_data"]
-    control_tag = (
-        request_data.get("custom_control_tag") or request_data.get("control_tag")
-    )
-    with_counters = request_data.get("with_counters", "Yes").lower() == 'yes'
-    column_name = f"cache_{control_tag}"
+    request_data = kwargs['request_data']
+    control_tag = request_data.get('custom_control_tag') or request_data.get('control_tag')
+    with_counters = request_data.get('with_counters', 'Yes').lower() == 'yes'
+    column_name = f'cache_{control_tag}'
 
     # ALL is a special case, we will cache all labels from all control tags into one column
-    if control_tag == "ALL" or control_tag is None:
+    if control_tag == 'ALL' or control_tag is None:
         control_tag = None
-        column_name = "cache_all"
+        column_name = 'cache_all'
 
-    tasks = list(queryset.only("data"))
-    logger.info(f"Cache labels for {len(tasks)} tasks and control tag {control_tag}")
+    tasks = list(queryset.only('data'))
+    logger.info(f'Cache labels for {len(tasks)} tasks and control tag {control_tag}')
 
     for task in tasks:
         task_labels = []
@@ -35,45 +33,41 @@ def cache_labels_job(project, queryset, **kwargs):
             task_labels.extend(labels)
 
         # cache labels in separate data column
+        # with counters
         if with_counters:
-            task.data[column_name] = ", ".join(sorted([
-                f"{label}: {task_labels.count(label)}"
-                for label in set(task_labels)
-            ]))
+            task.data[column_name] = ', '.join(
+                sorted([f'{label}: {task_labels.count(label)}' for label in set(task_labels)])
+            )
+        # no counters
         else:
-            task.data[column_name] = ", ".join(sorted(list(task_labels)))
+            task.data[column_name] = ', '.join(sorted(list(set(task_labels))))
 
-    Task.objects.bulk_update(tasks, fields=["data"], batch_size=1000)
+    Task.objects.bulk_update(tasks, fields=['data'], batch_size=1000)
     first_task = Task.objects.get(id=queryset.first().id)
     project.summary.update_data_columns([first_task])
-    return {"response_code": 200, "detail": f"Updated {len(tasks)} tasks"}
+    return {'response_code': 200, 'detail': f'Updated {len(tasks)} tasks'}
 
 
 def extract_labels(annotation, control_tag):
     labels = []
     for region in annotation.result:
         # find regions with specific control tag name or just all regions if control tag is None
-        if (
-            control_tag is None
-            or region["from_name"] == control_tag
-            and "value" in region
-        ):
+        if control_tag is None or region['from_name'] == control_tag and 'value' in region:
             # scan value for a field with list of strings,
             # as bonus it will work with textareas too
-            for key in region["value"]:
+            for key in region['value']:
                 if (
-                    isinstance(region["value"][key], list)
-                    and region["value"][key]
-                    and isinstance(region["value"][key][0], str)
+                    isinstance(region['value'][key], list)
+                    and region['value'][key]
+                    and isinstance(region['value'][key][0], str)
                 ):
-                    labels.extend(region["value"][key])
+                    labels.extend(region['value'][key])
                     break
     return labels
 
 
 def cache_labels(project, queryset, request, **kwargs):
     """Cache labels from annotations to a new column in tasks"""
-    print(f'\n\n\n\n==================> {request.data}\n\n\n\n')
     start_job_async_or_sync(
         cache_labels_job,
         project,
@@ -81,7 +75,7 @@ def cache_labels(project, queryset, request, **kwargs):
         organization_id=project.organization_id,
         request_data=request.data,
     )
-    return {"response_code": 200}
+    return {'response_code': 200}
 
 
 def cache_labels_form(user, project):
@@ -92,24 +86,24 @@ def cache_labels_form(user, project):
 
     return [
         {
-            "columnCount": 1,
-            "fields": [
+            'columnCount': 1,
+            'fields': [
                 {
-                    "type": "select",
-                    "name": "control_tag",
-                    "label": "Choose a control tag",
-                    "options": control_tags,
+                    'type': 'select',
+                    'name': 'control_tag',
+                    'label': 'Choose a control tag',
+                    'options': control_tags,
                 },
                 {
-                    "type": "input",
-                    "name": "custom_control_tag",
-                    "label": "Custom control tag or 'ALL' to mix all tags",
+                    'type': 'input',
+                    'name': 'custom_control_tag',
+                    'label': "Custom control tag or 'ALL' to mix all tags",
                 },
                 {
-                    "type": "select",
-                    "name": "with_counters",
-                    "label": "With counters",
-                    "options": ['Yes', 'No'],
+                    'type': 'select',
+                    'name': 'with_counters',
+                    'label': 'With counters',
+                    'options': ['Yes', 'No'],
                 },
             ],
         }
@@ -118,17 +112,17 @@ def cache_labels_form(user, project):
 
 actions = [
     {
-        "entry_point": cache_labels,
-        "permission": all_permissions.projects_change,
-        "title": "Cache Labels",
-        "order": 1,
-        "experimental": True,
-        "dialog": {
-            "text": "Confirm that you want to add a new task.data field with cached labels from annotations. "
-            "This field will help you to quickly filter or order tasks by labels. "
-            "After this operation you must refresh the Data Manager page fully to see the new column!",
-            "type": "confirm",
-            "form": cache_labels_form,
+        'entry_point': cache_labels,
+        'permission': all_permissions.projects_change,
+        'title': 'Cache Labels',
+        'order': 1,
+        'experimental': True,
+        'dialog': {
+            'text': 'Confirm that you want to add a new task.data field with cached labels from annotations. '
+            'This field will help you to quickly filter or order tasks by labels. '
+            'After this operation you must refresh the Data Manager page fully to see the new column!',
+            'type': 'confirm',
+            'form': cache_labels_form,
         },
     },
 ]

--- a/label_studio/data_manager/actions/cache_labels.py
+++ b/label_studio/data_manager/actions/cache_labels.py
@@ -12,22 +12,20 @@ all_permissions = AllPermissions()
 
 
 def cache_labels_job(project, queryset, **kwargs):
-    request_data = kwargs["request_data"]
-    source = request_data.get("source", "annotations").lower()
-    source_class = Annotation if source == "annotations" else Prediction
-    control_tag = request_data.get("custom_control_tag") or request_data.get(
-        "control_tag"
-    )
-    with_counters = request_data.get("with_counters", "Yes").lower() == "yes"
-    column_name = f"cache_{control_tag}"
+    request_data = kwargs['request_data']
+    source = request_data.get('source', 'annotations').lower()
+    source_class = Annotation if source == 'annotations' else Prediction
+    control_tag = request_data.get('custom_control_tag') or request_data.get('control_tag')
+    with_counters = request_data.get('with_counters', 'Yes').lower() == 'yes'
+    column_name = f'cache_{control_tag}'
 
     # ALL is a special case, we will cache all labels from all control tags into one column
-    if control_tag == "ALL" or control_tag is None:
+    if control_tag == 'ALL' or control_tag is None:
         control_tag = None
-        column_name = "cache_all"
+        column_name = 'cache_all'
 
-    tasks = list(queryset.only("data"))
-    logger.info(f"Cache labels for {len(tasks)} tasks and control tag {control_tag}")
+    tasks = list(queryset.only('data'))
+    logger.info(f'Cache labels for {len(tasks)} tasks and control tag {control_tag}')
 
     for task in tasks:
         task_labels = []
@@ -39,42 +37,33 @@ def cache_labels_job(project, queryset, **kwargs):
         # cache labels in separate data column
         # with counters
         if with_counters:
-            task.data[column_name] = ", ".join(
-                sorted(
-                    [
-                        f"{label}: {task_labels.count(label)}"
-                        for label in set(task_labels)
-                    ]
-                )
+            task.data[column_name] = ', '.join(
+                sorted([f'{label}: {task_labels.count(label)}' for label in set(task_labels)])
             )
         # no counters
         else:
-            task.data[column_name] = ", ".join(sorted(list(set(task_labels))))
+            task.data[column_name] = ', '.join(sorted(list(set(task_labels))))
 
-    Task.objects.bulk_update(tasks, fields=["data"], batch_size=1000)
+    Task.objects.bulk_update(tasks, fields=['data'], batch_size=1000)
     first_task = Task.objects.get(id=queryset.first().id)
     project.summary.update_data_columns([first_task])
-    return {"response_code": 200, "detail": f"Updated {len(tasks)} tasks"}
+    return {'response_code': 200, 'detail': f'Updated {len(tasks)} tasks'}
 
 
 def extract_labels(annotation, control_tag):
     labels = []
     for region in annotation.result:
         # find regions with specific control tag name or just all regions if control tag is None
-        if (
-            control_tag is None
-            or region["from_name"] == control_tag
-            and "value" in region
-        ):
+        if control_tag is None or region['from_name'] == control_tag and 'value' in region:
             # scan value for a field with list of strings,
             # as bonus it will work with textareas too
-            for key in region["value"]:
+            for key in region['value']:
                 if (
-                    isinstance(region["value"][key], list)
-                    and region["value"][key]
-                    and isinstance(region["value"][key][0], str)
+                    isinstance(region['value'][key], list)
+                    and region['value'][key]
+                    and isinstance(region['value'][key][0], str)
                 ):
-                    labels.extend(region["value"][key])
+                    labels.extend(region['value'][key])
                     break
     return labels
 
@@ -88,7 +77,7 @@ def cache_labels(project, queryset, request, **kwargs):
         organization_id=project.organization_id,
         request_data=request.data,
     )
-    return {"response_code": 200}
+    return {'response_code': 200}
 
 
 def cache_labels_form(user, project):
@@ -99,30 +88,30 @@ def cache_labels_form(user, project):
 
     return [
         {
-            "columnCount": 1,
-            "fields": [
+            'columnCount': 1,
+            'fields': [
                 {
-                    "type": "select",
-                    "name": "control_tag",
-                    "label": "Choose a control tag",
-                    "options": control_tags,
+                    'type': 'select',
+                    'name': 'control_tag',
+                    'label': 'Choose a control tag',
+                    'options': control_tags,
                 },
                 {
-                    "type": "input",
-                    "name": "custom_control_tag",
-                    "label": "Custom control tag or 'ALL' to mix all tags",
+                    'type': 'input',
+                    'name': 'custom_control_tag',
+                    'label': "Custom control tag or 'ALL' to mix all tags",
                 },
                 {
-                    "type": "select",
-                    "name": "with_counters",
-                    "label": "With counters",
-                    "options": ["Yes", "No"],
+                    'type': 'select',
+                    'name': 'with_counters',
+                    'label': 'With counters',
+                    'options': ['Yes', 'No'],
                 },
                 {
-                    "type": "select",
-                    "name": "source",
-                    "label": "Source",
-                    "options": ["Annotations", "Predictions"],
+                    'type': 'select',
+                    'name': 'source',
+                    'label': 'Source',
+                    'options': ['Annotations', 'Predictions'],
                 },
             ],
         }
@@ -131,17 +120,17 @@ def cache_labels_form(user, project):
 
 actions = [
     {
-        "entry_point": cache_labels,
-        "permission": all_permissions.projects_change,
-        "title": "Cache Labels",
-        "order": 1,
-        "experimental": True,
-        "dialog": {
-            "text": "Confirm that you want to add a new task.data field with cached labels from annotations. "
-            "This field will help you to quickly filter or order tasks by labels. "
-            "After this operation you must refresh the Data Manager page fully to see the new column!",
-            "type": "confirm",
-            "form": cache_labels_form,
+        'entry_point': cache_labels,
+        'permission': all_permissions.projects_change,
+        'title': 'Cache Labels',
+        'order': 1,
+        'experimental': True,
+        'dialog': {
+            'text': 'Confirm that you want to add a new task.data field with cached labels from annotations. '
+            'This field will help you to quickly filter or order tasks by labels. '
+            'After this operation you must refresh the Data Manager page fully to see the new column!',
+            'type': 'confirm',
+            'form': cache_labels_form,
         },
     },
 ]

--- a/label_studio/data_manager/actions/cache_labels.py
+++ b/label_studio/data_manager/actions/cache_labels.py
@@ -5,29 +5,33 @@ import logging
 
 from core.permissions import AllPermissions
 from core.redis import start_job_async_or_sync
-from tasks.models import Annotation, Task
+from tasks.models import Annotation, Prediction, Task
 
 logger = logging.getLogger(__name__)
 all_permissions = AllPermissions()
 
 
 def cache_labels_job(project, queryset, **kwargs):
-    request_data = kwargs['request_data']
-    control_tag = request_data.get('custom_control_tag') or request_data.get('control_tag')
-    with_counters = request_data.get('with_counters', 'Yes').lower() == 'yes'
-    column_name = f'cache_{control_tag}'
+    request_data = kwargs["request_data"]
+    source = request_data.get("source", "annotations").lower()
+    source_class = Annotation if source == "annotations" else Prediction
+    control_tag = request_data.get("custom_control_tag") or request_data.get(
+        "control_tag"
+    )
+    with_counters = request_data.get("with_counters", "Yes").lower() == "yes"
+    column_name = f"cache_{control_tag}"
 
     # ALL is a special case, we will cache all labels from all control tags into one column
-    if control_tag == 'ALL' or control_tag is None:
+    if control_tag == "ALL" or control_tag is None:
         control_tag = None
-        column_name = 'cache_all'
+        column_name = "cache_all"
 
-    tasks = list(queryset.only('data'))
-    logger.info(f'Cache labels for {len(tasks)} tasks and control tag {control_tag}')
+    tasks = list(queryset.only("data"))
+    logger.info(f"Cache labels for {len(tasks)} tasks and control tag {control_tag}")
 
     for task in tasks:
         task_labels = []
-        annotations = Annotation.objects.filter(task=task)
+        annotations = source_class.objects.filter(task=task)
         for annotation in annotations:
             labels = extract_labels(annotation, control_tag)
             task_labels.extend(labels)
@@ -35,33 +39,42 @@ def cache_labels_job(project, queryset, **kwargs):
         # cache labels in separate data column
         # with counters
         if with_counters:
-            task.data[column_name] = ', '.join(
-                sorted([f'{label}: {task_labels.count(label)}' for label in set(task_labels)])
+            task.data[column_name] = ", ".join(
+                sorted(
+                    [
+                        f"{label}: {task_labels.count(label)}"
+                        for label in set(task_labels)
+                    ]
+                )
             )
         # no counters
         else:
-            task.data[column_name] = ', '.join(sorted(list(set(task_labels))))
+            task.data[column_name] = ", ".join(sorted(list(set(task_labels))))
 
-    Task.objects.bulk_update(tasks, fields=['data'], batch_size=1000)
+    Task.objects.bulk_update(tasks, fields=["data"], batch_size=1000)
     first_task = Task.objects.get(id=queryset.first().id)
     project.summary.update_data_columns([first_task])
-    return {'response_code': 200, 'detail': f'Updated {len(tasks)} tasks'}
+    return {"response_code": 200, "detail": f"Updated {len(tasks)} tasks"}
 
 
 def extract_labels(annotation, control_tag):
     labels = []
     for region in annotation.result:
         # find regions with specific control tag name or just all regions if control tag is None
-        if control_tag is None or region['from_name'] == control_tag and 'value' in region:
+        if (
+            control_tag is None
+            or region["from_name"] == control_tag
+            and "value" in region
+        ):
             # scan value for a field with list of strings,
             # as bonus it will work with textareas too
-            for key in region['value']:
+            for key in region["value"]:
                 if (
-                    isinstance(region['value'][key], list)
-                    and region['value'][key]
-                    and isinstance(region['value'][key][0], str)
+                    isinstance(region["value"][key], list)
+                    and region["value"][key]
+                    and isinstance(region["value"][key][0], str)
                 ):
-                    labels.extend(region['value'][key])
+                    labels.extend(region["value"][key])
                     break
     return labels
 
@@ -75,7 +88,7 @@ def cache_labels(project, queryset, request, **kwargs):
         organization_id=project.organization_id,
         request_data=request.data,
     )
-    return {'response_code': 200}
+    return {"response_code": 200}
 
 
 def cache_labels_form(user, project):
@@ -86,24 +99,30 @@ def cache_labels_form(user, project):
 
     return [
         {
-            'columnCount': 1,
-            'fields': [
+            "columnCount": 1,
+            "fields": [
                 {
-                    'type': 'select',
-                    'name': 'control_tag',
-                    'label': 'Choose a control tag',
-                    'options': control_tags,
+                    "type": "select",
+                    "name": "control_tag",
+                    "label": "Choose a control tag",
+                    "options": control_tags,
                 },
                 {
-                    'type': 'input',
-                    'name': 'custom_control_tag',
-                    'label': "Custom control tag or 'ALL' to mix all tags",
+                    "type": "input",
+                    "name": "custom_control_tag",
+                    "label": "Custom control tag or 'ALL' to mix all tags",
                 },
                 {
-                    'type': 'select',
-                    'name': 'with_counters',
-                    'label': 'With counters',
-                    'options': ['Yes', 'No'],
+                    "type": "select",
+                    "name": "with_counters",
+                    "label": "With counters",
+                    "options": ["Yes", "No"],
+                },
+                {
+                    "type": "select",
+                    "name": "source",
+                    "label": "Source",
+                    "options": ["Annotations", "Predictions"],
                 },
             ],
         }
@@ -112,17 +131,17 @@ def cache_labels_form(user, project):
 
 actions = [
     {
-        'entry_point': cache_labels,
-        'permission': all_permissions.projects_change,
-        'title': 'Cache Labels',
-        'order': 1,
-        'experimental': True,
-        'dialog': {
-            'text': 'Confirm that you want to add a new task.data field with cached labels from annotations. '
-            'This field will help you to quickly filter or order tasks by labels. '
-            'After this operation you must refresh the Data Manager page fully to see the new column!',
-            'type': 'confirm',
-            'form': cache_labels_form,
+        "entry_point": cache_labels,
+        "permission": all_permissions.projects_change,
+        "title": "Cache Labels",
+        "order": 1,
+        "experimental": True,
+        "dialog": {
+            "text": "Confirm that you want to add a new task.data field with cached labels from annotations. "
+            "This field will help you to quickly filter or order tasks by labels. "
+            "After this operation you must refresh the Data Manager page fully to see the new column!",
+            "type": "confirm",
+            "form": cache_labels_form,
         },
     },
 ]

--- a/label_studio/data_manager/actions/cache_labels.py
+++ b/label_studio/data_manager/actions/cache_labels.py
@@ -1,0 +1,134 @@
+"""This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
+"""
+
+import logging
+
+from core.permissions import AllPermissions
+from core.redis import start_job_async_or_sync
+from tasks.models import Task, Annotation
+
+logger = logging.getLogger(__name__)
+all_permissions = AllPermissions()
+
+
+def cache_labels_job(project, queryset, **kwargs):
+    request_data = kwargs["request_data"]
+    control_tag = (
+        request_data.get("custom_control_tag") or request_data.get("control_tag")
+    )
+    with_counters = request_data.get("with_counters", "Yes").lower() == 'yes'
+    column_name = f"cache_{control_tag}"
+
+    # ALL is a special case, we will cache all labels from all control tags into one column
+    if control_tag == "ALL" or control_tag is None:
+        control_tag = None
+        column_name = "cache_all"
+
+    tasks = list(queryset.only("data"))
+    logger.info(f"Cache labels for {len(tasks)} tasks and control tag {control_tag}")
+
+    for task in tasks:
+        task_labels = []
+        annotations = Annotation.objects.filter(task=task)
+        for annotation in annotations:
+            labels = extract_labels(annotation, control_tag)
+            task_labels.extend(labels)
+
+        # cache labels in separate data column
+        if with_counters:
+            task.data[column_name] = ", ".join(sorted([
+                f"{label}: {task_labels.count(label)}"
+                for label in set(task_labels)
+            ]))
+        else:
+            task.data[column_name] = ", ".join(sorted(list(task_labels)))
+
+    Task.objects.bulk_update(tasks, fields=["data"], batch_size=1000)
+    first_task = Task.objects.get(id=queryset.first().id)
+    project.summary.update_data_columns([first_task])
+    return {"response_code": 200, "detail": f"Updated {len(tasks)} tasks"}
+
+
+def extract_labels(annotation, control_tag):
+    labels = []
+    for region in annotation.result:
+        # find regions with specific control tag name or just all regions if control tag is None
+        if (
+            control_tag is None
+            or region["from_name"] == control_tag
+            and "value" in region
+        ):
+            # scan value for a field with list of strings,
+            # as bonus it will work with textareas too
+            for key in region["value"]:
+                if (
+                    isinstance(region["value"][key], list)
+                    and region["value"][key]
+                    and isinstance(region["value"][key][0], str)
+                ):
+                    labels.extend(region["value"][key])
+                    break
+    return labels
+
+
+def cache_labels(project, queryset, request, **kwargs):
+    """Cache labels from annotations to a new column in tasks"""
+    print(f'\n\n\n\n==================> {request.data}\n\n\n\n')
+    start_job_async_or_sync(
+        cache_labels_job,
+        project,
+        queryset,
+        organization_id=project.organization_id,
+        request_data=request.data,
+    )
+    return {"response_code": 200}
+
+
+def cache_labels_form(user, project):
+    labels = project.get_parsed_config()
+    control_tags = []
+    for key, _ in labels.items():
+        control_tags.append(key)
+
+    return [
+        {
+            "columnCount": 1,
+            "fields": [
+                {
+                    "type": "select",
+                    "name": "control_tag",
+                    "label": "Choose a control tag",
+                    "options": control_tags,
+                },
+                {
+                    "type": "input",
+                    "name": "custom_control_tag",
+                    "label": "Custom control tag or 'ALL' to mix all tags",
+                },
+                {
+                    "type": "select",
+                    "name": "with_counters",
+                    "label": "With counters",
+                    "options": ['Yes', 'No'],
+                },
+            ],
+        }
+    ]
+
+
+actions = [
+    {
+        "entry_point": cache_labels,
+        "permission": all_permissions.projects_change,
+        "title": "Cache Labels",
+        "order": 1,
+        "experimental": True,
+        "dialog": {
+            "text": "Confirm that you want to add a new task.data field with cached labels from annotations. "
+            "This field will help you to quickly filter or order tasks by labels. "
+            "After this operation you must refresh the Data Manager page fully to see the new column!",
+            "type": "confirm",
+            "form": cache_labels_form,
+        },
+    },
+]

--- a/label_studio/data_manager/actions/cache_labels.py
+++ b/label_studio/data_manager/actions/cache_labels.py
@@ -82,7 +82,7 @@ def cache_labels(project, queryset, request, **kwargs):
 
 def cache_labels_form(user, project):
     labels = project.get_parsed_config()
-    control_tags = []
+    control_tags = ['ALL']
     for key, _ in labels.items():
         control_tags.append(key)
 
@@ -99,7 +99,7 @@ def cache_labels_form(user, project):
                 {
                     'type': 'input',
                     'name': 'custom_control_tag',
-                    'label': "Custom control tag or 'ALL' to mix all tags",
+                    'label': "Custom control tag if it's not in label config",
                 },
                 {
                     'type': 'select',

--- a/label_studio/data_manager/actions/experimental.py
+++ b/label_studio/data_manager/actions/experimental.py
@@ -6,10 +6,12 @@ import random
 
 import ujson as json
 from core.permissions import AllPermissions
+from core.utils.db import fast_first
 from data_manager.functions import DataManagerException
 from django.conf import settings
 from tasks.models import Annotation, Task
 from tasks.serializers import TaskSerializerBulk
+
 
 logger = logging.getLogger(__name__)
 all_permissions = AllPermissions()
@@ -55,7 +57,7 @@ def propagate_annotations(project, queryset, **kwargs):
 
 
 def propagate_annotations_form(user, project):
-    first_annotation = Annotation.objects.filter(project=project).first()
+    first_annotation = fast_first(Annotation.objects.filter(project=project))
     field = {
         'type': 'number',
         'name': 'source_annotation_id',

--- a/label_studio/data_manager/actions/experimental.py
+++ b/label_studio/data_manager/actions/experimental.py
@@ -12,7 +12,6 @@ from django.conf import settings
 from tasks.models import Annotation, Task
 from tasks.serializers import TaskSerializerBulk
 
-
 logger = logging.getLogger(__name__)
 all_permissions = AllPermissions()
 

--- a/label_studio/tests/data_manager/test_api_actions.py
+++ b/label_studio/tests/data_manager/test_api_actions.py
@@ -5,9 +5,15 @@ import json
 
 import pytest
 from django.db import transaction
-from io_storages.azure_blob.models import AzureBlobImportStorage, AzureBlobImportStorageLink
+from io_storages.azure_blob.models import (
+    AzureBlobImportStorage,
+    AzureBlobImportStorageLink,
+)
 from io_storages.gcs.models import GCSImportStorage, GCSImportStorageLink
-from io_storages.localfiles.models import LocalFilesImportStorage, LocalFilesImportStorageLink
+from io_storages.localfiles.models import (
+    LocalFilesImportStorage,
+    LocalFilesImportStorageLink,
+)
 from io_storages.redis.models import RedisImportStorage, RedisImportStorageLink
 from io_storages.s3.models import S3ImportStorage, S3ImportStorageLink
 from projects.models import Project
@@ -203,6 +209,7 @@ def test_action_remove_duplicates_with_annotations(business_client, project_id):
     assert task2.annotations.count() == 6, 'task2 annotations count wrong'
     assert task2.annotations.filter(was_cancelled=True).count() == 1, 'was_cancelled counter wrong'
 
+
 @pytest.mark.django_db
 def test_action_cache_labels(business_client, project_id):
     """This test checks that the "cache_labels" action works correctly
@@ -214,21 +221,78 @@ def test_action_cache_labels(business_client, project_id):
     # task 1: add a task with specific labels
     task_data = {'data': {'image': 'image1.jpg'}}
     task1 = make_task(task_data, project)
-    make_annotation({'result': [{'from_name': 'label1', 'to_name': 'image', 'type': 'labels', 'value': {'labels': ['Label1']}}]}, task1.id)
+    make_annotation(
+        {
+            'result': [
+                {
+                    'from_name': 'label1',
+                    'to_name': 'image',
+                    'type': 'labels',
+                    'value': {'labels': ['Car']},
+                }
+            ]
+        },
+        task1.id,
+    )
 
     # task 2: add a task with different labels
     task_data = {'data': {'image': 'image2.jpg'}}
     task2 = make_task(task_data, project)
-    make_annotation({'result': [{'from_name': 'label2', 'to_name': 'image', 'type': 'labels', 'value':  {'labels': ['Label2']}}]}, task2.id)
+    make_annotation(
+        {
+            'result': [
+                {
+                    'from_name': 'label1',
+                    'to_name': 'image',
+                    'type': 'labels',
+                    'value': {'labels': ['Car']},
+                },
+                {
+                    'from_name': 'label1',
+                    'to_name': 'image',
+                    'type': 'labels',
+                    'value': {'labels': ['Car', 'Airplane']},
+                },
+            ]
+        },
+        task2.id,
+    )
 
-    # call the "cache_labels" action
+    # call the "cache_labels" action with counters
     status = business_client.post(
         f'/api/dm/actions?project={project_id}&id=cache_labels',
-        json={'selectedItems': {'all': True, 'excluded': []}, 'control_tag': 'label1', 'with_counters': 'yes'},
+        data=json.dumps(
+            {
+                'selectedItems': {'all': True, 'excluded': []},
+                'control_tag': 'label1',
+                'with_counters': 'yes',
+            }
+        ),
+        content_type='application/json',
     )
 
     # Assertions
     # Replace these with the actual assertions for your cache_labels function
     assert status.status_code == 200, 'status code wrong'
     assert project.tasks.count() == 2, 'tasks count wrong'
-    assert project.tasks.first().data.get('cache_label1') == 'Label1 (1)', 'cache_label1 wrong for task 1'
+    assert project.tasks.first().data.get('cache_label1') == 'Car: 1', 'cache_label1 wrong for task 1'
+    assert project.tasks.all()[1].data.get('cache_label1') == 'Airplane: 1, Car: 2', 'cache_label1 wrong for task 2'
+
+    # call the "cache_labels" action without counters
+    status = business_client.post(
+        f'/api/dm/actions?project={project_id}&id=cache_labels',
+        data=json.dumps(
+            {
+                'selectedItems': {'all': True, 'excluded': []},
+                'control_tag': 'label1',
+                'with_counters': 'no',
+            }
+        ),
+        content_type='application/json',
+    )
+
+    # Assertions
+    # Replace these with the actual assertions for your cache_labels function
+    assert status.status_code == 200, 'status code wrong'
+    assert project.tasks.first().data.get('cache_label1') == 'Car', 'cache_label1 wrong for task 1'
+    assert project.tasks.all()[1].data.get('cache_label1') == 'Airplane, Car', 'cache_label1 wrong for task 2'


### PR DESCRIPTION
#### How to enable and use this action?

1. `EXPERIMENTAL_FEATURES=1 label-studio` (or set EXPERIMENTAL_FEATURES=1 as env var). 
2. Go to the Data Manager.
3. Select tasks.
4. Click Actions => Cache Labels

**Note**: This action can take some time. Label Studio Community doesn't have background workers and it can fail if you have too many tasks and annotations in your project. To avoid this you can split your dataset into parts by filter with the Inner ID column and apply the action "Cache Labels" part by part. 

#### Summary

The "Cache Labels" action introduces a new feature that allows caching labels from annotations (or predictions) into a specified column in task data. The main functionality is encapsulated in the `cache_labels_job` function, which processes tasks and annotations to extract and store labels based on a specified control tag from the labeling config. Additionally, a form is provided to configure this feature through the UI.

![image](https://github.com/HumanSignal/label-studio/assets/501780/7cdc5619-999a-4679-9206-4413e1427aea)


#### Details

- **Caching Labels**:
  - Extracts labels from annotations and caches them into a new column in the task data.
  - Supports optional counters to indicate the frequency of each label.
  - Special case handling for the control tag `ALL`, which aggregates labels from all control tags.

- **Form Configuration**:
  - Provides a form to select the control tag, specify a custom control tag, and choose whether to include counters.
  - Form options are dynamically generated based on the project's configuration.

- **Job Execution**:
  - Uses `start_job_async_or_sync` to handle the job execution, allowing for asynchronous or synchronous processing.
  - Logs the number of tasks processed and updates the project summary with new data columns.

- **Bulk Update**:
  - Uses `bulk_update` to efficiently update task data in batches of 1000.
  - Ensures data integrity by updating the project summary with the new columns.

#### Usage

- **Cache Labels Action**:
  - Available as an action with the title "Cache Labels".
  - Requires confirmation through a dialog that explains the impact of the operation.
  - After execution, users must refresh the Data Manager page to see the new column.


#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Backend (Database)
- [x] Backend (API)
- [ ] Frontend



#### Describe the reason for change
* Annotation.result filters work very slowly, we need to improve filters
* We need to display labels in the data manager in more accurate way


#### What does this fix?
It fixes performance for filters by annotation labels. 


#### What is the new behavior?
1. You have to cache labels first using DM actions. 
2. Then you will be able to filter over new column (field) in DM. 


#### What feature flags were used to cover this change?
`EXPERIMENTAL_FEATURES=1` or `ff_back_experimental_features=1`


#### Does this PR introduce a breaking change?
_(check only one)_
- [x] No


#### What level of testing was included in the change?
_(check all that apply)_
- [x] integration