### PR TITLE
ci: Fix RichText docs to unblock docs auto-generation

### DIFF
--- a/web/libs/editor/src/tags/object/RichText/model.js
+++ b/web/libs/editor/src/tags/object/RichText/model.js
@@ -355,7 +355,7 @@ const Model = types
        * @param {number} startOffset - The offset within the starting node.
        * @param {Node} end - The ending node of the range.
        * @param {number} endOffset - The offset within the ending node.
-       * @return {undefined|[number,number]} - An array containing the calculated global offsets in codepoints in the form [startGlobalOffset, endGlobalOffset].
+       * @return {number[]|undefined} - An array containing the calculated global offsets in codepoints in the form of [startGlobalOffset, endGlobalOffset].
        */
       relativeOffsetsToGlobalOffsets(start, startOffset, end, endOffset) {
         return domManager.relativeOffsetsToGlobalOffsets(start, startOffset, end, endOffset);
@@ -365,7 +365,7 @@ const Model = types
        * Converts the given range to its global offset.
        *
        * @param {Range} range - The range to convert.
-       * @returns {[number, number]|undefined} - The global offsets of the range.
+       * @returns {number[]|undefined} - The global offsets of the range in the form of [startGlobalOffset, endGlobalOffset].
        */
       rangeToGlobalOffset(range) {
         return domManager.rangeToGlobalOffset(range);


### PR DESCRIPTION
Script to generate docs parses all jsdocs and fails if it finds something unusual. [Recent changes to RichText](https://github.com/HumanSignal/label-studio/pull/6135) broke this script and it was [silently failing](https://github.com/HumanSignal/label-studio/actions/runs/10190323471/job/28191940396).

Now [script failures are blocking](https://github.com/HumanSignal/label-studio/commit/b29b4f3604f5f440198abb43d36d9f13d7e111d7) so we have to fix docs to unblock develop and other PRs