### PR TITLE
fix: LEAP-1586: Fix CommentsOverlay display without preloading image functionality

### DIFF
--- a/web/libs/editor/src/components/InteractiveOverlays/CommentsOverlay.tsx
+++ b/web/libs/editor/src/components/InteractiveOverlays/CommentsOverlay.tsx
@@ -242,9 +242,7 @@ const WhenTagsReady: React.FC<WhenTagsReadyProps> = memo(
     if (
       !Array.from(tags.values()).every((tag) => {
         if (!isAlive(tag)) return false;
-        // Unfortunately, for some reason image do not use `isReady` in the way it was planed to do, so we need to check it separately
-        // @ts-ignore
-        if (tag.imageIsLoaded === false) return false;
+
         return tag?.isReady ?? true;
       }, true)
     ) {


### PR DESCRIPTION
Apparently, the conditions we used do not work without feature flag  `fflag_feat_front_lsdv_4583_6_images_preloading_short`.  

But it also seems that this condition made sense only at the stage of developing the CommentsOverlay functionality. Somehow, I can't find a reason why I needed it before. So I'm removing it for the greater good.

### PR fulfills these requirements
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
Comments overlay is not displayed with some feature flags states.



#### What alternative approaches were there?
We could change the condition to
```TypeScript
if (isFF(FF_LSDV_4583_6) && tag.imageIsLoaded === false) return false;
```
but that leads to the blinking of all comment icons when switching pages for multi-item object tags.


### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
`CommentsOverlay`

