### PR TITLE
refactor: OPTIC-1031: Remove Stale Feature Flag - ff_front_DEV_1507_stuck_userpic_210122_short

### DIFF
--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -61,7 +61,6 @@ STALE_FEATURE_FLAGS = {
     'ff_front_dev_1598_empty_toname_240222_short': True,
     'ff_front_dev_1372_visible_when_choice_unselected_11022022_short': True,
     'ff_front_dev_1621_interactive_mode_150222_short': True,
-    'ff_front_DEV_1507_stuck_userpic_210122_short': True,
     'ff_front_dev_1566_shortcuts_in_results_010222_short': True,
     'ff_front_dev_1564_dev_1565_shortcuts_focus_and_cursor_010222_short': True,
     'ff_front_dev_1495_avatar_mess_210122_short': True,

--- a/web/libs/editor/src/common/Userpic/Userpic.tsx
+++ b/web/libs/editor/src/common/Userpic/Userpic.tsx
@@ -1,7 +1,6 @@
 import chroma from "chroma-js";
 import { type CSSProperties, forwardRef, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Block, Elem } from "../../utils/bem";
-import { FF_DEV_1507, isFF } from "../../utils/feature-flags";
 import { isDefined, userDisplayName } from "../../utils/utilities";
 import { Tooltip } from "../Tooltip/Tooltip";
 import "./Userpic.scss";
@@ -46,15 +45,15 @@ export const Userpic = forwardRef<any, UserpicProps>(
     const [imgVisible, setImgVisible] = useState(false);
     const [nameVisible, setNameVisible] = useState(true);
 
-    if (isFF(FF_DEV_1507)) {
-      useEffect(() => {
-        if (propsSrc !== finalSrc) {
-          setFinalSrc(propsSrc);
-          setImgVisible(false);
-          setNameVisible(true);
-        }
-      }, [propsSrc]);
-    }
+
+    useEffect(() => {
+      if (propsSrc !== finalSrc) {
+        setFinalSrc(propsSrc);
+        setImgVisible(false);
+        setNameVisible(true);
+      }
+    }, [propsSrc]);
+
 
     if (size) {
       style = Object.assign({ width: size, height: size, fontSize: size * 0.4 }, style);

--- a/web/libs/editor/src/common/Userpic/Userpic.tsx
+++ b/web/libs/editor/src/common/Userpic/Userpic.tsx
@@ -45,7 +45,6 @@ export const Userpic = forwardRef<any, UserpicProps>(
     const [imgVisible, setImgVisible] = useState(false);
     const [nameVisible, setNameVisible] = useState(true);
 
-
     useEffect(() => {
       if (propsSrc !== finalSrc) {
         setFinalSrc(propsSrc);
@@ -53,7 +52,6 @@ export const Userpic = forwardRef<any, UserpicProps>(
         setNameVisible(true);
       }
     }, [propsSrc]);
-
 
     if (size) {
       style = Object.assign({ width: size, height: size, fontSize: size * 0.4 }, style);

--- a/web/libs/editor/src/utils/feature-flags.ts
+++ b/web/libs/editor/src/utils/feature-flags.ts
@@ -12,9 +12,6 @@ export const FF_DEV_1285 = "ff_front_dev_1285_crosshair_wrong_zoom_140122_short"
 
 export const FF_DEV_1442 = "ff_front_dev_1442_unselect_shape_on_click_outside_080622_short";
 
-// Fix stuck userpic
-export const FF_DEV_1507 = "ff_front_DEV_1507_stuck_userpic_210122_short";
-
 // User labels for Taxonomy
 export const FF_DEV_1536 = "ff_front_dev_1536_taxonomy_user_labels_150222_long";
 

--- a/web/libs/frontend-test/src/feature-flags.ts
+++ b/web/libs/frontend-test/src/feature-flags.ts
@@ -12,9 +12,6 @@ export const FF_DEV_1285 = "ff_front_dev_1285_crosshair_wrong_zoom_140122_short"
 
 export const FF_DEV_1442 = "ff_front_dev_1442_unselect_shape_on_click_outside_080622_short";
 
-// Fix stuck userpic
-export const FF_DEV_1507 = "ff_front_DEV_1507_stuck_userpic_210122_short";
-
 // User labels for Taxonomy
 export const FF_DEV_1536 = "ff_front_dev_1536_taxonomy_user_labels_150222_long";
 


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
The feature flag has been stale since June, so it is safe to remove it from our codebase.



#### What does this fix?
Clean code
