### PR TITLE
fix: LEAP-860: have GCS generate data URLs if presign is disabled

### DIFF
--- a/label_studio/io_storages/gcs/models.py
+++ b/label_studio/io_storages/gcs/models.py
@@ -87,6 +87,7 @@ class GCSImportStorageBase(GCSStorageMixin, ImportStorage):
     def generate_http_url(self, url):
         return GCS.generate_http_url(
             url=url,
+            presign=self.presign,
             google_application_credentials=self.google_application_credentials,
             google_project_id=self.google_project_id,
             presign_ttl=self.presign_ttl,

--- a/label_studio/io_storages/gcs/utils.py
+++ b/label_studio/io_storages/gcs/utils.py
@@ -207,9 +207,10 @@ class GCS(object):
             bucket_name=bucket_name,
         )
 
-        blob = bucket.get_blob(blob_name)
+        blob = bucket.blob(blob_name)
 
         if not presign:
+            blob.reload()  # needed to know the content type
             return f'data:{blob.content_type};base64,{base64.b64encode(blob.download_as_bytes()).decode("utf-8")}'
 
         # this flag should be OFF, maybe we need to enable it for 1-2 customers, we have to check it

--- a/label_studio/io_storages/gcs/utils.py
+++ b/label_studio/io_storages/gcs/utils.py
@@ -222,7 +222,8 @@ class GCS(object):
                 cls.get_client(google_application_credentials=maybe_credentials) if maybe_credentials else None
             )
             blob.reload(client=maybe_client)  # needed to know the content type
-            return f'data:{blob.content_type};base64,{base64.b64encode(blob.download_as_bytes()).decode("utf-8")}'
+            blob_bytes = blob.download_as_bytes(client=maybe_client)
+            return f'data:{blob.content_type};base64,{base64.b64encode(blob_bytes).decode("utf-8")}'
 
         url = blob.generate_signed_url(
             version='v4',

--- a/label_studio/io_storages/gcs/utils.py
+++ b/label_studio/io_storages/gcs/utils.py
@@ -214,13 +214,12 @@ class GCS(object):
             # google_application_credentials has higher priority,
             # use Application Default Credentials (ADC) when google_application_credentials is empty only
             maybe_credentials = {} if google_application_credentials else cls._get_default_credentials()
+            maybe_client = None if google_application_credentials else cls.get_client()
         else:
             maybe_credentials = {}
+            maybe_client = None
 
         if not presign:
-            maybe_client = (
-                cls.get_client(google_application_credentials=maybe_credentials) if maybe_credentials else None
-            )
             blob.reload(client=maybe_client)  # needed to know the content type
             blob_bytes = blob.download_as_bytes(client=maybe_client)
             return f'data:{blob.content_type};base64,{base64.b64encode(blob_bytes).decode("utf-8")}'

--- a/label_studio/io_storages/gcs/utils.py
+++ b/label_studio/io_storages/gcs/utils.py
@@ -176,6 +176,7 @@ class GCS(object):
     def generate_http_url(
         cls,
         url: str,
+        presign: bool,
         google_application_credentials: Union[str, dict] = None,
         google_project_id: str = None,
         presign_ttl: int = 1,
@@ -183,6 +184,7 @@ class GCS(object):
         """
         Gets gs:// like URI string and returns presigned https:// URL
         :param url: input URI
+        :param presign: Whether to generate presigned URL. If false, will generate base64 encoded data URL
         :param google_application_credentials:
         :param google_project_id:
         :param presign_ttl: Presign TTL in minutes
@@ -205,7 +207,10 @@ class GCS(object):
             bucket_name=bucket_name,
         )
 
-        blob = bucket.blob(blob_name)
+        blob = bucket.get_blob(blob_name)
+
+        if not presign:
+            return f'data:{blob.content_type};base64,{base64.b64encode(blob.download_as_bytes()).decode("utf-8")}'
 
         # this flag should be OFF, maybe we need to enable it for 1-2 customers, we have to check it
         if settings.GCS_CLOUD_STORAGE_FORCE_DEFAULT_CREDENTIALS:


### PR DESCRIPTION
Make GCS behave the same way as S3 import storages, in that when presign isn't enabled for the storage, we return data URLs containing b64-encoded data instead of presigned URLs in task data.

We don't have any unit tests that simulate fetching real data from GCS and while this code should have them, setting up a mock GCS is too large to be in-scope for this task, so I've carefully verified the behavior locally instead.

![image](https://github.com/HumanSignal/label-studio/assets/3943358/034ec49f-81e9-48f3-8103-06da94e66095)
