### PR TITLE
refactor: OPTIC-930: Remove Stale Feature Flag - ff_dev_2007_dev_2008_dynamic_tag_children_250322_short

### DIFF
--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -57,7 +57,6 @@ STALE_FEATURE_FLAGS = {
     'ff_dev_2100_clean_unnecessary_areas_140422_short': True,
     'ff_back_2070_inner_id_12052022_short': True,
     'ff_dev_2007_rework_choices_280322_short': True,
-    'ff_dev_2007_dev_2008_dynamic_tag_children_250322_short': True,
     'ff_front_dev_1566_shortcuts_in_results_010222_short': True,
     'ff_front_dev_1564_dev_1565_shortcuts_focus_and_cursor_010222_short': True,
     'ff_front_dev_1495_avatar_mess_210122_short': True,

--- a/web/apps/labelstudio/src/pages/CreateProject/Config/schema.json
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/schema.json
@@ -854,7 +854,7 @@
   },
   "Choices": {
     "name": "Choices",
-    "description": "The `Choices` tag is used to create a group of choices, with radio buttons or checkboxes. It can be used for single or multi-class classification. Also, it is used for advanced classification tasks where annotators can choose one or multiple answers.\n\nChoices can have dynamic value to load labels from task. This task data should contain a list of options to create underlying `<Choice>`s. All the parameters from options will be transferred to corresponding tags.\n\nThe `Choices` tag can be used with any data types.\n\n[^FF_LSDV_4583]: `fflag_feat_front_lsdv_4583_multi_image_segmentation_short` should be enabled for `perItem` functionality.\n[^FF_DEV_2007_DEV_2008]: `ff_dev_2007_dev_2008_dynamic_tag_children_250322_short` should be enabled to use dynamic options.\n[^FF_DEV_2007]: `ff_dev_2007_rework_choices_280322_short` should be enabled to use `html` attribute",
+    "description": "The `Choices` tag is used to create a group of choices, with radio buttons or checkboxes. It can be used for single or multi-class classification. Also, it is used for advanced classification tasks where annotators can choose one or multiple answers.\n\nChoices can have dynamic value to load labels from task. This task data should contain a list of options to create underlying `<Choice>`s. All the parameters from options will be transferred to corresponding tags.\n\nThe `Choices` tag can be used with any data types.\n\n[^FF_LSDV_4583]: `fflag_feat_front_lsdv_4583_multi_image_segmentation_short` should be enabled for `perItem` functionality.\n[^FF_DEV_2007]: `ff_dev_2007_rework_choices_280322_short` should be enabled to use `html` attribute",
     "attrs": {
       "name": {
         "name": "name",
@@ -933,7 +933,7 @@
       },
       "value": {
         "name": "value",
-        "description": "Task data field containing a list of dynamically loaded choices (see example below)[^FF_DEV_2007_DEV_2008]",
+        "description": "Task data field containing a list of dynamically loaded choices (see example below)",
         "type": "string",
         "required": false
       },


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
The feature flag has been stale since June, so it is safe to remove it from our codebase.



#### What does this fix?
Clean code



I did not find code related with this at all. only the docs... Also modification on LSE PR
