### PR TITLE
fix: LEAP-1577: Fix saving linked results at backend

### DIFF
--- a/web/libs/editor/src/stores/Comment/Comment.js
+++ b/web/libs/editor/src/stores/Comment/Comment.js
@@ -9,6 +9,12 @@ import { UserExtended } from "../UserStore";
 
 import { Anchor } from "./Anchor";
 
+/**
+ * A reduced version of the Comment model.
+ * It is used only for creating a new comment, storing values in the similar structure
+ * and to handle some actions that should be present in both cases (creating and editing).
+ * So that some actions have to be overridden in the Comment model in case we want them to work properly with the backend.
+ */
 export const CommentBase = types
   .model("CommentBase", {
     text: types.string,
@@ -84,6 +90,10 @@ export const CommentBase = types
     };
   });
 
+/**
+ * The main Comment model.
+ * Should be fully functional and used for all cases except creating a new comment.
+ */
 export const Comment = CommentBase.named("Comment")
   .props({
     id: types.identifierNumber,

--- a/web/libs/editor/src/stores/Comment/Comment.js
+++ b/web/libs/editor/src/stores/Comment/Comment.js
@@ -188,6 +188,14 @@ export const Comment = CommentBase.named("Comment")
       self.update({ regionRef });
     }
 
+    function setResultLink(result) {
+      const regionRef = {
+        regionId: result.area.cleanId,
+        controlName: result.from_name.name,
+      };
+      self.update({ regionRef });
+    }
+
     function unsetLink() {
       const regionRef = null;
       self.update({ regionRef });
@@ -224,6 +232,7 @@ export const Comment = CommentBase.named("Comment")
       update,
       deleteComment,
       setRegionLink,
+      setResultLink,
       unsetLink,
       scrollIntoView,
     };


### PR DESCRIPTION
Adding linked results did not save them in the backend.

The problem was that we had two models: one was just for creating comments and one was fully functional. In order to save information correctly, we needed to add a simple method to the CommentsBase model that only allowed data to be stored in the model. Overriding this method in the Comment model using , we could notify the external SDK of changes through the event system and handle cases where the SDKs were not allowed to apply those changes if there were problems with the network, for example.

### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
`Comments`, `LinkedModes`

