### PR TITLE
fix: RND-97: Support for multiple ML backend predictions per task

### DIFF
--- a/label_studio/ml/models.py
+++ b/label_studio/ml/models.py
@@ -1,8 +1,9 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
 import logging
+from typing import Dict, List
 
-from core.utils.common import conditional_atomic, db_is_not_sqlite, load_func, safe_float
+from core.utils.common import conditional_atomic, db_is_not_sqlite, load_func
 from django.conf import settings
 from django.db import models, transaction
 from django.db.models import Count, JSONField, Q
@@ -11,7 +12,6 @@ from django.dispatch import receiver
 from django.utils.translation import gettext_lazy as _
 from ml.api_connector import PREDICT_URL, TIMEOUT_PREDICT, MLApi
 from projects.models import Project
-from tasks.models import Prediction
 from tasks.serializers import PredictionSerializer, TaskSimpleSerializer
 from webhooks.serializers import Webhook, WebhookSerializer
 
@@ -258,6 +258,60 @@ class MLBackend(models.Model):
             },
         }
 
+    def _get_predictions_from_ml_backend(self, serialized_tasks: List[Dict]) -> List[Dict]:
+        result = self.api.make_predictions(serialized_tasks, self.project)
+
+        # response validation
+        if result.is_error:
+            logger.error(f'Error occurred: {result.error_message}')
+            return []
+        elif not isinstance(result.response, dict) or 'results' not in result.response:
+            logger.error(f'ML backend returns an incorrect response, it must be a dict: {result.response}')
+            return []
+        elif not isinstance(result.response['results'], list) or len(result.response['results']) == 0:
+            logger.error('ML backend returns an incorrect response, it must be a list with at least one result')
+            return []
+
+        responses = result.response['results']
+
+        predictions = []
+        if len(responses) == 1 and len(serialized_tasks) > 1:
+            # In case ML backend doesn't support batch of tasks, do it one by one
+            # TODO: remove this block after all ML backends will support batch processing
+            logger.warning(
+                f"'ML backend '{self.title}' doesn't support batch processing of tasks, "
+                f'switched to one-by-one task retrieval'
+            )
+            for serialized_task in serialized_tasks:
+                # get predictions per task
+                predictions.extend(self._get_predictions_from_ml_backend([serialized_task]))
+
+            return predictions
+
+        # ML backend supports batch processing
+        for task, response in zip(serialized_tasks, responses):
+            if isinstance(response, dict):
+                # ML backend can return single prediction per task or multiple predictions
+                response = [response]
+
+            # get  all predictions per task
+            for r in response:
+                if 'result' not in r:
+                    logger.error(
+                        f"ML backend returns an incorrect prediction, it should be a dict with the 'result' field:"
+                        f' {r}'
+                    )
+                    continue
+                predictions.append(
+                    {
+                        'task': task['id'],
+                        'result': r['result'],
+                        'score': r.get('score'),
+                        'model_version': r.get('model_version', self.model_version),
+                    }
+                )
+        return predictions
+
     def predict_tasks(self, tasks):
         model_version = self.update_state()
         if self.not_ready:
@@ -277,99 +331,12 @@ class MLBackend(models.Model):
             logger.debug(f'All tasks already have prediction from model version={self.model_version}')
             return model_version
         tasks_ser = TaskSimpleSerializer(tasks, many=True).data
-        ml_api_result = self.api.make_predictions(tasks_ser, self.project)
-        if ml_api_result.is_error:
-            logger.info(f'Prediction not created for project {self}: {ml_api_result.error_message}')
-            return
-
-        if not (isinstance(ml_api_result.response, dict) and 'results' in ml_api_result.response):
-            logger.info(f'ML backend returns an incorrect response, it should be a dict: {ml_api_result.response}')
-            return
-
-        responses = ml_api_result.response['results']
-
-        if len(responses) == 0:
-            logger.warning(f'ML backend returned empty prediction for project {self}')
-            return
-
-        # ML Backend doesn't support batch of tasks, do it one by one
-        elif len(responses) == 1 and len(tasks) != 1:
-            logger.warning(
-                f"'ML backend '{self.title}' doesn't support batch processing of tasks, "
-                f'switched to one-by-one task retrieval'
-            )
-            instances = [self.predict_one_task(task, model_version=model_version) for task in tasks]
-            return instances
-
-        # wrong result number
-        elif len(responses) != len(tasks_ser):
-            logger.warning(f'ML backend returned response number {len(responses)} != task number {len(tasks_ser)}')
-
-        predictions = []
-        for task, response in zip(tasks_ser, responses):
-            if 'result' not in response:
-                logger.info(
-                    f"ML backend returns an incorrect prediction, it should be a dict with the 'result' field:"
-                    f' {response}'
-                )
-                return
-            predictions.append(
-                {
-                    'task': task['id'],
-                    'result': response['result'],
-                    'score': response.get('score'),
-                    'model_version': response.get('model_version', self.model_version),
-                }
-            )
+        predictions = self._get_predictions_from_ml_backend(tasks_ser)
         with conditional_atomic(predicate=db_is_not_sqlite):
             prediction_ser = PredictionSerializer(data=predictions, many=True)
             prediction_ser.is_valid(raise_exception=True)
             instances = prediction_ser.save()
         return instances
-
-    def predict_one_task(self, task, model_version):
-        if not model_version:
-            self.update_state()
-            if self.not_ready:
-                logger.debug(f'ML backend {self} is not ready to predict {task}')
-                return
-
-        if task.predictions.filter(model_version=self.model_version).exists():
-            # prediction already exists
-            logger.info(
-                f'Skip creating prediction with ML backend {self} for task {task}: model version '
-                f'{self.model_version} is up-to-date'
-            )
-            return
-        ml_api = self.api
-
-        task_ser = TaskSimpleSerializer(task).data
-        ml_api_result = ml_api.make_predictions([task_ser], self.project)
-        if ml_api_result.is_error:
-            logger.info(f'Prediction not created for project {self}: {ml_api_result.error_message}')
-            return
-        results = ml_api_result.response['results']
-        if len(results) == 0:
-            logger.error(f'ML backend returned empty prediction for project {self.id}', extra={'sentry_skip': True})
-            return
-        prediction_response = results[0]
-        task_id = task_ser['id']
-        r = prediction_response['result']
-        score = prediction_response.get('score')
-        with conditional_atomic(predicate=db_is_not_sqlite):
-            prediction = Prediction.objects.create(
-                result=r,
-                score=safe_float(score),
-                model_version=self.model_version,
-                task_id=task_id,
-                project=task.project,
-                cluster=prediction_response.get('cluster'),
-                neighbors=prediction_response.get('neighbors'),
-                mislabeling=safe_float(prediction_response.get('mislabeling', 0)),
-            )
-            logger.debug(f'Prediction {prediction} created')
-
-        return prediction
 
     def interactive_annotating(self, task, context=None, user=None):
         result = {}

--- a/label_studio/ml/models.py
+++ b/label_studio/ml/models.py
@@ -308,6 +308,7 @@ class MLBackend(models.Model):
                         'result': r['result'],
                         'score': r.get('score'),
                         'model_version': r.get('model_version', self.model_version),
+                        'project': task['project']
                     }
                 )
         return predictions

--- a/label_studio/ml/models.py
+++ b/label_studio/ml/models.py
@@ -294,7 +294,7 @@ class MLBackend(models.Model):
                 # ML backend can return single prediction per task or multiple predictions
                 response = [response]
 
-            # get  all predictions per task
+            # get all predictions per task
             for r in response:
                 if 'result' not in r:
                     logger.error(

--- a/label_studio/tests/data_manager/test_api_actions.py
+++ b/label_studio/tests/data_manager/test_api_actions.py
@@ -273,10 +273,11 @@ def test_action_cache_labels(business_client, project_id):
 
     # Assertions
     # Replace these with the actual assertions for your cache_labels function
+    tasks = project.tasks
     assert status.status_code == 200, 'status code wrong'
-    assert project.tasks.count() == 2, 'tasks count wrong'
-    assert project.tasks.first().data.get('cache_label1') == 'Car: 1', 'cache_label1 wrong for task 1'
-    assert project.tasks.all()[1].data.get('cache_label1') == 'Airplane: 1, Car: 2', 'cache_label1 wrong for task 2'
+    assert tasks.count() == 2, 'tasks count wrong'
+    assert tasks.get(id=task1.id).data.get('cache_label1') == 'Car: 1', 'cache_label1 wrong for task 1'
+    assert tasks.get(id=task2.id).data.get('cache_label1') == 'Airplane: 1, Car: 2', 'cache_label1 wrong for task 2'
 
     # call the "cache_labels" action without counters
     status = business_client.post(
@@ -294,5 +295,5 @@ def test_action_cache_labels(business_client, project_id):
     # Assertions
     # Replace these with the actual assertions for your cache_labels function
     assert status.status_code == 200, 'status code wrong'
-    assert project.tasks.first().data.get('cache_label1') == 'Car', 'cache_label1 wrong for task 1'
-    assert project.tasks.all()[1].data.get('cache_label1') == 'Airplane, Car', 'cache_label1 wrong for task 2'
+    assert tasks.get(id=task1.id).data.get('cache_label1') == 'Car', 'cache_label1 wrong for task 1'
+    assert tasks.get(id=task2.id).data.get('cache_label1') == 'Airplane, Car', 'cache_label1 wrong for task 2'

--- a/label_studio/tests/ml/test_predict.py
+++ b/label_studio/tests/ml/test_predict.py
@@ -1,21 +1,63 @@
-import pytest
 import json
+
+import pytest
+
 from label_studio.tests.utils import make_project, make_task, register_ml_backend_mock
 
 
 @pytest.fixture
 def ml_backend_for_test_predict(ml_backend):
     # ML backend with single prediction per task
-    register_ml_backend_mock(ml_backend, url='http://localhost:9092', predictions={'results': [
-        {'model_version': 'ModelSingle', 'score': 0.1, 'result': [{'from_name': 'label', 'to_name': 'text', 'type': 'choices', 'value': {'choices': ['Single']}}]},
-    ]})
+    register_ml_backend_mock(
+        ml_backend,
+        url='http://localhost:9092',
+        predictions={
+            'results': [
+                {
+                    'model_version': 'ModelSingle',
+                    'score': 0.1,
+                    'result': [
+                        {'from_name': 'label', 'to_name': 'text', 'type': 'choices', 'value': {'choices': ['Single']}}
+                    ],
+                },
+            ]
+        },
+    )
     # ML backend with multiple predictions per task
-    register_ml_backend_mock(ml_backend, url='http://localhost:9093', predictions={'results': [
-        [
-            {'model_version': 'ModelA', 'score': 0.2, 'result': [{'from_name': 'label', 'to_name': 'text', 'type': 'choices', 'value': {'choices': ['label_A']}}]},
-            {'model_version': 'ModelB', 'score': 0.3, 'result': [{'from_name': 'label', 'to_name': 'text', 'type': 'choices', 'value': {'choices': ['label_B']}}]},
-        ]
-    ]})
+    register_ml_backend_mock(
+        ml_backend,
+        url='http://localhost:9093',
+        predictions={
+            'results': [
+                [
+                    {
+                        'model_version': 'ModelA',
+                        'score': 0.2,
+                        'result': [
+                            {
+                                'from_name': 'label',
+                                'to_name': 'text',
+                                'type': 'choices',
+                                'value': {'choices': ['label_A']},
+                            }
+                        ],
+                    },
+                    {
+                        'model_version': 'ModelB',
+                        'score': 0.3,
+                        'result': [
+                            {
+                                'from_name': 'label',
+                                'to_name': 'text',
+                                'type': 'choices',
+                                'value': {'choices': ['label_B']},
+                            }
+                        ],
+                    },
+                ]
+            ]
+        },
+    )
     yield ml_backend
 
 
@@ -35,7 +77,7 @@ def test_get_single_prediction_on_task(business_client, ml_backend_for_test_pred
             title='test_get_single_prediction_on_task',
         ),
         user=business_client.user,
-        use_ml_backend=False
+        use_ml_backend=False,
     )
 
     make_task({'data': {'text': 'test 1'}}, project)
@@ -79,7 +121,7 @@ def test_get_multiple_predictions_on_task(business_client, ml_backend_for_test_p
             title='test_get_multiple_predictions_on_task',
         ),
         user=business_client.user,
-        use_ml_backend=False
+        use_ml_backend=False,
     )
 
     make_task({'data': {'text': 'test 1'}}, project)

--- a/label_studio/tests/ml/test_predict.py
+++ b/label_studio/tests/ml/test_predict.py
@@ -1,0 +1,109 @@
+import pytest
+import json
+from label_studio.tests.utils import make_project, make_task, register_ml_backend_mock
+
+
+@pytest.fixture
+def ml_backend_for_test_predict(ml_backend):
+    # ML backend with single prediction per task
+    register_ml_backend_mock(ml_backend, url='http://localhost:9092', predictions={'results': [
+        {'model_version': 'ModelSingle', 'score': 0.1, 'result': [{'from_name': 'label', 'to_name': 'text', 'type': 'choices', 'value': {'choices': ['Single']}}]},
+    ]})
+    # ML backend with multiple predictions per task
+    register_ml_backend_mock(ml_backend, url='http://localhost:9093', predictions={'results': [
+        [
+            {'model_version': 'ModelA', 'score': 0.2, 'result': [{'from_name': 'label', 'to_name': 'text', 'type': 'choices', 'value': {'choices': ['label_A']}}]},
+            {'model_version': 'ModelB', 'score': 0.3, 'result': [{'from_name': 'label', 'to_name': 'text', 'type': 'choices', 'value': {'choices': ['label_B']}}]},
+        ]
+    ]})
+    yield ml_backend
+
+
+@pytest.mark.django_db
+def test_get_single_prediction_on_task(business_client, ml_backend_for_test_predict):
+    project = make_project(
+        config=dict(
+            is_published=True,
+            label_config="""
+                <View>
+                  <Text name="text" value="$text"></Text>
+                  <Choices name="label" choice="single">
+                    <Choice value="label_A"></Choice>
+                    <Choice value="label_B"></Choice>
+                  </Choices>
+                </View>""",
+            title='test_get_single_prediction_on_task',
+        ),
+        user=business_client.user,
+        use_ml_backend=False
+    )
+
+    make_task({'data': {'text': 'test 1'}}, project)
+    make_task({'data': {'text': 'test 2'}}, project)
+    make_task({'data': {'text': 'test 3'}}, project)
+
+    # setup ML backend with single prediction per task
+    response = business_client.post(
+        '/api/ml/',
+        data={
+            'project': project.id,
+            'title': 'ModelSingle',
+            'url': 'http://localhost:9092',
+        },
+    )
+    assert response.status_code == 201
+
+    # get next task
+    response = business_client.get(f'/api/projects/{project.id}/next')
+    payload = json.loads(response.content)
+
+    # ensure task has a single prediction with the correct value
+    assert len(payload['predictions']) == 1
+    assert payload['predictions'][0]['result'][0]['value']['choices'][0] == 'Single'
+    assert payload['predictions'][0]['model_version'] == 'ModelSingle'
+
+
+@pytest.mark.django_db
+def test_get_multiple_predictions_on_task(business_client, ml_backend_for_test_predict):
+    project = make_project(
+        config=dict(
+            is_published=True,
+            label_config="""
+                <View>
+                  <Text name="text" value="$text"></Text>
+                  <Choices name="label" choice="single">
+                    <Choice value="label_A"></Choice>
+                    <Choice value="label_B"></Choice>
+                  </Choices>
+                </View>""",
+            title='test_get_multiple_predictions_on_task',
+        ),
+        user=business_client.user,
+        use_ml_backend=False
+    )
+
+    make_task({'data': {'text': 'test 1'}}, project)
+    make_task({'data': {'text': 'test 2'}}, project)
+    make_task({'data': {'text': 'test 3'}}, project)
+
+    # setup ML backend with multiple predictions per task
+    response = business_client.post(
+        '/api/ml/',
+        data={
+            'project': project.id,
+            'title': 'ModelA',
+            'url': 'http://localhost:9093',
+        },
+    )
+    assert response.status_code == 201
+
+    # get next task
+    response = business_client.get(f'/api/projects/{project.id}/next')
+    payload = json.loads(response.content)
+
+    # ensure task has multiple predictions with the correct values
+    assert len(payload['predictions']) == 2
+    assert payload['predictions'][0]['result'][0]['value']['choices'][0] == 'label_A'
+    assert payload['predictions'][0]['model_version'] == 'ModelA'
+    assert payload['predictions'][1]['result'][0]['value']['choices'][0] == 'label_B'
+    assert payload['predictions'][1]['model_version'] == 'ModelB'

--- a/label_studio/tests/ml/test_predict.py
+++ b/label_studio/tests/ml/test_predict.py
@@ -81,8 +81,6 @@ def test_get_single_prediction_on_task(business_client, ml_backend_for_test_pred
     )
 
     make_task({'data': {'text': 'test 1'}}, project)
-    make_task({'data': {'text': 'test 2'}}, project)
-    make_task({'data': {'text': 'test 3'}}, project)
 
     # setup ML backend with single prediction per task
     response = business_client.post(
@@ -125,8 +123,6 @@ def test_get_multiple_predictions_on_task(business_client, ml_backend_for_test_p
     )
 
     make_task({'data': {'text': 'test 1'}}, project)
-    make_task({'data': {'text': 'test 2'}}, project)
-    make_task({'data': {'text': 'test 3'}}, project)
 
     # setup ML backend with multiple predictions per task
     response = business_client.post(

--- a/label_studio/tests/sdk/test_ml.py
+++ b/label_studio/tests/sdk/test_ml.py
@@ -1,27 +1,69 @@
 import pytest
-import json
-from label_studio.tests.utils import register_ml_backend_mock
 from label_studio_sdk.client import LabelStudio
+
+from label_studio.tests.utils import register_ml_backend_mock
 
 
 @pytest.fixture
 def ml_backend_for_test_batch_predictions(ml_backend):
     # ML backend with single prediction per task
-    register_ml_backend_mock(ml_backend, url='http://localhost:9094', predictions={'results': [
-        {'model_version': 'ModelSingle', 'score': 0.1, 'result': [{'from_name': 'label', 'to_name': 'text', 'type': 'choices', 'value': {'choices': ['Single']}}]},
-    ]})
+    register_ml_backend_mock(
+        ml_backend,
+        url='http://localhost:9094',
+        predictions={
+            'results': [
+                {
+                    'model_version': 'ModelSingle',
+                    'score': 0.1,
+                    'result': [
+                        {'from_name': 'label', 'to_name': 'text', 'type': 'choices', 'value': {'choices': ['Single']}}
+                    ],
+                },
+            ]
+        },
+    )
     # ML backend with multiple predictions per task
-    register_ml_backend_mock(ml_backend, url='http://localhost:9095', predictions={'results': [
-        [
-            {'model_version': 'ModelA', 'score': 0.2, 'result': [{'from_name': 'label', 'to_name': 'text', 'type': 'choices', 'value': {'choices': ['label_A']}}]},
-            {'model_version': 'ModelB', 'score': 0.3, 'result': [{'from_name': 'label', 'to_name': 'text', 'type': 'choices', 'value': {'choices': ['label_B']}}]},
-        ]
-    ]})
+    register_ml_backend_mock(
+        ml_backend,
+        url='http://localhost:9095',
+        predictions={
+            'results': [
+                [
+                    {
+                        'model_version': 'ModelA',
+                        'score': 0.2,
+                        'result': [
+                            {
+                                'from_name': 'label',
+                                'to_name': 'text',
+                                'type': 'choices',
+                                'value': {'choices': ['label_A']},
+                            }
+                        ],
+                    },
+                    {
+                        'model_version': 'ModelB',
+                        'score': 0.3,
+                        'result': [
+                            {
+                                'from_name': 'label',
+                                'to_name': 'text',
+                                'type': 'choices',
+                                'value': {'choices': ['label_B']},
+                            }
+                        ],
+                    },
+                ]
+            ]
+        },
+    )
     yield ml_backend
 
 
 @pytest.mark.django_db
-def test_batch_predictions_single_prediction_per_task(django_live_url, business_client, ml_backend_for_test_batch_predictions):
+def test_batch_predictions_single_prediction_per_task(
+    django_live_url, business_client, ml_backend_for_test_batch_predictions
+):
     ls = LabelStudio(base_url=django_live_url, api_key=business_client.api_key)
     p = ls.projects.create(
         title='New Project',
@@ -32,23 +74,22 @@ def test_batch_predictions_single_prediction_per_task(django_live_url, business_
                 <Choice value="label_A"></Choice>
                 <Choice value="label_B"></Choice>
               </Choices>
-            </View>"""
+            </View>""",
     )
-    ls.projects.import_tasks(p.id, request=[
-        {"data": {"text": "test 1"}},
-        {"data": {"text": "test 2"}},
-        {"data": {"text": "test 3"}},
-    ])
+    ls.projects.import_tasks(
+        p.id,
+        request=[
+            {'data': {'text': 'test 1'}},
+            {'data': {'text': 'test 2'}},
+            {'data': {'text': 'test 3'}},
+        ],
+    )
 
     tasks = [task for task in ls.tasks.list(project=p.id)]
     assert len(tasks) == 3
 
     # setup ML backend with single prediction per task
-    ls.ml.create(
-        url='http://localhost:9094',
-        project=p.id,
-        title='ModelSingle'
-    )
+    ls.ml.create(url='http://localhost:9094', project=p.id, title='ModelSingle')
 
     # batch predict tasks via actions
     ls.actions.create(
@@ -75,12 +116,15 @@ def test_batch_predictions_single_prediction_per_task(django_live_url, business_
     ls.actions.create(
         id='predictions_to_annotations',
         project=p.id,
-        selected_items={'all': False, 'included': [
-            predictions[0].task,
-            predictions[1].task,
-            # also emulate user error when trying to convert task with no predictions
-            tasks[1].id
-        ]},
+        selected_items={
+            'all': False,
+            'included': [
+                predictions[0].task,
+                predictions[1].task,
+                # also emulate user error when trying to convert task with no predictions
+                tasks[1].id,
+            ],
+        },
     )
 
     # get all annotations in project
@@ -99,7 +143,9 @@ def test_batch_predictions_single_prediction_per_task(django_live_url, business_
 
 
 @pytest.mark.django_db
-def test_batch_predictions_multiple_predictions_per_task(django_live_url, business_client, ml_backend_for_test_batch_predictions):
+def test_batch_predictions_multiple_predictions_per_task(
+    django_live_url, business_client, ml_backend_for_test_batch_predictions
+):
     ls = LabelStudio(base_url=django_live_url, api_key=business_client.api_key)
     p = ls.projects.create(
         title='New Project',
@@ -110,23 +156,22 @@ def test_batch_predictions_multiple_predictions_per_task(django_live_url, busine
                 <Choice value="label_A"></Choice>
                 <Choice value="label_B"></Choice>
               </Choices>
-            </View>"""
+            </View>""",
     )
-    ls.projects.import_tasks(p.id, request=[
-        {"data": {"text": "test 1"}},
-        {"data": {"text": "test 2"}},
-        {"data": {"text": "test 3"}},
-    ])
+    ls.projects.import_tasks(
+        p.id,
+        request=[
+            {'data': {'text': 'test 1'}},
+            {'data': {'text': 'test 2'}},
+            {'data': {'text': 'test 3'}},
+        ],
+    )
 
     tasks = [task for task in ls.tasks.list(project=p.id)]
     assert len(tasks) == 3
 
     # setup ML backend with multiple predictions per task
-    ls.ml.create(
-        url='http://localhost:9095',
-        project=p.id,
-        title='ModelMultiple'
-    )
+    ls.ml.create(url='http://localhost:9095', project=p.id, title='ModelMultiple')
 
     # batch predict tasks via actions
     ls.actions.create(

--- a/label_studio/tests/sdk/test_ml.py
+++ b/label_studio/tests/sdk/test_ml.py
@@ -1,0 +1,153 @@
+import pytest
+import json
+from label_studio.tests.utils import register_ml_backend_mock
+from label_studio_sdk.client import LabelStudio
+
+
+@pytest.fixture
+def ml_backend_for_test_batch_predictions(ml_backend):
+    # ML backend with single prediction per task
+    register_ml_backend_mock(ml_backend, url='http://localhost:9094', predictions={'results': [
+        {'model_version': 'ModelSingle', 'score': 0.1, 'result': [{'from_name': 'label', 'to_name': 'text', 'type': 'choices', 'value': {'choices': ['Single']}}]},
+    ]})
+    # ML backend with multiple predictions per task
+    register_ml_backend_mock(ml_backend, url='http://localhost:9095', predictions={'results': [
+        [
+            {'model_version': 'ModelA', 'score': 0.2, 'result': [{'from_name': 'label', 'to_name': 'text', 'type': 'choices', 'value': {'choices': ['label_A']}}]},
+            {'model_version': 'ModelB', 'score': 0.3, 'result': [{'from_name': 'label', 'to_name': 'text', 'type': 'choices', 'value': {'choices': ['label_B']}}]},
+        ]
+    ]})
+    yield ml_backend
+
+
+@pytest.mark.django_db
+def test_batch_predictions_single_prediction_per_task(django_live_url, business_client, ml_backend_for_test_batch_predictions):
+    ls = LabelStudio(base_url=django_live_url, api_key=business_client.api_key)
+    p = ls.projects.create(
+        title='New Project',
+        label_config="""
+            <View>
+              <Text name="text" value="$text"/>
+              <Choices name="label" toName="text" choice="single">
+                <Choice value="label_A"></Choice>
+                <Choice value="label_B"></Choice>
+              </Choices>
+            </View>"""
+    )
+    ls.projects.import_tasks(p.id, request=[
+        {"data": {"text": "test 1"}},
+        {"data": {"text": "test 2"}},
+        {"data": {"text": "test 3"}},
+    ])
+
+    tasks = [task for task in ls.tasks.list(project=p.id)]
+    assert len(tasks) == 3
+
+    # setup ML backend with single prediction per task
+    ls.ml.create(
+        url='http://localhost:9094',
+        project=p.id,
+        title='ModelSingle'
+    )
+
+    # batch predict tasks via actions
+    ls.actions.create(
+        id='retrieve_tasks_predictions',
+        project=p.id,
+        selected_items={'all': True, 'excluded': [tasks[1].id]},
+    )
+
+    # get all predictions in project
+    predictions = ls.predictions.list(project=p.id)
+
+    # check that only 2 predictions were created
+    assert len(predictions) == 2
+
+    # check that the first prediction has the correct value
+    assert predictions[0].result[0]['value']['choices'][0] == 'Single'
+    assert predictions[0].model_version == 'ModelSingle'
+
+    # check that the second prediction has the correct value
+    assert predictions[1].result[0]['value']['choices'][0] == 'Single'
+    assert predictions[1].model_version == 'ModelSingle'
+
+    # additionally let's test actions: convert predictions to annotations
+    ls.actions.create(
+        id='predictions_to_annotations',
+        project=p.id,
+        selected_items={'all': False, 'included': [
+            predictions[0].task,
+            predictions[1].task,
+            # also emulate user error when trying to convert task with no predictions
+            tasks[1].id
+        ]},
+    )
+
+    # get all annotations in project
+    for task in ls.tasks.list(project=p.id, fields='all'):
+        if task.id == tasks[1].id:
+            assert not task.annotations
+            assert not task.predictions
+        else:
+            assert len(task.annotations) == 1
+            assert task.annotations[0]['result'][0]['value']['choices'][0] == 'Single'
+
+            assert len(task.predictions) == 1
+            assert task.predictions[0]['result'][0]['value']['choices'][0] == 'Single'
+            assert task.predictions[0]['model_version'] == 'ModelSingle'
+            assert task.predictions[0]['score'] == 0.1
+
+
+@pytest.mark.django_db
+def test_batch_predictions_multiple_predictions_per_task(django_live_url, business_client, ml_backend_for_test_batch_predictions):
+    ls = LabelStudio(base_url=django_live_url, api_key=business_client.api_key)
+    p = ls.projects.create(
+        title='New Project',
+        label_config="""
+            <View>
+              <Text name="text" value="$text"/>
+              <Choices name="label" toName="text" choice="single">
+                <Choice value="label_A"></Choice>
+                <Choice value="label_B"></Choice>
+              </Choices>
+            </View>"""
+    )
+    ls.projects.import_tasks(p.id, request=[
+        {"data": {"text": "test 1"}},
+        {"data": {"text": "test 2"}},
+        {"data": {"text": "test 3"}},
+    ])
+
+    tasks = [task for task in ls.tasks.list(project=p.id)]
+    assert len(tasks) == 3
+
+    # setup ML backend with multiple predictions per task
+    ls.ml.create(
+        url='http://localhost:9095',
+        project=p.id,
+        title='ModelMultiple'
+    )
+
+    # batch predict tasks via actions
+    ls.actions.create(
+        id='retrieve_tasks_predictions',
+        project=p.id,
+        selected_items={'all': False, 'included': [tasks[0].id, tasks[2].id]},
+    )
+
+    # get all predictions in project
+    predictions = ls.predictions.list(project=p.id)
+
+    # check that there are 4 predictions as 2 tasks were predicted
+    assert len(predictions) == 4
+
+    for task in ls.tasks.list(project=p.id, fields='all'):
+        if task.id == tasks[1].id:
+            assert not task.predictions
+        else:
+            assert len(task.predictions) == 2
+
+            for i, prediction in enumerate(task.predictions):
+                assert prediction['result'][0]['value']['choices'][0] == f'label_{["A", "B"][i]}'
+                assert prediction['model_version'] == f'Model{"AB"[i]}'
+                assert prediction['score'] == 0.2 if i == 0 else 0.3

--- a/label_studio/tests/sdk/test_ml.py
+++ b/label_studio/tests/sdk/test_ml.py
@@ -1,64 +1,6 @@
 import pytest
 from label_studio_sdk.client import LabelStudio
 
-from label_studio.tests.utils import register_ml_backend_mock
-
-
-@pytest.fixture
-def ml_backend_for_test_batch_predictions(ml_backend):
-    # ML backend with single prediction per task
-    register_ml_backend_mock(
-        ml_backend,
-        url='http://localhost:9094',
-        predictions={
-            'results': [
-                {
-                    'model_version': 'ModelSingle',
-                    'score': 0.1,
-                    'result': [
-                        {'from_name': 'label', 'to_name': 'text', 'type': 'choices', 'value': {'choices': ['Single']}}
-                    ],
-                },
-            ]
-        },
-    )
-    # ML backend with multiple predictions per task
-    register_ml_backend_mock(
-        ml_backend,
-        url='http://localhost:9095',
-        predictions={
-            'results': [
-                [
-                    {
-                        'model_version': 'ModelA',
-                        'score': 0.2,
-                        'result': [
-                            {
-                                'from_name': 'label',
-                                'to_name': 'text',
-                                'type': 'choices',
-                                'value': {'choices': ['label_A']},
-                            }
-                        ],
-                    },
-                    {
-                        'model_version': 'ModelB',
-                        'score': 0.3,
-                        'result': [
-                            {
-                                'from_name': 'label',
-                                'to_name': 'text',
-                                'type': 'choices',
-                                'value': {'choices': ['label_B']},
-                            }
-                        ],
-                    },
-                ]
-            ]
-        },
-    )
-    yield ml_backend
-
 
 @pytest.mark.django_db
 def test_batch_predictions_single_prediction_per_task(
@@ -89,7 +31,7 @@ def test_batch_predictions_single_prediction_per_task(
     assert len(tasks) == 3
 
     # setup ML backend with single prediction per task
-    ls.ml.create(url='http://localhost:9094', project=p.id, title='ModelSingle')
+    ls.ml.create(url='http://localhost:9092', project=p.id, title='ModelSingle')
 
     # batch predict tasks via actions
     ls.actions.create(
@@ -171,7 +113,7 @@ def test_batch_predictions_multiple_predictions_per_task(
     assert len(tasks) == 3
 
     # setup ML backend with multiple predictions per task
-    ls.ml.create(url='http://localhost:9095', project=p.id, title='ModelMultiple')
+    ls.ml.create(url='http://localhost:9093', project=p.id, title='ModelMultiple')
 
     # batch predict tasks via actions
     ls.actions.create(


### PR DESCRIPTION
- Support for multiple predictions response from ML backend. Current version only supports ML backend /predict response with the following payload: `"results": [{}, {}, ...]` where it expects the list of the predictions of the same length as the number of submitted tasks. Now it can optionally handle the case when ML backend responds with `"results": [ [{}, {}], ...]` with each item represents the list of Predictions per task (e.g. with different model versions)
- refactor multiple calls to ML backend to simplify the code (most of the changes)
- added tests for single and multiple predictions, on task opening as using "actions" with sdk