### PR TITLE
fix: RND-92: Add missed API spec for 'query' parameter in tasks list

### DIFF
--- a/label_studio/tasks/api.py
+++ b/label_studio/tasks/api.py
@@ -120,7 +120,8 @@ logger = logging.getLogger(__name__)
                 in_=openapi.IN_QUERY,
                 description='Additional query to filter tasks. It must be JSON encoded string of dict containing '
                 'one of the following parameters: `{"filters": ..., "selectedItems": ..., "ordering": ...}`\n\n'
-                '* **filters**: dict with "conjunction": str ("or" / "and") and "items": list of filters. Each filter is a dictionary with keys: `"filter"`, `"operator"`, `"type"`, `"value"`. '
+                '* **filters**: dict with `"conjunction"` string (`"or"` or `"and"`) and list of filters in `"items"` array. '
+                'Each filter is a dictionary with keys: `"filter"`, `"operator"`, `"type"`, `"value"`. '
                 '[Read more about available filters](https://labelstud.io/sdk/data_manager.html)<br/>'
                 '                   Example: `{"conjunction": "or", "items": [{"filter": "filter:tasks:completed_at", "operator": "greater", "type": "Datetime", "value": "2021-01-01T00:00:00.000Z"}]}`\n'
                 '* **selectedItems**: dictionary with keys: `"all"`, `"included"`, `"excluded"`. If "all" is `false`, `"included"` must be used. If "all" is `true`, `"excluded"` must be used.<br/>'

--- a/label_studio/tasks/api.py
+++ b/label_studio/tasks/api.py
@@ -120,11 +120,11 @@ logger = logging.getLogger(__name__)
                 in_=openapi.IN_QUERY,
                 description='Additional query to filter tasks. It must be JSON encoded string of dict containing '
                 'one of the following parameters: `{"filters": ..., "selectedItems": ..., "ordering": ...}`\n\n'
-                '* **filters**: list of filters, each filter is a dictionary with keys: "filter", "operator", "type", "value".<br/>'
-                '                   Example: `[{"filter": "filter:completed_at", "operator": "gt", "type": "datetime", "value": "2021-01-01T00:00:00.000Z"}]`\n'
-                '* **selectedItems**: dictionary with keys: `"all"`, `"included"`, `"excluded"`.<br/>'
-                '                   Example: `{"all": false, "included": [1, 2, 3], "excluded": [4, 5]}`\n'
-                '* **ordering**: list of fields to order by.<br/>\n'
+                '* **filters**: list of filters, each filter is a dictionary with keys: `"filter"`, `"operator"`, `"type"`, `"value"`.<br/>'
+                '                   Example: `[{"filter": "filter:tasks:completed_at", "operator": "greater", "type": "Datetime", "value": "2021-01-01T00:00:00.000Z"}]`\n'
+                '* **selectedItems**: dictionary with keys: `"all"`, `"included"`, `"excluded"`. If "all" is `false`, `"included"` must be used. If "all" is `true`, `"excluded"` must be used.<br/>'
+                '                   Examples: `{"all": false, "included": [1, 2, 3]}` or `{"all": true, "excluded": [4, 5]}`\n'
+                '* **ordering**: list of fields to order by. Currently, ordering is supported by only one parameter. <br/>\n'
                 '                   Example: `["completed_at"]`',
             ),
         ],

--- a/label_studio/tasks/api.py
+++ b/label_studio/tasks/api.py
@@ -120,7 +120,7 @@ logger = logging.getLogger(__name__)
                 in_=openapi.IN_QUERY,
                 description='Additional query to filter tasks. It must be JSON encoded string of dict containing '
                 'one of the following parameters: `{"filters": ..., "selectedItems": ..., "ordering": ...}`\n\n'
-                '* **filters**: list of filters, each filter is a dictionary with keys: `"filter"`, `"operator"`, `"type"`, `"value"`.<br/>'
+                '* **filters**: dict with "conjunction": str ("or" / "and") and "items": list of filters. Each filter is a dictionary with keys: `"filter"`, `"operator"`, `"type"`, `"value"`.<br/>'
                 '                   Example: `[{"filter": "filter:tasks:completed_at", "operator": "greater", "type": "Datetime", "value": "2021-01-01T00:00:00.000Z"}]`\n'
                 '* **selectedItems**: dictionary with keys: `"all"`, `"included"`, `"excluded"`. If "all" is `false`, `"included"` must be used. If "all" is `true`, `"excluded"` must be used.<br/>'
                 '                   Examples: `{"all": false, "included": [1, 2, 3]}` or `{"all": true, "excluded": [4, 5]}`\n'

--- a/label_studio/tasks/api.py
+++ b/label_studio/tasks/api.py
@@ -121,7 +121,7 @@ logger = logging.getLogger(__name__)
                 description='Additional query to filter tasks. It must be JSON encoded string of dict containing '
                 'one of the following parameters: `{"filters": ..., "selectedItems": ..., "ordering": ...}`\n\n'
                 '* **filters**: dict with "conjunction": str ("or" / "and") and "items": list of filters. Each filter is a dictionary with keys: `"filter"`, `"operator"`, `"type"`, `"value"`.<br/>'
-                '                   Example: `[{"filter": "filter:tasks:completed_at", "operator": "greater", "type": "Datetime", "value": "2021-01-01T00:00:00.000Z"}]`\n'
+                '                   Example: `{"conjunction": "or", "items": [{"filter": "filter:tasks:completed_at", "operator": "greater", "type": "Datetime", "value": "2021-01-01T00:00:00.000Z"}]}`\n'
                 '* **selectedItems**: dictionary with keys: `"all"`, `"included"`, `"excluded"`. If "all" is `false`, `"included"` must be used. If "all" is `true`, `"excluded"` must be used.<br/>'
                 '                   Examples: `{"all": false, "included": [1, 2, 3]}` or `{"all": true, "excluded": [4, 5]}`\n'
                 '* **ordering**: list of fields to order by. Currently, ordering is supported by only one parameter. <br/>\n'

--- a/label_studio/tasks/api.py
+++ b/label_studio/tasks/api.py
@@ -114,6 +114,18 @@ logger = logging.getLogger(__name__)
                 in_=openapi.IN_QUERY,
                 description='Specify which fields to include in the response',
             ),
+            openapi.Parameter(
+                name='query',
+                type=openapi.TYPE_STRING,
+                in_=openapi.IN_QUERY,
+                description='Additional query to filter tasks. It must be JSON encoded string of dict containing '
+                'one of the following parameters: \n\n'
+                '- "filters": list of filters, each filter is a dictionary with keys: "filter", "operator", "type", "value". '
+                '             Example: [{"filter": "filter:completed_at", "operator": "gt", "type": "datetime", "value": "2021-01-01T00:00:00.000Z"}] \n'
+                '- "selectedItems": dictionary with keys: "all", "included", "excluded". '
+                '             Example: {"all": false, "included": [1, 2, 3], "excluded": [4, 5]} \n'
+                '- "ordering": list of fields to order by. Example: ["completed_at"]',
+            ),
         ],
         responses={
             '200': openapi.Response(

--- a/label_studio/tasks/api.py
+++ b/label_studio/tasks/api.py
@@ -120,7 +120,8 @@ logger = logging.getLogger(__name__)
                 in_=openapi.IN_QUERY,
                 description='Additional query to filter tasks. It must be JSON encoded string of dict containing '
                 'one of the following parameters: `{"filters": ..., "selectedItems": ..., "ordering": ...}`\n\n'
-                '* **filters**: dict with "conjunction": str ("or" / "and") and "items": list of filters. Each filter is a dictionary with keys: `"filter"`, `"operator"`, `"type"`, `"value"`.<br/>'
+                '* **filters**: dict with "conjunction": str ("or" / "and") and "items": list of filters. Each filter is a dictionary with keys: `"filter"`, `"operator"`, `"type"`, `"value"`. '
+                '[Read more about available filters](https://labelstud.io/sdk/data_manager.html)<br/>'
                 '                   Example: `{"conjunction": "or", "items": [{"filter": "filter:tasks:completed_at", "operator": "greater", "type": "Datetime", "value": "2021-01-01T00:00:00.000Z"}]}`\n'
                 '* **selectedItems**: dictionary with keys: `"all"`, `"included"`, `"excluded"`. If "all" is `false`, `"included"` must be used. If "all" is `true`, `"excluded"` must be used.<br/>'
                 '                   Examples: `{"all": false, "included": [1, 2, 3]}` or `{"all": true, "excluded": [4, 5]}`\n'

--- a/label_studio/tasks/api.py
+++ b/label_studio/tasks/api.py
@@ -119,12 +119,13 @@ logger = logging.getLogger(__name__)
                 type=openapi.TYPE_STRING,
                 in_=openapi.IN_QUERY,
                 description='Additional query to filter tasks. It must be JSON encoded string of dict containing '
-                'one of the following parameters: \n\n'
-                '- "filters": list of filters, each filter is a dictionary with keys: "filter", "operator", "type", "value". '
-                '             Example: [{"filter": "filter:completed_at", "operator": "gt", "type": "datetime", "value": "2021-01-01T00:00:00.000Z"}] \n'
-                '- "selectedItems": dictionary with keys: "all", "included", "excluded". '
-                '             Example: {"all": false, "included": [1, 2, 3], "excluded": [4, 5]} \n'
-                '- "ordering": list of fields to order by. Example: ["completed_at"]',
+                'one of the following parameters: `{"filters": ..., "selectedItems": ..., "ordering": ...}`\n\n'
+                '* **filters**: list of filters, each filter is a dictionary with keys: "filter", "operator", "type", "value".<br/>'
+                '                   Example: `[{"filter": "filter:completed_at", "operator": "gt", "type": "datetime", "value": "2021-01-01T00:00:00.000Z"}]`\n'
+                '* **selectedItems**: dictionary with keys: `"all"`, `"included"`, `"excluded"`.<br/>'
+                '                   Example: `{"all": false, "included": [1, 2, 3], "excluded": [4, 5]}`\n'
+                '* **ordering**: list of fields to order by.<br/>\n'
+                '                   Example: `["completed_at"]`',
             ),
         ],
         responses={


### PR DESCRIPTION
Missing the parameter query in the current implementation of `ls.tasks.list()`:

SDK<1.0:
```
        query = {
            "filters": filters,
            "ordering": ordering or [],
            "selectedItems": (
                {"all": False, "included": selected_ids}
                if selected_ids
                else {"all": True, "excluded": []}
            ),
        }
        params = {
            "project": self.id,
            "page": page,
            "page_size": page_size,
            "view": view_id,
            "query": json.dumps(query),
            "fields": "all",
            "resolve_uri": resolve_uri,
        }
        if only_ids:
            params["include"] = "id"

        response = self.make_request(
            "GET", "/api/tasks", params, raise_exceptions=False
        )
```

Added new option:
<img width="560" alt="image" src="https://github.com/HumanSignal/label-studio/assets/6087484/d4ed260d-3d63-4bdc-b238-992335c833a8">
