### PR TITLE
refactor: OPTIC-1070: restore stale ff 'ff_front_dev_2432_auto_save_polygon_draft_210622_short': True,

### DIFF
--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -44,6 +44,7 @@ STALE_FEATURE_FLAGS = {
     'fflag_feat_front_dev_2984_dm_draggable_columns_short': True,
     'fflag_feat_front_dev_2461_audio_paragraphs_seek_chunk_position_short': True,
     'fflag-feat-front-dev-2982-label-weights-settings': True,
+    'ff_front_dev_2432_auto_save_polygon_draft_210622_short': True,
     'ff_front_dev_2575_projects_list_performance_280622_short': True,
     'ff_front_dev_2431_delete_polygon_points_080622_short': True,
     'ff_front_dev_2290_draft_in_annotation_history_short': True,


### PR DESCRIPTION
No real changes but one ff was remove from stale file by mistake. 
The LaunchDarkly still have the correct value and it wasn't archived