### PR TITLE
fix: LEAP-1240: Prevent resizing of already loaded images due to original dimensions in results

### DIFF
--- a/web/libs/editor/src/stores/Annotation/Annotation.js
+++ b/web/libs/editor/src/stores/Annotation/Annotation.js
@@ -1124,7 +1124,9 @@ export const Annotation = types
 
           const imageEntity = tag.findImageEntity(obj.item_index ?? 0);
 
-          if (!imageEntity) return;
+          console.log(imageEntity.imageLoaded, imageEntity, tag);
+
+          if (!imageEntity || imageEntity.imageLoaded) return;
 
           imageEntity.setNaturalWidth(obj.original_width);
           imageEntity.setNaturalHeight(obj.original_height);

--- a/web/libs/editor/src/stores/Annotation/Annotation.js
+++ b/web/libs/editor/src/stores/Annotation/Annotation.js
@@ -1124,8 +1124,6 @@ export const Annotation = types
 
           const imageEntity = tag.findImageEntity(obj.item_index ?? 0);
 
-          console.log(imageEntity.imageLoaded, imageEntity, tag);
-
           if (!imageEntity || imageEntity.imageLoaded) return;
 
           imageEntity.setNaturalWidth(obj.original_width);


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
This PR addresses an issue where images that are already loaded are being resized based on their original_width and original_height from results data. The incorrect precedence of sizes from results is causing potential bugs in the display of images and regions.

With the introduction of Multi Image Labeling (MIG), functionality was added to detect image size from regions information to ensure proper display even if the image wasn't loaded yet.


#### What does this fix?
Ensure that if an image is already loaded, it should not be resized based on regions information.
