### PR TITLE
fix: RND-120: Redis storage doesn't have db field and redis target misses validation_connection()

### DIFF
--- a/label_studio/io_storages/redis/form_layout.yml
+++ b/label_studio/io_storages/redis/form_layout.yml
@@ -6,6 +6,10 @@ redis_title: &redis_title
 # 2x2 grid
 redis_params: &redis_params
   - type: text
+    name: db
+    label: Database Number
+    placeholder: 1
+  - type: text
     name: path
     label: Path
   - type: password

--- a/label_studio/io_storages/redis/form_layout.yml
+++ b/label_studio/io_storages/redis/form_layout.yml
@@ -7,7 +7,7 @@ redis_title: &redis_title
 redis_params: &redis_params
   - type: text
     name: db
-    label: Database Number
+    label: Database Number (db)
     placeholder: 1
   - type: text
     name: path

--- a/label_studio/io_storages/redis/models.py
+++ b/label_studio/io_storages/redis/models.py
@@ -124,6 +124,11 @@ class RedisExportStorage(RedisStorageMixin, ExportStorage):
         # create link if everything ok
         RedisExportStorageLink.create(annotation, self)
 
+    def validate_connection(self, client=None):
+        if client is None:
+            client = self.get_client()
+        client.ping()
+
 
 @receiver(post_save, sender=Annotation)
 def export_annotation_to_redis_storages(sender, instance, **kwargs):


### PR DESCRIPTION
1. Add Database number (db) on the Redis storage form:
![image](https://github.com/user-attachments/assets/c8f0bc24-6e33-453d-be45-5e77438f6694)

2. Add simple validate_connection() for Redis target storages. 


#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [x] Backend (API)
- [x] Frontend


