### PR TITLE
fix: LEAP-1456: CSRF - use $http_host instead of nginx $host so port will be included

### DIFF
--- a/deploy/default.conf
+++ b/deploy/default.conf
@@ -184,7 +184,7 @@ http {
         send_timeout 90;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Request-ID $request_id;
         proxy_pass_header Content-Type;
         proxy_redirect off;


### PR DESCRIPTION
`host` is just `localhost` when LSO is running in docker; `http_host` has the port number. If the port number isn't present in the result from `get_host`, this check will fail: https://github.com/django/django/blob/stable/4.2.x/django/middleware/csrf.py#L277-L288 