### PR TITLE
chore: LEAP-1118: Amplitude analytics integration

### DIFF
--- a/label_studio/core/settings/base.py
+++ b/label_studio/core/settings/base.py
@@ -707,6 +707,11 @@ DATA_MANAGER_FILTER_ALLOWLIST = list(
 )
 
 if ENABLE_CSP := get_bool_env('ENABLE_CSP', True):
+    CSP_FRAME_SRC = (
+        "'self'",
+        "'report-sample'",
+        'https://humansignal.com',
+    )
     CSP_DEFAULT_SRC = (
         "'self'",
         "'report-sample'",
@@ -719,6 +724,7 @@ if ENABLE_CSP := get_bool_env('ENABLE_CSP', True):
         "'unsafe-eval'",
         'blob:',
         'browser.sentry-cdn.com',
+        'https://*.amplitude.com',
         'https://*.googletagmanager.com',
     )
     CSP_IMG_SRC = (
@@ -732,6 +738,7 @@ if ENABLE_CSP := get_bool_env('ENABLE_CSP', True):
     CSP_CONNECT_SRC = (
         "'self'",
         "'report-sample'",
+        'https://*.amplitude.com',
         'https://*.google-analytics.com',
         'https://*.analytics.google.com',
         'https://analytics.google.com',

--- a/label_studio/templates/base.html
+++ b/label_studio/templates/base.html
@@ -55,9 +55,44 @@
 
   {% get_current_language as LANGUAGE_CODE %}
   {% get_available_languages as LANGUAGES %}
+
+  {% if settings.COLLECT_ANALYTICS %}
+    <script id="amplitude-init" nonce="{{request.csp_nonce}}">
+      window.addEventListener("message", initAmplitude, false);
+      function initAmplitude(event) {
+          if (event.origin !== "https://humansignal.com") {
+            return;
+          }
+          if (!'deviceId' in event.data) {
+            console.log('unexpected event data', event.data);
+            return;
+          }
+
+          const opts = {
+            defaultTracking: {
+              attribution: true,
+              pageViews: true,
+              sessions: true,
+              formInteractions: true,
+              fileDownloads: true,
+            },
+            deviceId: event.data.deviceId,
+          };
+
+          // prettier-ignore
+          !function(){"use strict";!function(e,t){var r=e.amplitude||{_q:[],_iq:{}};if(r.invoked)e.console&&console.error&&console.error("Amplitude snippet has been loaded.");else{var n=function(e,t){e.prototype[t]=function(){return this._q.push({name:t,args:Array.prototype.slice.call(arguments,0)}),this}},o=function(e,t,r){return function(n){e._q.push({name:t,args:Array.prototype.slice.call(r,0),resolve:n})}},s=function(e,t,r){e._q.push({name:t,args:Array.prototype.slice.call(r,0)})},i=function(e,t,r){e[t]=function(){if(r)return{promise:new Promise(o(e,t,Array.prototype.slice.call(arguments)))};s(e,t,Array.prototype.slice.call(arguments))}},a=function(e){for(var t=0;t<g.length;t++)i(e,g[t],!1);for(var r=0;r<m.length;r++)i(e,m[r],!0)};r.invoked=!0;var c=t.createElement("script");c.type="text/javascript",c.integrity="sha384-r58GovPc8jo7o9PFd/Y8xHwOiockvJvuIBZZqsA7I8EzliMj0Pe0Sbx7Ti2ClxDD",c.crossOrigin="anonymous",c.async=!0,c.src="https://cdn.amplitude.com/libs/analytics-browser-2.8.0-min.js.gz",c.onload=function(){e.amplitude.runQueuedFunctions||console.log("[Amplitude] Error: could not load SDK")};var u=t.getElementsByTagName("script")[0];u.parentNode.insertBefore(c,u);for(var l=function(){return this._q=[],this},p=["add","append","clearAll","prepend","set","setOnce","unset","preInsert","postInsert","remove","getUserProperties"],d=0;d<p.length;d++)n(l,p[d]);r.Identify=l;for(var v=function(){return this._q=[],this},f=["getEventProperties","setProductId","setQuantity","setPrice","setRevenue","setRevenueType","setEventProperties"],y=0;y<f.length;y++)n(v,f[y]);r.Revenue=v;var g=["getDeviceId","setDeviceId","getSessionId","setSessionId","getUserId","setUserId","setOptOut","setTransport","reset","extendSession"],m=["init","add","remove","track","logEvent","identify","groupIdentify","setGroup","revenue","flush"];a(r),r.createInstance=function(e){return r._iq[e]={_q:[]},a(r._iq[e]),r._iq[e]},e.amplitude=r}}(window,document)}();
+          amplitude.init("b31f0f12b3309671ac50471a820cad8c", "{{user.email}}", opts).promise.then(() => console.log('initialized amplitude with device id', amplitude.getDeviceId()));
+
+      }
+    </script>
+  {% endif %}
 </head>
 
 <body>
+
+{% if settings.COLLECT_ANALYTICS %}
+  <iframe src="https://humansignal.com/amplitude/" style="display: none;"></iframe>
+{% endif %}
 
 <div class="app-wrapper"></div>
 

--- a/label_studio/users/templates/users/new-ui/user_base.html
+++ b/label_studio/users/templates/users/new-ui/user_base.html
@@ -13,44 +13,10 @@ window.dataLayer = window.dataLayer || [];
 function gtag(){dataLayer.push(arguments);}
 gtag('js', new Date());
 gtag('config', 'UA-129877673-1');
-
-{% if settings.COLLECT_ANALYTICS %}
-  window.addEventListener("message", initAmplitude, false);
-  function initAmplitude(event) {
-      if (event.origin !== "https://humansignal.com") {
-        return;
-      }
-      if (!'deviceId' in event.data) {
-        console.log('unexpected event data', event.data);
-        return;
-      }
-
-      const opts = {
-        defaultTracking: {
-          attribution: true,
-          pageViews: true,
-          sessions: true,
-          formInteractions: true,
-          fileDownloads: true,
-        },
-        deviceId: event.data.deviceId,
-      };
-
-      // prettier-ignore
-      !function(){"use strict";!function(e,t){var r=e.amplitude||{_q:[],_iq:{}};if(r.invoked)e.console&&console.error&&console.error("Amplitude snippet has been loaded.");else{var n=function(e,t){e.prototype[t]=function(){return this._q.push({name:t,args:Array.prototype.slice.call(arguments,0)}),this}},o=function(e,t,r){return function(n){e._q.push({name:t,args:Array.prototype.slice.call(r,0),resolve:n})}},s=function(e,t,r){e._q.push({name:t,args:Array.prototype.slice.call(r,0)})},i=function(e,t,r){e[t]=function(){if(r)return{promise:new Promise(o(e,t,Array.prototype.slice.call(arguments)))};s(e,t,Array.prototype.slice.call(arguments))}},a=function(e){for(var t=0;t<g.length;t++)i(e,g[t],!1);for(var r=0;r<m.length;r++)i(e,m[r],!0)};r.invoked=!0;var c=t.createElement("script");c.type="text/javascript",c.integrity="sha384-r58GovPc8jo7o9PFd/Y8xHwOiockvJvuIBZZqsA7I8EzliMj0Pe0Sbx7Ti2ClxDD",c.crossOrigin="anonymous",c.async=!0,c.src="https://cdn.amplitude.com/libs/analytics-browser-2.8.0-min.js.gz",c.onload=function(){e.amplitude.runQueuedFunctions||console.log("[Amplitude] Error: could not load SDK")};var u=t.getElementsByTagName("script")[0];u.parentNode.insertBefore(c,u);for(var l=function(){return this._q=[],this},p=["add","append","clearAll","prepend","set","setOnce","unset","preInsert","postInsert","remove","getUserProperties"],d=0;d<p.length;d++)n(l,p[d]);r.Identify=l;for(var v=function(){return this._q=[],this},f=["getEventProperties","setProductId","setQuantity","setPrice","setRevenue","setRevenueType","setEventProperties"],y=0;y<f.length;y++)n(v,f[y]);r.Revenue=v;var g=["getDeviceId","setDeviceId","getSessionId","setSessionId","getUserId","setUserId","setOptOut","setTransport","reset","extendSession"],m=["init","add","remove","track","logEvent","identify","groupIdentify","setGroup","revenue","flush"];a(r),r.createInstance=function(e){return r._iq[e]={_q:[]},a(r._iq[e]),r._iq[e]},e.amplitude=r}}(window,document)}();
-      amplitude.init("b31f0f12b3309671ac50471a820cad8c", opts).promise.then(() => console.log('initialized amplitude with device id', amplitude.getDeviceId()));
-  }
-
-
-{% endif %}
 </script>
-
 {% endblock %}
 
 {% block content %}
-{% if settings.COLLECT_ANALYTICS %}
-  <iframe src="https://humansignal.com/amplitude/" style="display: none;"></iframe>
-{% endif %}
 <div class="login_page_new_ui">
   <div class="left">
     <h2>Welcome</h2>

--- a/label_studio/users/templates/users/new-ui/user_base.html
+++ b/label_studio/users/templates/users/new-ui/user_base.html
@@ -13,10 +13,44 @@ window.dataLayer = window.dataLayer || [];
 function gtag(){dataLayer.push(arguments);}
 gtag('js', new Date());
 gtag('config', 'UA-129877673-1');
+
+{% if settings.COLLECT_ANALYTICS %}
+  window.addEventListener("message", initAmplitude, false);
+  function initAmplitude(event) {
+      if (event.origin !== "https://humansignal.com") {
+        return;
+      }
+      if (!'deviceId' in event.data) {
+        console.log('unexpected event data', event.data);
+        return;
+      }
+
+      const opts = {
+        defaultTracking: {
+          attribution: true,
+          pageViews: true,
+          sessions: true,
+          formInteractions: true,
+          fileDownloads: true,
+        },
+        deviceId: event.data.deviceId,
+      };
+
+      // prettier-ignore
+      !function(){"use strict";!function(e,t){var r=e.amplitude||{_q:[],_iq:{}};if(r.invoked)e.console&&console.error&&console.error("Amplitude snippet has been loaded.");else{var n=function(e,t){e.prototype[t]=function(){return this._q.push({name:t,args:Array.prototype.slice.call(arguments,0)}),this}},o=function(e,t,r){return function(n){e._q.push({name:t,args:Array.prototype.slice.call(r,0),resolve:n})}},s=function(e,t,r){e._q.push({name:t,args:Array.prototype.slice.call(r,0)})},i=function(e,t,r){e[t]=function(){if(r)return{promise:new Promise(o(e,t,Array.prototype.slice.call(arguments)))};s(e,t,Array.prototype.slice.call(arguments))}},a=function(e){for(var t=0;t<g.length;t++)i(e,g[t],!1);for(var r=0;r<m.length;r++)i(e,m[r],!0)};r.invoked=!0;var c=t.createElement("script");c.type="text/javascript",c.integrity="sha384-r58GovPc8jo7o9PFd/Y8xHwOiockvJvuIBZZqsA7I8EzliMj0Pe0Sbx7Ti2ClxDD",c.crossOrigin="anonymous",c.async=!0,c.src="https://cdn.amplitude.com/libs/analytics-browser-2.8.0-min.js.gz",c.onload=function(){e.amplitude.runQueuedFunctions||console.log("[Amplitude] Error: could not load SDK")};var u=t.getElementsByTagName("script")[0];u.parentNode.insertBefore(c,u);for(var l=function(){return this._q=[],this},p=["add","append","clearAll","prepend","set","setOnce","unset","preInsert","postInsert","remove","getUserProperties"],d=0;d<p.length;d++)n(l,p[d]);r.Identify=l;for(var v=function(){return this._q=[],this},f=["getEventProperties","setProductId","setQuantity","setPrice","setRevenue","setRevenueType","setEventProperties"],y=0;y<f.length;y++)n(v,f[y]);r.Revenue=v;var g=["getDeviceId","setDeviceId","getSessionId","setSessionId","getUserId","setUserId","setOptOut","setTransport","reset","extendSession"],m=["init","add","remove","track","logEvent","identify","groupIdentify","setGroup","revenue","flush"];a(r),r.createInstance=function(e){return r._iq[e]={_q:[]},a(r._iq[e]),r._iq[e]},e.amplitude=r}}(window,document)}();
+      amplitude.init("b31f0f12b3309671ac50471a820cad8c", opts).promise.then(() => console.log('initialized amplitude with device id', amplitude.getDeviceId()));
+  }
+
+
+{% endif %}
 </script>
+
 {% endblock %}
 
 {% block content %}
+{% if settings.COLLECT_ANALYTICS %}
+  <iframe src="https://humansignal.com/amplitude/" style="display: none;"></iframe>
+{% endif %}
 <div class="login_page_new_ui">
   <div class="left">
     <h2>Welcome</h2>


### PR DESCRIPTION
If settings.COLLECT_ANALYTICS is true, use Amplitude to track page views and similar data within the open source product. Leverages a third party cookie on humansignal.com to make this work; the approach should be viable in Google Chrome til Q1 2025.