### PR TITLE
docs: try to fix editor’s height

### DIFF
--- a/docs/themes/v2/source/css/styles.css
+++ b/docs/themes/v2/source/css/styles.css
@@ -2281,7 +2281,8 @@ code.hljs {
   min-height: 100vh;
 }
 
-#render-editor-loader {
+#render-editor-loader,
+.render-editor-loader {
   max-width: 1200px;
   background: var(--color-white);
   padding: 3%;

--- a/docs/themes/v2/source/css/styles.css
+++ b/docs/themes/v2/source/css/styles.css
@@ -2305,6 +2305,8 @@ code.hljs {
   width: 500px;
   height: 500px;
   border-radius: 10px;
+  box-sizing: content-box;
+  width: 94%;
 }
 
 #main-preview iframe#render-editor {

--- a/docs/themes/v2/source/css/styles.css
+++ b/docs/themes/v2/source/css/styles.css
@@ -2264,7 +2264,8 @@ code.hljs {
   Playground
 ****************************/
 
-#preview-wrapper {
+#preview-wrapper,
+.api-preview-wrapper {
   width: 100%;
   height: 100%;
   top: 0;

--- a/docs/themes/v2/source/css/styles.css
+++ b/docs/themes/v2/source/css/styles.css
@@ -2294,7 +2294,8 @@ code.hljs {
   text-align: center;
 }
 
-#render-editor {
+#render-editor,
+.api-render-editor {
   max-width: 1200px;
   border: none;
   background: var(--color-white);

--- a/docs/themes/v2/source/css/styles.css
+++ b/docs/themes/v2/source/css/styles.css
@@ -2304,15 +2304,11 @@ code.hljs {
   width: 500px;
   height: 500px;
   border-radius: 10px;
-  box-sizing: border-box;
-  padding: 3%;
 }
 
 #main-preview iframe {
   width: 100%;
   margin: 1em 0;
-  padding: 0;
-  box-sizing: content-box;
 }
 
 .page-type-playground .content-markdown {

--- a/docs/themes/v2/source/css/styles.css
+++ b/docs/themes/v2/source/css/styles.css
@@ -2309,7 +2309,7 @@ code.hljs {
   width: 94%;
 }
 
-#main-preview iframe#render-editor {
+#main-preview iframe {
   width: 100%;
   padding: 5px;
   margin: 1em 0;

--- a/docs/themes/v2/source/css/styles.css
+++ b/docs/themes/v2/source/css/styles.css
@@ -2301,19 +2301,14 @@ code.hljs {
   max-width: 1200px;
   border: none;
   background: var(--color-white);
-  padding: 3%;
   width: 500px;
   height: 500px;
   border-radius: 10px;
-  box-sizing: content-box;
-  width: 94%;
 }
 
 #main-preview iframe {
   width: 100%;
-  padding: 5px;
   margin: 1em 0;
-  margin-left: -20px;
 }
 
 .page-type-playground .content-markdown {

--- a/docs/themes/v2/source/css/styles.css
+++ b/docs/themes/v2/source/css/styles.css
@@ -2304,11 +2304,15 @@ code.hljs {
   width: 500px;
   height: 500px;
   border-radius: 10px;
+  box-sizing: border-box;
+  padding: 3%;
 }
 
 #main-preview iframe {
   width: 100%;
   margin: 1em 0;
+  padding: 0;
+  box-sizing: content-box;
 }
 
 .page-type-playground .content-markdown {

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -21,7 +21,7 @@ var iframeTimer = null;
 
 
       if (iframe.contentWindow) {
-        iframe.style.height = (iframe.contentWindow.document.body.scrollHeight) + 200 + 'px';
+        iframe.style.height = (iframe.contentWindow.document.body.scrollHeight) + 'px';
 
         const segmentBlock = iframe.contentDocument.body.querySelector('div[class*="Segment_block"]');
 

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -19,17 +19,15 @@ var iframeTimer = null;
 
       clearTimeout(iframeTimer);
 
-        if (iframe.contentWindow) {
-
-          console.log(iframe.contentWindow);
-          
-          // fix editor height
+      iframeTimer = setInterval(function () {
+        if (obj.contentWindow) {
           iframe.style.height = (iframe.contentWindow.document.body.scrollHeight) + 'px';
 
           const segmentBlock = iframe.contentDocument.body.querySelector('div[class*="Segment_block"]');
 
           if(segmentBlock) segmentBlock.style.margin='0'
         }
+      }, 200);
 
     })
 

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -41,12 +41,11 @@ function show_render_editor(config) {
   const modalTemplate = `
   <div id="preview-wrapper-${id}" class="api-preview-wrapper" onclick="this.remove()">
     <div class="render-editor-loader"><img width="50px" src="/images/design/loading.gif"></div>
-    <div id="preview-wrapper-iframe-${id}"></div>
   </div>
   `
   body.insertAdjacentHTML("beforeend", modalTemplate)
 
-  const modal = document.querySelector(`#preview-wrapper-iframe-${id}`);
+  const modal = document.querySelector(`#preview-wrapper-${id}`);
 
   insert_render_editor(config, modal, true, id);
 }

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -1,11 +1,9 @@
 var iframeTimer = null;
 
-  function editor_iframe(res, modal, full) {
-    
-    var id = "id" + Math.random().toString(16).slice(2);
+  function editor_iframe(res, modal, full, id) {
 
     // generate new iframe
-    var iframeTemplate = `<iframe onclick="event.stopPropagation()" id="render-editor-${id}" style="display: none"></iframe>`;
+    var iframeTemplate = `<iframe onclick="event.stopPropagation()" id="render-editor-${id}" class="api-render-editor" style="display: none"></iframe>`;
 
     modal.insertAdjacentHTML("beforeend", iframeTemplate)
 
@@ -39,17 +37,18 @@ var iframeTimer = null;
   }
   
 function show_render_editor(config) {
+  var id = "id" + Math.random().toString(16).slice(2);
   const body = document.querySelector("body");
   const modalTemplate = `
-  <div id="preview-wrapper" onclick="this.remove()">
+  <div id="preview-wrapper-${id}" class="api-preview-wrapper" onclick="this.remove()">
     <div class="render-editor-loader"><img width="50px" src="/images/design/loading.gif"></div>
   </div>
   `
   body.insertAdjacentHTML("beforeend", modalTemplate)
 
-  const modal = document.querySelector("#preview-wrapper");
+  const modal = document.querySelector(`#preview-wrapper-${id}`);
 
-  insert_render_editor(config, modal, true);
+  insert_render_editor(config, modal, true, id);
 }
 
 function insert_render_editor(config, modal, full) {

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -21,9 +21,8 @@ var iframeTimer = null;
 
       iframeTimer = setInterval(function () {
         if (iframe.contentWindow) {
-          console.log(iframe.contentWindow.document)
-          console.log(iframe.contentWindow.document.querySelector("#label-studio"))
-          iframe.style.height = (iframe.contentWindow.innerHeight) + 'px';
+          const componentHeight = iframe.contentWindow.document.querySelector("#label-studio").innerHeight;
+          iframe.style.height = componentHeight + 'px';
         }
       }, 200);
 

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -7,9 +7,7 @@ var iframeTimer = null;
     modal.insertAdjacentHTML("beforeend", iframeTemplate)
 
     const iframe = document.querySelector(`#render-editor-${id}`);
-    const spinner = iframe.querySelector(".render-editor-loader");
-
-    console.log(spinner);
+    const spinner = modal.querySelector(".render-editor-loader");
 
     if (full) {
       iframe.style.width = window.innerWidth * 0.9 + "px"
@@ -22,6 +20,8 @@ var iframeTimer = null;
       clearTimeout(iframeTimer);
 
         if (iframe.contentWindow) {
+
+          console.log(iframe.contentWindow);
           
           // fix editor height
           iframe.style.height = (iframe.contentWindow.document.body.scrollHeight) + 'px';

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -1,19 +1,16 @@
 var iframeTimer = null;
 
-
-
   function editor_iframe(res, modal, full) {
-    // generate new iframe
-    var iframeTemplate = `<iframe onclick="event.stopPropagation()" id="render-editor" style="display: none"></iframe>`;
+    
+    var id = "id" + Math.random().toString(16).slice(2);
 
-    /* if (full) {
-      iframe.css('width', $(window).width() * 0.9);
-    } */
+    // generate new iframe
+    var iframeTemplate = `<iframe onclick="event.stopPropagation()" id="render-editor-${id}" style="display: none"></iframe>`;
 
     modal.insertAdjacentHTML("beforeend", iframeTemplate)
 
-    const iframe = document.querySelector("#render-editor");
-    const spinner = document.querySelector("#render-editor-loader");
+    const iframe = document.querySelector(`#render-editor-${id}`);
+    const spinner = iframe.querySelector(".render-editor-loader");
 
     if (full) {
       iframe.style.width = window.innerWidth * 0.9 + "px"
@@ -23,26 +20,18 @@ var iframeTimer = null;
       if(spinner) spinner.style.display = "none";
       iframe.style.display = "block";
 
-      var obj = document.getElementById('render-editor');
       clearTimeout(iframeTimer);
 
-      console.log(obj.contentWindow);
-          console.log(obj.contentWindow.document.body.scrollHeight);
-
-      iframeTimer = setInterval(function () {
-        if (obj.contentWindow) {
+        if (iframe.contentWindow) {
           
           // fix editor height
-          obj.style.height = (obj.contentWindow.document.body.scrollHeight) + 'px';
+          iframe.style.height = (iframe.contentWindow.document.body.scrollHeight) + 'px';
 
-          // fix editor width
-          // let app_editor = obj.contentDocument.body.querySelector('div[class*="App_editor"]').style;
-          //app_editor.setProperty('min-width', '100%', 'important');
-          const segmentBlock = obj.contentDocument.body.querySelector('div[class*="Segment_block"]');
+          const segmentBlock = iframe.contentDocument.body.querySelector('div[class*="Segment_block"]');
 
           if(segmentBlock) segmentBlock.style.margin='0'
         }
-      }, 200);
+
     })
 
     // load new data into iframe
@@ -53,7 +42,7 @@ function show_render_editor(config) {
   const body = document.querySelector("body");
   const modalTemplate = `
   <div id="preview-wrapper" onclick="this.remove()">
-    <div id="render-editor-loader"><img width="50px" src="/images/design/loading.gif"></div>
+    <div class="render-editor-loader"><img width="50px" src="/images/design/loading.gif"></div>
   </div>
   `
   body.insertAdjacentHTML("beforeend", modalTemplate)

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -21,12 +21,8 @@ var iframeTimer = null;
 
       iframeTimer = setInterval(function () {
         if (iframe.contentWindow) {
-          console.log(iframe.contentWindow);
-          iframe.style.height = (iframe.contentWindow.document.body.scrollHeight) + 'px';
-
-          const segmentBlock = iframe.contentDocument.body.querySelector('div[class*="Segment_block"]');
-
-          if(segmentBlock) segmentBlock.style.margin='0'
+          console.log(iframe.contentWindow.getComputedStyle())
+          iframe.style.height = (iframe.contentWindow.innerHeight) + 'px';
         }
       }, 200);
 

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -19,15 +19,15 @@ var iframeTimer = null;
 
       clearTimeout(iframeTimer);
 
+      iframeTimer = setInterval(function () {
+        if (iframe.contentWindow) {
+          iframe.style.height = (iframe.contentWindow.document.body.scrollHeight) + 'px';
 
-      if (iframe.contentWindow) {
-        iframe.style.height = (iframe.contentWindow.document.body.scrollHeight) + 'px';
+          const segmentBlock = iframe.contentDocument.body.querySelector('div[class*="Segment_block"]');
 
-        const segmentBlock = iframe.contentDocument.body.querySelector('div[class*="Segment_block"]');
-
-        if(segmentBlock) segmentBlock.style.margin='0'
-      }
-
+          if(segmentBlock) segmentBlock.style.margin='0'
+        }
+      }, 200);
 
     })
 

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -19,15 +19,15 @@ var iframeTimer = null;
 
       clearTimeout(iframeTimer);
 
-      iframeTimer = setInterval(function () {
-        if (iframe.contentWindow) {
-          iframe.style.height = (iframe.contentWindow.document.body.scrollHeight) + 'px';
 
-          const segmentBlock = iframe.contentDocument.body.querySelector('div[class*="Segment_block"]');
+      if (iframe.contentWindow) {
+        iframe.style.height = (iframe.contentWindow.document.body.scrollHeight) + 200 + 'px';
 
-          if(segmentBlock) segmentBlock.style.margin='0'
-        }
-      }, 200);
+        const segmentBlock = iframe.contentDocument.body.querySelector('div[class*="Segment_block"]');
+
+        if(segmentBlock) segmentBlock.style.margin='0'
+      }
+
 
     })
 

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -21,9 +21,9 @@ var iframeTimer = null;
 
       iframeTimer = setInterval(function () {
         if (iframe.contentWindow) {
-          const component = iframe.contentWindow.document.querySelector("#label-studio");
-          const height = component.clientHeight;
-          iframe.style.height = height + 'px';
+
+          iframe.style.height = (iframe.contentWindow.innerHeight) + 'px';
+
         }
       }, 200);
 

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -1,7 +1,6 @@
 var iframeTimer = null;
 
   function editor_iframe(res, modal, full, id) {
-
     // generate new iframe
     var iframeTemplate = `<iframe onclick="event.stopPropagation()" id="render-editor-${id}" class="api-render-editor" style="display: none"></iframe>`;
 
@@ -9,6 +8,8 @@ var iframeTimer = null;
 
     const iframe = document.querySelector(`#render-editor-${id}`);
     const spinner = iframe.querySelector(".render-editor-loader");
+
+    console.log(iframe);
 
     if (full) {
       iframe.style.width = window.innerWidth * 0.9 + "px"
@@ -51,7 +52,7 @@ function show_render_editor(config) {
   insert_render_editor(config, modal, true, id);
 }
 
-function insert_render_editor(config, modal, full) {
+function insert_render_editor(config, modal, full, id) {
   let url = "https://app.heartex.ai/demo/render-editor?playground=1&open_preview=1";
   if (full) {
     url += '&full_editor=t';
@@ -69,7 +70,7 @@ function insert_render_editor(config, modal, full) {
   })
   .then((response) => response.text())
   .then((data) => {
-    editor_iframe(data, modal, full)
+    editor_iframe(data, modal, full, id)
   })
   .catch((error) => {
     console.log(error);
@@ -132,9 +133,9 @@ function insert_render_editor(config, modal, full) {
     const openPreviewButton = pre.querySelector(".code-block-open-preview");
     openPreviewButton.addEventListener("click", () => show_render_editor(code))
 
-    const inlinePlayground = document.querySelector("#main-preview");
+  /*   const inlinePlayground = document.querySelector("#main-preview");
 
-    if(inlinePlayground) insert_render_editor(code, inlinePlayground);
+    if(inlinePlayground) insert_render_editor(code, inlinePlayground); */
   }
 
   const enhanceCodeBlocks = (codeBlock) => {

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -21,7 +21,8 @@ var iframeTimer = null;
 
       iframeTimer = setInterval(function () {
         if (iframe.contentWindow) {
-          console.log(iframe.contentWindow)
+          console.log(iframe.contentWindow.document)
+          console.log(iframe.contentWindow.document.querySelector("#label-studio"))
           iframe.style.height = (iframe.contentWindow.innerHeight) + 'px';
         }
       }, 200);

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -22,10 +22,7 @@ var iframeTimer = null;
       iframeTimer = setInterval(function () {
         if (iframe.contentWindow) {
           const component = iframe.contentWindow.document.querySelector("#label-studio");
-          console.log(component);
-          console.log(iframe.contentWindow.document.body.clientHeight)
-          const height = component.offsetHeight;
-          console.log(height);
+          const height = component.clientHeight;
           iframe.style.height = height + 'px';
         }
       }, 200);

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -21,7 +21,7 @@ var iframeTimer = null;
 
       iframeTimer = setInterval(function () {
         if (iframe.contentWindow) {
-          console.log(iframe.contentWindow.getComputedStyle())
+          console.log(iframe.contentWindow)
           iframe.style.height = (iframe.contentWindow.innerHeight) + 'px';
         }
       }, 200);

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -41,11 +41,12 @@ function show_render_editor(config) {
   const modalTemplate = `
   <div id="preview-wrapper-${id}" class="api-preview-wrapper" onclick="this.remove()">
     <div class="render-editor-loader"><img width="50px" src="/images/design/loading.gif"></div>
+    <div id="preview-wrapper-iframe-${id}"></div>
   </div>
   `
   body.insertAdjacentHTML("beforeend", modalTemplate)
 
-  const modal = document.querySelector(`#preview-wrapper-${id}`);
+  const modal = document.querySelector(`#preview-wrapper-iframe-${id}`);
 
   insert_render_editor(config, modal, true, id);
 }

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -21,8 +21,10 @@ var iframeTimer = null;
 
       iframeTimer = setInterval(function () {
         if (iframe.contentWindow) {
-          const componentHeight = iframe.contentWindow.document.querySelector("#label-studio").innerHeight;
-          iframe.style.height = componentHeight + 'px';
+          const component = iframe.contentWindow.document.querySelector("#label-studio");
+          const height = component.clientHeight;
+          console.log(height);
+          iframe.style.height = height + 'px';
         }
       }, 200);
 

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -21,6 +21,7 @@ var iframeTimer = null;
 
       iframeTimer = setInterval(function () {
         if (iframe.contentWindow) {
+          console.log(iframe.contentWindow);
           iframe.style.height = (iframe.contentWindow.document.body.scrollHeight) + 'px';
 
           const segmentBlock = iframe.contentDocument.body.querySelector('div[class*="Segment_block"]');

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -21,7 +21,7 @@ var iframeTimer = null;
 
       iframeTimer = setInterval(function () {
         if (iframe.contentWindow) {
-          iframe.style.height = (iframe.contentWindow.document.body.scrollHeight) + 200 + 'px';
+          iframe.style.height = (iframe.contentWindow.document.body.scrollHeight) + 'px';
 
           const segmentBlock = iframe.contentDocument.body.querySelector('div[class*="Segment_block"]');
 

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -9,7 +9,7 @@ var iframeTimer = null;
     const iframe = document.querySelector(`#render-editor-${id}`);
     const spinner = iframe.querySelector(".render-editor-loader");
 
-    console.log(iframe);
+    console.log(spinner);
 
     if (full) {
       iframe.style.width = window.innerWidth * 0.9 + "px"
@@ -133,9 +133,9 @@ function insert_render_editor(config, modal, full, id) {
     const openPreviewButton = pre.querySelector(".code-block-open-preview");
     openPreviewButton.addEventListener("click", () => show_render_editor(code))
 
-  /*   const inlinePlayground = document.querySelector("#main-preview");
+    const inlinePlayground = document.querySelector("#main-preview");
 
-    if(inlinePlayground) insert_render_editor(code, inlinePlayground); */
+    if(inlinePlayground) insert_render_editor(code, inlinePlayground);
   }
 
   const enhanceCodeBlocks = (codeBlock) => {

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -18,12 +18,15 @@ var iframeTimer = null;
       iframe.style.display = "block";
 
       clearTimeout(iframeTimer);
+
+      iframeTimer = setInterval(function () {
         if (iframe.contentWindow) {
           const component = iframe.contentWindow.document.querySelector("#label-studio");
           const height = component.clientHeight;
-
-          iframe.style.height = height + 10 + 'px';
+          iframe.style.height = height + 10 +  'px';
         }
+      }, 200);
+
     })
 
     // load new data into iframe

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -22,6 +22,8 @@ var iframeTimer = null;
       iframeTimer = setInterval(function () {
         if (iframe.contentWindow) {
           const component = iframe.contentWindow.document.querySelector("#label-studio");
+          console.log(component);
+          console.log(iframe.contentWindow.document.body.clientHeight)
           const height = component.offsetHeight;
           console.log(height);
           iframe.style.height = height + 'px';

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -18,16 +18,12 @@ var iframeTimer = null;
       iframe.style.display = "block";
 
       clearTimeout(iframeTimer);
-
-      iframeTimer = setInterval(function () {
         if (iframe.contentWindow) {
           const component = iframe.contentWindow.document.querySelector("#label-studio");
           const height = component.clientHeight;
-          console.log(height);
-          iframe.style.height = height + 'px';
-        }
-      }, 200);
 
+          iframe.style.height = height + 10 + 'px';
+        }
     })
 
     // load new data into iframe

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -26,10 +26,14 @@ var iframeTimer = null;
       var obj = document.getElementById('render-editor');
       clearTimeout(iframeTimer);
 
+      console.log(obj.contentWindow);
+          console.log(obj.contentWindow.document.body.scrollHeight);
+
       iframeTimer = setInterval(function () {
         if (obj.contentWindow) {
+          
           // fix editor height
-          /* obj.style.height = (obj.contentWindow.document.body.scrollHeight) + 'px'; */
+          obj.style.height = (obj.contentWindow.document.body.scrollHeight) + 'px';
 
           // fix editor width
           // let app_editor = obj.contentDocument.body.querySelector('div[class*="App_editor"]').style;

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -22,7 +22,7 @@ var iframeTimer = null;
       iframeTimer = setInterval(function () {
         if (iframe.contentWindow) {
           const component = iframe.contentWindow.document.querySelector("#label-studio");
-          const height = component.clientHeight;
+          const height = component.offsetHeight;
           console.log(height);
           iframe.style.height = height + 'px';
         }

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -24,7 +24,7 @@ var iframeTimer = null;
 
           console.log(iframe.contentWindow.innerHeight);
           console.log(iframe.contentWindow.document.querySelector("#label-studio"))
-          console.log(iframe.contentWindow.document.querySelector("#label-studio").offsetHeight)
+          console.log(iframe.contentWindow.document.querySelector("#label-studio div[class^='App_editor'], #label-studio div[class*='App_editor']").offsetHeight)
 
           iframe.style.height = (iframe.contentWindow.innerHeight) + 'px';
 

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -21,7 +21,7 @@ var iframeTimer = null;
 
       iframeTimer = setInterval(function () {
         if (iframe.contentWindow) {
-          iframe.style.height = (iframe.contentWindow.document.body.scrollHeight) + 'px';
+          iframe.style.height = (iframe.contentWindow.document.body.scrollHeight) + 200 + 'px';
 
           const segmentBlock = iframe.contentDocument.body.querySelector('div[class*="Segment_block"]');
 

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -22,6 +22,10 @@ var iframeTimer = null;
       iframeTimer = setInterval(function () {
         if (iframe.contentWindow) {
 
+          console.log(iframe.contentWindow.innerHeight);
+          console.log(iframe.contentWindow.document.querySelector("#label-studio"))
+          console.log(iframe.contentWindow.document.querySelector("#label-studio").offsetHeight)
+
           iframe.style.height = (iframe.contentWindow.innerHeight) + 'px';
 
         }

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -20,7 +20,7 @@ var iframeTimer = null;
       clearTimeout(iframeTimer);
 
       iframeTimer = setInterval(function () {
-        if (obj.contentWindow) {
+        if (iframe.contentWindow) {
           iframe.style.height = (iframe.contentWindow.document.body.scrollHeight) + 'px';
 
           const segmentBlock = iframe.contentDocument.body.querySelector('div[class*="Segment_block"]');

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -21,12 +21,9 @@ var iframeTimer = null;
 
       iframeTimer = setInterval(function () {
         if (iframe.contentWindow) {
+          const height = iframe.contentWindow.document.querySelector("#label-studio div[class^='App_editor'], #label-studio div[class*='App_editor']").offsetHeight;
 
-          console.log(iframe.contentWindow.innerHeight);
-          console.log(iframe.contentWindow.document.querySelector("#label-studio"))
-          console.log(iframe.contentWindow.document.querySelector("#label-studio div[class^='App_editor'], #label-studio div[class*='App_editor']").offsetHeight)
-
-          iframe.style.height = (iframe.contentWindow.innerHeight) + 'px';
+          iframe.style.height = height + 'px';
 
         }
       }, 200);

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -29,7 +29,7 @@ var iframeTimer = null;
       iframeTimer = setInterval(function () {
         if (obj.contentWindow) {
           // fix editor height
-          obj.style.height = (obj.contentWindow.document.body.scrollHeight) + 'px';
+          /* obj.style.height = (obj.contentWindow.document.body.scrollHeight) + 'px'; */
 
           // fix editor width
           // let app_editor = obj.contentDocument.body.querySelector('div[class*="App_editor"]').style;
@@ -156,4 +156,3 @@ function insert_render_editor(config, modal, full) {
   codeBlocks.forEach(block => enhanceCodeBlocks(block));
 
 })();
-

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -23,7 +23,8 @@ var iframeTimer = null;
         if (iframe.contentWindow) {
           const component = iframe.contentWindow.document.querySelector("#label-studio");
           const height = component.clientHeight;
-          iframe.style.height = height + 10 +  'px';
+          console.log(height);
+          iframe.style.height = height + 'px';
         }
       }, 200);
 


### PR DESCRIPTION
Fix playground demos height
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 85df1bf66051bb0ed86d88f35b580b495ee71bae  | 
|--------|--------|

### Summary:
This PR updates CSS and JavaScript to dynamically adjust the editor's height in the playground demo by introducing unique iframe IDs and modifying height calculation logic.

**Key points**:
- Updated `docs/themes/v2/source/css/styles.css` to add `.api-preview-wrapper` and `.api-render-editor` classes for consistent styling.
- Modified `#render-editor-loader` and `#main-preview iframe` styles to remove padding and adjust margins.
- Updated `docs/themes/v2/source/js/code-blocks-enhancements.js` to generate unique iframe IDs using `id` parameter.
- Adjusted `editor_iframe` function to calculate iframe height based on `App_editor` div height.
- Modified `show_render_editor` and `insert_render_editor` functions to pass unique `id` for iframe handling.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->