### PR TITLE
fix: DIA-1360: Revert prediction serialization

### DIFF
--- a/label_studio/tasks/models.py
+++ b/label_studio/tasks/models.py
@@ -1035,7 +1035,7 @@ class Prediction(models.Model):
                 model_version=model_version,
                 model_run=model_run,
                 score=1.0,  # Setting to 1.0 for now as we don't get back a score
-                result=pred['result']
+                result=pred['result'],
             )
             return prediction
         except Exception as exc:

--- a/label_studio/tasks/models.py
+++ b/label_studio/tasks/models.py
@@ -1027,7 +1027,7 @@ class Prediction(models.Model):
 
             # given the data receive, create annotation regions in LS format
             # e.g. {"sentiment": "positive"} -> {"value": {"choices": ["positive"]}, "from_name": "", "to_name": "", ..}
-            pred = PredictionValue(result=label_interface.create_regions(data))
+            pred = PredictionValue(result=label_interface.create_regions(data)).model_dump()
 
             prediction = Prediction(
                 project=project,
@@ -1035,7 +1035,7 @@ class Prediction(models.Model):
                 model_version=model_version,
                 model_run=model_run,
                 score=1.0,  # Setting to 1.0 for now as we don't get back a score
-                result=pred.result,
+                result=pred['result']
             )
             return prediction
         except Exception as exc:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 6d3285c9fb9563ce122644b0ea3e1f898a810fe5  | 
|--------|--------|

### Summary:
Reverts prediction serialization using `model_dump()` on `PredictionValue` in `label_studio/tasks/models.py`.

**Key points**:
- Reverts prediction serialization in `label_studio/tasks/models.py`.
- Modifies `create_no_commit` function in `Prediction` class.
- Uses `model_dump()` on `PredictionValue` to serialize results.
- Accesses prediction result as a dictionary with `pred['result']`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->