### PR TITLE
feat: OPTIC-1183: Improve is_delete flow

### DIFF
--- a/label_studio/users/models.py
+++ b/label_studio/users/models.py
@@ -187,7 +187,7 @@ class User(UserMixin, AbstractBaseUser, PermissionsMixin, UserLastActivityMixin)
         initials = '?'
 
         if (
-            settings.CLOUD_INSTANCE
+            getattr(settings, 'CLOUD_INSTANCE', False)
             or flag_set('fflag_feat_all_optic_114_soft_delete_for_churned_employees', user=self)
         ) and is_deleted:
 

--- a/label_studio/users/models.py
+++ b/label_studio/users/models.py
@@ -186,7 +186,11 @@ class User(UserMixin, AbstractBaseUser, PermissionsMixin, UserLastActivityMixin)
     def get_initials(self, is_deleted=False):
         initials = '?'
 
-        if flag_set('fflag_feat_all_optic_114_soft_delete_for_churned_employees', user=self) and is_deleted:
+        if (
+            settings.CLOUD_INSTANCE
+            or flag_set('fflag_feat_all_optic_114_soft_delete_for_churned_employees', user=self)
+        ) and is_deleted:
+
             return 'DU'
 
         if not self.first_name and not self.last_name:

--- a/label_studio/users/serializers.py
+++ b/label_studio/users/serializers.py
@@ -20,7 +20,9 @@ class BaseUserSerializer(FlexFieldsModelSerializer):
         return instance.avatar_url
 
     def get_initials(self, instance):
-        if flag_set('fflag_feat_all_optic_114_soft_delete_for_churned_employees', user=instance):
+        if settings.CLOUD_INSTANCE or flag_set(
+            'fflag_feat_all_optic_114_soft_delete_for_churned_employees', user=instance
+        ):
             return instance.get_initials(self._is_deleted(instance))
         else:
             return instance.get_initials()
@@ -65,7 +67,9 @@ class BaseUserSerializer(FlexFieldsModelSerializer):
         if uid not in self.context[key]:
             self.context[key][uid] = super().to_representation(instance)
 
-        if flag_set('fflag_feat_all_optic_114_soft_delete_for_churned_employees', user=instance):
+        if settings.CLOUD_INSTANCE or flag_set(
+            'fflag_feat_all_optic_114_soft_delete_for_churned_employees', user=instance
+        ):
             if self._is_deleted(instance):
                 for field in ['username', 'first_name', 'last_name', 'email']:
                     self.context[key][uid][field] = 'User' if field == 'last_name' else 'Deleted'

--- a/label_studio/users/serializers.py
+++ b/label_studio/users/serializers.py
@@ -20,7 +20,7 @@ class BaseUserSerializer(FlexFieldsModelSerializer):
         return instance.avatar_url
 
     def get_initials(self, instance):
-        if settings.CLOUD_INSTANCE or flag_set(
+        if getattr(settings, 'CLOUD_INSTANCE', False) or flag_set(
             'fflag_feat_all_optic_114_soft_delete_for_churned_employees', user=instance
         ):
             return instance.get_initials(self._is_deleted(instance))
@@ -67,7 +67,7 @@ class BaseUserSerializer(FlexFieldsModelSerializer):
         if uid not in self.context[key]:
             self.context[key][uid] = super().to_representation(instance)
 
-        if settings.CLOUD_INSTANCE or flag_set(
+        if getattr(settings, 'CLOUD_INSTANCE', False) or flag_set(
             'fflag_feat_all_optic_114_soft_delete_for_churned_employees', user=instance
         ):
             if self._is_deleted(instance):


### PR DESCRIPTION
While investigating an organization with a large number of users, we realized that this FF check triggers unnecessary calls because it checks users in a loop rather than the request.
This feature flag is fully deprecated on cloud, so we create this initial patch.

We will have a quick follow up to make this more reusable.

