### PR TITLE
fix: LEAP-1367: Revert mistakenly removed styles for timeline regions

### DIFF
--- a/web/libs/editor/src/components/Timeline/Views/Frames/Keypoints.scss
+++ b/web/libs/editor/src/components/Timeline/Views/Frames/Keypoints.scss
@@ -75,6 +75,22 @@
     background-color: var(--point-color);
   }
 
+  &_timeline &__point {
+    width: 3px;
+    height: 20px;
+    transform: translate3d(-100%, -50%, 0);
+  }
+
+  &_timeline &__point:last-child {
+    transform: translate3d(0, -50%, 0);
+  }
+
+  /** instant */
+  &_timeline &__point:first-child:last-child {
+    width: 6px;
+    transform: translate3d(-50%, -50%, 0);
+  }
+
   &__actions {
     display: flex;
   }


### PR DESCRIPTION
Styles for time spans were removed by mistake. Reverting this.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 3bf4b9925573de68fe50ed3c13af24edc3dacccd  | 
|--------|--------|

### Summary:
Reverts mistakenly removed styles for timeline points in `Keypoints.scss`, restoring specific width, height, and transform properties for timeline regions.

**Key points**:
- Reverts styles in `web/libs/editor/src/components/Timeline/Views/Frames/Keypoints.scss`.
- Restores styles for `&_timeline &__point` with specific width, height, and transform properties.
- Handles last-child and first-child:last-child cases for `&_timeline &__point` with specific transform adjustments.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->