### PR TITLE
fix: Return users in project.all_members()

### DIFF
--- a/label_studio/projects/mixins.py
+++ b/label_studio/projects/mixins.py
@@ -1,7 +1,8 @@
-from typing import Mapping, Optional, List
+from typing import List, Mapping, Optional
+
+from django.utils.functional import cached_property
 
 from core.redis import start_job_async_or_sync
-from django.utils.functional import cached_property
 from users.models import User
 
 

--- a/label_studio/projects/mixins.py
+++ b/label_studio/projects/mixins.py
@@ -1,5 +1,6 @@
-from typing import List, Mapping, Optional
+from typing import Mapping, Optional
 
+from django.db.models import QuerySet
 from django.utils.functional import cached_property
 
 from core.redis import start_job_async_or_sync
@@ -87,7 +88,7 @@ class ProjectMixin:
         return True
 
     @cached_property
-    def all_members(self) -> List[User]:
+    def all_members(self) -> QuerySet[User]:
         """
         Returns all users of project
         :return: List[User]

--- a/label_studio/projects/mixins.py
+++ b/label_studio/projects/mixins.py
@@ -1,7 +1,8 @@
-from typing import Mapping, Optional
+from typing import Mapping, Optional, List
 
 from core.redis import start_job_async_or_sync
 from django.utils.functional import cached_property
+from users.models import User
 
 
 class ProjectMixin:
@@ -85,9 +86,9 @@ class ProjectMixin:
         return True
 
     @cached_property
-    def all_members(self):
+    def all_members(self) -> List[User]:
         """
-        Returns all members of project
-        :return:
+        Returns all users of project
+        :return: List[User]
         """
-        return self.organization.members.values_list('user__id', flat=True)
+        return User.objects.filter(id__in=self.organization.members.values_list('user__id'))

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -108,26 +108,6 @@ ProjectMixin = load_func(settings.PROJECT_MIXIN)
 recalculate_all_stats = load_func(settings.RECALCULATE_ALL_STATS)
 
 
-def update_stats(project):
-    tasks = project.tasks
-    task_count = len(tasks)
-    annotation_count = len(project.annotations)
-    prediction_count = len(project.predictions)
-    recalculate_stats_counts = {
-        'task_count': task_count,
-        'annotation_count': annotation_count,
-        'prediction_count': prediction_count,
-    }
-    project.update_tasks_counters_and_task_states(
-        tasks_queryset=tasks,
-        maximum_annotations_changed=False,
-        overlap_cohort_percentage_changed=False,
-        tasks_number_changed=True,
-        recalculate_stats_counts=recalculate_stats_counts,
-    )
-    project.summary.update_data_columns(tasks)
-
-
 class Project(ProjectMixin, models.Model):
     class SkipQueue(models.TextChoices):
         # requeue to the end of the same annotator’s queue => annotator gets this task at the end of the queue

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -108,6 +108,26 @@ ProjectMixin = load_func(settings.PROJECT_MIXIN)
 recalculate_all_stats = load_func(settings.RECALCULATE_ALL_STATS)
 
 
+def update_stats(project):
+    tasks = project.tasks
+    task_count = len(tasks)
+    annotation_count = len(project.annotations)
+    prediction_count = len(project.predictions)
+    recalculate_stats_counts = {
+        'task_count': task_count,
+        'annotation_count': annotation_count,
+        'prediction_count': prediction_count,
+    }
+    project.update_tasks_counters_and_task_states(
+        tasks_queryset=tasks,
+        maximum_annotations_changed=False,
+        overlap_cohort_percentage_changed=False,
+        tasks_number_changed=True,
+        recalculate_stats_counts=recalculate_stats_counts,
+    )
+    project.summary.update_data_columns(tasks)
+
+
 class Project(ProjectMixin, models.Model):
     class SkipQueue(models.TextChoices):
         # requeue to the end of the same annotator’s queue => annotator gets this task at the end of the queue

--- a/label_studio/tests/test_project.py
+++ b/label_studio/tests/test_project.py
@@ -1,6 +1,8 @@
 import json
-
 import pytest
+
+from django.db.models.query import QuerySet
+from users.models import User
 from tests.utils import make_project
 
 
@@ -29,3 +31,11 @@ def test_update_tasks_counters_and_task_states(business_client):
     ids = set(project.tasks.all().values_list('id', flat=True))
     obj = project._update_tasks_counters_and_task_states(ids, True, True, True)
     assert obj == 0
+
+@pytest.mark.django_db
+def test_project_all_members(business_client):
+    project = make_project({}, business_client.user, use_ml_backend=False)
+    members = project.all_members
+
+    assert isinstance(members, QuerySet)
+    assert isinstance(members.first(), User)


### PR DESCRIPTION
#### Change has impacts in these area(s)
_(check all that apply)_
- [x] Backend (API)



### Describe the reason for change
project.all_members() returned member ids instead of user ids


#### What does this fix?
all_members() returns user ids now. 


#### What is the new behavior?
Data manager filters display the correct user list. 



#### What is the current behavior?
Data manager filters displayed empty user items. 
![image](https://github.com/HumanSignal/label-studio/assets/501780/67daf1d8-acf9-416e-9efc-9917872be121)

### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit
