### PR TITLE
fix: LEAP-552: Hide the comments tab on preview

### DIFF
--- a/web/apps/labelstudio/src/pages/CreateProject/Config/Preview.jsx
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/Preview.jsx
@@ -59,7 +59,7 @@ export const Preview = ({ config, data, error, loading, project }) => {
         const lsf = new window.LabelStudio(rootRef.current, {
           config,
           task,
-          interfaces: ["side-column", "annotations:comments", "comments:resolve-any"],
+          interfaces: ["side-column", "comments:resolve-any"],
           // with SharedStore we should use more late event
           [isFF(FF_DEV_3617) ? "onStorageInitialized" : "onLabelStudioLoad"](LS) {
             LS.settings.bottomSidePanel = true;

--- a/web/apps/labelstudio/src/pages/CreateProject/Config/Preview.jsx
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/Preview.jsx
@@ -59,7 +59,7 @@ export const Preview = ({ config, data, error, loading, project }) => {
         const lsf = new window.LabelStudio(rootRef.current, {
           config,
           task,
-          interfaces: ["side-column", "comments:resolve-any"],
+          interfaces: ["side-column"],
           // with SharedStore we should use more late event
           [isFF(FF_DEV_3617) ? "onStorageInitialized" : "onLabelStudioLoad"](LS) {
             LS.settings.bottomSidePanel = true;


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
The comments tab should be displayed just on LSE, on LSO we should hide it



#### What does this fix?
We are removing the interface `annotations:comments` on LS initialization on LSO preview page

![Screenshot 2024-07-25 at 14 19 52](https://github.com/user-attachments/assets/aebde79f-fdc5-4820-96bd-38f52e8d6cc3)
