### PR TITLE
fix: OPTIC-883: Export data modal footer not visible when scrollable

### DIFF
--- a/web/apps/labelstudio/src/components/Modal/Modal.styl
+++ b/web/apps/labelstudio/src/components/Modal/Modal.styl
@@ -13,8 +13,7 @@
   justify-content center
   background-color rgba(#000, 0.3)
   will-change opacity
-  overflow hidden
-  
+
   &_optimize &__wrapper
     will-change transform
 
@@ -35,9 +34,6 @@
     background-color var(--sand_0)
     border-radius .5rem
     box-shadow 0 10px 30px rgba(#000, 0.3)
-    display flex
-    flex-direction column
-    overflow hidden
 
   &__header
     display flex

--- a/web/apps/labelstudio/src/pages/ExportPage/ExportPage.styl
+++ b/web/apps/labelstudio/src/pages/ExportPage/ExportPage.styl
@@ -7,7 +7,7 @@
     grid-auto-flow rows
 
   &__footer
-    margin 0 -40px -32px
+    margin 0 -32px -32px
     padding 32px 40px 32px
     position sticky
     bottom -40px
@@ -20,7 +20,7 @@
 
   &__list
     margin 10px -7px
-  
+
   & a
     color var(--primary_link)
     text-decoration underline


### PR DESCRIPTION
App redesign had changed a couple of the overflow values on modals, which broke the ability to provide a position sticky footer. This made it difficult to present modal forms with scrolling content and have the form submit button visible at all times.

_Before_
![image](https://github.com/user-attachments/assets/839b77f9-8f3e-467d-adb2-5c8ac3727ade)

_After_
![image](https://github.com/user-attachments/assets/cb1dd835-a537-43a7-8951-c1dd896ae615)
