### PR TITLE
fix: LEAP-1358: Update config for relevant hasChanges value after prettifying

### DIFF
--- a/web/apps/labelstudio/src/pages/Settings/LabelingSettings.jsx
+++ b/web/apps/labelstudio/src/pages/Settings/LabelingSettings.jsx
@@ -20,6 +20,8 @@ export const LabelingSettings = () => {
           });
 
           if (res?.$meta?.ok) {
+            // Backend can prettify the config, so we need to update it to have relevant hasChanges value
+            setConfig(res.label_config);
             return true;
           }
 


### PR DESCRIPTION
On saving the config it could be prettified a bit by the back end. To keep hasChanges value relevant we need to update the config in the state or we will be blocked by UnsavedChanges  component.

### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)

#### Change has impacts in these area(s)
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend

#### What feature flags were used to cover this change?
`fflag_feat_front_leap_1198_unsaved_changes_180724`

### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
- [ ] e2e
- [ ] integration
- [ ] unit


### Which logical domain(s) does this change affect?
`LabelingConfig`

