### PR TITLE
fix: OPTIC-954: Project card default color change broke the text color

### DIFF
--- a/web/apps/labelstudio/src/pages/Projects/ProjectsList.jsx
+++ b/web/apps/labelstudio/src/pages/Projects/ProjectsList.jsx
@@ -7,6 +7,8 @@ import { Button, Dropdown, Menu, Pagination, Userpic } from "../../components";
 import { Block, Elem } from "../../utils/bem";
 import { absoluteURL } from "../../utils/helpers";
 
+const DEFAULT_CARD_COLORS = ["#FFFFFF", "#FDFDFC"];
+
 export const ProjectsList = ({ projects, currentPage, totalItems, loadNextPage, pageSize }) => {
   return (
     <>
@@ -48,7 +50,7 @@ export const EmptyProjectsList = ({ openModal }) => {
 
 const ProjectCard = ({ project }) => {
   const color = useMemo(() => {
-    return project.color === "#FFFFFF" ? null : project.color;
+    return DEFAULT_CARD_COLORS.includes(project.color) ? null : project.color;
   }, [project]);
 
   const projectColors = useMemo(() => {


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)


#### Change has impacts in these area(s)
_(check all that apply)_
- [X] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [X] Frontend

#### What does this fix?

With the redesign the base colors considered for a background on a project card went from `#FFFFFF` -> `#FDFDFC` which caused the logic of when to set an alternate contrast color to be constantly being invoked and rendering a completely blank looking card. This fix makes it so that it handles both the old default and new one, rendering the correct text color in scenarios where there is a color applied that is not the default.
_Before_
[Kapture 2024-07-23 at 11.58.31.webm](https://github.com/user-attachments/assets/e20a0fd9-554f-454e-8e28-d051b2f4a737)
_After_
[Kapture 2024-07-23 at 11.41.19.webm](https://github.com/user-attachments/assets/bae2d7bc-db62-4974-8c47-1d642061433a)


### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)


### Which logical domain(s) does this change affect?
ProjectCard

