### PR TITLE
feat: Add hiding resolved comments in CommentsOverlay

### DIFF
--- a/web/libs/editor/src/components/InteractiveOverlays/CommentsOverlay.tsx
+++ b/web/libs/editor/src/components/InteractiveOverlays/CommentsOverlay.tsx
@@ -37,7 +37,7 @@ const CommentItem: React.FC<CommentItemProps> = observer(({ comment, rootRef }) 
   const node = comment.regionRef?.overlayNode;
   // result is hidden when it's per-region and the region is not selected
   const isHiddenResult = node?.area && !node.area.selected && !node.area.classification;
-  const isHidden = !node || node.hidden || isHiddenResult;
+  const isHidden = comment.isResolved || !node || node.hidden || isHiddenResult;
   // {} !== {} it's always so, and it's a way to force re-render
   const [forceUpdateId, forceUpdate] = useState<any>({});
 


### PR DESCRIPTION
This PR applies hiding comments icon in the CommentsOverlay when the comments is self are marked as resolved. 

### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)


### Which logical domain(s) does this change affect?
`Comments`, `CommentsOverlay`

