### PR TITLE
fix: OPTIC-884: Incorrect block style name for prediction card (#6089)

### DIFF
--- a/web/apps/labelstudio/src/pages/Settings/PredictionsSettings/PredictionsList.styl
+++ b/web/apps/labelstudio/src/pages/Settings/PredictionsSettings/PredictionsList.styl
@@ -1,4 +1,4 @@
-.predictionCard {
+.prediction-card {
   width: 100%;
   padding: 15px;
   border-radius: 5px;


### PR DESCRIPTION
Cherry picks:
- 515fb3eb7fb5ce1835cf7adbb8be6bc60a0d735b