### PR TITLE
refactor: OPTIC-1033: Remove Stale Feature Flag - ff_front_dev_1598_empty_toname_240222_short

### DIFF
--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -58,7 +58,6 @@ STALE_FEATURE_FLAGS = {
     'ff_back_2070_inner_id_12052022_short': True,
     'ff_dev_2007_rework_choices_280322_short': True,
     'ff_dev_2007_dev_2008_dynamic_tag_children_250322_short': True,
-    'ff_front_dev_1598_empty_toname_240222_short': True,
     'ff_front_dev_1372_visible_when_choice_unselected_11022022_short': True,
     'ff_front_dev_1621_interactive_mode_150222_short': True,
     'ff_front_DEV_1507_stuck_userpic_210122_short': True,

--- a/web/libs/editor/src/stores/Annotation/Annotation.js
+++ b/web/libs/editor/src/stores/Annotation/Annotation.js
@@ -12,7 +12,6 @@ import Result from "../../regions/Result";
 import Utils from "../../utils";
 import {
   FF_DEV_1284,
-  FF_DEV_1598,
   FF_DEV_2100,
   FF_DEV_2432,
   FF_DEV_3391,
@@ -236,9 +235,7 @@ export const Annotation = types
 
     get objects() {
       // Without correct validation toname may be null for control tags so we need to check isObjectTag instead of it
-      return Array.from(self.names.values()).filter(
-        isFF(FF_DEV_1598) ? (tag) => tag.isObjectTag : (tag) => !tag.toname,
-      );
+      return Array.from(self.names.values()).filter((tag) => tag.isObjectTag);
     },
 
     get regions() {
@@ -943,7 +940,7 @@ export const Annotation = types
 
     createResult(areaValue, resultValue, control, object, skipAfrerCreate = false) {
       // Without correct validation object may be null, but it it shouldn't be so in results - so we should find any
-      if (isFF(FF_DEV_1598) && !object && control.type === "textarea") {
+      if (!object && control.type === "textarea") {
         object = self.objects[0];
       }
       const objectTag = self.names.get(object.name ?? object);

--- a/web/libs/editor/src/utils/feature-flags.ts
+++ b/web/libs/editor/src/utils/feature-flags.ts
@@ -34,8 +34,6 @@ export const FF_DEV_1564_DEV_1565 = "ff_front_dev_1564_dev_1565_shortcuts_focus_
 /** @requires FF_DEV_1564_DEV_1565 */
 export const FF_DEV_1566 = "ff_front_dev_1566_shortcuts_in_results_010222_short";
 
-export const FF_DEV_1598 = "ff_front_dev_1598_empty_toname_240222_short";
-
 // Add an interactivity flag to the results to make some predictions' results be able to be automatically added to newly created annotations.
 export const FF_DEV_1621 = "ff_front_dev_1621_interactive_mode_150222_short";
 

--- a/web/libs/frontend-test/src/feature-flags.ts
+++ b/web/libs/frontend-test/src/feature-flags.ts
@@ -37,8 +37,6 @@ export const FF_DEV_1564_DEV_1565 = "ff_front_dev_1564_dev_1565_shortcuts_focus_
 /** @requires FF_DEV_1564_DEV_1565 */
 export const FF_DEV_1566 = "ff_front_dev_1566_shortcuts_in_results_010222_short";
 
-export const FF_DEV_1598 = "ff_front_dev_1598_empty_toname_240222_short";
-
 // Add an interactivity flag to the results to make some predictions' results be able to be automatically added to newly created annotations.
 export const FF_DEV_1621 = "ff_front_dev_1621_interactive_mode_150222_short";
 


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
The feature flag has been stale since June, so it is safe to remove it from our codebase.



#### What does this fix?
Clean code
