### PR TITLE
docs: add /redirect for HumanSignal docs

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -11,10 +11,11 @@ status = 301
 force = true
 
 [[redirects]]
-from = "https://docs.humansignal.com/redirect/*"
-to = "https://docs.humansignal.com/:splat"
+from = "/redirect/*"
+to = "/:splat"
 status = 301
 force = true
+query = { preserve = true }
 
 [[redirects]]
 from = "/guide/starter_cloud"

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,4 +1,10 @@
 [[redirects]]
+from = "/redirect/guide/*"
+to = "/guide/:splat"
+status = 301
+force = true
+
+[[redirects]]
 from = "https://heartex-docs.netlify.app/api/*"
 to = "https://app.heartex.com/docs/api/:splat"
 status = 301
@@ -9,13 +15,6 @@ from = "https://docs.humansignal.com/api/*"
 to = "https://app.heartex.com/docs/api/:splat"
 status = 301
 force = true
-
-[[redirects]]
-from = "/redirect/guide/*"
-to = "/guide/:splat"
-status = 301
-force = true
-query = { preserve = true }
 
 [[redirects]]
 from = "/guide/starter_cloud"

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -11,8 +11,8 @@ status = 301
 force = true
 
 [[redirects]]
-from = "/redirect/*"
-to = "/:splat"
+from = "/redirect/guide/*"
+to = "/guide/:splat"
 status = 301
 force = true
 query = { preserve = true }

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -11,6 +11,12 @@ status = 301
 force = true
 
 [[redirects]]
+from = "https://docs.humansignal.com/redirect/*"
+to = "https://docs.humansignal.com/:splat"
+status = 301
+force = true
+
+[[redirects]]
 from = "/guide/starter_cloud"
 to = "https://humansignal.com/platform/starter-cloud/manage"
 status = 301


### PR DESCRIPTION
### How to test

https://deploy-preview-6183--heartex-docs.netlify.app/redirect/guide/setup_project?experiment=organization_page_tip&treatment=automate_distribution&server_id=72c73e6e-d5a2-4658-b4a2-77a31aa9d22d&user_id=1#Set-up-annotation-settings-for-your-project

should redirect to https://deploy-preview-6183--heartex-docs.netlify.app/guide/setup_project?experiment=organization_page_tip&treatment=automate_distribution&server_id=72c73e6e-d5a2-4658-b4a2-77a31aa9d22d&user_id=1#Set-up-annotation-settings-for-your-project (and keep all the query params)