### PR TITLE
fix: FF naming with feat_ for env override

### DIFF
--- a/label_studio/core/feature_flags/base.py
+++ b/label_studio/core/feature_flags/base.py
@@ -131,8 +131,10 @@ def all_flags(user):
     env_ff = get_all_env_with_prefix('ff_', is_bool=True)
     env_fflag = get_all_env_with_prefix('fflag_', is_bool=True)
     env_fflag2 = get_all_env_with_prefix('fflag-', is_bool=True)
+    env_fflag3 = get_all_env_with_prefix('feat_', is_bool=True)
     env_ff.update(env_fflag)
     env_ff.update(env_fflag2)
+    env_ff.update(env_fflag3)
 
     for env_flag_name, env_flag_on in env_ff.items():
         flags[env_flag_name] = env_flag_on


### PR DESCRIPTION
Fixed a bug when you can not override flag with `feat_` prefix
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d3c53082223fc15f5407fafee12fdcc5665f9f59  | 
|--------|--------|

fix: support `feat_` prefix for feature flag overrides in `all_flags()`

### Summary:
Fixes bug in `all_flags()` in `base.py` to support feature flag overrides with `feat_` prefix.

**Key points**:
- **Behavior**:
  - Fixes bug in `all_flags()` in `base.py` to allow feature flag overrides with `feat_` prefix.
  - Merges environment variables with `feat_` prefix into existing feature flags.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->