### PR TITLE
refactor: OPTIC-912: Remove Stale Feature Flag - fflag_feat_front_prod_e_111_annotator_workflow_control_short

### DIFF
--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -7,7 +7,6 @@ STALE_FEATURE_FLAGS = {
     'fflag_fix_back_leap_24_tasks_api_optimization_05092023_short': False,
     'fflag_feat_optic_2_ensure_draft_saved_short': True,
     'fflag_fix_front_lsdv_5248_double_click_delay_280823_short': True,
-    'fflag_feat_front_prod_e_111_annotator_workflow_control_short': True,
     'fflag_perf_back_lsdv_4695_update_prediction_query_to_use_direct_project_relation': True,
     'fflag_feat_front_lsdv_4620_outliner_optimization_310723_short': True,
     'fflag_fix_front_lsdv_4600_lead_time_27072023_short': False,

--- a/web/libs/editor/src/components/BottomBar/Controls.jsx
+++ b/web/libs/editor/src/components/BottomBar/Controls.jsx
@@ -10,7 +10,7 @@ import { Tooltip } from "../../common/Tooltip/Tooltip";
 import { Block, Elem } from "../../utils/bem";
 import { isDefined } from "../../utils/utilities";
 import { IconBan } from "../../assets/icons";
-import { FF_PROD_E_111, FF_REVIEWER_FLOW, isFF } from "../../utils/feature-flags";
+import { FF_REVIEWER_FLOW, isFF } from "../../utils/feature-flags";
 import "./Controls.styl";
 import { useCallback, useMemo, useState } from "react";
 import { LsChevron } from "../../assets/icons";
@@ -176,105 +176,63 @@ export const Controls = controlsInjector(
       const isDisabled = disabled || submitDisabled;
       const look = isDisabled ? "disabled" : "primary";
 
-      if (isFF(FF_PROD_E_111)) {
-        const useExitOption = !isDisabled && isNotQuickView;
+      const useExitOption = !isDisabled && isNotQuickView;
 
-        const SubmitOption = ({ isUpdate, onClickMethod }) => {
-          return (
-            <Button
-              name="submit-option"
-              look="secondary"
-              onClick={async (event) => {
-                event.preventDefault();
+      const SubmitOption = ({ isUpdate, onClickMethod }) => {
+        return (
+          <Button
+            name="submit-option"
+            look="secondary"
+            onClick={async (event) => {
+              event.preventDefault();
 
-                const selected = store.annotationStore?.selected;
+              const selected = store.annotationStore?.selected;
 
-                selected?.submissionInProgress();
+              selected?.submissionInProgress();
 
-                if ("URLSearchParams" in window) {
-                  const searchParams = new URLSearchParams(window.location.search);
+              if ("URLSearchParams" in window) {
+                const searchParams = new URLSearchParams(window.location.search);
 
-                  searchParams.set("exitStream", "true");
-                  const newRelativePathQuery = `${window.location.pathname}?${searchParams.toString()}`;
+                searchParams.set("exitStream", "true");
+                const newRelativePathQuery = `${window.location.pathname}?${searchParams.toString()}`;
 
-                  window.history.pushState(null, "", newRelativePathQuery);
-                }
+                window.history.pushState(null, "", newRelativePathQuery);
+              }
 
-                await store.commentStore.commentFormSubmit();
-                onClickMethod();
-              }}
-            >
-              {`${isUpdate ? "Update" : "Submit"} and exit`}
-            </Button>
-          );
-        };
+              await store.commentStore.commentFormSubmit();
+              onClickMethod();
+            }}
+          >
+            {`${isUpdate ? "Update" : "Submit"} and exit`}
+          </Button>
+        );
+      };
 
-        if (userGenerate || (store.explore && !userGenerate && store.hasInterface("submit"))) {
-          const title = submitDisabled ? "Empty annotations denied in this project" : "Save results: [ Ctrl+Enter ]";
+      if (userGenerate || (store.explore && !userGenerate && store.hasInterface("submit"))) {
+        const title = submitDisabled ? "Empty annotations denied in this project" : "Save results: [ Ctrl+Enter ]";
 
-          buttons.push(
-            <ButtonTooltip key="submit" title={title}>
-              <Elem name="tooltip-wrapper">
-                <Button
-                  aria-label="submit"
-                  name="submit"
-                  disabled={isDisabled}
-                  look={look}
-                  mod={{ has_icon: useExitOption, disabled: isDisabled }}
-                  onClick={async (event) => {
-                    if (event.target.classList.contains("lsf-dropdown__trigger")) return;
-                    const selected = store.annotationStore?.selected;
-
-                    selected?.submissionInProgress();
-                    await store.commentStore.commentFormSubmit();
-                    store.submitAnnotation();
-                  }}
-                  icon={
-                    useExitOption && (
-                      <Dropdown.Trigger
-                        alignment="top-right"
-                        content={<SubmitOption onClickMethod={store.submitAnnotation} isUpdate={false} />}
-                      >
-                        <div>
-                          <LsChevron />
-                        </div>
-                      </Dropdown.Trigger>
-                    )
-                  }
-                >
-                  Submit
-                </Button>
-              </Elem>
-            </ButtonTooltip>,
-          );
-        }
-
-        if ((userGenerate && sentUserGenerate) || (!userGenerate && store.hasInterface("update"))) {
-          const isUpdate = isFF(FF_REVIEWER_FLOW) || sentUserGenerate || versions.result;
-          // no changes were made over previously submitted version — no drafts, no pending changes
-          const noChanges = isFF(FF_REVIEWER_FLOW) && !history.canUndo && !annotation.draftId;
-          const isUpdateDisabled = isDisabled || noChanges;
-          const button = (
-            <ButtonTooltip key="update" title={noChanges ? "No changes were made" : "Update this task: [ Ctrl+Enter ]"}>
+        buttons.push(
+          <ButtonTooltip key="submit" title={title}>
+            <Elem name="tooltip-wrapper">
               <Button
                 aria-label="submit"
                 name="submit"
-                disabled={isUpdateDisabled}
+                disabled={isDisabled}
                 look={look}
-                mod={{ has_icon: useExitOption, disabled: isUpdateDisabled }}
+                mod={{ has_icon: useExitOption, disabled: isDisabled }}
                 onClick={async (event) => {
                   if (event.target.classList.contains("lsf-dropdown__trigger")) return;
                   const selected = store.annotationStore?.selected;
 
                   selected?.submissionInProgress();
                   await store.commentStore.commentFormSubmit();
-                  store.updateAnnotation();
+                  store.submitAnnotation();
                 }}
                 icon={
                   useExitOption && (
                     <Dropdown.Trigger
                       alignment="top-right"
-                      content={<SubmitOption onClickMethod={store.updateAnnotation} isUpdate={isUpdate} />}
+                      content={<SubmitOption onClickMethod={store.submitAnnotation} isUpdate={false} />}
                     >
                       <div>
                         <LsChevron />
@@ -283,65 +241,53 @@ export const Controls = controlsInjector(
                   )
                 }
               >
-                {isUpdate ? "Update" : "Submit"}
+                Submit
               </Button>
-            </ButtonTooltip>
-          );
+            </Elem>
+          </ButtonTooltip>,
+        );
+      }
 
-          buttons.push(button);
-        }
-      } else {
-        if (userGenerate || (store.explore && !userGenerate && store.hasInterface("submit"))) {
-          const title = submitDisabled ? "Empty annotations denied in this project" : "Save results: [ Ctrl+Enter ]";
+      if ((userGenerate && sentUserGenerate) || (!userGenerate && store.hasInterface("update"))) {
+        const isUpdate = isFF(FF_REVIEWER_FLOW) || sentUserGenerate || versions.result;
+        // no changes were made over previously submitted version — no drafts, no pending changes
+        const noChanges = isFF(FF_REVIEWER_FLOW) && !history.canUndo && !annotation.draftId;
+        const isUpdateDisabled = isDisabled || noChanges;
+        const button = (
+          <ButtonTooltip key="update" title={noChanges ? "No changes were made" : "Update this task: [ Ctrl+Enter ]"}>
+            <Button
+              aria-label="submit"
+              name="submit"
+              disabled={isUpdateDisabled}
+              look={look}
+              mod={{ has_icon: useExitOption, disabled: isUpdateDisabled }}
+              onClick={async (event) => {
+                if (event.target.classList.contains("lsf-dropdown__trigger")) return;
+                const selected = store.annotationStore?.selected;
 
-          buttons.push(
-            <ButtonTooltip key="submit" title={title}>
-              <Elem name="tooltip-wrapper">
-                <Button
-                  aria-label="submit"
-                  disabled={isDisabled}
-                  look={look}
-                  onClick={async () => {
-                    const selected = store.annotationStore?.selected;
+                selected?.submissionInProgress();
+                await store.commentStore.commentFormSubmit();
+                store.updateAnnotation();
+              }}
+              icon={
+                useExitOption && (
+                  <Dropdown.Trigger
+                    alignment="top-right"
+                    content={<SubmitOption onClickMethod={store.updateAnnotation} isUpdate={isUpdate} />}
+                  >
+                    <div>
+                      <LsChevron />
+                    </div>
+                  </Dropdown.Trigger>
+                )
+              }
+            >
+              {isUpdate ? "Update" : "Submit"}
+            </Button>
+          </ButtonTooltip>
+        );
 
-                    selected?.submissionInProgress();
-                    await store.commentStore.commentFormSubmit();
-                    store.submitAnnotation();
-                  }}
-                >
-                  Submit
-                </Button>
-              </Elem>
-            </ButtonTooltip>,
-          );
-        }
-
-        if ((userGenerate && sentUserGenerate) || (!userGenerate && store.hasInterface("update"))) {
-          const isUpdate = isFF(FF_REVIEWER_FLOW) || sentUserGenerate || versions.result;
-          // no changes were made over previously submitted version — no drafts, no pending changes
-          const noChanges = isFF(FF_REVIEWER_FLOW) && !history.canUndo && !annotation.draftId;
-          const isUpdateDisabled = isDisabled || noChanges;
-          const button = (
-            <ButtonTooltip key="update" title={noChanges ? "No changes were made" : "Update this task: [ Ctrl+Enter ]"}>
-              <Button
-                aria-label="submit"
-                disabled={isUpdateDisabled}
-                look={look}
-                onClick={async () => {
-                  const selected = store.annotationStore?.selected;
-
-                  selected?.submissionInProgress();
-                  await store.commentStore.commentFormSubmit();
-                  store.updateAnnotation();
-                }}
-              >
-                {isUpdate ? "Update" : "Submit"}
-              </Button>
-            </ButtonTooltip>
-          );
-
-          buttons.push(button);
-        }
+        buttons.push(button);
       }
     }
 

--- a/web/libs/editor/src/utils/feature-flags.ts
+++ b/web/libs/editor/src/utils/feature-flags.ts
@@ -308,10 +308,6 @@ export const FF_TAXONOMY_LABELING = "fflag_feat_front_lsdv_5452_taxonomy_labelin
  */
 
 export const FF_TASK_COUNT_FIX = "fflag_fix_all_optic_79_task_count_is_wrong_short";
-/**
- * Annotator workflow control for lead time calculation
- */
-export const FF_PROD_E_111 = "fflag_feat_front_prod_e_111_annotator_workflow_control_short";
 
 /**
  * Adding a property snap to Polygon, PolygonLabels, KeyPoint and KeyPoinLabels to snap points to image pixel when user sets snap="pixel".


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [ ] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
Remove a Feature Flag that is being stale sing June. fflag_feat_front_prod_e_111_annotator_workflow_control_short
No expected changes in LSE



#### What does this fix?
Clean Code



#### What is the new behavior?
N/A
