### PR TITLE
fix: OPTIC-875,OPTIC-876,OPTIC-877,OPTIC-878,OPTIC-879: Visual conflicts due to design updates

### DIFF
--- a/label_studio/users/templates/users/new-ui/user_login.html
+++ b/label_studio/users/templates/users/new-ui/user_login.html
@@ -27,8 +27,10 @@
       <button type="submit" aria-label="Log In" class="ls-button ls-button_look_primary">Log in</button>
     </form>
   </div>
+  {% if not settings.DISABLE_SIGNUP_WITHOUT_LINK %}
   <div class="text-wrapper">
     <p class="">Don't have an account?</p>
     <a href="{{ settings.HOSTNAME }}/user/signup">Sign up</a>
   </div>
+  {% endif %}
 {% endblock %}

--- a/web/apps/labelstudio/src/components/Button/Button.styl
+++ b/web/apps/labelstudio/src/components/Button/Button.styl
@@ -17,6 +17,7 @@
   --button-margin-left 0
   --button-margin-right 0
   --button-border 1px solid var(--button-color)
+  --button-gap 6px
 
   border var(--button-border)
   cursor pointer
@@ -35,6 +36,7 @@
   height var(--button-height)
   min-width var(--button-min-width)
   padding var(--button-padding)
+  gap var(--button-gap)
   align-items var(--button-content-align)
   justify-content var(--button-content-justify)
   margin-left var(--button-margin-left)

--- a/web/apps/labelstudio/src/components/Button/Button.styl
+++ b/web/apps/labelstudio/src/components/Button/Button.styl
@@ -106,9 +106,6 @@
       --button-content-justify flex-end
 
   &_type
-    &_text
-      --button-padding 0
-
     &_text, &_link
       --button-padding 0
       min-width 0

--- a/web/apps/labelstudio/src/components/Button/Button.styl
+++ b/web/apps/labelstudio/src/components/Button/Button.styl
@@ -86,13 +86,11 @@
     width var(--icon-size)
     height var(--icon-size)
     align-items center
-    padding-right .75rem
 
     &:only-child
       flex 1
       --button-content-align center
       --button-content-justify center
-      padding-left .75rem
 
     svg
       width 100%
@@ -107,10 +105,10 @@
 
   &_type
     &_text
-      padding 0
+      --button-padding 0
 
     &_text, &_link
-      padding 0
+      --button-padding 0
       min-width 0
       --button-background-color none
       border none

--- a/web/apps/labelstudio/src/pages/Projects/Projects.styl
+++ b/web/apps/labelstudio/src/pages/Projects/Projects.styl
@@ -54,7 +54,7 @@
   flex-direction column
   align-items center
   &__heidi
-    height 12rem 
+    height 12rem
     margin-top 6rem
   &__header
     font-size 32px
@@ -89,7 +89,6 @@
 
     .button
       opacity 0.5
-      margin-right -10px
       --button-color var(--text-color)
 
       &__icon

--- a/web/apps/labelstudio/src/pages/Projects/Projects.styl
+++ b/web/apps/labelstudio/src/pages/Projects/Projects.styl
@@ -28,6 +28,7 @@
       color #000
 
   &__pages
+    background-color var(--sand_0);
     bottom 0
     width 100%
     position sticky

--- a/web/apps/labelstudio/src/pages/Projects/Projects.styl
+++ b/web/apps/labelstudio/src/pages/Projects/Projects.styl
@@ -88,6 +88,7 @@
     margin-left auto
 
     .button
+      margin-right -10px
       opacity 0.5
       --button-color var(--text-color)
 

--- a/web/libs/datamanager/src/components/DataManager/Toolbar/instruments.jsx
+++ b/web/libs/datamanager/src/components/DataManager/Toolbar/instruments.jsx
@@ -1,4 +1,4 @@
-import { FaCaretDown, FaChevronDown } from "react-icons/fa";
+import { FaAngleDown, FaCaretDown, FaChevronDown } from "react-icons/fa";
 import { Block } from "../../../utils/bem";
 import { FF_LOPS_E_10, FF_SELF_SERVE, isFF } from "../../../utils/feature-flags";
 import { ErrorBox } from "../../Common/ErrorBox";
@@ -70,20 +70,23 @@ export const instruments = {
     return <ViewToggle size={size} style={style} />;
   },
   columns: ({ size }) => {
-    const iconProps = {};
-    const isNewUI = isFF(FF_LOPS_E_10);
-
-    if (isNewUI) {
+    const iconProps = {
+      size: 16,
+      style: {
+        marginRight: 4,
+      },
+      icon: FaAngleDown,
+      color: "#566fcf",
+    };
+    if (isFF(FF_LOPS_E_10)) {
       iconProps.size = 12;
-      iconProps.style = {
-        marginRight: 3,
-      };
-      iconProps.color = "#566fcf";
+      iconProps.style.marginRight = 3;
+      iconProps.icon = FaCaretDown;
     }
     return (
       <FieldsButton
         wrapper={FieldsButton.Checkbox}
-        trailingIcon={<Icon {...iconProps} icon={isNewUI ? FaChevronDown : FaChevronDown} />}
+        trailingIcon={<Icon {...iconProps} />}
         title={"Columns"}
         size={size}
         style={style}


### PR DESCRIPTION
Fixes design update issues pertaining to the following:

- OPTIC-875 Close button is not visible at Export Modal 
- OPTIC-876 Project settings icons are displayed only on initial load. 
- OPTIC-877 Gray background is missing on pagination bar
- OPTIC-878 LABEL_STUDIO_DISABLE_SIGNUP_WITHOUT_LINK property is not taken into consideration in new app redesign
- OPTIC-879 '+' icon is missing on Add People button