### PR TITLE
docs: Show 10 search results instead of the default 5

### DIFF
--- a/docs/themes/v2/source/js/header.js
+++ b/docs/themes/v2/source/js/header.js
@@ -50,7 +50,8 @@
         inputSelector: '#docsearch-input',
         appId,
         apiKey,
-        indexName
+        indexName,
+        algoliaOptions: { hitsPerPage: 10 },
       });
     
       const handleFocusSearch = (e) => {


### PR DESCRIPTION
<img width="616" alt="Screenshot 2024-07-19 at 8 50 19 AM" src="https://github.com/user-attachments/assets/fade5e23-d78b-4dc5-8ec3-ebc464467dbe">
