### PR TITLE
feat: LEAP-1476: Add ability to edit classifications on existing comments

### DIFF
--- a/web/libs/editor/src/components/Comments/Comment/CommentForm.tsx
+++ b/web/libs/editor/src/components/Comments/Comment/CommentForm.tsx
@@ -12,9 +12,7 @@ import { LinkState } from "./LinkState";
 import "./CommentForm.scss";
 import { NewTaxonomy as Taxonomy, type TaxonomyPath } from "../../../components/NewTaxonomy/NewTaxonomy";
 import { CommentFormButtons } from "./CommentFormButtons";
-import { taxonomyPathsToSelectedItems } from "../../../utils/commentClassification";
-
-const TAXONOMY_OPTIONS = { pathSeparator: "/", showFullPath: true };
+import { taxonomyPathsToSelectedItems, COMMENT_TAXONOMY_OPTIONS } from "../../../utils/commentClassification";
 
 export type CommentFormProps = {
   commentStore: any;
@@ -174,7 +172,7 @@ export const CommentForm: FC<CommentFormProps> = observer(({ commentStore, annot
               selected={selections}
               items={classificationsItems}
               onChange={taxonomyOnChange}
-              options={TAXONOMY_OPTIONS}
+              options={COMMENT_TAXONOMY_OPTIONS}
               defaultSearch={false}
             />
           </Elem>

--- a/web/libs/editor/src/components/Comments/Comment/CommentItem.scss
+++ b/web/libs/editor/src/components/Comments/Comment/CommentItem.scss
@@ -115,6 +115,10 @@
     overflow: hidden;
   }
 
+  &__classifications-row > div {
+    width: 100%;
+  }
+
   &__linkState {
     padding: 4px 0 0;
     margin-left: -5px;

--- a/web/libs/editor/src/components/Comments/Comment/CommentItem.tsx
+++ b/web/libs/editor/src/components/Comments/Comment/CommentItem.tsx
@@ -13,9 +13,13 @@ import { Block, Elem } from "../../../utils/bem";
 import { humanDateDiff, userDisplayName } from "../../../utils/utilities";
 import { CommentFormBase } from "../CommentFormBase";
 import { CommentsContext } from "./CommentsList";
+import { NewTaxonomy as Taxonomy, type TaxonomyPath } from "../../../components/NewTaxonomy/NewTaxonomy";
+import { taxonomyPathsToSelectedItems } from "../../../utils/commentClassification";
 
 import "./CommentItem.scss";
 import { LinkState } from "./LinkState";
+
+const TAXONOMY_OPTIONS = { pathSeparator: "/", showFullPath: true };
 
 interface CommentItemProps {
   comment: {
@@ -33,6 +37,7 @@ interface CommentItemProps {
     updateComment: (comment: string, classifications?: any) => void;
     deleteComment: () => void;
     setConfirmMode: (confirmMode: boolean) => void;
+    setClassifications: (classifications: any) => void;
     setEditMode: (isGoingIntoEditMode: boolean) => void;
     toggleResolve: () => void;
     canResolveAny: boolean;
@@ -42,198 +47,222 @@ interface CommentItemProps {
     _commentRef: React.Ref<HTMLElement>;
   };
   listComments: ({ suppressClearComments }: { suppressClearComments: boolean }) => void;
+  classificationsItems: any;
 }
 
-export const CommentItem: FC<CommentItemProps> = observer(({ comment, listComments }: CommentItemProps) => {
-  const {
-    classifications,
-    updatedAt,
-    isEditMode,
-    isConfirmDelete,
-    createdAt,
-    isPersisted,
-    isDeleted,
-    createdBy,
-    text: initialText,
-    regionRef,
-    isResolved: resolved,
-    updateComment,
-    deleteComment,
-    setConfirmMode,
-    setEditMode,
-    toggleResolve,
-    canResolveAny,
-    isHighlighted,
-    setHighlighted,
-    _commentRef,
-  } = comment;
-  const { startLinkingMode: _startLinkingMode, currentComment, globalLinking } = useContext(CommentsContext);
-  const currentUser = window.APP_SETTINGS?.user;
-  const isCreator = currentUser?.id === createdBy.id;
-  const [text, setText] = useState(initialText);
+export const CommentItem: FC<CommentItemProps> = observer(
+  ({ comment, listComments, classificationsItems }: CommentItemProps) => {
+    const {
+      classifications,
+      updatedAt,
+      isEditMode,
+      isConfirmDelete,
+      createdAt,
+      isPersisted,
+      isDeleted,
+      createdBy,
+      text: initialText,
+      regionRef,
+      isResolved: resolved,
+      updateComment,
+      deleteComment,
+      setConfirmMode,
+      setClassifications,
+      setEditMode,
+      toggleResolve,
+      canResolveAny,
+      isHighlighted,
+      setHighlighted,
+      _commentRef,
+    } = comment;
+    const { startLinkingMode: _startLinkingMode, currentComment, globalLinking } = useContext(CommentsContext);
+    const currentUser = window.APP_SETTINGS?.user;
+    const isCreator = currentUser?.id === createdBy.id;
+    const [text, setText] = useState(initialText);
 
-  const [linkingComment, setLinkingComment] = useState();
-  const region = regionRef?.region;
-  const result = regionRef?.result;
-  const linking = !!(linkingComment && currentComment === linkingComment && globalLinking);
-  const hasLinkState = linking || region;
+    const [linkingComment, setLinkingComment] = useState();
+    const region = regionRef?.region;
+    const result = regionRef?.result;
+    const linking = !!(linkingComment && currentComment === linkingComment && globalLinking);
+    const hasLinkState = linking || region;
 
-  const startLinkingMode = useCallback(
-    (comment: any) => {
-      setLinkingComment(comment);
-      _startLinkingMode(comment);
-    },
-    [_startLinkingMode],
-  );
+    const startLinkingMode = useCallback(
+      (comment: any) => {
+        setLinkingComment(comment);
+        _startLinkingMode(comment);
+      },
+      [_startLinkingMode],
+    );
 
-  const toggleLink = useCallback(() => {
-    if (regionRef?.region) {
-      comment.unsetLink();
-    } else {
-      startLinkingMode(comment);
-    }
-  }, [comment, startLinkingMode, regionRef?.region]);
+    const toggleLink = useCallback(() => {
+      if (regionRef?.region) {
+        comment.unsetLink();
+      } else {
+        startLinkingMode(comment);
+      }
+    }, [comment, startLinkingMode, regionRef?.region]);
 
-  if (isDeleted) return null;
+    if (isDeleted) return null;
 
-  const TimeTracker = () => {
-    const editedTimeAchondritic = new Date(updatedAt);
-    const createdTimeAchondritic = new Date(createdAt);
+    const TimeTracker = () => {
+      const editedTimeAchondritic = new Date(updatedAt);
+      const createdTimeAchondritic = new Date(createdAt);
 
-    editedTimeAchondritic.setMilliseconds(0);
-    createdTimeAchondritic.setMilliseconds(0);
+      editedTimeAchondritic.setMilliseconds(0);
+      createdTimeAchondritic.setMilliseconds(0);
 
-    const isEdited = editedTimeAchondritic > createdTimeAchondritic;
-    const time = isEdited ? updatedAt : createdAt;
+      const isEdited = editedTimeAchondritic > createdTimeAchondritic;
+      const time = isEdited ? updatedAt : createdAt;
 
-    if (isPersisted && time)
-      return (
-        <Elem name="date">
-          <Tooltip placement="topRight" title={new Date(time).toLocaleString()}>
-            {`${isEdited ? "updated" : ""} ${humanDateDiff(time)}`}
-          </Tooltip>
-        </Elem>
-      );
-    return null;
-  };
-
-  return (
-    <Block
-      name="comment-item"
-      mod={{ resolved, highlighted: isHighlighted }}
-      onMouseEnter={() => {
-        setHighlighted(true);
-      }}
-      onMouseLeave={() => {
-        setHighlighted(false);
-      }}
-      ref={_commentRef}
-    >
-      <Space spread size="medium" truncated>
-        <Space size="small" truncated>
-          <Elem tag={Userpic} user={createdBy} name="userpic" showUsername username={createdBy} />
-          <Elem name="name" tag="span">
-            {userDisplayName(createdBy)}
+      if (isPersisted && time)
+        return (
+          <Elem name="date">
+            <Tooltip placement="topRight" title={new Date(time).toLocaleString()}>
+              {`${isEdited ? "updated" : ""} ${humanDateDiff(time)}`}
+            </Tooltip>
           </Elem>
-        </Space>
+        );
+      return null;
+    };
 
-        <Space size="small">
-          <Elem name="resolved" component={IconCheck} />
-          <Elem name="saving" mod={{ hide: isPersisted }}>
-            <Elem name="dot" />
-          </Elem>
-          <TimeTracker />
-        </Space>
-      </Space>
-
-      <Elem name="content">
-        <Elem name="text">
-          {isEditMode ? (
-            <CommentFormBase
-              value={text}
-              onSubmit={async (value) => {
-                await updateComment(value);
-                setText(value);
-                await listComments({ suppressClearComments: true });
-              }}
-            />
-          ) : isConfirmDelete ? (
-            <Elem name="confirmForm">
-              <Elem name="question">Are you sure?</Elem>
-              <Elem name="controls">
-                <Button onClick={() => deleteComment()} size="compact" look="danger" autoFocus>
-                  Yes
-                </Button>
-                <Button onClick={() => setConfirmMode(false)} size="compact">
-                  No
-                </Button>
-              </Elem>
+    return (
+      <Block
+        name="comment-item"
+        mod={{ resolved, highlighted: isHighlighted }}
+        onMouseEnter={() => {
+          setHighlighted(true);
+        }}
+        onMouseLeave={() => {
+          setHighlighted(false);
+        }}
+        ref={_commentRef}
+      >
+        <Space spread size="medium" truncated>
+          <Space size="small" truncated>
+            <Elem tag={Userpic} user={createdBy} name="userpic" showUsername username={createdBy} />
+            <Elem name="name" tag="span">
+              {userDisplayName(createdBy)}
             </Elem>
-          ) : (
-            <>
-              {classifications?.default?.values?.length > 0 && (
-                <Elem name="classifications" tag="ul">
-                  {classifications?.default?.values?.map((valueArray: string[], index: number) => (
-                    <li key={index}>{valueArray.join("/")}</li>
-                  ))}
-                </Elem>
-              )}
-              {text}
-              {hasLinkState && (
-                <Elem name="linkState">
-                  <LinkState linking={linking} region={region} result={result} interactive />
-                </Elem>
-              )}
-            </>
-          )}
-        </Elem>
+          </Space>
 
-        <Elem
-          name="actions"
-          onClick={(e: any) => {
-            e.stopPropagation();
-            e.preventDefault();
-          }}
-        >
-          {isPersisted && (isCreator || canResolveAny) && (
-            <Dropdown.Trigger
-              content={
-                <Menu size="auto">
-                  <Menu.Item onClick={toggleResolve}>{resolved ? "Unresolve" : "Resolve"}</Menu.Item>
-                  {isCreator && (
-                    <>
-                      <Menu.Item
-                        onClick={() => {
-                          const isGoingIntoEditMode = !isEditMode;
+          <Space size="small">
+            <Elem name="resolved" component={IconCheck} />
+            <Elem name="saving" mod={{ hide: isPersisted }}>
+              <Elem name="dot" />
+            </Elem>
+            <TimeTracker />
+          </Space>
+        </Space>
 
-                          setEditMode(isGoingIntoEditMode);
-                          if (!isGoingIntoEditMode) {
-                            setText(initialText);
+        <Elem name="content">
+          <Elem name="text">
+            {isEditMode ? (
+              <>
+                <CommentFormBase
+                  value={text}
+                  onSubmit={async (value) => {
+                    await updateComment(value, classifications);
+                    setText(value);
+                    await listComments({ suppressClearComments: true });
+                  }}
+                />
+                <Taxonomy
+                  selected={taxonomyPathsToSelectedItems(classifications?.default?.values)}
+                  items={classificationsItems}
+                  onChange={async (_: Node, values: TaxonomyPath[]) => {
+                    const newClassifications =
+                      values.length > 0
+                        ? {
+                            default: {
+                              type: "taxonomy",
+                              values,
+                            },
                           }
-                        }}
-                      >
-                        {isEditMode ? "Cancel edit" : "Edit"}
-                      </Menu.Item>
-                      <Menu.Item onClick={toggleLink}>{regionRef?.region ? "Unlink" : "Link to..."}</Menu.Item>
-                      {!isConfirmDelete && (
+                        : null;
+                    setClassifications(newClassifications);
+                  }}
+                  options={TAXONOMY_OPTIONS}
+                  defaultSearch={false}
+                />
+              </>
+            ) : isConfirmDelete ? (
+              <Elem name="confirmForm">
+                <Elem name="question">Are you sure?</Elem>
+                <Elem name="controls">
+                  <Button onClick={() => deleteComment()} size="compact" look="danger" autoFocus>
+                    Yes
+                  </Button>
+                  <Button onClick={() => setConfirmMode(false)} size="compact">
+                    No
+                  </Button>
+                </Elem>
+              </Elem>
+            ) : (
+              <>
+                {classifications?.default?.values?.length > 0 && (
+                  <Elem name="classifications" tag="ul">
+                    {classifications?.default?.values?.map((valueArray: string[], index: number) => (
+                      <li key={index}>{valueArray.join("/")}</li>
+                    ))}
+                  </Elem>
+                )}
+                {text}
+                {hasLinkState && (
+                  <Elem name="linkState">
+                    <LinkState linking={linking} region={region} result={result} interactive />
+                  </Elem>
+                )}
+              </>
+            )}
+          </Elem>
+
+          <Elem
+            name="actions"
+            onClick={(e: any) => {
+              e.stopPropagation();
+              e.preventDefault();
+            }}
+          >
+            {isPersisted && (isCreator || canResolveAny) && (
+              <Dropdown.Trigger
+                content={
+                  <Menu size="auto">
+                    <Menu.Item onClick={toggleResolve}>{resolved ? "Unresolve" : "Resolve"}</Menu.Item>
+                    {isCreator && (
+                      <>
                         <Menu.Item
                           onClick={() => {
-                            setConfirmMode(true);
+                            const isGoingIntoEditMode = !isEditMode;
+
+                            setEditMode(isGoingIntoEditMode);
+                            if (!isGoingIntoEditMode) {
+                              setText(initialText);
+                            }
                           }}
                         >
-                          Delete
+                          {isEditMode ? "Cancel edit" : "Edit"}
                         </Menu.Item>
-                      )}
-                    </>
-                  )}
-                </Menu>
-              }
-            >
-              <Button size="small" type="text" icon={<IconEllipsis />} />
-            </Dropdown.Trigger>
-          )}
+                        <Menu.Item onClick={toggleLink}>{regionRef?.region ? "Unlink" : "Link to..."}</Menu.Item>
+                        {!isConfirmDelete && (
+                          <Menu.Item
+                            onClick={() => {
+                              setConfirmMode(true);
+                            }}
+                          >
+                            Delete
+                          </Menu.Item>
+                        )}
+                      </>
+                    )}
+                  </Menu>
+                }
+              >
+                <Button size="small" type="text" icon={<IconEllipsis />} />
+              </Dropdown.Trigger>
+            )}
+          </Elem>
         </Elem>
-      </Elem>
-    </Block>
-  );
-});
+      </Block>
+    );
+  },
+);

--- a/web/libs/editor/src/components/Comments/Comment/CommentItem.tsx
+++ b/web/libs/editor/src/components/Comments/Comment/CommentItem.tsx
@@ -14,12 +14,10 @@ import { humanDateDiff, userDisplayName } from "../../../utils/utilities";
 import { CommentFormBase } from "../CommentFormBase";
 import { CommentsContext } from "./CommentsList";
 import { NewTaxonomy as Taxonomy, type TaxonomyPath } from "../../../components/NewTaxonomy/NewTaxonomy";
-import { taxonomyPathsToSelectedItems } from "../../../utils/commentClassification";
+import { taxonomyPathsToSelectedItems, COMMENT_TAXONOMY_OPTIONS } from "../../../utils/commentClassification";
 
 import "./CommentItem.scss";
 import { LinkState } from "./LinkState";
-
-const TAXONOMY_OPTIONS = { pathSeparator: "/", showFullPath: true };
 
 interface CommentItemProps {
   comment: {
@@ -165,25 +163,30 @@ export const CommentItem: FC<CommentItemProps> = observer(
                     setText(value);
                     await listComments({ suppressClearComments: true });
                   }}
+                  classifications={classifications}
                 />
-                <Taxonomy
-                  selected={taxonomyPathsToSelectedItems(classifications?.default?.values)}
-                  items={classificationsItems}
-                  onChange={async (_: Node, values: TaxonomyPath[]) => {
-                    const newClassifications =
-                      values.length > 0
-                        ? {
-                            default: {
-                              type: "taxonomy",
-                              values,
-                            },
-                          }
-                        : null;
-                    setClassifications(newClassifications);
-                  }}
-                  options={TAXONOMY_OPTIONS}
-                  defaultSearch={false}
-                />
+                {classificationsItems.length > 0 && (
+                  <Elem name="classifications-row">
+                    <Taxonomy
+                      selected={taxonomyPathsToSelectedItems(classifications?.default?.values)}
+                      items={classificationsItems}
+                      onChange={async (_: Node, values: TaxonomyPath[]) => {
+                        const newClassifications =
+                          values.length > 0
+                            ? {
+                                default: {
+                                  type: "taxonomy",
+                                  values,
+                                },
+                              }
+                            : null;
+                        setClassifications(newClassifications);
+                      }}
+                      options={COMMENT_TAXONOMY_OPTIONS}
+                      defaultSearch={false}
+                    />
+                  </Elem>
+                )}
               </>
             ) : isConfirmDelete ? (
               <Elem name="confirmForm">

--- a/web/libs/editor/src/components/Comments/Comment/CommentsList.tsx
+++ b/web/libs/editor/src/components/Comments/Comment/CommentsList.tsx
@@ -41,7 +41,12 @@ export const CommentsListInner: FC<{ commentStore: any }> = observer(({ commentS
   return (
     <Block name="comments-list">
       {commentStore.comments.map((comment: any) => (
-        <CommentItem key={comment.id} comment={comment} listComments={commentStore.listComments} />
+        <CommentItem
+          key={comment.id}
+          comment={comment}
+          listComments={commentStore.listComments}
+          classificationsItems={commentStore.commentClassificationsItems}
+        />
       ))}
     </Block>
   );

--- a/web/libs/editor/src/components/Comments/CommentFormBase.tsx
+++ b/web/libs/editor/src/components/Comments/CommentFormBase.tsx
@@ -13,10 +13,11 @@ export type CommentFormProps = {
   inline?: boolean;
   rows?: number;
   maxRows?: number;
+  classifications?: object | null;
 };
 
 export const CommentFormBase: FC<CommentFormProps> = observer(
-  ({ value = "", inline = true, onChange, onSubmit, onBlur, rows = 1, maxRows = 4 }) => {
+  ({ value = "", inline = true, onChange, onSubmit, onBlur, rows = 1, maxRows = 4, classifications }) => {
     const formRef = useRef<HTMLFormElement>(null);
     const actionRef = useRef<{ update?: (text?: string) => void; el?: RefObject<HTMLTextAreaElement> }>({});
 
@@ -28,7 +29,7 @@ export const CommentFormBase: FC<CommentFormProps> = observer(
 
         const comment = (new FormData(formRef.current).get("comment") as string)?.trim();
 
-        if (!comment) return;
+        if (!comment && !classifications) return;
 
         onSubmit?.(comment);
       },

--- a/web/libs/editor/src/stores/Comment/Comment.js
+++ b/web/libs/editor/src/stores/Comment/Comment.js
@@ -147,12 +147,18 @@ export const Comment = CommentBase.named("Comment")
       self.isConfirmDelete = newMode;
     }
 
-    const updateComment = flow(function* (comment) {
+    const updateComment = flow(function* (comment, classifications = undefined) {
       if (self.isPersisted && !self.isDeleted) {
-        yield self.sdk.invoke("comments:update", {
+        const payload = {
           id: self.id,
           text: comment,
-        });
+        };
+
+        if (classifications !== undefined) {
+          payload.classifications = classifications;
+        }
+
+        yield self.sdk.invoke("comments:update", payload);
       }
 
       self.setEditMode(false);

--- a/web/libs/editor/src/utils/commentClassification.ts
+++ b/web/libs/editor/src/utils/commentClassification.ts
@@ -54,3 +54,5 @@ export const taxonomyPathsToSelectedItems = (paths: TaxonomyPath[] | null): Sele
         })),
       )
     : [];
+
+export const COMMENT_TAXONOMY_OPTIONS = { pathSeparator: "/", showFullPath: true };


### PR DESCRIPTION
If there's no taxonomy defined or the FF is off, there are no changes. Otherwise, allow submitting a comment edit if it has either a category selected or a nonempty body (just like when creating a comment). Best viewed with `?w=1` because the formatter made a bunch of changes to whitespace. Simple UX has been cleared with @alecjonharris.

![Screenshot from 2024-10-16 15-46-29](https://github.com/user-attachments/assets/1a867cf5-d42a-481c-88b2-89e607a9737c)
