### PR TITLE
fix: LEAP-1161: fix User import in mixin

### DIFF
--- a/label_studio/projects/mixins.py
+++ b/label_studio/projects/mixins.py
@@ -92,7 +92,7 @@ class ProjectMixin:
     def all_members(self) -> QuerySet['User']:
         """
         Returns all users of project
-        :return: List[User]
+        :return: QuerySet[User]
         """
         from users.models import User
 

--- a/label_studio/projects/mixins.py
+++ b/label_studio/projects/mixins.py
@@ -1,10 +1,11 @@
-from typing import Mapping, Optional
+from typing import TYPE_CHECKING, Mapping, Optional
 
+from core.redis import start_job_async_or_sync
 from django.db.models import QuerySet
 from django.utils.functional import cached_property
 
-from core.redis import start_job_async_or_sync
-from users.models import User
+if TYPE_CHECKING:
+    from users.models import User
 
 
 class ProjectMixin:
@@ -88,9 +89,11 @@ class ProjectMixin:
         return True
 
     @cached_property
-    def all_members(self) -> QuerySet[User]:
+    def all_members(self) -> QuerySet['User']:
         """
         Returns all users of project
         :return: List[User]
         """
+        from users.models import User
+
         return User.objects.filter(id__in=self.organization.members.values_list('user__id'))

--- a/label_studio/tests/conftest.py
+++ b/label_studio/tests/conftest.py
@@ -316,6 +316,62 @@ def redis_client():
         yield
 
 
+@pytest.fixture
+def ml_backend_for_test_predict(ml_backend):
+    # ML backend with single prediction per task
+    register_ml_backend_mock(
+        ml_backend,
+        url='http://localhost:9092',
+        predictions={
+            'results': [
+                {
+                    'model_version': 'ModelSingle',
+                    'score': 0.1,
+                    'result': [
+                        {'from_name': 'label', 'to_name': 'text', 'type': 'choices', 'value': {'choices': ['Single']}}
+                    ],
+                },
+            ]
+        },
+    )
+    # ML backend with multiple predictions per task
+    register_ml_backend_mock(
+        ml_backend,
+        url='http://localhost:9093',
+        predictions={
+            'results': [
+                [
+                    {
+                        'model_version': 'ModelA',
+                        'score': 0.2,
+                        'result': [
+                            {
+                                'from_name': 'label',
+                                'to_name': 'text',
+                                'type': 'choices',
+                                'value': {'choices': ['label_A']},
+                            }
+                        ],
+                    },
+                    {
+                        'model_version': 'ModelB',
+                        'score': 0.3,
+                        'result': [
+                            {
+                                'from_name': 'label',
+                                'to_name': 'text',
+                                'type': 'choices',
+                                'value': {'choices': ['label_B']},
+                            }
+                        ],
+                    },
+                ]
+            ]
+        },
+    )
+    yield ml_backend
+
+
 @pytest.fixture(autouse=True)
 def ml_backend():
     with ml_backend_mock() as m:

--- a/label_studio/tests/ml/test_predict.py
+++ b/label_studio/tests/ml/test_predict.py
@@ -2,63 +2,7 @@ import json
 
 import pytest
 
-from label_studio.tests.utils import make_project, make_task, register_ml_backend_mock
-
-
-@pytest.fixture
-def ml_backend_for_test_predict(ml_backend):
-    # ML backend with single prediction per task
-    register_ml_backend_mock(
-        ml_backend,
-        url='http://localhost:9092',
-        predictions={
-            'results': [
-                {
-                    'model_version': 'ModelSingle',
-                    'score': 0.1,
-                    'result': [
-                        {'from_name': 'label', 'to_name': 'text', 'type': 'choices', 'value': {'choices': ['Single']}}
-                    ],
-                },
-            ]
-        },
-    )
-    # ML backend with multiple predictions per task
-    register_ml_backend_mock(
-        ml_backend,
-        url='http://localhost:9093',
-        predictions={
-            'results': [
-                [
-                    {
-                        'model_version': 'ModelA',
-                        'score': 0.2,
-                        'result': [
-                            {
-                                'from_name': 'label',
-                                'to_name': 'text',
-                                'type': 'choices',
-                                'value': {'choices': ['label_A']},
-                            }
-                        ],
-                    },
-                    {
-                        'model_version': 'ModelB',
-                        'score': 0.3,
-                        'result': [
-                            {
-                                'from_name': 'label',
-                                'to_name': 'text',
-                                'type': 'choices',
-                                'value': {'choices': ['label_B']},
-                            }
-                        ],
-                    },
-                ]
-            ]
-        },
-    )
-    yield ml_backend
+from label_studio.tests.utils import make_project, make_task
 
 
 @pytest.mark.django_db

--- a/label_studio/tests/sdk/test_ml.py
+++ b/label_studio/tests/sdk/test_ml.py
@@ -1,6 +1,5 @@
 import pytest
 from label_studio_sdk.client import LabelStudio
-from label_studio.tests.ml.test_predict import ml_backend_for_test_predict as ml_backend_for_test_batch_predictions
 
 
 @pytest.mark.django_db

--- a/label_studio/tests/sdk/test_ml.py
+++ b/label_studio/tests/sdk/test_ml.py
@@ -3,9 +3,7 @@ from label_studio_sdk.client import LabelStudio
 
 
 @pytest.mark.django_db
-def test_batch_predictions_single_prediction_per_task(
-    django_live_url, business_client, ml_backend_for_test_batch_predictions
-):
+def test_batch_predictions_single_prediction_per_task(django_live_url, business_client, ml_backend_for_test_predict):
     ls = LabelStudio(base_url=django_live_url, api_key=business_client.api_key)
     p = ls.projects.create(
         title='New Project',
@@ -86,7 +84,7 @@ def test_batch_predictions_single_prediction_per_task(
 
 @pytest.mark.django_db
 def test_batch_predictions_multiple_predictions_per_task(
-    django_live_url, business_client, ml_backend_for_test_batch_predictions
+    django_live_url, business_client, ml_backend_for_test_predict
 ):
     ls = LabelStudio(base_url=django_live_url, api_key=business_client.api_key)
     p = ls.projects.create(

--- a/label_studio/tests/test_project.py
+++ b/label_studio/tests/test_project.py
@@ -1,9 +1,9 @@
 import json
-import pytest
 
+import pytest
 from django.db.models.query import QuerySet
-from users.models import User
 from tests.utils import make_project
+from users.models import User
 
 
 @pytest.mark.django_db
@@ -31,6 +31,7 @@ def test_update_tasks_counters_and_task_states(business_client):
     ids = set(project.tasks.all().values_list('id', flat=True))
     obj = project._update_tasks_counters_and_task_states(ids, True, True, True)
     assert obj == 0
+
 
 @pytest.mark.django_db
 def test_project_all_members(business_client):


### PR DESCRIPTION
Need to late import the User model to avoid circular import issues in LSE. Also some misc formatting fixes from ruff/blue, as well as an issue with a fixture that's not available in some tests.