### PR TITLE
feat: LEAP-1441: Allow to connect comments to classifications

### DIFF
--- a/web/libs/editor/src/components/Comments/Comment/CommentForm.tsx
+++ b/web/libs/editor/src/components/Comments/Comment/CommentForm.tsx
@@ -115,7 +115,7 @@ export const CommentForm: FC<CommentFormProps> = observer(({ commentStore, annot
   const currentLinkingComment = annotationStore.selected.currentLinkingMode?.comment;
   const currentComment = getCurrentComment();
   const { text = "", regionRef } = currentComment || {};
-  const { region } = regionRef || {};
+  const { region, result } = regionRef || {};
   const linking = !!linkingComment && currentLinkingComment === linkingComment && globalLinking;
   const hasLinkState = linking || region;
 
@@ -146,7 +146,7 @@ export const CommentForm: FC<CommentFormProps> = observer(({ commentStore, annot
       </Elem>
       {hasLinkState && (
         <Elem name="link-state">
-          <LinkState linking={linking} region={region} onUnlink={currentComment?.unsetLink} />
+          <LinkState linking={linking} region={region} result={result} onUnlink={currentComment?.unsetLink} />
         </Elem>
       )}
       {commentStore.tooltipMessage && <Elem name="tooltipMessage">{commentStore.tooltipMessage}</Elem>}

--- a/web/libs/editor/src/components/Comments/Comment/CommentItem.scss
+++ b/web/libs/editor/src/components/Comments/Comment/CommentItem.scss
@@ -116,7 +116,8 @@
   }
 
   &__linkState {
-    padding: 9px 3px 4px;
+    padding: 4px 0 0;
+    margin-left: -5px;
     width: 100%;
     overflow: hidden;
   }

--- a/web/libs/editor/src/components/Comments/Comment/CommentItem.tsx
+++ b/web/libs/editor/src/components/Comments/Comment/CommentItem.tsx
@@ -71,6 +71,7 @@ export const CommentItem: FC<CommentItemProps> = observer(({ comment, listCommen
   const [text, setText] = useState(initialText);
   const [linkingComment, setLinkingComment] = useState();
   const region = regionRef?.region;
+  const result = regionRef?.result;
   const linking = !!(linkingComment && currentComment === linkingComment && globalLinking);
   const hasLinkState = linking || region;
 
@@ -170,7 +171,7 @@ export const CommentItem: FC<CommentItemProps> = observer(({ comment, listCommen
               {text}
               {hasLinkState && (
                 <Elem name="linkState">
-                  <LinkState linking={linking} region={region} interactive />
+                  <LinkState linking={linking} region={region} result={result} interactive />
                 </Elem>
               )}
             </>

--- a/web/libs/editor/src/components/Comments/Comment/LinkState.scss
+++ b/web/libs/editor/src/components/Comments/Comment/LinkState.scss
@@ -9,7 +9,7 @@
   padding: 6px 4px 5px;
 
   &_display {
-    padding: 2px 9px 5px 4px;
+    padding: 2px 9px 2px 4px;
     gap: 2px;
     font-size: 14px;
     line-height: 22px;
@@ -88,6 +88,10 @@
     flex: 1;
     color: var(--text-color, var(--sand_900));
     min-width: 0;
+    //// @todo use these styles if we don't need multiline texts
+    // overflow: hidden;
+    // white-space: nowrap;
+    // text-overflow: ellipsis;
   }
 
   &__label {

--- a/web/libs/editor/src/components/Comments/Comment/LinkState.scss
+++ b/web/libs/editor/src/components/Comments/Comment/LinkState.scss
@@ -100,8 +100,13 @@
 
     & div {
       overflow: hidden;
-      white-space: nowrap;
+      //// @todo disabled for now to allow multiline texts
+      // white-space: nowrap;
       text-overflow: ellipsis;
+    }
+
+    .labels-list {
+      display: inline;
     }
   }
 

--- a/web/libs/editor/src/components/Comments/Comment/LinkState.scss
+++ b/web/libs/editor/src/components/Comments/Comment/LinkState.scss
@@ -88,6 +88,7 @@
     flex: 1;
     color: var(--text-color, var(--sand_900));
     min-width: 0;
+
     //// @todo use these styles if we don't need multiline texts
     // overflow: hidden;
     // white-space: nowrap;
@@ -100,6 +101,7 @@
 
     & div {
       overflow: hidden;
+
       //// @todo disabled for now to allow multiline texts
       // white-space: nowrap;
       text-overflow: ellipsis;

--- a/web/libs/editor/src/components/Comments/Comment/LinkState.tsx
+++ b/web/libs/editor/src/components/Comments/Comment/LinkState.tsx
@@ -6,18 +6,21 @@ import { Button } from "antd";
 import { IconCommentLinkTo, LsClose } from "../../../assets/icons";
 import { Block, Elem } from "../../../utils/bem";
 import { NodeIcon } from "../../Node/Node";
+// @todo use own version of it to have more control over styles and display more relevant info
+import { ResultItem } from "../../SidePanels/DetailsPanel/RegionDetails";
 import { RegionLabel } from "../../SidePanels/OutlinerPanel/RegionLabel";
 
 import "./LinkState.scss";
 
 type LinkStateProps = {
   linking: boolean;
-  region: any;
+  region: MSTRegion;
+  result: MSTResult;
   onUnlink?: (region: any) => void;
-  interactive: boolean;
+  interactive?: boolean;
 };
 
-export const LinkState: FC<LinkStateProps> = ({ linking, region, onUnlink, interactive }) => {
+export const LinkState: FC<LinkStateProps> = ({ linking, region, result, onUnlink, interactive }) => {
   const isVisible = linking || region;
   const mod = useMemo(() => {
     if (linking) return { action: true };
@@ -31,34 +34,36 @@ export const LinkState: FC<LinkStateProps> = ({ linking, region, onUnlink, inter
         <IconCommentLinkTo />
       </Elem>
       {mod?.action && "Select an object to link it to this comment."}
-      {mod?.display && <LinkedRegion item={region} onUnlink={onUnlink} interactive={interactive} />}
+      {mod?.display && <LinkedRegion region={region} result={result} onUnlink={onUnlink} interactive={interactive} />}
     </Block>
   );
 };
 
 type LinkedRegionProps = {
-  item: any;
+  region: any;
+  result?: MSTResult;
   onUnlink?: (item: any) => void;
-  interactive: boolean;
+  interactive?: boolean;
 };
 
-const LinkedRegion: FC<LinkedRegionProps> = observer(({ item, interactive, onUnlink }) => {
-  const itemColor = item?.background ?? item?.getOneColor?.();
+const LinkedRegion: FC<LinkedRegionProps> = observer(({ region, result, interactive, onUnlink }) => {
+  const itemColor = region?.background ?? region?.getOneColor?.();
+  const isClassification: boolean = region.classification;
 
   const { mouseEnterHandler, mouseLeaveHandler, clickHandler } = useMemo(() => {
     if (!interactive) return {};
 
     const mouseEnterHandler = () => {
-      item?.setHighlight?.(true);
+      region?.setHighlight?.(true);
     };
     const mouseLeaveHandler = () => {
-      item?.setHighlight?.(false);
+      region?.setHighlight?.(false);
     };
     const clickHandler = () => {
-      item.annotation.selectArea(item);
+      region.annotation.selectArea(region);
     };
     return { mouseEnterHandler, mouseLeaveHandler, clickHandler };
-  }, [interactive, item]);
+  }, [interactive, region]);
 
   const style = useMemo(() => {
     const color = chroma(itemColor ?? "#666").alpha(1);
@@ -77,16 +82,26 @@ const LinkedRegion: FC<LinkedRegionProps> = observer(({ item, interactive, onUnl
       onMouseLeave={mouseLeaveHandler}
       onClick={clickHandler}
     >
-      <Elem name="icon">
-        <NodeIcon node={item} />
-      </Elem>
-      <Elem name="index">{item.region_index}</Elem>
-      <Elem name="title">
-        <Elem name="label">
-          <RegionLabel item={item} />
+      {!isClassification && (
+        <>
+          <Elem name="icon">
+            <NodeIcon node={region} />
+          </Elem>
+          <Elem name="index">{region.region_index}</Elem>
+        </>
+      )}
+      {result ? (
+        <Elem name="title">
+          <ResultItem result={result} />
         </Elem>
-        {item?.text && <Elem name="text">{item.text.replace(/\\n/g, "\n")}</Elem>}
-      </Elem>
+      ) : (
+        <Elem name="title">
+          <Elem name="label">
+            <RegionLabel item={region} />
+          </Elem>
+          {region?.text && <Elem name="text">{region.text.replace(/\\n/g, "\n")}</Elem>}
+        </Elem>
+      )}
       {onUnlink && (
         <Elem name="close">
           <Button size="small" type="text" icon={<LsClose />} onClick={onUnlink} />

--- a/web/libs/editor/src/components/Comments/Comment/LinkState.tsx
+++ b/web/libs/editor/src/components/Comments/Comment/LinkState.tsx
@@ -6,8 +6,6 @@ import { Button } from "antd";
 import { IconCommentLinkTo, LsClose } from "../../../assets/icons";
 import { Block, Elem } from "../../../utils/bem";
 import { NodeIcon } from "../../Node/Node";
-// @todo use own version of it to have more control over styles and display more relevant info
-import { ResultItem } from "../../SidePanels/DetailsPanel/RegionDetails";
 import { RegionLabel } from "../../SidePanels/OutlinerPanel/RegionLabel";
 
 import "./LinkState.scss";
@@ -92,7 +90,7 @@ const LinkedRegion: FC<LinkedRegionProps> = observer(({ region, result, interact
       )}
       {result ? (
         <Elem name="title">
-          <ResultItem result={result} />
+          <ResultText result={result} />
         </Elem>
       ) : (
         <Elem name="title">
@@ -109,4 +107,21 @@ const LinkedRegion: FC<LinkedRegionProps> = observer(({ region, result, interact
       )}
     </Block>
   );
+});
+
+/**
+ * Simply displaying the content of classification result
+ */
+const ResultText: FC<{ result: MSTResult }> = observer(({ result }) => {
+  const { from_name: control, type, mainValue } = result;
+  const { name } = control;
+
+  if (type === "textarea") return [name, mainValue.join(" | ")].join(": ");
+  if (type === "choices") return [name, mainValue.join(", ")].join(": ");
+  if (type === "taxonomy") {
+    const values = mainValue.map((v: string[]) => v.join("/"));
+    return [name, values.join(", ")].join(": ");
+  }
+
+  return [name, String(mainValue)].join(": ");
 });

--- a/web/libs/editor/src/components/Comments/Comment/LinkState.tsx
+++ b/web/libs/editor/src/components/Comments/Comment/LinkState.tsx
@@ -58,6 +58,7 @@ const LinkedRegion: FC<LinkedRegionProps> = observer(({ region, result, interact
       region?.setHighlight?.(false);
     };
     const clickHandler = () => {
+      if (region.classification) return null;
       region.annotation.selectArea(region);
     };
     return { mouseEnterHandler, mouseLeaveHandler, clickHandler };

--- a/web/libs/editor/src/components/InteractiveOverlays/BoundingBox.js
+++ b/web/libs/editor/src/components/InteractiveOverlays/BoundingBox.js
@@ -74,8 +74,11 @@ const stageRelatedBBox = (region, bbox) => {
 };
 
 const _detect = (region) => {
-  if (region.classification) {
-    return Geometry.getDOMBBox(region.control.elementRef?.current);
+  // that's a tricky way to detect bbox of exact result instead of whole region
+  // works for global classifications and per-regions
+  const isResult = !!region.from_name;
+  if (isResult) {
+    return Geometry.getDOMBBox(region.from_name.elementRef?.current);
   }
   switch (region.type) {
     case "textrange":

--- a/web/libs/editor/src/components/InteractiveOverlays/BoundingBox.js
+++ b/web/libs/editor/src/components/InteractiveOverlays/BoundingBox.js
@@ -74,6 +74,9 @@ const stageRelatedBBox = (region, bbox) => {
 };
 
 const _detect = (region) => {
+  if (region.classification) {
+    return Geometry.getDOMBBox(region.control.elementRef?.current);
+  }
   switch (region.type) {
     case "textrange":
     case "richtextregion":

--- a/web/libs/editor/src/components/InteractiveOverlays/CommentsOverlay.tsx
+++ b/web/libs/editor/src/components/InteractiveOverlays/CommentsOverlay.tsx
@@ -90,6 +90,15 @@ const CommentItem: React.FC<CommentItemProps> = observer(({ comment, rootRef }) 
   );
 });
 
+/** Is used to narrow all results down to classifications good to be selected */
+const isClassification = (result: MSTResult) => {
+  const { isClassificationTag } = result.from_name;
+  const isGlobalClassification = result.area.classification;
+  const isActivePerRegion = result.area.selected;
+
+  return isClassificationTag && (isGlobalClassification || isActivePerRegion);
+};
+
 type ResultItemProps = {
   result: MSTResult;
   rootRef: React.MutableRefObject<HTMLOrSVGElement | undefined>;
@@ -152,7 +161,7 @@ type CommentsOverlayProps = {
   commentStore: MSTCommentStore;
   annotation: MSTAnnotation;
 };
-const CommentsOverlayInner: React.FC<CommentsOverlayProps> = observer(({ annotation, commentStore }) => {
+const CommentsOverlayInner = observer(({ annotation, commentStore }: CommentsOverlayProps) => {
   const { overlayComments } = commentStore || {};
   const rootRef = useRef<SVGSVGElement>();
   const [uniqKey, forceUpdate] = useState<any>(guidGenerator());
@@ -210,9 +219,9 @@ const CommentsOverlayInner: React.FC<CommentsOverlayProps> = observer(({ annotat
     <svg className={containerStyles.join(" ")} ref={setRef} xmlns="http://www.w3.org/2000/svg">
       <g key={uniqKey}>
         {annotation.linkingMode === LINK_COMMENT_MODE &&
-          annotation.results.map((result: MSTResult) => (
-            <ResultTagBbox key={result.id} result={result} rootRef={rootRef} />
-          ))}
+          annotation.results
+            .filter(isClassification)
+            .map((result) => <ResultTagBbox key={result.id} result={result} rootRef={rootRef} />)}
         {overlayComments.map((comment: MSTComment) => {
           const { id } = comment;
           return <CommentItem key={id} comment={comment} rootRef={rootRef} />;

--- a/web/libs/editor/src/components/InteractiveOverlays/CommentsOverlay.tsx
+++ b/web/libs/editor/src/components/InteractiveOverlays/CommentsOverlay.tsx
@@ -103,8 +103,8 @@ const ResultTagBbox: React.FC<ResultItemProps> = observer(({ result, rootRef }) 
   const [hovered, setHovered] = useState(false);
 
   const shape = useMemo(() => {
-    return node && root ? NodesConnector.createShape(node, root) : null;
-  }, [node, root]);
+    return result && root ? NodesConnector.createShape(result, root) : null;
+  }, [result, root]);
 
   const bbox = useMemo(() => {
     if (!shape || !root) return { x: 0, y: 0, width: 0, height: 0 };
@@ -211,16 +211,9 @@ const CommentsOverlayInner: React.FC<CommentsOverlayProps> = observer(({ annotat
     // biome-ignore lint/a11y/noSvgWithoutTitle: It's not just an icon or a figure; it's an entire interactive layer.
     <svg className={containerStyles.join(" ")} ref={setRef} xmlns="http://www.w3.org/2000/svg">
       <g key={uniqKey}>
-        {/* @todo for now we'll render only global classifications but the goal is to render pre-regions as well */}
-        {/* {annotation.isLinkingMode && annotation.results.map((result: MSTResult) => (
+        {annotation.isLinkingMode && annotation.results.map((result: MSTResult) => (
           <ResultTagBbox key={result.id} result={result} rootRef={rootRef} />
-        ))} */}
-        {annotation.isLinkingMode && annotation.regions.filter(r => r.classification)
-          .map((region) => region.results[0])
-          .map((result) => (
-            <ResultTagBbox key={result.id} result={result} rootRef={rootRef} />
-          ))
-        }
+        ))}
         {overlayComments.map((comment: MSTComment) => {
           const { id } = comment;
           return <CommentItem key={id} comment={comment} rootRef={rootRef} />;

--- a/web/libs/editor/src/components/InteractiveOverlays/CommentsOverlay.tsx
+++ b/web/libs/editor/src/components/InteractiveOverlays/CommentsOverlay.tsx
@@ -3,7 +3,7 @@ import { isAlive } from "mobx-state-tree";
 import type React from "react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useMounted } from "../../common/Utils/useMounted";
-
+import { LINK_COMMENT_MODE } from "../../stores/Annotation/LinkingModes";
 import ResizeObserver from "../../utils/resize-observer";
 import { guidGenerator } from "../../utils/unique";
 import NodesConnector from "./NodesConnector";
@@ -78,7 +78,6 @@ const CommentItem: React.FC<CommentItemProps> = observer(({ comment, rootRef }) 
     itemStyles.push(styles._highlighted);
   }
   return (
-    // biome-ignore lint/a11y/noSvgWithoutTitle: Intentionally not displaying the title over the comment icon
     <g
       className={itemStyles.join(" ")}
       style={positionStyle}
@@ -145,8 +144,7 @@ const ResultTagBbox: React.FC<ResultItemProps> = observer(({ result, rootRef }) 
         result.annotation.addLinkedResult(result);
         result.annotation.stopLinkingMode();
       }}
-    >
-    </rect>
+    />
   );
 });
 
@@ -211,9 +209,10 @@ const CommentsOverlayInner: React.FC<CommentsOverlayProps> = observer(({ annotat
     // biome-ignore lint/a11y/noSvgWithoutTitle: It's not just an icon or a figure; it's an entire interactive layer.
     <svg className={containerStyles.join(" ")} ref={setRef} xmlns="http://www.w3.org/2000/svg">
       <g key={uniqKey}>
-        {annotation.linkingMode === LINK_COMMENT_MODE && annotation.results.map((result: MSTResult) => (
-          <ResultTagBbox key={result.id} result={result} rootRef={rootRef} />
-        ))}
+        {annotation.linkingMode === LINK_COMMENT_MODE &&
+          annotation.results.map((result: MSTResult) => (
+            <ResultTagBbox key={result.id} result={result} rootRef={rootRef} />
+          ))}
         {overlayComments.map((comment: MSTComment) => {
           const { id } = comment;
           return <CommentItem key={id} comment={comment} rootRef={rootRef} />;

--- a/web/libs/editor/src/components/InteractiveOverlays/CommentsOverlay.tsx
+++ b/web/libs/editor/src/components/InteractiveOverlays/CommentsOverlay.tsx
@@ -35,7 +35,9 @@ type CommentItemProps = {
 const CommentItem: React.FC<CommentItemProps> = observer(({ comment, rootRef }) => {
   const root = rootRef.current;
   const node = comment.regionRef?.overlayNode;
-  const isHidden = !node || node.hidden;
+  // result is hidden when it's per-region and the region is not selected
+  const isHiddenResult = node?.area && !node.area.selected && !node.area.classification;
+  const isHidden = !node || node.hidden || isHiddenResult;
   // {} !== {} it's always so, and it's a way to force re-render
   const [forceUpdateId, forceUpdate] = useState<any>({});
 

--- a/web/libs/editor/src/components/InteractiveOverlays/CommentsOverlay.tsx
+++ b/web/libs/editor/src/components/InteractiveOverlays/CommentsOverlay.tsx
@@ -124,7 +124,7 @@ const ResultTagBbox: React.FC<ResultItemProps> = observer(({ result, rootRef }) 
 
   const itemStyle = {
     pointerEvents: "all" as const,
-    stroke: "var(--grape-600)",
+    stroke: "var(--grape_600)",
     strokeDasharray: "4 2",
   };
 

--- a/web/libs/editor/src/components/InteractiveOverlays/CommentsOverlay.tsx
+++ b/web/libs/editor/src/components/InteractiveOverlays/CommentsOverlay.tsx
@@ -100,6 +100,7 @@ const ResultTagBbox: React.FC<ResultItemProps> = observer(({ result, rootRef }) 
   const node = result.area;
   const isHidden = !node || node.hidden;
   const [forceUpdateId, forceUpdate] = useState<any>({});
+  const [hovered, setHovered] = useState(false);
 
   const shape = useMemo(() => {
     return node && root ? NodesConnector.createShape(node, root) : null;
@@ -125,15 +126,18 @@ const ResultTagBbox: React.FC<ResultItemProps> = observer(({ result, rootRef }) 
   const itemStyle = {
     pointerEvents: "all" as const,
     stroke: "var(--grape_600)",
-    strokeDasharray: "4 2",
+    strokeDasharray: hovered ? undefined : "4 2",
+    cursor: "crosshair",
   };
 
   return (
     <rect
       {...bbox}
+      rx={3}
+      ry={3}
       style={itemStyle}
-      // onMouseEnter={onHover}
-      // onMouseLeave={onUnHover}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
       stroke="red"
       strokeWidth={1}
       fill="none"
@@ -207,9 +211,16 @@ const CommentsOverlayInner: React.FC<CommentsOverlayProps> = observer(({ annotat
     // biome-ignore lint/a11y/noSvgWithoutTitle: It's not just an icon or a figure; it's an entire interactive layer.
     <svg className={containerStyles.join(" ")} ref={setRef} xmlns="http://www.w3.org/2000/svg">
       <g key={uniqKey}>
-        {annotation.isLinkingMode && annotation.results.map((result: MSTResult) => (
+        {/* @todo for now we'll render only global classifications but the goal is to render pre-regions as well */}
+        {/* {annotation.isLinkingMode && annotation.results.map((result: MSTResult) => (
           <ResultTagBbox key={result.id} result={result} rootRef={rootRef} />
-        ))}
+        ))} */}
+        {annotation.isLinkingMode && annotation.regions.filter(r => r.classification)
+          .map((region) => region.results[0])
+          .map((result) => (
+            <ResultTagBbox key={result.id} result={result} rootRef={rootRef} />
+          ))
+        }
         {overlayComments.map((comment: MSTComment) => {
           const { id } = comment;
           return <CommentItem key={id} comment={comment} rootRef={rootRef} />;

--- a/web/libs/editor/src/components/InteractiveOverlays/CommentsOverlay.tsx
+++ b/web/libs/editor/src/components/InteractiveOverlays/CommentsOverlay.tsx
@@ -211,7 +211,7 @@ const CommentsOverlayInner: React.FC<CommentsOverlayProps> = observer(({ annotat
     // biome-ignore lint/a11y/noSvgWithoutTitle: It's not just an icon or a figure; it's an entire interactive layer.
     <svg className={containerStyles.join(" ")} ref={setRef} xmlns="http://www.w3.org/2000/svg">
       <g key={uniqKey}>
-        {annotation.isLinkingMode && annotation.results.map((result: MSTResult) => (
+        {annotation.linkingMode === LINK_COMMENT_MODE && annotation.results.map((result: MSTResult) => (
           <ResultTagBbox key={result.id} result={result} rootRef={rootRef} />
         ))}
         {overlayComments.map((comment: MSTComment) => {

--- a/web/libs/editor/src/components/SidePanels/DetailsPanel/RegionDetails.tsx
+++ b/web/libs/editor/src/components/SidePanels/DetailsPanel/RegionDetails.tsx
@@ -67,6 +67,16 @@ export const ResultItem: FC<{ result: any }> = observer(({ result }) => {
         </Elem>
       );
     }
+    if (type === "taxonomy") {
+      return (
+        <Elem name="result">
+          <Text>Taxonomy: </Text>
+          <Elem name="value">
+            <ChoicesResult mainValue={mainValue.map((v: string[]) => v.join("/"))} />
+          </Elem>
+        </Elem>
+      );
+    }
   }, [type, mainValue]);
 
   return content ? <Block name="region-meta">{content}</Block> : null;

--- a/web/libs/editor/src/components/SidePanels/DetailsPanel/RegionDetails.tsx
+++ b/web/libs/editor/src/components/SidePanels/DetailsPanel/RegionDetails.tsx
@@ -27,7 +27,7 @@ const RatingResult: FC<{ mainValue: string[] }> = observer(({ mainValue }) => {
   return <span>{mainValue}</span>;
 });
 
-const ResultItem: FC<{ result: any }> = observer(({ result }) => {
+export const ResultItem: FC<{ result: any }> = observer(({ result }) => {
   const { type, mainValue } = result;
   /**
    * @todo before fix this var was always false, so fix is left commented out

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/TreeView.scss
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/TreeView.scss
@@ -56,7 +56,7 @@
       max-width: 100%;
 
       .ff_outliner_optim & {
-        align-items: flex-start;
+        align-items: center;
       }
     }
   }
@@ -93,7 +93,11 @@
     min-width: 0;
 
     .labels-list {
-      display: inline-block;
+      display: inline;
+      // make it dense for multiline labels
+      line-height: 1.2;
+      //+ add a little padding so it won't be too close to the item edges
+      padding: 2px 0;
     }
   }
 

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/TreeView.scss
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/TreeView.scss
@@ -94,10 +94,8 @@
 
     .labels-list {
       display: inline;
-      // make it dense for multiline labels
-      line-height: 1.2;
-      //+ add a little padding so it won't be too close to the item edges
-      padding: 2px 0;
+      line-height: 1.2; // make it dense for multiline labels
+      padding: 2px 0; // + add a little padding so it won't be too close to the item edges
     }
   }
 

--- a/web/libs/editor/src/regions/Area.js
+++ b/web/libs/editor/src/regions/Area.js
@@ -28,9 +28,15 @@ const ClassificationArea = types.compose(
       // true only for global classifications
       classification: true,
     })
-    .views(() => ({
+    .views((self) => ({
+      get control() {
+        return self.results[0].from_name;
+      },
       get supportSuggestions() {
         return false;
+      },
+      get type() {
+        return "";
       },
     }))
     .actions(() => ({

--- a/web/libs/editor/src/regions/Area.js
+++ b/web/libs/editor/src/regions/Area.js
@@ -29,12 +29,10 @@ const ClassificationArea = types.compose(
       classification: true,
     })
     .views((self) => ({
-      get control() {
-        return self.results[0].from_name;
-      },
       get supportSuggestions() {
         return false;
       },
+      // it's required in some contexts when it's treated as a region
       get type() {
         return "";
       },

--- a/web/libs/editor/src/stores/Annotation/LinkingModes.js
+++ b/web/libs/editor/src/stores/Annotation/LinkingModes.js
@@ -66,6 +66,13 @@ export const LinkingModes = types
           self.currentLinkingMode.addLinkedRegion?.(region);
         }
       },
+
+      addLinkedResult(region) {
+        if (self.currentLinkingMode) {
+          self.currentLinkingMode.addLinkedResult?.(region);
+        }
+      },
+
       // @deprecated Use `startLinkingMode(CREATE_RELATION_MODE, obj)` instead
       startRelationMode(obj) {
         console.warn("`startRelationMode` is deprecated. Use `startLinkingMode(CREATE_RELATION_MODE, obj)` instead.");

--- a/web/libs/editor/src/stores/Annotation/LinkingModes/CommentMode.js
+++ b/web/libs/editor/src/stores/Annotation/LinkingModes/CommentMode.js
@@ -28,6 +28,10 @@ const CommentModeModel = types
         self.comment.setRegionLink(region);
         self.stop();
       },
+      addLinkedResult(result) {
+        self.comment.setResultLink(result);
+        self.stop();
+      },
     };
   });
 

--- a/web/libs/editor/src/stores/Comment/Anchor.js
+++ b/web/libs/editor/src/stores/Comment/Anchor.js
@@ -19,7 +19,7 @@ export const Anchor = types
       if (!self.controlName) return null;
       // if we just removed the region
       if (!self.region) return null;
-      return self.region.results.find(r => r.from_name.name === self.controlName);
+      return self.region.results.find((r) => r.from_name.name === self.controlName);
     },
     /**
      * This will be provided to CommentsOverlay to observe changes in bbox coordinates and sizes

--- a/web/libs/editor/src/stores/Comment/Anchor.js
+++ b/web/libs/editor/src/stores/Comment/Anchor.js
@@ -11,7 +11,15 @@ export const Anchor = types
       return getParent(self).annotation;
     },
     get region() {
-      return self.annotation.regionStore.regions.find((r) => r.cleanId === self.regionId);
+      return self.annotation.regions.find((r) => r.cleanId === self.regionId);
+    },
+    get result() {
+      // @todo we might link global classifications via region id only in a future
+      // @todo so then we have to check for `region.classification === true`
+      if (!self.controlName) return null;
+      // if we just removed the region
+      if (!self.region) return null;
+      return self.region.results.find(r => r.from_name.name === self.controlName);
     },
     /**
      * This will be provided to CommentsOverlay to observe changes in bbox coordinates and sizes

--- a/web/libs/editor/src/stores/Comment/Anchor.js
+++ b/web/libs/editor/src/stores/Comment/Anchor.js
@@ -27,7 +27,7 @@ export const Anchor = types
      * @return {Object} The overlays-applicable node of the anchor.
      */
     get overlayNode() {
-      return self.region;
+      return self.result ?? self.region;
     },
     /**
      * A key that should be unique in the context of the current annotation and current moment

--- a/web/libs/editor/src/stores/Comment/Comment.js
+++ b/web/libs/editor/src/stores/Comment/Comment.js
@@ -57,6 +57,12 @@ export const CommentBase = types
           regionId: region.cleanId,
         };
       },
+      setResultLink(result) {
+        self.regionRef = {
+          regionId: result.area.cleanId,
+          controlName: result.from_name.name,
+        };
+      },
       setHighlighted(value = true) {
         const commentsStore = self.commentsStore;
         if (commentsStore) {

--- a/web/libs/editor/src/stores/Comment/CommentStore.js
+++ b/web/libs/editor/src/stores/Comment/CommentStore.js
@@ -118,7 +118,7 @@ export const CommentStore = types
      * @returns {boolean}
      */
     get isRelevantList() {
-      if (!self.commentsKey) return false;
+      if (!self.commentsKey || !self.targetCommentsKey) return false;
       if (Object.keys(self.commentsKey).length !== Object.keys(self.targetCommentsKey).length) return false;
       return Object.keys(self.commentsKey).every((key) => {
         return self.commentsKey[key] === self.targetCommentsKey[key];

--- a/web/libs/editor/src/stores/types.d.ts
+++ b/web/libs/editor/src/stores/types.d.ts
@@ -12,7 +12,7 @@ type MSTResult = {
   mainValue: any;
   // @todo tag
   from_name: any;
-}
+};
 
 type MSTagProps = {
   isReady?: boolean;
@@ -27,13 +27,7 @@ type MSTTagImage = {
   canvasSize?: { width: number; height: number };
 } & MSTagProps;
 
-type MSTTag = (
-  | MSTTagImage
-  | {
-      type: string;
-    }
-  )
-  & MSTagProps;
+type MSTTag = MSTTagImage | (MSTagProps & { type: string });
 
 type MixinMSTArea = {
   id: string;
@@ -43,6 +37,7 @@ type MixinMSTArea = {
   control: object;
   object: object;
   classification?: boolean;
+  selected: boolean;
 };
 
 type MixinMSTRegion = {
@@ -83,6 +78,7 @@ type MSTAnnotation = {
   results: MSTResult[];
   names: Map<string, MSTTag>;
   isLinkingMode: boolean;
+  linkingMode: "create_relation" | "link_to_comment";
 
   submissionInProgress: () => void;
 };

--- a/web/libs/editor/src/stores/types.d.ts
+++ b/web/libs/editor/src/stores/types.d.ts
@@ -8,6 +8,10 @@ type MSTResult = {
   id: string;
   area: MSTRegion;
   annotation: MSTAnnotation;
+  type: string;
+  mainValue: any;
+  // @todo tag
+  from_name: any;
 }
 
 type MSTagProps = {

--- a/web/libs/editor/src/stores/types.d.ts
+++ b/web/libs/editor/src/stores/types.d.ts
@@ -4,6 +4,12 @@ type RawResult = {
   value: object;
 };
 
+type MSTResult = {
+  id: string;
+  area: MSTRegion;
+  annotation: MSTAnnotation;
+}
+
 type MSTagProps = {
   isReady?: boolean;
 };
@@ -22,14 +28,16 @@ type MSTTag = (
   | {
       type: string;
     }
-) &
-  MSTagProps;
+  )
+  & MSTagProps;
 
 type MixinMSTArea = {
   id: string;
   ouid: number;
   results: RawResult[];
   parentID: string | null;
+  control: object;
+  object: object;
 };
 
 type MixinMSTRegion = {
@@ -66,8 +74,9 @@ type MSTAnnotation = {
     draft?: RawResult[];
     result?: RawResult[];
   };
-  results: RawResult[];
+  results: MSTResult[];
   names: Map<string, MSTTag>;
+  isLinkingMode: boolean;
 
   submissionInProgress: () => void;
 };

--- a/web/libs/editor/src/stores/types.d.ts
+++ b/web/libs/editor/src/stores/types.d.ts
@@ -34,10 +34,11 @@ type MSTTag = (
 type MixinMSTArea = {
   id: string;
   ouid: number;
-  results: RawResult[];
+  results: MSTResult[];
   parentID: string | null;
   control: object;
   object: object;
+  classification?: boolean;
 };
 
 type MixinMSTRegion = {
@@ -74,6 +75,7 @@ type MSTAnnotation = {
     draft?: RawResult[];
     result?: RawResult[];
   };
+  regions: MSTRegion[];
   results: MSTResult[];
   names: Map<string, MSTTag>;
   isLinkingMode: boolean;

--- a/web/libs/editor/src/tags/control/Choices.jsx
+++ b/web/libs/editor/src/tags/control/Choices.jsx
@@ -287,7 +287,11 @@ const ChoicesSelectLayout = observer(({ item }) => {
 
 const HtxChoices = observer(({ item }) => {
   return (
-    <Block name="choices" mod={{ hidden: !item.isVisible || !item.perRegionVisible(), layout: item.layout }}>
+    <Block
+      name="choices"
+      mod={{ hidden: !item.isVisible || !item.perRegionVisible(), layout: item.layout }}
+      ref={item.elementRef}
+    >
       {item.layout === "select" ? <ChoicesSelectLayout item={item} /> : Tree.renderChildren(item, item.annotation)}
     </Block>
   );

--- a/web/libs/editor/src/tags/control/ClassificationBase.js
+++ b/web/libs/editor/src/tags/control/ClassificationBase.js
@@ -1,4 +1,5 @@
 import { types } from "mobx-state-tree";
+import React from "react";
 import { FF_LSDV_4583, isFF } from "../../utils/feature-flags";
 
 /**
@@ -29,6 +30,10 @@ const ClassificationBase = types
     }
     return {};
   })
+  .volatile(() => ({
+    // for interactions with the tag, i.e. linking comments to classification
+    elementRef: React.createRef(),
+  }))
   .views((self) => {
     return {
       selectedValues() {

--- a/web/libs/editor/src/tags/control/DateTime.jsx
+++ b/web/libs/editor/src/tags/control/DateTime.jsx
@@ -365,7 +365,7 @@ const HtxDateTime = inject("store")(
     };
 
     return (
-      <div className="htx-datetime" style={visibleStyle}>
+      <div className="htx-datetime" style={visibleStyle} ref={item.elementRef}>
         {item.showMonth && (
           <select
             {...visual}

--- a/web/libs/editor/src/tags/control/Number.jsx
+++ b/web/libs/editor/src/tags/control/Number.jsx
@@ -203,7 +203,7 @@ const HtxNumber = inject("store")(
     const numberClassName = cn("number").toClassName();
 
     return (
-      <div className={numberClassName} style={visibleStyle}>
+      <div className={numberClassName} style={visibleStyle} ref={item.elementRef}>
         <input
           disabled={disabled}
           style={sliderStyle}

--- a/web/libs/editor/src/tags/control/Rating.jsx
+++ b/web/libs/editor/src/tags/control/Rating.jsx
@@ -158,7 +158,7 @@ const HtxRating = inject("store")(
     };
 
     return (
-      <div style={visibleStyle} onKeyDownCapture={dontBreakSubmit}>
+      <div style={visibleStyle} onKeyDownCapture={dontBreakSubmit} ref={item.elementRef}>
         <Rate
           character={<StarOutlined style={{ fontSize: iconSize }} />}
           value={item.rating}

--- a/web/libs/editor/src/tags/control/Taxonomy/Taxonomy.jsx
+++ b/web/libs/editor/src/tags/control/Taxonomy/Taxonomy.jsx
@@ -630,7 +630,7 @@ const HtxTaxonomy = observer(({ item }) => {
   }
 
   return (
-    <div className={className} style={visibleStyle}>
+    <div className={className} style={visibleStyle} ref={item.elementRef}>
       {isFF(FF_TAXONOMY_ASYNC) && !item.legacy ? (
         <NewTaxonomy
           items={item.items}

--- a/web/libs/editor/src/tags/control/TextArea/TextArea.jsx
+++ b/web/libs/editor/src/tags/control/TextArea/TextArea.jsx
@@ -403,7 +403,7 @@ const HtxTextArea = observer(({ item }) => {
   visibleStyle.marginTop = "4px";
 
   return item.displaymode === PER_REGION_MODES.TAG ? (
-    <div className={textareaClassName} style={visibleStyle}>
+    <div className={textareaClassName} style={visibleStyle} ref={item.elementRef}>
       {Tree.renderChildren(item, item.annotation)}
 
       {item.showSubmit && (


### PR DESCRIPTION
Modify comments to allow to attach results. This includes global classifications like Choices and TextArea + per-region results connected to a region.

### Code
Technically this adds `controlName` to `Anchor` to distinguish regions from results. Bboxes are created over the tag defined by this `controlName`. Comment can be attached to existing result only, so if tag has no value added to it, it can't be attached.

### UI
In linking mode there is a highlight around a tag holding a result, so user can select it to attach the result. Any change to result is reflected in a comment. If that's the per-region result it will be styled as a region and will display region index. Comment icons are added directly to a result.
<img width="669" alt="results with comments" src="https://github.com/user-attachments/assets/9687039e-1bc9-494f-911e-dbbcbf692c84">



### PR fulfills these requirements
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)

#### Change has impacts in these area(s)
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend

#### Does this change affect performance?
It's iterating over all the results in linking mode, that should be checked.

#### Does this change affect security?
nope

#### What feature flags were used to cover this change?
All this is hidden behind `fflag_feat_all_leap_1430_per_field_comments_100924_short`

### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
- [ ] e2e
- [ ] integration
- [ ] unit

