### PR TITLE
refactor: OPTIC-1028: Remove Stale Feature Flag - ff_front_dev_1372_visible_when_choice_unselected_11022022_short

### DIFF
--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -58,7 +58,6 @@ STALE_FEATURE_FLAGS = {
     'ff_back_2070_inner_id_12052022_short': True,
     'ff_dev_2007_rework_choices_280322_short': True,
     'ff_dev_2007_dev_2008_dynamic_tag_children_250322_short': True,
-    'ff_front_dev_1372_visible_when_choice_unselected_11022022_short': True,
     'ff_front_dev_1566_shortcuts_in_results_010222_short': True,
     'ff_front_dev_1564_dev_1565_shortcuts_focus_and_cursor_010222_short': True,
     'ff_front_dev_1495_avatar_mess_210122_short': True,


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
The feature flag has been stale since June, so it is safe to remove it from our codebase.



#### What does this fix?
Clean code

**This variable is no longer in use after the deprecation of the frontend folder.**
