### PR TITLE
fix: OPTIC-884: Incorrect block style name for prediction card

### DIFF
--- a/web/apps/labelstudio/src/pages/Settings/PredictionsSettings/PredictionsList.styl
+++ b/web/apps/labelstudio/src/pages/Settings/PredictionsSettings/PredictionsList.styl
@@ -1,4 +1,4 @@
-.predictionCard {
+.prediction-card {
   width: 100%;
   padding: 15px;
   border-radius: 5px;


### PR DESCRIPTION
Small fix to address an issue with release 1.13.0 and an incorrect block style name.

`predictionCard` -> `prediction-card`