### PR TITLE
fix: LEAP-1596: Missed check for review_settings

### DIFF
--- a/web/libs/datamanager/src/sdk/lsf-sdk.js
+++ b/web/libs/datamanager/src/sdk/lsf-sdk.js
@@ -155,7 +155,7 @@ export class LSFWrapper {
       interfaces.push("comments:resolve-any");
     }
 
-    if (this.project.review_settings.require_comment_on_reject) {
+    if (this.project.review_settings?.require_comment_on_reject) {
       interfaces.push("comments:reject");
     }
 


### PR DESCRIPTION
`review_settings` are not defined in LSO, leading to app crash.

