### PR TITLE
fix: OPTIC-765: TypeError: Cannot read properties of null (reading 'getBoundingClientRect')

### DIFF
--- a/web/libs/datamanager/src/components/Common/Tooltip/Tooltip.jsx
+++ b/web/libs/datamanager/src/components/Common/Tooltip/Tooltip.jsx
@@ -15,11 +15,14 @@ export const Tooltip = forwardRef(({ title, children, defaultVisible, disabled, 
   const [align, setAlign] = useState("top-center");
 
   const calculatePosition = useCallback(() => {
+    // If the tooltip is not injected, we cannot yet calculate the position
+    // Without this check the alignElements function will throw an error if the async transition is not finished but the component is already unmounted
+    if (!triggerElement.current || !tooltipElement.current) return;
     const { left, top, align: resultAlign } = alignElements(triggerElement.current, tooltipElement.current, align, 10);
 
     setOffset({ left, top });
     setAlign(resultAlign);
-  }, [triggerElement.current, tooltipElement.current]);
+  }, []);
 
   const performAnimation = useCallback(
     (visible) => {
@@ -39,7 +42,7 @@ export const Tooltip = forwardRef(({ title, children, defaultVisible, disabled, 
         });
       }
     },
-    [injected, calculatePosition, tooltipElement],
+    [injected, calculatePosition],
   );
 
   const visibilityClasses = useMemo(() => {
@@ -72,7 +75,7 @@ export const Tooltip = forwardRef(({ title, children, defaultVisible, disabled, 
           <Elem name="body">{title}</Elem>
         </Block>
       ) : null,
-    [injected, offset, title, visibilityClasses, tooltipElement],
+    [injected, offset, title, visibilityClasses],
   );
 
   useEffect(() => {


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [X] Frontend



#### What does this fix?
The Tooltip in certain circumstances could throw an error trying to align the position of an already unmounted component which threw the error in the PR title. Added a check to ensure this does not attempt to recalculate the position of the tooltip if either the trigger or tooltip component has unmounted from the DOM during the async transition. Also I cleaned up the deps arrays to remove any stable refs from here as it is not required.


#### Notes to reviewers
I was not able to reproduce this in any of the Tooltip usages I was able to determine. The Sentry stack trace points directly to this function being the culprit, and given the fact we have these async functions happening within useEffects without the guard proposed in this PR, it aligns with the type of behaviour that would result in this exact error.


