### PR TITLE
fix: LEAP-1209: Make displaying of resolve comment button dependent on interfaces

### DIFF
--- a/web/apps/labelstudio/src/pages/CreateProject/Config/Preview.jsx
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/Preview.jsx
@@ -59,7 +59,7 @@ export const Preview = ({ config, data, error, loading, project }) => {
         const lsf = new window.LabelStudio(rootRef.current, {
           config,
           task,
-          interfaces: ["side-column", "annotations:comments"],
+          interfaces: ["side-column", "annotations:comments", "comments:resolve-any"],
           // with SharedStore we should use more late event
           [isFF(FF_DEV_3617) ? "onStorageInitialized" : "onLabelStudioLoad"](LS) {
             LS.settings.bottomSidePanel = true;

--- a/web/libs/datamanager/src/sdk/lsf-sdk.js
+++ b/web/libs/datamanager/src/sdk/lsf-sdk.js
@@ -141,6 +141,7 @@ export class LSFWrapper {
     }
     if (isFF(FF_DEV_2887)) {
       interfaces.push("annotations:comments");
+      interfaces.push("comments:resolve-any");
     }
 
     console.group("Interfaces");

--- a/web/libs/datamanager/src/sdk/lsf-sdk.js
+++ b/web/libs/datamanager/src/sdk/lsf-sdk.js
@@ -136,12 +136,14 @@ export class LSFWrapper {
     if (this.datamanager.hasInterface("autoAnnotation")) {
       interfaces.push("auto-annotation");
     }
-    if (this.interfacesModifier) {
-      interfaces = this.interfacesModifier(interfaces, this.labelStream);
-    }
+
     if (isFF(FF_DEV_2887)) {
       interfaces.push("annotations:comments");
       interfaces.push("comments:resolve-any");
+    }
+
+    if (this.interfacesModifier) {
+      interfaces = this.interfacesModifier(interfaces, this.labelStream);
     }
 
     console.group("Interfaces");

--- a/web/libs/editor/src/components/Comments/CommentItem.tsx
+++ b/web/libs/editor/src/components/Comments/CommentItem.tsx
@@ -29,6 +29,7 @@ interface Comment {
     setConfirmMode: (confirmMode: boolean) => void;
     setEditMode: (isGoingIntoEditMode: boolean) => void;
     toggleResolve: () => void;
+    canResolveAny: boolean;
   };
   listComments: ({ suppressClearComments }: { suppressClearComments: boolean }) => void;
 }
@@ -50,10 +51,12 @@ export const CommentItem: FC<any> = observer(
       setConfirmMode,
       setEditMode,
       toggleResolve,
+      canResolveAny,
     },
     listComments,
   }: Comment) => {
     const currentUser = window.APP_SETTINGS?.user;
+    const isCreator = currentUser?.id === createdBy.id;
     const [currentComment, setCurrentComment] = useState(initialComment);
 
     if (isDeleted) return null;
@@ -133,12 +136,12 @@ export const CommentItem: FC<any> = observer(
               e.preventDefault();
             }}
           >
-            {isPersisted && (
+            {isPersisted && (isCreator || canResolveAny) && (
               <Dropdown.Trigger
                 content={
                   <Menu size="auto">
                     <Menu.Item onClick={toggleResolve}>{resolved ? "Unresolve" : "Resolve"}</Menu.Item>
-                    {currentUser?.id === createdBy.id && (
+                    {isCreator && (
                       <>
                         <Menu.Item
                           onClick={() => {

--- a/web/libs/editor/src/stores/Comment/Comment.js
+++ b/web/libs/editor/src/stores/Comment/Comment.js
@@ -1,4 +1,4 @@
-import { flow, getEnv, types } from "mobx-state-tree";
+import { flow, getEnv, getRoot, types } from "mobx-state-tree";
 import Utils from "../../utils";
 import { camelizeKeys } from "../../utils/utilities";
 import { UserExtended } from "../UserStore";
@@ -25,6 +25,10 @@ export const Comment = types
     },
     get isPersisted() {
       return self.id > 0;
+    },
+    get canResolveAny() {
+      const p = getRoot(self);
+      return p.interfaces.includes("comments:resolve-any");
     },
   }))
   .actions((self) => {


### PR DESCRIPTION
Resolving comment shouldn't be avaliable every time. To control that we used an interface `comments:resolve-any`.

### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)

#### What is the new behavior?
By not providing comments:resolve-any interface we can disallow resolving functionality for comments created not by ourself.


#### What is the current behavior?
We can't control appearances of resolving comments functionality.


#### What alternative approaches were there?
There could be other flags with different, broader semantics. But for now it would be against the usual practices.

### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [ ] No
- [x] Not sure (briefly explain the situation below)

It could affect custom setups based on just `lsf`.


### Which logical domain(s) does this change affect?
`Comments`, `Interfaces`

