### PR TITLE
chore: Remove404s

### DIFF
--- a/docs/source/guide/install_enterprise_k8s.md
+++ b/docs/source/guide/install_enterprise_k8s.md
@@ -47,7 +47,7 @@ If you want to install Label Studio Enterprise on Kubernetes and you have unrest
 9. (Optional) [Set up TLS for Redis](#Optional-set-up-TLS-for-Redis)
 10. [Use Helm to install Label Studio Enterprise on your Kubernetes cluster](#Use-Helm-to-install-Label-Studio-Enterprise-on-your-Kubernetes-cluster).
 
-If you use a proxy to access the internet from your Kubernetes cluster, or it is airgapped from the internet, see how to [Install Label Studio Enterprise without public internet access](install_airgapped.html).
+If you use a proxy to access the internet from your Kubernetes cluster, or it is airgapped from the internet, see how to [Install Label Studio Enterprise without public internet access](install_k8s_airgapped.html).
 
 ### Required software prerequisites
 

--- a/docs/source/guide/install_k8s.md
+++ b/docs/source/guide/install_k8s.md
@@ -35,7 +35,7 @@ If you want to install Label Studio on Kubernetes and you have unrestricted acce
 7. (Optional) [Set up TLS for PostgreSQL](#Optional-set-up-TLS-for-PostgreSQL)
 8. [Use Helm to install Label Studio on your Kubernetes cluster](#Use-Helm-to-install-Label-Studio-on-your-Kubernetes-cluster).
 
-If you use a proxy to access the internet from your Kubernetes cluster, or it is airgapped from the internet, see how to [Install Label Studio without public internet access](/guide/install_airgapped.html).
+If you use a proxy to access the internet from your Kubernetes cluster, or it is airgapped from the internet, see how to [Install Label Studio without public internet access](/guide/install_k8s_airgapped.html).
 
 ### Required software prerequisites
 

--- a/docs/source/guide/setup_project.md
+++ b/docs/source/guide/setup_project.md
@@ -99,7 +99,7 @@ When you're done, click **Save**.
 <div class="opensource-only">
 
 !!! error Enterprise
-    Workspaces are only available for Label Studio Enterprise users. Label Studio Enterprise also includes many additional configuration options for projects, such as role-based access control and workflow automation. For more information, see [Compare Community and Enterprise Features](label_studio_comparison). 
+    Workspaces are only available for Label Studio Enterprise users. Label Studio Enterprise also includes many additional configuration options for projects, such as role-based access control and workflow automation. For more information, see [Compare Community and Enterprise Features](label_studio_compare). 
 
 </div>
 

--- a/docs/source/guide/tasks.md
+++ b/docs/source/guide/tasks.md
@@ -195,15 +195,6 @@ For example:
     <Image name="image" value="$images[0]"/>
     ```
 
-3. The `value` parameter can include [`Repeater`](/tags/repeater.html) tag substitution, by default `{{idx}}`.
-
-    For example:
-    ```xml
-    <Repeater on="$audios">
-      <Audio name="audio_{{idx}}" value="$audios[{{idx}}].url"/>
-    </Repeater>
-    ```
-
 
 ### `valueType` (optional)
 

--- a/docs/source/templates/multi-page-document-annotation.md
+++ b/docs/source/templates/multi-page-document-annotation.md
@@ -89,14 +89,6 @@ You can add a [header](/tags/header.html) tag to provide instructions to the ann
 <Header>Label the video:</Header>
 ```
 
-Use the [Repeater](/tags/repeater.html) tag to annotate multiple data objects in a dynamic range with the same semantics. You can loop through data items in a python-like `for` cycle in the labeling process.
-It repeats tags inside it for every item in a given data array from your dataset. All the occurrences of `indexFlag` (default is `{{idx}}`) in parameter values will be replaced by the current index.
-Names should always be unique, so you can use this placeholder in tag names. The **Repeater** tag supports the `mode` property. This creates the possibility to enable pagination in **Repeater** for performance improvement. You can add a parameter `<Repeater mode="pagination" ...>` to show only one page at a time, shrinking memory used to one tag set.
-
-```xml
-<Repeater on="$images" indexFlag="{{idx}}" mode="pagination">
-```
-
 Use the [Choices](/tags/choices.html) tag to create a group of choices, with radio buttons, or checkboxes.
 
 ```xml
@@ -218,4 +210,3 @@ Example of using outliner document title:
 - [Choices](/tags/choices.html)
 - [Labels](/tags/labels.html)
 - [RectangleLabels](/tags/rectanglelabels.html)
-- [Repeater](/tags/repeater.html)

--- a/docs/source/templates/taxonomy.md
+++ b/docs/source/templates/taxonomy.md
@@ -103,7 +103,7 @@ The `apiUrl` must be accessible to Label Studio. You can accomplish this in seve
 1. Save your taxonomy in a separate bucket from your task data. 
 
     If you are unable to use a separate bucket for your taxonomy, see the workaround below. 
-2. [Follow these instructions](storage) to set up cloud storage for Label Studio. This should be a separate connection from your other storage connections.
+2. [Follow these instructions](/guide/storage) to set up cloud storage for Label Studio. This should be a separate connection from your other storage connections.
 
     <div class="admonition note"><p class="admonition-title">note</p><p>Do not sync this storage connection. If you do, you will need to delete the task that is automatically created when syncing the taxonomy.</p></div>
 

--- a/docs/themes/v2/layout/partials/footer.ejs
+++ b/docs/themes/v2/layout/partials/footer.ejs
@@ -45,7 +45,7 @@
                 </a>
               </li>
             <li>
-                <a href="https://www.linkedin.com/company/heartex/" aria-label="LinkedIn" target="_blank" rel="noopener noreferrer">
+                <a href="https://www.linkedin.com/company/humansignal/" aria-label="LinkedIn" target="_blank" rel="noopener noreferrer">
                   <svg viewBox="0 0 24 24" astro-icon="bx:bxl-linkedin"><circle cx="4.983" cy="5.009" r="2.188" fill="currentColor"></circle><path fill="currentColor" d="M9.237 8.855v12.139h3.769v-6.003c0-1.584.298-3.118 2.262-3.118 1.937 0 1.961 1.811 1.961 3.218v5.904H21v-6.657c0-3.27-.704-5.783-4.526-5.783-1.835 0-3.065 1.007-3.568 1.96h-.051v-1.66H9.237zm-6.142 0H6.87v12.139H3.095z"></path></svg>
                 </a>
               </li>


### PR DESCRIPTION
@caitlinwheeless Originally I was just going to remove some deprecated references to Repeater but I did a quick 404 pass and removed a few more. Hopefully a PR is easier than a ticket.

Some 404's that I didn't remove:
-  links to [https://labelstud.io/guide/saas.html](https://github.com/HumanSignal/label-studio/blob/79ba0602e4a685eea778f5cd0f84d4fa4d63f5c4/docs/themes/v2/layout/home.ejs#L23) since they seem to be hidden with CSS
- There are a few 404s from the blog, like `https://labelstud.io/blog/introducing-ranker-for-fine-tuning-llms-generative-ai-templates-ui-improvements` and `https://labelstud.io/blog/categories/undefined/ `
- There's a `<a href="labelstud.io">Label Studio</a>` snuck into https://labelstud.io/sdk/index.html that's missing an `https://`