### PR TITLE
fix: OPTIC-885: Links not clickable from within Radio Button

### DIFF
--- a/web/apps/labelstudio/src/components/Form/Elements/RadioGroup/RadioGroup.jsx
+++ b/web/apps/labelstudio/src/components/Form/Elements/RadioGroup/RadioGroup.jsx
@@ -74,6 +74,7 @@ const RadioButton = ({ value, disabled, children, label, description, ...props }
 
   const clickHandler = useCallback(
     (e) => {
+      if (e.target.tagName === "A") return;
       e.preventDefault();
       e.stopPropagation();
       if (disabled) return;

--- a/web/apps/labelstudio/src/components/Form/Elements/RadioGroup/RadioGroup.jsx
+++ b/web/apps/labelstudio/src/components/Form/Elements/RadioGroup/RadioGroup.jsx
@@ -74,6 +74,8 @@ const RadioButton = ({ value, disabled, children, label, description, ...props }
 
   const clickHandler = useCallback(
     (e) => {
+      // TODO: Find a better way to prevent the click event from being triggered by the child element
+      // that works beyond just the anchor tag. Otherwise there will be problems with other components/elements.
       if (e.target.tagName === "A") return;
       e.preventDefault();
       e.stopPropagation();


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [X] Frontend



### Describe the reason for change
The Radio Component allows an extended description to be provided as a label to the element, and when this option is utilized with links embedded in the description JSX the clickHandler would stop propagation of this event from the anchor tag which never allows for the links to be clickable. If the element which sourced the bubbled event is an anchor tag, leave the event alone to retain normal web behaviour and skip the Radio Component clickHandler.