### PR TITLE
refactor: OPTIC-1029: Remove Stale Feature Flag - ff_front_dev_1285_crosshair_wrong_zoom_140122_short

### DIFF
--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -64,5 +64,4 @@ STALE_FEATURE_FLAGS = {
     'ff_front_dev_1564_dev_1565_shortcuts_focus_and_cursor_010222_short': True,
     'ff_front_dev_1495_avatar_mess_210122_short': True,
     'ff_front_1170_outliner_030222_short': True,
-    'ff_front_dev_1285_crosshair_wrong_zoom_140122_short': True,
 }

--- a/web/libs/editor/src/components/ImageView/ImageView.jsx
+++ b/web/libs/editor/src/components/ImageView/ImageView.jsx
@@ -22,7 +22,6 @@ import Constants from "../../core/Constants";
 import { fixRectToFit } from "../../utils/image";
 import {
   FF_DBLCLICK_DELAY,
-  FF_DEV_1285,
   FF_DEV_1442,
   FF_DEV_3077,
   FF_DEV_3793,
@@ -385,11 +384,8 @@ const Crosshair = memo(
     const [visible, setVisible] = useState(false);
     const strokeWidth = 1;
     const dashStyle = [3, 3];
-    let enableStrokeScale = true;
+    const enableStrokeScale = false;
 
-    if (isFF(FF_DEV_1285)) {
-      enableStrokeScale = false;
-    }
 
     if (ref) {
       ref.current = {
@@ -737,12 +733,7 @@ export default observer(
     updateCrosshair = (e) => {
       if (this.crosshairRef.current) {
         const { x, y } = e.currentTarget.getPointerPosition();
-
-        if (isFF(FF_DEV_1285)) {
-          this.crosshairRef.current.updatePointer(...this.props.item.fixZoomedCoords([x, y]));
-        } else {
-          this.crosshairRef.current.updatePointer(x, y);
-        }
+        this.crosshairRef.current.updatePointer(...this.props.item.fixZoomedCoords([x, y]));
       }
     };
 
@@ -1201,16 +1192,12 @@ const StageContent = observer(({ item, store, state, crosshairRef }) => {
           width={
             isFF(FF_ZOOM_OPTIM)
               ? item.containerWidth
-              : isFF(FF_DEV_1285)
-                ? item.stageWidth
-                : item.stageComponentSize.width
+              : item.stageWidth
           }
           height={
             isFF(FF_ZOOM_OPTIM)
               ? item.containerHeight
-              : isFF(FF_DEV_1285)
-                ? item.stageHeight
-                : item.stageComponentSize.height
+              : item.stageHeight
           }
         />
       )}

--- a/web/libs/editor/src/components/ImageView/ImageView.jsx
+++ b/web/libs/editor/src/components/ImageView/ImageView.jsx
@@ -386,7 +386,6 @@ const Crosshair = memo(
     const dashStyle = [3, 3];
     const enableStrokeScale = false;
 
-
     if (ref) {
       ref.current = {
         updatePointer(newX, newY) {
@@ -1189,16 +1188,8 @@ const StageContent = observer(({ item, store, state, crosshairRef }) => {
       {item.crosshair && (
         <Crosshair
           ref={crosshairRef}
-          width={
-            isFF(FF_ZOOM_OPTIM)
-              ? item.containerWidth
-              : item.stageWidth
-          }
-          height={
-            isFF(FF_ZOOM_OPTIM)
-              ? item.containerHeight
-              : item.stageHeight
-          }
+          width={isFF(FF_ZOOM_OPTIM) ? item.containerWidth : item.stageWidth}
+          height={isFF(FF_ZOOM_OPTIM) ? item.containerHeight : item.stageHeight}
         />
       )}
     </>

--- a/web/libs/editor/src/utils/feature-flags.ts
+++ b/web/libs/editor/src/utils/feature-flags.ts
@@ -7,9 +7,6 @@ export const FF_DEV_1170 = "ff_front_1170_outliner_030222_short";
  */
 export const FF_DEV_1284 = "fflag_fix_front_dev_1284_auto_detect_undo_281022_short";
 
-// Fix crosshair working with zoom & rotation
-export const FF_DEV_1285 = "ff_front_dev_1285_crosshair_wrong_zoom_140122_short";
-
 export const FF_DEV_1442 = "ff_front_dev_1442_unselect_shape_on_click_outside_080622_short";
 
 // User labels for Taxonomy

--- a/web/libs/frontend-test/src/feature-flags.ts
+++ b/web/libs/frontend-test/src/feature-flags.ts
@@ -7,9 +7,6 @@ export const FF_DEV_1170 = "ff_front_1170_outliner_030222_short";
  */
 export const FF_DEV_1284 = "fflag_fix_front_dev_1284_auto_detect_undo_281022_short";
 
-// Fix crosshair working with zoom & rotation
-export const FF_DEV_1285 = "ff_front_dev_1285_crosshair_wrong_zoom_140122_short";
-
 export const FF_DEV_1442 = "ff_front_dev_1442_unselect_shape_on_click_outside_080622_short";
 
 // User labels for Taxonomy


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
The feature flag has been stale since June, so it is safe to remove it from our codebase.



#### What does this fix?
Clean code
