### PR TITLE
feat: make html sanitization optional

### DIFF
--- a/docs/source/tags/hypertext.md
+++ b/docs/source/tags/hypertext.md
@@ -18,6 +18,7 @@ Use with the following data types: HTML.
 | value | <code>string</code> |  | Value of the element |
 | [valueType] | <code>url</code> \| <code>text</code> | <code>text</code> | Whether the text is stored directly in uploaded data or needs to be loaded from a URL |
 | [inline] | <code>boolean</code> | <code>false</code> | Whether to embed HTML directly in Label Studio or use an iframe |
+| [sanitizeHtml] | <code>boolean</code> | <code>true</code> | Whether to sanitize the provided html (remove scripts etc) |
 | [saveTextResult] | <code>yes</code> \| <code>no</code> |  | Whether to store labeled text along with the results. By default, doesn't store text for `valueType=url` |
 | [encoding] | <code>none</code> \| <code>base64</code> \| <code>base64unicode</code> |  | How to decode values from encoded strings |
 | [selectionEnabled] | <code>boolean</code> | <code>true</code> | Enable or disable selection |

--- a/web/libs/editor/src/tags/object/RichText/model.js
+++ b/web/libs/editor/src/tags/object/RichText/model.js
@@ -41,6 +41,7 @@ const WARNING_MESSAGES = {
  * @param {string} value                                  - value of the element
  * @param {url|text} [valueType=url|text]                 – source of the data, check (Data retrieval)[https://labelstud.io/guide/tasks.html] page for more inforamtion
  * @param {boolean} [inline=false]                        - whether to embed html directly to LS or use iframe (only HyperText)
+ * @param {boolean} [sanitizeHtml=true]                   - whether to sanitize the provided html (only HyperText)
  * @param {boolean} [saveTextResult=true]                 – whether or not to save selected text to the serialized data
  * @param {boolean} [selectionEnabled=true]               - enable or disable selection
  * @param {boolean} [clickableLinks=false]                – allow annotator to open resources from links
@@ -56,6 +57,8 @@ const TagAttrs = types.model("RichTextModel", {
   valuetype: types.optional(types.enumeration(["text", "url"]), () => (window.LS_SECURE_MODE ? "url" : "text")),
 
   inline: false,
+
+  sanitizehtml: types.optional(types.boolean, true),
 
   /** Whether or not to save selected text to the serialized data */
   savetextresult: types.optional(types.enumeration(["none", "no", "yes"]), () =>
@@ -235,7 +238,7 @@ const Model = types
         // clean up the html — remove scripts and iframes
         // nodes count better be the same, so replace them with stubs
         // we should not sanitize text tasks because we already have htmlEscape in view.js
-        if (isFF(FF_SAFE_TEXT) && self.type === "text") {
+        if (!self.sanitizehtml || (isFF(FF_SAFE_TEXT) && self.type === "text")) {
           self._value = String(val);
         } else {
           self._value = sanitizeHtml(String(val));


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend

### Describe the reason for change

We inject supplementary details into the labeler's interface that they need when making informed labeling decisions (but which isn't the object being labelled). This is usually data types which are not currently supported by LS (for example an interactive scrollable/zoomable map showing some geojson). Additionally this lets us smooth over any small gaps between what LS offers and what we need for any specific use case, without needing to fork LS.

Until #5232, we could use the `HyperText` tag for this, injecting elements & scripts. However that no longer works. It is pretty reasonable that you want to limit peoples ability to mess with the DOM, but in practice this code injection approach can work well.

#### What does this fix?
See above. Here's a few other people encountering similar issues #5860 #5688

#### What is the new behavior?
The `<HyperText>` tag now has an optional `sanitizeHtml` argument (default true; keep the old behavior), which can be used to bypass sanitization.

#### What is the current behavior?
When using the `<HyperText>` tag, the specified html is always sanitized, removing several tag types (script etc). There is no way to opt out of this.

#### What libraries were added/updated?
None

#### Does this change affect performance?
Not measurably 

#### Does this change affect security?
Code injection if misused, but its opt-in, user is accepting that risk. Partially mitigated via CSP.

#### What alternative approaches were there?
Currently we are using v1.10.01 as its the last version before html sanitization was added.

A better overall approach might be to support a html/iframe "visual & experience tag" as the use case for this is not as part of the object being labeled.

#### What feature flags were used to cover this change?
None, its already opt-in

### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit

I'd happily take some guidance on where there relevant tests are, and fill the gap. I struggled to orient myself within the mobx-statetree stuff.


### Which logical domain(s) does this change affect?
frontend

