### PR TITLE
docs: Include video links in documentation

### DIFF
--- a/docs/source/guide/dashboards.md
+++ b/docs/source/guide/dashboards.md
@@ -12,6 +12,10 @@ section: "Create & Manage Projects"
 
 You can use the Label Studio Enterprise dashboards to help visualize your labeling progress across projects and resources. 
 
+See the following video for a brief overview of the analytics available in Label Studio Enterprise:
+
+<iframe width="560" height="315" src="https://www.youtube.com/watch?v=mkaLdrF1Pn8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 ### Project dashboard
 
 This dashboard provides information about project progress and task completion. Available to Managers, Administrators, and Owners.  

--- a/docs/source/guide/dashboards.md
+++ b/docs/source/guide/dashboards.md
@@ -14,7 +14,7 @@ You can use the Label Studio Enterprise dashboards to help visualize your labeli
 
 See the following video for a brief overview of the analytics available in Label Studio Enterprise:
 
-<iframe width="560" height="315" src="https://www.youtube.com/watch?v=mkaLdrF1Pn8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/mkaLdrF1Pn8?si=jAqTUOyNu0lkw3E-" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ### Project dashboard
 

--- a/docs/source/guide/ml_create.md
+++ b/docs/source/guide/ml_create.md
@@ -15,7 +15,11 @@ Use the Label Studio ML backend to integrate Label Studio with machine learning 
 
 Follow the steps below to wrap custom machine learning model code with the Label Studio ML SDK, or see [our library of example ML backends](ml_tutorials.html) to integrate with popular machine learning frameworks and tools such as [Huggingface's Transformers](https://huggingface.co/docs/transformers/index), [OpenAI](https://openai.com/), [Langchain](https://www.langchain.com/) and others. 
 
-For information on using one of Label Studio's example backends, see [Set up an example ML backend](ml#Set-up-an-example-ML-backend)
+For information on using one of Label Studio's example backends, see [Set up an example ML backend](ml#Set-up-an-example-ML-backend). 
+
+For a video tutorial, see the following:
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/cEwMNOlOUjI?si=sEPTUPOyyzZlA-n5" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 
 ## 1. Install the ML backend repo

--- a/docs/source/guide/quality.md
+++ b/docs/source/guide/quality.md
@@ -139,7 +139,8 @@ Review a table to see the following for each annotator:
 
 See the following video for an overview of annotator agreement metrics: 
 
-<iframe width="560" height="315" src="https://www.youtube.com/watch?v=Lo_PVE9Pyw4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe class="video-border" width="560" height="315" src="https://www.youtube.com/watch?v=Lo_PVE9Pyw4" width="100%" height="400vh" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 
 ### Review annotator agreement matrix
 

--- a/docs/source/guide/quality.md
+++ b/docs/source/guide/quality.md
@@ -16,7 +16,7 @@ The annotation review workflow is only available in Label Studio Enterprise Edit
 
 See the following video for an overview of reviewer workflows: 
 
-<iframe width="560" height="315" src="https://www.youtube.com/watch?v=dhBrphE7PHo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/dhBrphE7PHo?si=YMRI-omwxoQFuhma" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 
 ## Why review annotations?
@@ -139,7 +139,7 @@ Review a table to see the following for each annotator:
 
 See the following video for an overview of annotator agreement metrics: 
 
-<iframe class="video-border" width="560" height="315" src="https://www.youtube.com/watch?v=Lo_PVE9Pyw4" width="100%" height="400vh" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video-border" width="560" height="315" src="https://www.youtube.com/embed/Lo_PVE9Pyw4?si=z1vtyI_xIo8aR8fY" width="100%" height="400vh" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 
 ### Review annotator agreement matrix

--- a/docs/source/guide/quality.md
+++ b/docs/source/guide/quality.md
@@ -145,7 +145,7 @@ See the following video for an overview of annotator agreement metrics:
 
 You can also review the overall annotator agreement on a more individual basis with the annotator agreement matrix.
 
-Review the annotator agreement matrix to understand which annotator's annotations consistently agree with or don't agree with other annotator's annotations. You can also filter the matrix to show specific agreement statistics for each label, or view the **Overall** agreement matrix. See more about [how annotator agreement is calculated](stats.html).
+Review the annotator agreement matrix to understand which annotator's annotations consistently agree with or don't agree with other annotator's annotations. You can also filter the matrix to show specific agreement statistics for each label, or view the **Overall** agreement matrix. See more about [how annotator agreement is calculated](stats).
 
 To see the specific annotations contributing to the agreement, do the following:
 

--- a/docs/source/guide/quality.md
+++ b/docs/source/guide/quality.md
@@ -14,6 +14,10 @@ After multiple labelers have annotated tasks, review their output to validate th
 
 The annotation review workflow is only available in Label Studio Enterprise Edition. If you're using Label Studio Community Edition, see <a href="https://labelstud.io/guide/label_studio_compare.html">Label Studio Features</a> to learn more.
 
+See the following video for an overview of reviewer workflows: 
+
+<iframe width="560" height="315" src="https://www.youtube.com/watch?v=dhBrphE7PHo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 
 ## Why review annotations?
 
@@ -132,6 +136,10 @@ Review a table to see the following for each annotator:
 - The mean time to annotate the tasks. Select this header to view the `median time` instead. Mean time and median time are calculated using the total time spent on each task by an annotator, including idle time.
 - The agreement of their annotations with the ground truth annotations, if there are any.
 - The agreement of their annotations with predicted annotations, if there are any.
+
+See the following video for an overview of annotator agreement metrics: 
+
+<iframe width="560" height="315" src="https://www.youtube.com/watch?v=Lo_PVE9Pyw4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ### Review annotator agreement matrix
 

--- a/docs/source/guide/scripts.md
+++ b/docs/source/guide/scripts.md
@@ -24,6 +24,10 @@ Custom scripts are defined in the project settings under the Labeling Interface 
 !!! note
     Only users who are in the Admin, Owner, or Manager role can access the project settings to configure custom scripts. 
 
+See the following video for a brief overview and demonstration of custom scripts:
+
+<iframe width="560" height="315" src="https://www.youtube.com/watch?v=Spwg81kJdGo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 ## Use cases
 
 Custom scripts allow you to enhance and tailor your labeling interface and workflow. For example:

--- a/docs/source/guide/scripts.md
+++ b/docs/source/guide/scripts.md
@@ -26,7 +26,7 @@ Custom scripts are defined in the project settings under the Labeling Interface 
 
 See the following video for a brief overview and demonstration of custom scripts:
 
-<iframe width="560" height="315" src="https://www.youtube.com/watch?v=Spwg81kJdGo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/Spwg81kJdGo?si=miRkS7DDYe9aLyUw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Use cases
 

--- a/docs/source/guide/setup_project.md
+++ b/docs/source/guide/setup_project.md
@@ -177,6 +177,9 @@ Annotators are the users who are labeling project tasks.
 
 For a description of all the settings available for annotators, see [Project settings - Annotation](project_settings_lse#Annotation) and [Project settings - Quality](project_settings_lse#Quality). 
 
+See the following video for a brief overview of automated task assignments:
+
+<iframe width="560" height="315" src="https://www.youtube.com/watch?v=b1_o-yhT1uY" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 #### Review settings
 

--- a/docs/source/guide/setup_project.md
+++ b/docs/source/guide/setup_project.md
@@ -179,7 +179,7 @@ For a description of all the settings available for annotators, see [Project set
 
 See the following video for a brief overview of automated task assignments:
 
-<iframe width="560" height="315" src="https://www.youtube.com/watch?v=b1_o-yhT1uY" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/b1_o-yhT1uY?si=NspgI-rWwE6l7ZIN" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 #### Review settings
 


### PR DESCRIPTION
Add links to YouTube videos to docs where appropriate.

This change affects:
- [X] Community docs
- [X] Enterprise docs

