### PR TITLE
refactor: OPTIC-1165: stale fflag_feat_front_prod_292_archive_workspa…

### DIFF
--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -55,4 +55,5 @@ STALE_FEATURE_FLAGS = {
     'ff_front_1170_outliner_030222_short': True,
     'fflag_fix_front_lsdv_4620_memory_leaks_100723_short': False,
     'fflag_fix_back_lsdv_5410_temporary_disable_auto_inference_jobs_short': True,
+    'fflag_feat_front_prod_292_archive_workspaces_short': True,
 }


### PR DESCRIPTION
…ces_short

### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ x Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change

Just stale a feature flag that is on in all org in LD

