### PR TITLE
refactor: OPTIC 932 remove stale feature flags

### DIFF
--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -57,7 +57,6 @@ STALE_FEATURE_FLAGS = {
     'ff_dev_2100_clean_unnecessary_areas_140422_short': True,
     'ff_back_2070_inner_id_12052022_short': True,
     'ff_dev_2007_rework_choices_280322_short': True,
-    'ff_front_dev_1564_dev_1565_shortcuts_focus_and_cursor_010222_short': True,
     'ff_front_dev_1495_avatar_mess_210122_short': True,
     'ff_front_1170_outliner_030222_short': True,
 }

--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -57,7 +57,6 @@ STALE_FEATURE_FLAGS = {
     'ff_dev_2100_clean_unnecessary_areas_140422_short': True,
     'ff_back_2070_inner_id_12052022_short': True,
     'ff_dev_2007_rework_choices_280322_short': True,
-    'ff_front_dev_1566_shortcuts_in_results_010222_short': True,
     'ff_front_dev_1564_dev_1565_shortcuts_focus_and_cursor_010222_short': True,
     'ff_front_dev_1495_avatar_mess_210122_short': True,
     'ff_front_1170_outliner_030222_short': True,

--- a/web/libs/editor/src/components/HtxTextBox/HtxTextBox.jsx
+++ b/web/libs/editor/src/components/HtxTextBox/HtxTextBox.jsx
@@ -3,7 +3,6 @@ import { Tooltip, Typography } from "antd";
 import { DeleteOutlined, EditOutlined, EnterOutlined } from "@ant-design/icons";
 import styles from "./HtxTextBox.module.scss";
 import throttle from "lodash.throttle";
-import { FF_DEV_1566, isFF } from "../../utils/feature-flags";
 
 const { Paragraph } = Typography;
 // used for correct auto-height calculation
@@ -20,7 +19,7 @@ export class HtxTextBox extends React.Component {
   inputRef = React.createRef();
 
   static getDerivedStateFromProps(props, state) {
-    if (isFF(FF_DEV_1566) && props.text !== state.prevPropsText) {
+    if (props.text !== state.prevPropsText) {
       return {
         value: props.text,
         prevPropsText: props.text,
@@ -30,15 +29,11 @@ export class HtxTextBox extends React.Component {
   }
 
   componentDidMount() {
-    if (isFF(FF_DEV_1566)) {
-      window.addEventListener("click", this.handleGlobalClick, { capture: true });
-    }
+    window.addEventListener("click", this.handleGlobalClick, { capture: true });
   }
 
   componentWillUnmount() {
-    if (isFF(FF_DEV_1566)) {
-      window.removeEventListener("click", this.handleGlobalClick, { capture: true });
-    }
+    window.removeEventListener("click", this.handleGlobalClick, { capture: true });
   }
 
   handleGlobalClick = (e) => {
@@ -124,11 +119,9 @@ export class HtxTextBox extends React.Component {
       autoFocus: true,
       ref: this.inputRef,
       value,
-      onBlur: isFF(FF_DEV_1566)
-        ? () => {
-            onChange(this.state.value);
-          }
-        : this.save,
+      onBlur: () => {
+        onChange(this.state.value);
+      },
       onFocus,
       onChange: (e) => {
         this.setValue(e.target.value);
@@ -146,7 +139,7 @@ export class HtxTextBox extends React.Component {
           }
         } else if (key === "Escape") {
           this.cancel();
-        } else if (isFF(FF_DEV_1566) && key === "Tab") {
+        } else if (key === "Tab") {
           this.setEditing(false);
         }
       },

--- a/web/libs/editor/src/regions/TextAreaRegion.jsx
+++ b/web/libs/editor/src/regions/TextAreaRegion.jsx
@@ -10,7 +10,7 @@ import { guidGenerator } from "../core/Helpers";
 
 import styles from "./TextAreaRegion/TextAreaRegion.module.scss";
 import { HtxTextBox } from "../components/HtxTextBox/HtxTextBox";
-import { FF_DEV_1566, FF_LSDV_4712, isFF } from "../utils/feature-flags";
+import { FF_LSDV_4712, isFF } from "../utils/feature-flags";
 
 const Model = types
   .model("TextAreaRegionModel", {
@@ -123,7 +123,7 @@ const HtxTextAreaRegionView = ({ item, onFocus }) => {
         rows={parent.rows}
         text={item._value}
         {...params}
-        ignoreShortcuts={isFF(FF_DEV_1566)}
+        ignoreShortcuts={true}
       />
     </div>
   );

--- a/web/libs/editor/src/tags/control/Shortcut.jsx
+++ b/web/libs/editor/src/tags/control/Shortcut.jsx
@@ -8,7 +8,6 @@ import ProcessAttrsMixin from "../../mixins/ProcessAttrs";
 import Registry from "../../core/Registry";
 import { guidGenerator } from "../../core/Helpers";
 import { Hotkey } from "../../core/Hotkey";
-import { FF_DEV_1564_DEV_1565, isFF } from "../../utils/feature-flags";
 import { customTypes } from "../../core/CustomTypes";
 import chroma from "chroma-js";
 
@@ -66,9 +65,7 @@ const Model = types
 
       if (textarea.onShortcut) {
         textarea.onShortcut(self.value);
-        if (isFF(FF_DEV_1564_DEV_1565)) {
-          textarea.returnFocus?.();
-        }
+        textarea.returnFocus?.();
       }
     },
 
@@ -78,9 +75,7 @@ const Model = types
       // fired on a wrong element
 
       if (textarea.name !== name && !name.startsWith(`${textarea.name}:`)) return;
-      if (isFF(FF_DEV_1564_DEV_1565)) {
-        event.preventDefault();
-      }
+      event.preventDefault();
       return self.onClick();
     },
   }));
@@ -100,10 +95,8 @@ const HtxShortcutView = inject("store")(
       <Tag
         data-shortcut={true}
         onClick={(e) => {
-          if (isFF(FF_DEV_1564_DEV_1565)) {
-            e.preventDefault();
-            e.stopPropagation();
-          }
+          e.preventDefault();
+          e.stopPropagation();
           item.onClick();
           return false;
         }}

--- a/web/libs/editor/src/tags/control/Shortcut.jsx
+++ b/web/libs/editor/src/tags/control/Shortcut.jsx
@@ -8,7 +8,7 @@ import ProcessAttrsMixin from "../../mixins/ProcessAttrs";
 import Registry from "../../core/Registry";
 import { guidGenerator } from "../../core/Helpers";
 import { Hotkey } from "../../core/Hotkey";
-import { FF_DEV_1564_DEV_1565, FF_DEV_1566, isFF } from "../../utils/feature-flags";
+import { FF_DEV_1564_DEV_1565, isFF } from "../../utils/feature-flags";
 import { customTypes } from "../../core/CustomTypes";
 import chroma from "chroma-js";
 
@@ -77,7 +77,7 @@ const Model = types
       const name = (event.target || event.srcElement).name;
       // fired on a wrong element
 
-      if (textarea.name !== name && (!isFF(FF_DEV_1566) || !name.startsWith(`${textarea.name}:`))) return;
+      if (textarea.name !== name && !name.startsWith(`${textarea.name}:`)) return;
       if (isFF(FF_DEV_1564_DEV_1565)) {
         event.preventDefault();
       }
@@ -98,7 +98,7 @@ const HtxShortcutView = inject("store")(
 
     return (
       <Tag
-        {...(isFF(FF_DEV_1566) ? { "data-shortcut": true } : {})}
+        data-shortcut={true}
         onClick={(e) => {
           if (isFF(FF_DEV_1564_DEV_1565)) {
             e.preventDefault();

--- a/web/libs/editor/src/tags/control/TextArea/TextArea.jsx
+++ b/web/libs/editor/src/tags/control/TextArea/TextArea.jsx
@@ -17,14 +17,7 @@ import ProcessAttrsMixin from "../../../mixins/ProcessAttrs";
 import { ReadOnlyControlMixin } from "../../../mixins/ReadOnlyMixin";
 import RequiredMixin from "../../../mixins/Required";
 import { HtxTextAreaRegion, TextAreaRegionModel } from "../../../regions/TextAreaRegion";
-import {
-  FF_DEV_1564_DEV_1565,
-  FF_DEV_3730,
-  FF_LEAD_TIME,
-  FF_LSDV_4583,
-  FF_LSDV_4659,
-  isFF,
-} from "../../../utils/feature-flags";
+import { FF_DEV_3730, FF_LEAD_TIME, FF_LSDV_4583, FF_LSDV_4659, isFF } from "../../../utils/feature-flags";
 import ControlBase from "../Base";
 import ClassificationBase from "../ClassificationBase";
 import "./TextAreaRegionView";
@@ -304,33 +297,24 @@ const Model = types
       },
 
       onShortcut(value) {
-        if (isFF(FF_DEV_1564_DEV_1565)) {
-          if (!isAvailableElement(lastActiveElement, lastActiveElementModel)) {
-            if (isFF(FF_DEV_3730)) {
-              // Try to use main textarea element
-              const textareaElement =
-                self.textareaRef.current?.input || self.textareaRef.current?.resizableTextArea?.textArea;
+        if (!isAvailableElement(lastActiveElement, lastActiveElementModel)) {
+          if (isFF(FF_DEV_3730)) {
+            // Try to use main textarea element
+            const textareaElement =
+              self.textareaRef.current?.input || self.textareaRef.current?.resizableTextArea?.textArea;
 
-              if (isAvailableElement(textareaElement, self)) {
-                lastActiveElement = textareaElement;
-                lastActiveElementModel = self;
-              } else {
-                return;
-              }
+            if (isAvailableElement(textareaElement, self)) {
+              lastActiveElement = textareaElement;
+              lastActiveElementModel = self;
             } else {
               return;
             }
+          } else {
+            return;
           }
-          lastActiveElement.setRangeText(
-            value,
-            lastActiveElement.selectionStart,
-            lastActiveElement.selectionEnd,
-            "end",
-          );
-          lastActiveElementModel.setValue(lastActiveElement.value);
-        } else {
-          self.setValue(self._value + value);
         }
+        lastActiveElement.setRangeText(value, lastActiveElement.selectionStart, lastActiveElement.selectionEnd, "end");
+        lastActiveElementModel.setValue(lastActiveElement.value);
       },
 
       setLastFocusedElement(element, model = self) {
@@ -363,9 +347,7 @@ const HtxTextArea = observer(({ item }) => {
   const rows = Number.parseInt(item.rows);
   const onFocus = useCallback(
     (ev, model) => {
-      if (isFF(FF_DEV_1564_DEV_1565)) {
-        item.setLastFocusedElement(ev.target, model);
-      }
+      item.setLastFocusedElement(ev.target, model);
     },
     [item],
   );

--- a/web/libs/editor/src/utils/feature-flags.ts
+++ b/web/libs/editor/src/utils/feature-flags.ts
@@ -15,10 +15,6 @@ export const FF_DEV_1536 = "ff_front_dev_1536_taxonomy_user_labels_150222_long";
 // Fix shortcuts focus and cursor problems
 export const FF_DEV_1564_DEV_1565 = "ff_front_dev_1564_dev_1565_shortcuts_focus_and_cursor_010222_short";
 
-// Fix work of shortcuts in results
-/** @requires FF_DEV_1564_DEV_1565 */
-export const FF_DEV_1566 = "ff_front_dev_1566_shortcuts_in_results_010222_short";
-
 // New Audio 2.0 UI
 export const FF_DEV_1713 = "ff_front_DEV_1713_audio_ui_150222_short";
 

--- a/web/libs/editor/src/utils/feature-flags.ts
+++ b/web/libs/editor/src/utils/feature-flags.ts
@@ -12,9 +12,6 @@ export const FF_DEV_1442 = "ff_front_dev_1442_unselect_shape_on_click_outside_08
 // User labels for Taxonomy
 export const FF_DEV_1536 = "ff_front_dev_1536_taxonomy_user_labels_150222_long";
 
-// Fix shortcuts focus and cursor problems
-export const FF_DEV_1564_DEV_1565 = "ff_front_dev_1564_dev_1565_shortcuts_focus_and_cursor_010222_short";
-
 // New Audio 2.0 UI
 export const FF_DEV_1713 = "ff_front_DEV_1713_audio_ui_150222_short";
 

--- a/web/libs/editor/tests/e2e/tests/shortcuts.test.js
+++ b/web/libs/editor/tests/e2e/tests/shortcuts.test.js
@@ -161,7 +161,6 @@ Data(configParams).Scenario("Should work with existent regions.", async ({ I, La
   I.amOnPage("/");
   LabelStudio.setFeatureFlags({
     ff_front_dev_1564_dev_1565_shortcuts_focus_and_cursor_010222_short: true,
-    ff_front_dev_1566_shortcuts_in_results_010222_short: true,
   });
   LabelStudio.init(params);
   AtSidebar.seeRegions(1);
@@ -245,7 +244,6 @@ Data(configParams).Scenario("Should work with existent regions.", async ({ I, La
     I.amOnPage("/");
     LabelStudio.setFeatureFlags({
       ff_front_dev_1564_dev_1565_shortcuts_focus_and_cursor_010222_short: true,
-      ff_front_dev_1566_shortcuts_in_results_010222_short: true,
       ff_front_1170_outliner_030222_short: true,
       fflag_fix_front_dev_3730_shortcuts_initial_input_22122022_short: true,
     });

--- a/web/libs/editor/tests/e2e/tests/shortcuts.test.js
+++ b/web/libs/editor/tests/e2e/tests/shortcuts.test.js
@@ -41,9 +41,6 @@ Data(configParams).Scenario(
     };
 
     I.amOnPage("/");
-    LabelStudio.setFeatureFlags({
-      ff_front_dev_1564_dev_1565_shortcuts_focus_and_cursor_010222_short: true,
-    });
     LabelStudio.init(params);
     AtSidebar.seeRegions(0);
 
@@ -104,9 +101,6 @@ Data(configParams).Scenario("Should work with emoji.", async ({ I, LabelStudio, 
   };
 
   I.amOnPage("/");
-  LabelStudio.setFeatureFlags({
-    ff_front_dev_1564_dev_1565_shortcuts_focus_and_cursor_010222_short: true,
-  });
   LabelStudio.init(params);
   AtSidebar.seeRegions(0);
 
@@ -159,9 +153,6 @@ Data(configParams).Scenario("Should work with existent regions.", async ({ I, La
   };
 
   I.amOnPage("/");
-  LabelStudio.setFeatureFlags({
-    ff_front_dev_1564_dev_1565_shortcuts_focus_and_cursor_010222_short: true,
-  });
   LabelStudio.init(params);
   AtSidebar.seeRegions(1);
 
@@ -243,7 +234,6 @@ Data(configParams).Scenario("Should work with existent regions.", async ({ I, La
 
     I.amOnPage("/");
     LabelStudio.setFeatureFlags({
-      ff_front_dev_1564_dev_1565_shortcuts_focus_and_cursor_010222_short: true,
       ff_front_1170_outliner_030222_short: true,
       fflag_fix_front_dev_3730_shortcuts_initial_input_22122022_short: true,
     });

--- a/web/libs/frontend-test/src/feature-flags.ts
+++ b/web/libs/frontend-test/src/feature-flags.ts
@@ -15,10 +15,6 @@ export const FF_DEV_1536 = "ff_front_dev_1536_taxonomy_user_labels_150222_long";
 // Fix shortcuts focus and cursor problems
 export const FF_DEV_1564_DEV_1565 = "ff_front_dev_1564_dev_1565_shortcuts_focus_and_cursor_010222_short";
 
-// Fix work of shortcuts in results
-/** @requires FF_DEV_1564_DEV_1565 */
-export const FF_DEV_1566 = "ff_front_dev_1566_shortcuts_in_results_010222_short";
-
 // New Audio 2.0 UI
 export const FF_DEV_1713 = "ff_front_DEV_1713_audio_ui_150222_short";
 

--- a/web/libs/frontend-test/src/feature-flags.ts
+++ b/web/libs/frontend-test/src/feature-flags.ts
@@ -12,9 +12,6 @@ export const FF_DEV_1442 = "ff_front_dev_1442_unselect_shape_on_click_outside_08
 // User labels for Taxonomy
 export const FF_DEV_1536 = "ff_front_dev_1536_taxonomy_user_labels_150222_long";
 
-// Fix shortcuts focus and cursor problems
-export const FF_DEV_1564_DEV_1565 = "ff_front_dev_1564_dev_1565_shortcuts_focus_and_cursor_010222_short";
-
 // New Audio 2.0 UI
 export const FF_DEV_1713 = "ff_front_DEV_1713_audio_ui_150222_short";
 


### PR DESCRIPTION
2 depended feature flags in one

### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
The feature flag has been stale since June, so it is safe to remove it from our codebase.



#### What does this fix?
Clean code
