### PR TITLE
fix: LEAP-1620: Ignore prefixes for storage url resolving

### DIFF
--- a/label_studio/io_storages/utils.py
+++ b/label_studio/io_storages/utils.py
@@ -78,7 +78,4 @@ def storage_can_resolve_bucket_url(storage, url) -> bool:
     if storage_bucket != uri.bucket:
         return False
 
-    if storage.prefix and not uri.path.startswith(storage.prefix):
-        return False
-
     return True


### PR DESCRIPTION
* remove recently added prefix check, because it broke existing user pipelines