### PR TITLE
feat: LEAP-1592: Hide task navigation arrow based on setting

### DIFF
--- a/web/libs/datamanager/src/sdk/lsf-sdk.js
+++ b/web/libs/datamanager/src/sdk/lsf-sdk.js
@@ -120,7 +120,7 @@ export class LSFWrapper {
 
     if (this.labelStream) {
       interfaces.push("infobar");
-      interfaces.push("topbar:prevnext");
+      if (!window.APP_SETTINGS.label_stream_navigation_disabled) interfaces.push("topbar:prevnext");
       if (FF_DEV_2186 && this.project.review_settings?.require_comment_on_reject) {
         interfaces.push("comments:update");
       }

--- a/web/libs/editor/src/components/TopBar/CurrentTask.jsx
+++ b/web/libs/editor/src/components/TopBar/CurrentTask.jsx
@@ -65,7 +65,8 @@ export const CurrentTask = observer(({ store }) => {
       >
         <Elem name="task-id" style={{ fontSize: isFF(FF_DEV_3873) ? 12 : 14 }}>
           {store.task.id ?? guidGenerator()}
-          {(historyEnabled || showCounter) &&
+          {historyEnabled &&
+            showCounter &&
             (isFF(FF_TASK_COUNT_FIX) ? (
               <Elem name="task-count">
                 {store.queuePosition} of {store.queueTotal}

--- a/web/libs/editor/src/components/TopBar/CurrentTask.jsx
+++ b/web/libs/editor/src/components/TopBar/CurrentTask.jsx
@@ -65,8 +65,7 @@ export const CurrentTask = observer(({ store }) => {
       >
         <Elem name="task-id" style={{ fontSize: isFF(FF_DEV_3873) ? 12 : 14 }}>
           {store.task.id ?? guidGenerator()}
-          {historyEnabled &&
-            showCounter &&
+          {(historyEnabled || showCounter) &&
             (isFF(FF_TASK_COUNT_FIX) ? (
               <Elem name="task-count">
                 {store.queuePosition} of {store.queueTotal}


### PR DESCRIPTION
If `label_stream_navigation_disabled` is set to true, hide arrows. Hide task counter as well with this setting.

### PR fulfills these requirements
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)

#### Change has impacts in these area(s)
- [x] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend

### Describe the reason for change
This leads to annotators overlap sometimes because it's hard to track all possible combinations of people working on a task/annotation.

#### What alternative approaches were there?
In general there are different approaches to prevent overlap, that's one of experiments.

#### What feature flags were used to cover this change?
It's org setting, so no FF needed.

### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
- [ ] e2e
- [ ] integration
- [ ] unit
