### PR TITLE
fix: DIA-1419: RunTime error occurs on trying to delete certain prompts

### DIFF
--- a/label_studio/tasks/models.py
+++ b/label_studio/tasks/models.py
@@ -1291,7 +1291,21 @@ def remove_predictions_from_project(sender, instance, **kwargs):
     """Remove predictions counters"""
     instance.task.total_predictions = instance.task.predictions.all().count() - 1
     instance.task.save(update_fields=['total_predictions'])
+
+    # if there is PredictionMeta object associated with the Prediction object, delete it
+    if hasattr(instance, 'meta'):
+        logger.debug(f'Deleting PredictionMeta object associated with Prediction object {instance.id}')
+        instance.meta.delete()
+
     logger.debug(f'Updated total_predictions for {instance.task.id}.')
+
+
+@receiver(pre_delete, sender=FailedPrediction)
+def remove_failed_predictions_from_project(sender, instance, **kwargs):
+    # if there is PredictionMeta object associated with the Prediction object, delete it
+    if hasattr(instance, 'meta'):
+        logger.debug(f'Deleting PredictionMeta object associated with Prediction object {instance.id}')
+        instance.meta.delete()
 
 
 @receiver(post_save, sender=Prediction)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 282dd9af146deeb08e9dfba68a78365bc5f9e6d9  | 
|--------|--------|

fix: delete associated PredictionMeta on Prediction/FailedPrediction deletion

### Summary:
Fix runtime error by deleting associated `PredictionMeta` objects when `Prediction` or `FailedPrediction` objects are deleted in `models.py`.

**Key points**:
- **Behavior**:
  - Deletes `PredictionMeta` objects associated with `Prediction` and `FailedPrediction` objects upon their deletion.
  - Adds `remove_failed_predictions_from_project` function to handle `FailedPrediction` deletions.
- **Logging**:
  - Logs deletion of `PredictionMeta` objects in `remove_predictions_from_project` and `remove_failed_predictions_from_project`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->