### PR TITLE
refactor: OPTIC-1200: stale ff fflag_feat_all_optic_114_soft_delete_f…

### DIFF
--- a/label_studio/core/feature_flags/base.py
+++ b/label_studio/core/feature_flags/base.py
@@ -107,7 +107,6 @@ def flag_set(feature_flag, user=None, override_system_default=None):
         if request and getattr(request, 'user', None) and request.user.is_authenticated:
             user = request.user
 
-    user_dict = _get_user_repr(user)
     env_value = get_bool_env(feature_flag, default=None)
     if env_value is not None:
         return env_value
@@ -115,6 +114,7 @@ def flag_set(feature_flag, user=None, override_system_default=None):
         system_default = override_system_default
     else:
         system_default = settings.FEATURE_FLAGS_DEFAULT_VALUE
+    user_dict = _get_user_repr(user)
     return client.variation(feature_flag, user_dict, system_default)
 
 

--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -57,4 +57,5 @@ STALE_FEATURE_FLAGS = {
     'fflag_feat_optic_198_multi_select_users_short': True,
     'fflag_fix_back_lsdv_5410_temporary_disable_auto_inference_jobs_short': True,
     'fflag_feat_front_prod_292_archive_workspaces_short': True,
+    'fflag_feat_all_optic_114_soft_delete_for_churned_employees': True,
 }


### PR DESCRIPTION
Stale a feature flag that is already filtering in the cloud. We know that disablig this has a negative impact on performance and is an unsupported path, so it should remain enabled.

