### PR TITLE
docs: Fix contextual_scrolling.png image path

### DIFF
--- a/docs/source/templates/gallery_asr.ejs
+++ b/docs/source/templates/gallery_asr.ejs
@@ -73,6 +73,6 @@ cards:
   - dialogue analysis
   - audio transcription
   - speech recognition and segmentation
-  image: "/images/templates-misc/contextual-scrolling.png"
+  image: "/images/templates-misc/contextual_scrolling.png"
   url: "/templates/contextual_scrolling.html"
 ---


### PR DESCRIPTION
Fix the image in the Contextual Scrolling card on https://deploy-preview-6130--label-studio-docs-new-theme.netlify.app/templates/gallery_asr



<img width="838" alt="Screenshot 2024-07-24 at 10 45 42 PM" src="https://github.com/user-attachments/assets/e0225074-e8c9-4d8a-9ee4-a549af5a773c">
