### PR TITLE
chore: Ensure the one time dev build does not incorrectly default to using the HMR frontend host

### DIFF
--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -20,9 +20,10 @@ const css_prefix = "lsf-";
 const mode = process.env.BUILD_MODULE ? "production" : process.env.NODE_ENV || "development";
 const isDevelopment = mode !== "production";
 const devtool = process.env.NODE_ENV === "production" ? "source-map" : "cheap-module-source-map";
-const FRONTEND_HOSTNAME = process.env.FRONTEND_HOSTNAME || "http://localhost:8010";
+const FRONTEND_HMR = process.env.FRONTEND_HMR === "true";
+const FRONTEND_HOSTNAME = FRONTEND_HMR ? process.env.FRONTEND_HOSTNAME || "http://localhost:8010" : "";
 const DJANGO_HOSTNAME = process.env.DJANGO_HOSTNAME || "http://localhost:8080";
-const HMR_PORT = +new URL(FRONTEND_HOSTNAME).port;
+const HMR_PORT = FRONTEND_HMR ? +new URL(FRONTEND_HOSTNAME).port : 8010;
 
 const LOCAL_ENV = {
   NODE_ENV: mode,


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [X] Frontend



### Describe the reason for change
With the recent release to make HMR support in development for LabelStudio, there were some parts that were a bit too aggressive and were causing non HMR development builds to fail.


### Which logical domain(s) does this change affect?
Webpack/Dev-tooling


<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit bf0ec9719e92dfb968e1ebd5a83f310a6b8e45b0  | 
|--------|--------|

chore: ensure non-HMR dev builds don't default to HMR settings

### Summary:
Introduces `FRONTEND_HMR` to control HMR usage in `webpack.config.js`, ensuring non-HMR builds don't default to HMR settings.

**Key points**:
- **Behavior**:
  - Introduces `FRONTEND_HMR` environment variable in `webpack.config.js` to control HMR usage.
  - Sets `FRONTEND_HOSTNAME` to an empty string if `FRONTEND_HMR` is not "true".
  - Sets `HMR_PORT` to 8010 if `FRONTEND_HMR` is not "true".
- **Configuration**:
  - Modifies `devServer` configuration to use `HMR_PORT` and `FRONTEND_HOSTNAME` based on `FRONTEND_HMR`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->