### PR TITLE
fix: LEAP-1507: show review instructions in review stream

### DIFF
--- a/web/libs/editor/src/components/App/App.jsx
+++ b/web/libs/editor/src/components/App/App.jsx
@@ -235,7 +235,7 @@ class App extends Component {
             <InstructionsModal
               visible={store.showingDescription}
               onCancel={() => store.toggleDescription()}
-              title="Labeling Instructions"
+              title={store.hasInterface("review") ? "Review Instructions" : "Labeling Instructions"}
             >
               {store.description}
             </InstructionsModal>


### PR DESCRIPTION
Laying the groundwork for showing review instructions when user enters review stream (which is an enterprise feature)