### PR TITLE
fix: OPTIC-447: Filters don't pass to label stream in DM

### DIFF
--- a/web/libs/datamanager/src/stores/AppStore.js
+++ b/web/libs/datamanager/src/stores/AppStore.js
@@ -635,7 +635,7 @@ export const AppStore = types
       };
 
       if (actionId === "next_task") {
-        const isSelectAll = actionParams.selectedItems.all === true && actionParams.selectedItems.excluded.length === 0;
+        const isSelectAll = actionParams.selectedItems.all === true;
         const isAllLabelStreamMode = labelStreamMode === "all";
         const isFilteredLabelStreamMode = labelStreamMode === "filtered";
         if (isAllLabelStreamMode && !isSelectAll) {

--- a/web/libs/datamanager/src/stores/AppStore.js
+++ b/web/libs/datamanager/src/stores/AppStore.js
@@ -635,14 +635,17 @@ export const AppStore = types
       };
 
       if (actionId === "next_task") {
-        if (labelStreamMode === "all") {
+        const isSelectAll = actionParams.selectedItems.all === true && actionParams.selectedItems.excluded.length === 0;
+        const isAllLabelStreamMode = labelStreamMode === "all";
+        const isFilteredLabelStreamMode = labelStreamMode === "filtered";
+        if (isAllLabelStreamMode && !isSelectAll) {
           delete actionParams.filters;
 
           if (actionParams.selectedItems.all === false && actionParams.selectedItems.included.length === 0) {
             delete actionParams.selectedItems;
             delete actionParams.ordering;
           }
-        } else if (labelStreamMode === "filtered") {
+        } else if (isFilteredLabelStreamMode) {
           delete actionParams.selectedItems;
         }
       }


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
this resolves a bug where selecting all tasks while having a filter applied then going through labeling stream would give us tasks that are outside the filter