### PR TITLE
fix: LEAP-1609: Fix missing `useState` import

### DIFF
--- a/web/apps/labelstudio/src/pages/CreateProject/Config/Preview.jsx
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/Preview.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Spinner } from "../../../components";
 import { cn } from "../../../utils/bem";
 import { FF_DEV_3617, isFF } from "../../../utils/feature-flags";


### PR DESCRIPTION
It was removed by accident in https://github.com/HumanSignal/label-studio/pull/6425
