### PR TITLE
fix: OPTIC-1080: buttons failure in review annotations

### DIFF
--- a/web/libs/editor/src/components/BottomBar/CurrentTask.scss
+++ b/web/libs/editor/src/components/BottomBar/CurrentTask.scss
@@ -5,14 +5,10 @@
   align-items: center;
 
   &_with-history {
-    height: 100%;
     display: grid;
+    grid-template: "id buttons" 1fr "id buttons" 1fr / 1fr min-content;
+    height: 100%;
     width: 220px;
-    grid-template:
-      "id buttons"
-      "id buttons"
-      1fr 1fr
-      / 1fr min-content;
   }
 
   &__task-id {

--- a/web/libs/editor/src/components/TopBar/CurrentTask.scss
+++ b/web/libs/editor/src/components/TopBar/CurrentTask.scss
@@ -8,11 +8,7 @@
     height: 100%;
     display: grid;
     width: 220px;
-    grid-template:
-      "id buttons"
-      "id buttons"
-      1fr 1fr
-      / 1fr min-content;
+    grid-template: "id buttons" 1fr "id buttons" 1fr / 1fr min-content;
   }
 
   &__task-id {


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
The arrows in annotation reviews overlap the text in the top and bottom menu



#### What does this fix?
N/A



#### What is the new behavior?
No overlaping


#### What is the current behavior?
Overlaping

