### PR TITLE
fix: OPTIC-1079: Converted Stylus to SCSS included invalid usages of some css variables follow up

### DIFF
--- a/web/apps/labelstudio/src/components/Modal/Modal.scss
+++ b/web/apps/labelstudio/src/components/Modal/Modal.scss
@@ -107,12 +107,12 @@
 
   &_visible {
     opacity: 0;
-    transition: opacity 100ms ease;
+    transition: opacity var(--transition-duration) ease;
   }
 
   &_visible &__wrapper {
     transform: scale(1.05);
-    transition: transform 100ms ease;
+    transition: transform var(--transition-duration) ease;
   }
 
   &.visible {

--- a/web/apps/labelstudio/src/components/Spinner/Spinner.scss
+++ b/web/apps/labelstudio/src/components/Spinner/Spinner.scss
@@ -75,14 +75,14 @@
   }
 
   70% {
-    width: 50px;
-    height: 50px;
+    width: var(--spinner-size);
+    height: var(--spinner-size);
     transform: translate(-50%, -50%) rotate(90deg);
   }
 
   100% {
-    width: 50px;
-    height: 50px;
+    width: var(--spinner-size);
+    height: var(--spinner-size);
     transform: translate(-50%, -50%) rotate(90deg);
   }
 }

--- a/web/libs/editor/src/common/Button/Button.scss
+++ b/web/libs/editor/src/common/Button/Button.scss
@@ -117,13 +117,13 @@
       }
 
       &:hover {
-        color: var(rgb(255 255 255 / 80%));
+        color: rgb(255 255 255 / 80%);
         background: linear-gradient(0deg, rgb(255 255 255 / 10%), rgb(255 255 255 / 10%)), var(--primary_link);
         box-shadow: 0 2px 4px var(--grape_100), inset 0 -1px 0 rgb(0 0 0 / 10%);
       }
 
       &:active {
-        color: var(rgb(255 255 255 / 80%));
+        color: rgb(255 255 255 / 80%);
         background: linear-gradient(0deg, rgb(0 0 0 / 4%), rgb(0 0 0 / 4%)), var(--primary_link);
         box-shadow: inset 0 1px 0 rgb(0 0 0 / 10%);
       }

--- a/web/libs/editor/src/common/Button/Button.scss
+++ b/web/libs/editor/src/common/Button/Button.scss
@@ -117,13 +117,13 @@
       }
 
       &:hover {
-        color: rgb(255 255 255 / 80%);
+        color: var(--button-color);
         background: linear-gradient(0deg, rgb(255 255 255 / 10%), rgb(255 255 255 / 10%)), var(--primary_link);
         box-shadow: 0 2px 4px var(--grape_100), inset 0 -1px 0 rgb(0 0 0 / 10%);
       }
 
       &:active {
-        color: rgb(255 255 255 / 80%);
+        color: var(--button-color);
         background: linear-gradient(0deg, rgb(0 0 0 / 4%), rgb(0 0 0 / 4%)), var(--primary_link);
         box-shadow: inset 0 1px 0 rgb(0 0 0 / 10%);
       }

--- a/web/libs/editor/src/common/Tag/Tag.scss
+++ b/web/libs/editor/src/common/Tag/Tag.scss
@@ -9,7 +9,7 @@
 
   font-weight: 500;
   padding: var(--padding);
-  height: 22px;
+  height: var(--height);
   color: var(--color);
   background-color: var(--background);
   border-radius: var(--radius);

--- a/web/libs/editor/src/components/SidePanels/PanelBase.scss
+++ b/web/libs/editor/src/components/SidePanels/PanelBase.scss
@@ -150,7 +150,7 @@
     cursor: pointer;
     line-height: normal;
     justify-content: center;
-    border-radius: 4px 0 0 4px;
+    border-radius: var(--header-border-radius);
   }
 
   &__toggle {

--- a/web/libs/editor/src/components/SidePanels/TabPanels/PanelTabsBase.scss
+++ b/web/libs/editor/src/components/SidePanels/TabPanels/PanelTabsBase.scss
@@ -316,7 +316,7 @@
     &[data-resize="top"]::before,
     &[data-resize="bottom"]::before {
       top: 50%;
-      height: 2px;
+      height: var(--visual-size);
       transform: translate(0, -50%);
       width: calc(100% + var(--size));
       left: calc(var(--size) / 2 * -1);

--- a/web/libs/editor/src/components/Timeline/Views/Frames/Keypoints.scss
+++ b/web/libs/editor/src/components/Timeline/Views/Frames/Keypoints.scss
@@ -16,7 +16,7 @@
     display: flex;
     padding: 0 8px;
     justify-content: space-between;
-    background: linear-gradient(0deg, var(transparent), var(transparent) 100%), linear-gradient(0deg, #FAFAFA, #FAFAFA 100%);
+    background: linear-gradient(0deg, var(--hover), var(--hover) 100%), linear-gradient(0deg, #FAFAFA, #FAFAFA 100%);
     box-shadow: 1px 0 0 rgb(0 0 0 / 5%);
   }
 


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
fixing css variables that were missed - issues resolved here happened due to the stylus to sass conversion - the converter we used had a bug where it would replace the name of the css variable declared in the same file with its value leading to situations like `var(transparent)` instead of the intended `var(--hover)`