### PR TITLE
fix: can not filte with predicion score when `model_version` is empty string

### DIFF
--- a/label_studio/data_manager/managers.py
+++ b/label_studio/data_manager/managers.py
@@ -643,12 +643,12 @@ def annotate_predictions_score(queryset):
             )
     else:
         model_version = first_task.project.model_version
-        if model_version is None:
-            return queryset.annotate(predictions_score=Avg('predictions__score'))
-        else:
+        if model_version:
             return queryset.annotate(
                 predictions_score=Avg('predictions__score', filter=Q(predictions__model_version=model_version))
             )
+        else:
+            return queryset.annotate(predictions_score=Avg('predictions__score'))
 
 
 def annotate_annotations_ids(queryset):


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [ ] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Backend (Database)
- [ ] Backend (API)
- [ ] Frontend



### Describe the reason for change
#5871 



#### What does this fix?
Can not filte with predicion score when project `model_version` is empty string
```
project.model_version
''
project.model_version == None
False
```
