### PR TITLE
refactor: OPTIC-1032: Remove Stale Feature Flag - ff_front_dev_1621_interactive_mode_150222_short

### DIFF
--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -132,7 +132,7 @@ function insert_render_editor(config, modal, full) {
     const htmlTemplate = `
     <div class="playground-buttons">
       <button class="code-block-open-preview">Open Preview</button>
-      <a href="/playground?config=${encodeURI(code)}" target="_blank" rel="noreferrer noopener">Launch in Playground</a>
+      <a href="/playground?config=${encodeURIComponent(code)}" target="_blank" rel="noreferrer noopener">Launch in Playground</a>
     </div>
     `
     pre.insertAdjacentHTML("beforeend", htmlTemplate);

--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -59,7 +59,6 @@ STALE_FEATURE_FLAGS = {
     'ff_dev_2007_rework_choices_280322_short': True,
     'ff_dev_2007_dev_2008_dynamic_tag_children_250322_short': True,
     'ff_front_dev_1372_visible_when_choice_unselected_11022022_short': True,
-    'ff_front_dev_1621_interactive_mode_150222_short': True,
     'ff_front_dev_1566_shortcuts_in_results_010222_short': True,
     'ff_front_dev_1564_dev_1565_shortcuts_focus_and_cursor_010222_short': True,
     'ff_front_dev_1495_avatar_mess_210122_short': True,

--- a/web/libs/editor/src/stores/Annotation/store.js
+++ b/web/libs/editor/src/stores/Annotation/store.js
@@ -9,7 +9,7 @@ import Types from "../../core/Types";
 import { StoreExtender } from "../../mixins/SharedChoiceStore/extender";
 import { ViewModel } from "../../tags/visual";
 import Utils from "../../utils";
-import { FF_DEV_1621, FF_DEV_3034, FF_DEV_3391, FF_DEV_3617, FF_SIMPLE_INIT, isFF } from "../../utils/feature-flags";
+import { FF_DEV_3034, FF_DEV_3391, FF_DEV_3617, FF_SIMPLE_INIT, isFF } from "../../utils/feature-flags";
 import { emailFromCreatedBy } from "../../utils/utilities";
 import { Annotation } from "./Annotation";
 import { HistoryItem } from "./HistoryItem";
@@ -375,7 +375,7 @@ const AnnotationStoreModel = types
     }
 
     function createAnnotation(options = { userGenerate: true }) {
-      const result = isFF(FF_DEV_1621) ? findNonInteractivePredictionResults() : [];
+      const result = findNonInteractivePredictionResults();
       const c = self.addAnnotation({ ...options, result });
 
       if (result && result.length) {

--- a/web/libs/editor/src/utils/feature-flags.ts
+++ b/web/libs/editor/src/utils/feature-flags.ts
@@ -22,9 +22,6 @@ export const FF_DEV_1564_DEV_1565 = "ff_front_dev_1564_dev_1565_shortcuts_focus_
 /** @requires FF_DEV_1564_DEV_1565 */
 export const FF_DEV_1566 = "ff_front_dev_1566_shortcuts_in_results_010222_short";
 
-// Add an interactivity flag to the results to make some predictions' results be able to be automatically added to newly created annotations.
-export const FF_DEV_1621 = "ff_front_dev_1621_interactive_mode_150222_short";
-
 // New Audio 2.0 UI
 export const FF_DEV_1713 = "ff_front_DEV_1713_audio_ui_150222_short";
 

--- a/web/libs/frontend-test/src/feature-flags.ts
+++ b/web/libs/frontend-test/src/feature-flags.ts
@@ -22,9 +22,6 @@ export const FF_DEV_1564_DEV_1565 = "ff_front_dev_1564_dev_1565_shortcuts_focus_
 /** @requires FF_DEV_1564_DEV_1565 */
 export const FF_DEV_1566 = "ff_front_dev_1566_shortcuts_in_results_010222_short";
 
-// Add an interactivity flag to the results to make some predictions' results be able to be automatically added to newly created annotations.
-export const FF_DEV_1621 = "ff_front_dev_1621_interactive_mode_150222_short";
-
 // New Audio 2.0 UI
 export const FF_DEV_1713 = "ff_front_DEV_1713_audio_ui_150222_short";
 


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
The feature flag has been stale since June, so it is safe to remove it from our codebase.



#### What does this fix?
Clean code
