### PR TITLE
fix: OPTIC-1058: Ensure all css variables converted from stylus to scss are valid properties.

### DIFF
--- a/web/apps/labelstudio/src/components/Modal/Modal.scss
+++ b/web/apps/labelstudio/src/components/Modal/Modal.scss
@@ -105,12 +105,12 @@
 
   &_visible {
     opacity: 0;
-    transition: opacity var(100ms) ease;
+    transition: opacity 100ms ease;
   }
 
   &_visible &__wrapper {
     transform: scale(1.05);
-    transition: transform var(100ms) ease;
+    transition: transform 100ms ease;
   }
 
   &.visible {

--- a/web/apps/labelstudio/src/components/Spinner/Spinner.scss
+++ b/web/apps/labelstudio/src/components/Spinner/Spinner.scss
@@ -75,14 +75,14 @@
   }
 
   70% {
-    width: var(50px);
-    height: var(50px);
+    width: 50px;
+    height: 50px;
     transform: translate(-50%, -50%) rotate(90deg);
   }
 
   100% {
-    width: var(50px);
-    height: var(50px);
+    width: 50px;
+    height: 50px;
     transform: translate(-50%, -50%) rotate(90deg);
   }
 }

--- a/web/libs/editor/src/common/Button/Button.scss
+++ b/web/libs/editor/src/common/Button/Button.scss
@@ -113,13 +113,13 @@
       }
 
       &:hover {
-        color: var(rgba(255, 255, 255, 0.8));
+        color: rgba(255, 255, 255, 0.8);
         background: linear-gradient(0deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.1)), var(--primary_link);
         box-shadow: 0px 2px 4px var(--grape_100), inset 0px -1px 0px rgba(0, 0, 0, 0.1);
       }
 
       &:active {
-        color: var(rgba(255, 255, 255, 0.8));
+        color: rgba(255, 255, 255, 0.8);
         background: linear-gradient(0deg, rgba(0, 0, 0, 0.04), rgba(0, 0, 0, 0.04)), var(--primary_link);
         box-shadow: inset 0px 1px 0px rgba(0, 0, 0, 0.1);
       }

--- a/web/libs/editor/src/common/Tag/Tag.scss
+++ b/web/libs/editor/src/common/Tag/Tag.scss
@@ -9,7 +9,7 @@
 
   font-weight: 500;
   padding: var(--padding);
-  height: var(22px);
+  height: 22px;
   color: var(--color);
   background-color: var(--background);
   border-radius: var(--radius);

--- a/web/libs/editor/src/components/SidePanels/DetailsPanel/DetailsPanel.scss
+++ b/web/libs/editor/src/components/SidePanels/DetailsPanel/DetailsPanel.scss
@@ -16,11 +16,11 @@
   }
 
   &__section {
-    border-top: 1px solid var(var(--sand_300));
+    border-top: 1px solid var(--sand_300);
     width: 100%;
 
     &:last-child {
-      border-bottom: 1px solid var(var(--sand_300));
+      border-bottom: 1px solid var(--sand_300);
     }
 
     &-head {

--- a/web/libs/editor/src/components/SidePanels/PanelBase.scss
+++ b/web/libs/editor/src/components/SidePanels/PanelBase.scss
@@ -150,7 +150,7 @@
     cursor: pointer;
     line-height: normal;
     justify-content: center;
-    border-radius: var(4px 0 0 4px);
+    border-radius: 4px 0 0 4px;
   }
 
   &__toggle {

--- a/web/libs/editor/src/components/SidePanels/TabPanels/PanelTabsBase.scss
+++ b/web/libs/editor/src/components/SidePanels/TabPanels/PanelTabsBase.scss
@@ -37,7 +37,7 @@
       border-right: 1px solid var(--sand_300);
       --header-border-radius: 0 4px 4px 0;
     }
-    
+
     &_right {
       border-left: 1px solid var(--sand_300);
       --header-border-radius: 4px 0 0 4px;
@@ -188,7 +188,7 @@
     width: 100%;
     height: 100%;
 
-    & .tabs-panel_resizing { 
+    & .tabs-panel_resizing {
       pointer-events: none;
     }
   }
@@ -315,7 +315,7 @@
     &[data-resize=bottom]::before {
       left: 0;
       top: 50%;
-      height: var(2px);
+      height: 2px;
       transform: translate(0, -50%);
       width: calc(100% + var(--size));
       left: calc(var(--size) / 2 * -1);

--- a/web/libs/editor/src/components/Timeline/Views/Frames/Keypoints.scss
+++ b/web/libs/editor/src/components/Timeline/Views/Frames/Keypoints.scss
@@ -3,7 +3,7 @@
 
   height: 24px;
   display: flex;
-  background-color: var(transparent);
+  background-color: transparent;
 
   &__label {
     left: 0;
@@ -17,7 +17,7 @@
     display: flex;
     padding: 0 8px;
     justify-content: space-between;
-    background: linear-gradient(0deg, var(transparent), var(transparent) 100%), linear-gradient(0deg, #FAFAFA, #FAFAFA 100%);
+    background: linear-gradient(0deg, transparent, transparent 100%), linear-gradient(0deg, #FAFAFA, #FAFAFA 100%);
     box-shadow: 1px 0px 0px rgba(0, 0, 0, 0.05);
   }
 


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [X] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [X] Frontend



### Describe the reason for change
After the conversion of all Stylus to SCSS, there were a few instances where the conversion of code with respect to css variables didn't completely end up as expected, producing invalid css properties for those affected. I ran a regex search across the codebase and amended them to their correct css properties.



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)


### Which logical domain(s) does this change affect?
Mostly Editor components.

