### PR TITLE
fix: OPTIC-683: Detect and convert large integers automatically in API responses before parsing as JSON to retain precision

### DIFF
--- a/web/libs/datamanager/src/utils/__tests__/helpers.test.ts
+++ b/web/libs/datamanager/src/utils/__tests__/helpers.test.ts
@@ -4,7 +4,7 @@ describe("helpers", () => {
   const originalMaxSafeInteger = Number.MAX_SAFE_INTEGER;
 
   beforeEach(() => {
-    // Mock Number.MAX_SAFE_INTEGER to a smaller value for testing purposes
+    // Mock Number.MAX_SAFE_INTEGER to a smaller value for testing purposes as NodeJS supports larger integers than Web.
     Object.defineProperty(Number, "MAX_SAFE_INTEGER", {
       value: 9007199254740991,
     });

--- a/web/libs/datamanager/src/utils/__tests__/helpers.test.ts
+++ b/web/libs/datamanager/src/utils/__tests__/helpers.test.ts
@@ -1,0 +1,60 @@
+import * as helpers from "../helpers";
+
+describe("helpers", () => {
+  const originalMaxSafeInteger = Number.MAX_SAFE_INTEGER;
+
+  beforeEach(() => {
+    // Mock Number.MAX_SAFE_INTEGER to a smaller value for testing purposes
+    Object.defineProperty(Number, "MAX_SAFE_INTEGER", {
+      value: 9007199254740991,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(Number, "MAX_SAFE_INTEGER", {
+      value: originalMaxSafeInteger,
+    });
+  });
+
+  describe("jsonReviverWithBigInt", () => {
+    it("should return the source value if the value is a number and the source is defined and exceeds MAX_SAFE_INTEGER", () => {
+      const key = "key";
+      const value = 9007199254740992;
+      const source = "9007199254740992";
+      const context = { source };
+
+      const result = helpers.jsonReviverWithBigInt(key, value, context);
+      expect(result).toBe(source);
+    });
+
+    it("should return the source value if the value is a number and the source defined is less than -MAX_SAFE_INTEGER", () => {
+      const key = "key";
+      const value = -9007199254740992;
+      const source = "-9007199254740992";
+      const context = { source };
+
+      const result = helpers.jsonReviverWithBigInt(key, value, context);
+      expect(result).toBe(source);
+    });
+
+    it("should return the value if the value is a number and the source defined is less than or equal to MAX_SAFE_INTEGER", () => {
+      const key = "key";
+      const value = 9007199254740991;
+      const source = 9007199254740991;
+      const context = { source };
+
+      const result = helpers.jsonReviverWithBigInt(key, value, context);
+      expect(result).toBe(source);
+    });
+  });
+
+  it("should return the value if the value is a number and the source defined is greater than or equal to -MAX_SAFE_INTEGER", () => {
+    const key = "key";
+    const value = -9007199254740991;
+    const source = -9007199254740991;
+    const context = { source };
+
+    const result = helpers.jsonReviverWithBigInt(key, value, context);
+    expect(result).toBe(source);
+  });
+});

--- a/web/libs/datamanager/src/utils/api-proxy/index.js
+++ b/web/libs/datamanager/src/utils/api-proxy/index.js
@@ -9,7 +9,7 @@
  * }} EndpointConfig
  */
 
-import { formDataToJPO } from "../helpers";
+import { formDataToJPO, replaceBigIntegersFromJsonString } from "../helpers";
 import statusCodes from "./status-codes.json";
 
 /**
@@ -242,7 +242,9 @@ export class APIProxy {
           try {
             const responseData =
               rawResponse.status !== 204
-                ? JSON.parse(this.alwaysExpectJSON ? responseText : responseText || "{}")
+                ? JSON.parse(
+                    replaceBigIntegersFromJsonString(this.alwaysExpectJSON ? responseText : responseText || "{}"),
+                  )
                 : { ok: true };
 
             if (methodSettings.convert instanceof Function) {

--- a/web/libs/datamanager/src/utils/api-proxy/index.js
+++ b/web/libs/datamanager/src/utils/api-proxy/index.js
@@ -9,7 +9,7 @@
  * }} EndpointConfig
  */
 
-import { formDataToJPO, replaceBigIntegersFromJsonString } from "../helpers";
+import { formDataToJPO, parseJson } from "../helpers";
 import statusCodes from "./status-codes.json";
 
 /**
@@ -242,9 +242,7 @@ export class APIProxy {
           try {
             const responseData =
               rawResponse.status !== 204
-                ? JSON.parse(
-                    replaceBigIntegersFromJsonString(this.alwaysExpectJSON ? responseText : responseText || "{}"),
-                  )
+                ? parseJson(this.alwaysExpectJSON ? responseText : responseText || "{}")
                 : { ok: true };
 
             if (methodSettings.convert instanceof Function) {

--- a/web/libs/datamanager/src/utils/helpers.ts
+++ b/web/libs/datamanager/src/utils/helpers.ts
@@ -37,7 +37,6 @@ export const jsonReviverWithBigInt = (_key: any, value: any, context?: any) => {
  *     { "meta": { "id": -12345678901234567890 } } => { "meta": { "id": "-12345678901234567890" } }
  **/
 export const parseJson = <T = any>(jsonString: string): T => {
-  // @ts-ignore The types were complaining about the signature which I believe is due to the NodeJS types of JSON.parse getting in the way
   return JSON.parse(jsonString, jsonReviverWithBigInt) as T;
 };
 

--- a/web/libs/datamanager/src/utils/helpers.ts
+++ b/web/libs/datamanager/src/utils/helpers.ts
@@ -15,7 +15,7 @@ export const formDataToJPO = (formData: FormData) => {
 /**
  * Hydrate JSON values that are large integers to strings.
  */
-export const jsonReviverWithBigInt = (_key: any, value: any, context: any) => {
+export const jsonReviverWithBigInt = (_key: any, value: any, context?: any) => {
   if (typeof value === "number" && context?.source !== undefined && Math.abs(value) > Number.MAX_SAFE_INTEGER) {
     // If the number would overflow the JS number precision, retain it to a string
     // from the original source string.

--- a/web/libs/datamanager/src/utils/helpers.ts
+++ b/web/libs/datamanager/src/utils/helpers.ts
@@ -12,6 +12,19 @@ export const formDataToJPO = (formData: FormData) => {
   return formData;
 };
 
+/**
+ * Convert only big integers that are still integers within the json string
+ * to avoid JS number precision issues when displaying them in the UI.
+ * This is a workaround for the fact that JSON.parse does not support big integers and will
+ * immediately convert them to numbers (losing precision).
+ *
+ * ex. { "id": 12345678901234567890 } => { "id": "12345678901234567890" }
+ *     { "id": -12345678901234567890 } => { "id": "-12345678901234567890" }
+ **/
+export const replaceBigIntegersFromJsonString = (jsonString: string) => {
+  return jsonString.replace(/:\s*(-?\d{16,})/g, (_, p1) => `: "${p1}"`);
+};
+
 export const objectToMap = <T extends Record<string, any>>(object: T) => {
   return new Map(Object.entries(object ?? {}));
 };

--- a/web/libs/datamanager/src/utils/helpers.ts
+++ b/web/libs/datamanager/src/utils/helpers.ts
@@ -14,9 +14,9 @@ export const formDataToJPO = (formData: FormData) => {
 
 /**
  * Parse a JSON string and convert big integers to strings.
- * We convert only big integers that are still integers within the json string
+ * We convert only big integers that are still integers within the JSON string
  * to avoid JS number precision issues when displaying them in the UI.
- * This is a workaround for the fact that JSON.parse does not support big integers and will
+ * This is a workaround for the fact that JSON.parse does not directly support big integers and will
  * immediately convert them to numbers (losing precision).
  *
  * ex. { "id": 12345678901234567890 } => { "id": "12345678901234567890" }

--- a/web/libs/datamanager/src/utils/helpers.ts
+++ b/web/libs/datamanager/src/utils/helpers.ts
@@ -13,6 +13,18 @@ export const formDataToJPO = (formData: FormData) => {
 };
 
 /**
+ * Hydrate JSON values that are large integers to strings.
+ */
+export const jsonReviverWithBigInt = (_key: any, value: any, context: any) => {
+  if (typeof value === "number" && context?.source !== undefined && Math.abs(value) > Number.MAX_SAFE_INTEGER) {
+    // If the number would overflow the JS number precision, retain it to a string
+    // from the original source string.
+    // Leaving as a string and not a BigInt to avoid issues with JSON.stringify or other cases downstream.
+    return context.source;
+  }
+  return value;
+};
+/**
  * Parse a JSON string and convert big integers to strings.
  * We convert only big integers that are still integers within the JSON string
  * to avoid JS number precision issues when displaying them in the UI.
@@ -25,15 +37,8 @@ export const formDataToJPO = (formData: FormData) => {
  *     { "meta": { "id": -12345678901234567890 } } => { "meta": { "id": "-12345678901234567890" } }
  **/
 export const parseJson = <T = any>(jsonString: string): T => {
-  return JSON.parse(jsonString, (_key: any, value: any, context: any) => {
-    if (typeof value === "number" && value.toString().length > 15) {
-      // If the number would overflow the JS number precision, retain it to a string
-      // from the original source string.
-      // Leaving as a string and not a BigInt to avoid issues with JSON.stringify or other cases downstream.
-      return context.source;
-    }
-    return value;
-  }) as T;
+  // @ts-ignore The types were complaining about the signature which I believe is due to the NodeJS types of JSON.parse getting in the way
+  return JSON.parse(jsonString, jsonReviverWithBigInt) as T;
 };
 
 export const objectToMap = <T extends Record<string, any>>(object: T) => {


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [X] Tests for the changes have been added/updated (for bug fixes/features)
- [X] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [X] Frontend



### Describe the reason for change
When data within JSONB fields of the database would store large integers from other processes, when it came time to displaying these visually it would be done with loss of precision. The JS support for large integers is not very good being it only actually stores floats and has only 32bit support. Therefore to fix the display issues of these, I found that we were already performing a 2 stage response with all api calls from datamanager, therefore I added a method to replace large integers that are present in the textual data as the reviver function to JSON.parse running. This solves the issue and ultimately ensures we do not modify unknowingly data stored on the server while still retaining the visual accuracy for consumption in the UI.

_Before_
![image](https://github.com/user-attachments/assets/185739e3-fc59-4c18-8dde-3ce281670bbd)

_After_
![image](https://github.com/user-attachments/assets/80ee8180-53cb-45ef-884c-45112c2ebf3c)



#### What alternative approaches were there?
- Support BigInt in JS.
    - Problem here is it doesn't actually solve the original problem.
    - Can be explicitly supported in addition to this solution but this requires that all other Number values be converted to BigInt to be able to perform mathematical operations on them.
    - Many caveats to cover which ultimately the solution we need is to be as low risk to data corruption as possible.



#### What feature flags were used to cover this change?
Don't have one yet, will entertain one if we feel it necessary.



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [X] unit



### Which logical domain(s) does this change affect?
DataManager API proxy.

