### PR TITLE
ci: enable some rules in biome 

### DIFF
--- a/web/apps/labelstudio/src/pages/CreateProject/Config/Config.jsx
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/Config.jsx
@@ -461,7 +461,9 @@ const Configurator = ({
       <div className={configClass.elem("container")}>
         <h1>Labeling Interface</h1>
         <header>
-          <button onClick={onBrowse}>Browse Templates</button>
+          <button type="button" onClick={onBrowse}>
+            Browse Templates
+          </button>
           <ToggleItems items={{ code: "Code", visual: "Visual" }} active={configure} onSelect={onSelect} />
         </header>
         <div className={configClass.elem("editor")}>

--- a/web/apps/labelstudio/src/pages/CreateProject/Import/Import.jsx
+++ b/web/apps/labelstudio/src/pages/CreateProject/Import/Import.jsx
@@ -339,6 +339,7 @@ export const ImportPage = ({
         </form>
         <span>or</span>
         <button
+          type="button"
           onClick={() => document.getElementById("file-input").click()}
           className={importClass.elem("upload-button")}
         >

--- a/web/biome.json
+++ b/web/biome.json
@@ -46,7 +46,6 @@
       },
       "complexity": {
         "noForEach": "off",
-        "noUselessSwitchCase": "off",
         "useOptionalChain": "off",
         "noBannedTypes": "off",
         "noStaticOnlyClass": "off",

--- a/web/biome.json
+++ b/web/biome.json
@@ -31,7 +31,6 @@
       "recommended": true,
       "a11y": {
         "noAutofocus": "off",
-        "noRedundantAlt": "off",
         "useButtonType": "off",
         "useKeyWithClickEvents": "off"
       },

--- a/web/biome.json
+++ b/web/biome.json
@@ -42,7 +42,6 @@
         "noConfusingVoidType": "off",
         "noImplicitAnyLet": "off",
         "noShadowRestrictedNames": "off",
-        "useDefaultSwitchClauseLast": "off",
         "useGetterReturn": "off"
       },
       "complexity": {

--- a/web/biome.json
+++ b/web/biome.json
@@ -64,7 +64,6 @@
         "noNonNullAssertion": "off",
         "useDefaultParameterLast": "off",
         "useNodejsImportProtocol": "off",
-        "noCommaOperator": "off",
         "noParameterAssign": "off"
       },
       "nursery": {},

--- a/web/biome.json
+++ b/web/biome.json
@@ -31,7 +31,6 @@
       "recommended": true,
       "a11y": {
         "noAutofocus": "off",
-        "useButtonType": "off",
         "useKeyWithClickEvents": "off"
       },
       "suspicious": {

--- a/web/libs/datamanager/src/components/Common/Form/Elements/Select/Select.jsx
+++ b/web/libs/datamanager/src/components/Common/Form/Elements/Select/Select.jsx
@@ -42,7 +42,8 @@ const Select = ({
               ref={ref}
               value={value}
               onChange={(e) => {
-                setValue(e.target.value), props.onChange?.(e);
+                setValue(e.target.value);
+                props.onChange?.(e);
               }}
               className={rootClass.elem("list")}
             >

--- a/web/libs/datamanager/src/stores/Tabs/tab_column.jsx
+++ b/web/libs/datamanager/src/stores/Tabs/tab_column.jsx
@@ -31,61 +31,37 @@ export const ViewColumnType = types.enumeration([
   "Unknown",
 ]);
 
-export const ViewColumnTypeShort = (type) => {
-  switch (type) {
-    default:
-    case "String":
-      return "str";
-    case "Number":
-      return "num";
-    case "Boolean":
-      return "bool";
-    case "Datetime":
-      return "date";
-    case "Image":
-      return "img";
-    case "Audio":
-      return "aud";
-    case "AudioPlus":
-      return "aud";
-    case "Video":
-      return "vid";
-    case "Text":
-      return "txt";
-    case "HyperText":
-      return "html";
-    case "TimeSeries":
-      return "ts";
-  }
+const typeShortMap = {
+  String: "str",
+  Number: "num",
+  Boolean: "bool",
+  Datetime: "date",
+  Image: "img",
+  Audio: "aud",
+  AudioPlus: "aud",
+  Video: "vid",
+  Text: "txt",
+  HyperText: "html",
+  TimeSeries: "ts",
 };
 
-export const ViewColumnTypeName = (type) => {
-  switch (type) {
-    default:
-    case "String":
-      return "String";
-    case "Number":
-      return "Number";
-    case "Boolean":
-      return "Boolean";
-    case "Datetime":
-      return "Date Time";
-    case "Image":
-      return "Image";
-    case "Audio":
-      return "Audio";
-    case "AudioPlus":
-      return "Audio";
-    case "Video":
-      return "Video";
-    case "Text":
-      return "Text";
-    case "HyperText":
-      return "Hyper Text";
-    case "TimeSeries":
-      return "Time Series";
-  }
+export const ViewColumnTypeShort = (type) => typeShortMap[type] || "str";
+
+const typeNameMap = {
+  String: "String",
+  Number: "Number",
+  Boolean: "Boolean",
+  Datetime: "Date Time",
+  Image: "Image",
+  Audio: "Audio",
+  AudioPlus: "Audio",
+  Video: "Video",
+  Text: "Text",
+  HyperText: "Hyper Text",
+  TimeSeries: "Time Series",
 };
+
+export const ViewColumnTypeName = (type) => typeNameMap[type] || "String";
 
 export const TabColumn = types
   .model("ViewColumn", {
@@ -185,8 +161,6 @@ export const TabColumn = types
 
     get icon() {
       switch (self.alias) {
-        default:
-          return null;
         case "total_annotations":
           return <LsAnnotation width="20" height="20" style={{ color: "#617ADA" }} />;
         case "cancelled_annotations":
@@ -203,6 +177,8 @@ export const TabColumn = types
           return <CommentCheck width="20" height="20" style={{ color: "#FFB700" }} />;
         case "unresolved_comment_count":
           return <CommentRed width="20" height="20" style={{ color: "#FFB700" }} />;
+        default:
+          return null;
       }
     },
 

--- a/web/libs/datamanager/src/stores/Tabs/tab_filter.js
+++ b/web/libs/datamanager/src/stores/Tabs/tab_filter.js
@@ -12,17 +12,11 @@ const operatorNames = Array.from(new Set([].concat(...Object.values(Filters).map
 const Operators = types.enumeration(operatorNames);
 
 const getOperatorDefaultValue = (operator) => {
-  if (operatorNames.includes(operator)) {
-    switch (operator) {
-      default:
-        return null;
-
-      case "empty":
-        return false;
-    }
+  if (!operatorNames.includes(operator)) {
+    return null;
   }
 
-  return null;
+  return operator === "empty" ? false : null;
 };
 
 export const TabFilter = types

--- a/web/libs/editor/src/components/DraftPanel/DraftPanel.jsx
+++ b/web/libs/editor/src/components/DraftPanel/DraftPanel.jsx
@@ -21,7 +21,7 @@ export const DraftPanel = observer(({ item }) => {
   return (
     <div className={panel}>
       <Tooltip placement="topLeft" title={item.draftSelected ? "switch to original result" : "switch to current draft"}>
-        <button onClick={() => item.toggleDraft()} className={panel.elem("toggle")}>
+        <button type="button" onClick={() => item.toggleDraft()} className={panel.elem("toggle")}>
           {item.draftSelected ? "draft" : "original"}
         </button>
       </Tooltip>

--- a/web/libs/editor/src/components/ImageView/Image.jsx
+++ b/web/libs/editor/src/components/ImageView/Image.jsx
@@ -89,6 +89,7 @@ const ImageRenderer = observer(
       return { ...style, visibility: isLoaded ? "visible" : "hidden" };
     }, [imageTransform, isLoaded]);
 
+    // biome-ignore lint/a11y/noRedundantAlt: The use of this component justifies this alt text
     return <img {...imgDefaultProps} ref={ref} alt="image" src={src} onLoad={onLoad} style={imageStyles} />;
   }),
 );

--- a/web/libs/editor/src/components/Ranker/Column.tsx
+++ b/web/libs/editor/src/components/Ranker/Column.tsx
@@ -28,7 +28,7 @@ const CollapsibleColumnTitle = ({ items, title }: { items: InputItem[]; title: s
   return (
     <h1 className={[styles.columnTitle, collapsed ? styles.collapsed : styles.expanded].join(" ")}>
       {title}
-      <button onClick={toggle}>
+      <button type="button" onClick={toggle}>
         <span />
       </button>
     </h1>

--- a/web/libs/editor/src/components/Settings/TagSettings/SettingsRenderer.tsx
+++ b/web/libs/editor/src/components/Settings/TagSettings/SettingsRenderer.tsx
@@ -41,7 +41,8 @@ const SettingsField: FC<{
   }
 
   if (value.type !== "boolean") {
-    (props.type = value.type), (props.value = store.settings[name]);
+    props.type = value.type;
+    props.value = store.settings[name];
     props.placeholder = value.description;
   }
 

--- a/web/libs/editor/src/components/SidePanels/Components/RegionControlButton.tsx
+++ b/web/libs/editor/src/components/SidePanels/Components/RegionControlButton.tsx
@@ -6,7 +6,8 @@ export const RegionControlButton: FC<ButtonProps> = ({ children, onClick, ...pro
     <Button
       {...props}
       onClick={(e) => {
-        e.stopPropagation(), onClick?.(e);
+        e.stopPropagation();
+        onClick?.(e);
       }}
       type="text"
       style={{ padding: 0, width: 24, height: 24, ...(props.style ?? {}) }}

--- a/web/libs/editor/src/components/Taxonomy/Taxonomy.tsx
+++ b/web/libs/editor/src/components/Taxonomy/Taxonomy.tsx
@@ -443,7 +443,9 @@ const TaxonomyDropdown = ({ show, flatten, items, dropdownRef, isEditable }: Tax
             <UserLabelForm path={[]} onAddLabel={onAddLabel} onFinish={closeForm} />
           ) : isEditable ? (
             <div className={styles.taxonomy__add}>
-              <button onClick={addInside}>Add</button>
+              <button type="button" onClick={addInside}>
+                Add
+              </button>
             </div>
           ) : null}
         </div>

--- a/web/libs/editor/src/components/Timeline/Plugins/Timeline.tsx
+++ b/web/libs/editor/src/components/Timeline/Plugins/Timeline.tsx
@@ -188,26 +188,23 @@ export class TimelinePlugin extends BaseTimelinePlugin {
 
     this.renderPositions((i, curSeconds, curPixel) => {
       if (i % primaryLabelInterval === 0) {
-        switch (labelPlacement) {
-          case "top":
-            this.setFillStyles(primaryColor!);
-            this.fillRect(curPixel, this.wrapperHeight - height + 1, 1, height);
+        if (labelPlacement === "top") {
+          this.setFillStyles(primaryColor!);
+          this.fillRect(curPixel, this.wrapperHeight - height + 1, 1, height);
 
-            this.setFillStyles(primaryFontColor!);
-            this.fillText(
-              (formatTime as any)(curSeconds, pixelsPerSecond),
-              curPixel * pxRatio,
-              height + Math.ceil(labelPadding! * 1.5),
-              "center",
-            );
-            break;
-          case "right":
-          default:
-            this.setFillStyles(primaryColor!);
-            this.fillRect(curPixel, 0, 1, height);
-            this.setFillStyles(primaryFontColor!);
-            this.fillText((formatTime as any)(curSeconds, pixelsPerSecond), curPixel + labelPadding! * pxRatio, height);
-            break;
+          this.setFillStyles(primaryFontColor!);
+          this.fillText(
+            (formatTime as any)(curSeconds, pixelsPerSecond),
+            curPixel * pxRatio,
+            height + Math.ceil(labelPadding! * 1.5),
+            "center",
+          );
+        } else {
+          // Handles "right" and any other values
+          this.setFillStyles(primaryColor!);
+          this.fillRect(curPixel, 0, 1, height);
+          this.setFillStyles(primaryFontColor!);
+          this.fillText((formatTime as any)(curSeconds, pixelsPerSecond), curPixel + labelPadding! * pxRatio, height);
         }
       }
     });
@@ -234,26 +231,23 @@ export class TimelinePlugin extends BaseTimelinePlugin {
 
     this.renderPositions((i, curSeconds, curPixel) => {
       if (i % secondaryLabelInterval === 0 && i % primaryLabelInterval !== 0) {
-        switch (labelPlacement) {
-          case "top":
-            this.setFillStyles(secondaryColor!);
-            this.fillRect(curPixel, this.wrapperHeight - height + 1, 1, height);
+        if (labelPlacement === "top") {
+          this.setFillStyles(secondaryColor!);
+          this.fillRect(curPixel, this.wrapperHeight - height + 1, 1, height);
 
-            this.setFillStyles(secondaryFontColor!);
-            this.fillText(
-              (formatTime as any)(curSeconds, pixelsPerSecond),
-              curPixel * pxRatio,
-              height + Math.ceil(labelPadding! * 1.5),
-              "center",
-            );
-            break;
-          case "right":
-          default:
-            this.setFillStyles(secondaryColor!);
-            this.fillRect(curPixel, 0, 1, height);
-            this.setFillStyles(secondaryFontColor!);
-            this.fillText((formatTime as any)(curSeconds, pixelsPerSecond), curPixel + labelPadding! * pxRatio, height);
-            break;
+          this.setFillStyles(secondaryFontColor!);
+          this.fillText(
+            (formatTime as any)(curSeconds, pixelsPerSecond),
+            curPixel * pxRatio,
+            height + Math.ceil(labelPadding! * 1.5),
+            "center",
+          );
+        } else {
+          // Handles "right" and any other values
+          this.setFillStyles(secondaryColor!);
+          this.fillRect(curPixel, 0, 1, height);
+          this.setFillStyles(secondaryFontColor!);
+          this.fillText((formatTime as any)(curSeconds, pixelsPerSecond), curPixel + labelPadding! * pxRatio, height);
         }
       }
     });
@@ -273,14 +267,11 @@ export class TimelinePlugin extends BaseTimelinePlugin {
 
     this.renderPositions((i, _, curPixel) => {
       if (i % secondaryLabelInterval !== 0 && i % primaryLabelInterval !== 0) {
-        switch (labelPlacement) {
-          case "top":
-            this.fillRect(curPixel, this.wrapperHeight - height + 1, 1, height);
-            break;
-          case "right":
-          default:
-            this.fillRect(curPixel, 0, 1, height);
-            break;
+        if (labelPlacement === "top") {
+          this.fillRect(curPixel, this.wrapperHeight - height + 1, 1, height);
+        } else {
+          // Handles "right" and any other value
+          this.fillRect(curPixel, 0, 1, height);
         }
       }
     });

--- a/web/libs/editor/src/utils/selection-tools.js
+++ b/web/libs/editor/src/utils/selection-tools.js
@@ -241,17 +241,16 @@ const applyTextGranularity = (selection, granularity) => {
     switch (granularity) {
       case "word":
         boundarySelection(selection, "word");
-        return;
+        break;
       case "sentence":
         boundarySelection(selection, "sentenceboundary");
-        return;
+        break;
       case "paragraph":
         boundarySelection(selection, "paragraphboundary");
-        return;
-      case "charater":
-      case "symbol":
+        break;
       default:
-        return;
+        // Handles "charater", "symbol", and any other unspecified granularities
+        break;
     }
   } catch {
     console.warn("Probably, you're using browser that doesn't support granularity.");


### PR DESCRIPTION
We re-enabled some biome rules that were previously disabled in our codebase. We made minimal changes to the code, focusing mainly on switch statements.
Each rule is enabled in a separate commit. Reviewing commit by commit is recommended.



### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
We aim to remove the exclusion in our biome.json file.



#### What does this fix?
Refactoring some code



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
Will run selenium in LSE



