### PR TITLE
refactor: OPTIC-910: Remove Stale Feature Flag - fflag_feat_front_lsdv_5518_snap_to_pixel_130923_short

### DIFF
--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -3,7 +3,6 @@ STALE_FEATURE_FLAGS = {
     'fflag_feat_all_dia_13_structured_data_support_short': False,
     'fflag_feat_front_optic_66_lazy_chart_evaluation_19092023_short': False,
     'fflag_feat_front_leap_187_video_seek_on_select_short': True,
-    'fflag_feat_front_lsdv_5518_snap_to_pixel_130923_short': True,
     'fflag_fix_back_leap_24_tasks_api_optimization_05092023_short': False,
     'fflag_feat_optic_2_ensure_draft_saved_short': True,
     'fflag_fix_front_lsdv_5248_double_click_delay_280823_short': True,

--- a/web/libs/editor/src/tags/control/Base.js
+++ b/web/libs/editor/src/tags/control/Base.js
@@ -1,5 +1,5 @@
 import { getRoot, types } from "mobx-state-tree";
-import { FF_DEV_3391, FF_SNAP_TO_PIXEL, isFF } from "../../utils/feature-flags";
+import { FF_DEV_3391, isFF } from "../../utils/feature-flags";
 import { BaseTag } from "../TagBase";
 import { SNAP_TO_PIXEL_MODE } from "../../components/ImageView/Image";
 
@@ -52,13 +52,12 @@ const ControlBase = types
     },
 
     getSnappedPoint(point) {
-      if (!isFF(FF_SNAP_TO_PIXEL)) return point;
-
       if (self.snap === "pixel") {
         return self.toNameTag.snapPointToPixel(point, self.snapMode);
       }
       return point;
     },
+
     get smartEnabled() {
       const smart = self.smart ?? false;
       const autoAnnotation = getRoot(self)?.autoAnnotation ?? false;

--- a/web/libs/editor/src/utils/feature-flags.ts
+++ b/web/libs/editor/src/utils/feature-flags.ts
@@ -313,11 +313,6 @@ export const FF_TASK_COUNT_FIX = "fflag_fix_all_optic_79_task_count_is_wrong_sho
  */
 export const FF_PROD_E_111 = "fflag_feat_front_prod_e_111_annotator_workflow_control_short";
 
-/**
- * Adding a property snap to Polygon, PolygonLabels, KeyPoint and KeyPoinLabels to snap points to image pixel when user sets snap="pixel".
- */
-export const FF_SNAP_TO_PIXEL = "fflag_feat_front_lsdv_5518_snap_to_pixel_130923_short";
-
 /** Fix taxonomy items init with DEV-3617 FF on; this allows to correctly preselect items on init */
 export const FF_TAXONOMY_SELECTED = "fflag_fix_front_leap_149_taxonomy_selected_true_short";
 


### PR DESCRIPTION


### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [ ] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
Removing a stale feature flag that is in this state since June `fflag_feat_front_lsdv_5518_snap_to_pixel_130923_short`
No changes in LSE



#### What does this fix?
Clean code


#### What is the new behavior?
No changes

