### PR TITLE
fix: LEAP-1560: Add interface for requiring comments on rejection in QuickView

### DIFF
--- a/web/libs/datamanager/src/sdk/lsf-sdk.js
+++ b/web/libs/datamanager/src/sdk/lsf-sdk.js
@@ -155,6 +155,10 @@ export class LSFWrapper {
       interfaces.push("comments:resolve-any");
     }
 
+    if (this.project.review_settings.require_comment_on_reject) {
+      interfaces.push("comments:reject");
+    }
+
     if (this.interfacesModifier) {
       interfaces = this.interfacesModifier(interfaces, this.labelStream);
     }


### PR DESCRIPTION
This PR makes an option
![image](https://github.com/user-attachments/assets/a995c198-94de-4ab5-a219-f557583f52fc)
work with QuickView when it is in a Review mode.

### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
In the context of last changes we gain an ability to make a review from QuickView. But as QuickView and ReviewStream modes are separated in code, we missed some interfaces when moved functionality.



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
 `QuickView`

