### PR TITLE
docs: add algolia crawler for LS docs

### DIFF
--- a/.github/workflows/algolia-crawler-hs-docs.yml
+++ b/.github/workflows/algolia-crawler-hs-docs.yml
@@ -1,11 +1,11 @@
-name: Algolia Indexer
+name: Algolia Indexer for HumanSignal Docs
 
 on:
   push:
-    branches: [ 'develop' ]
+    branches: ["develop"]
     paths:
-      - 'docs/**'
-      - '.github/workflows/algolia-crawler.yml'
+      - "docs/**"
+      - ".github/workflows/algolia-crawler-hs-docs.yml"
 
 jobs:
   algolia_indexer:
@@ -32,4 +32,4 @@ jobs:
     steps:
       - name: Algolia Docsearch Action
         id: algolia
-        uses:  adapttive/algolia-docsearch-action@1.1.1
+        uses: adapttive/algolia-docsearch-action@1.1.1

--- a/.github/workflows/algolia-crawler-hs-docs.yml
+++ b/.github/workflows/algolia-crawler-hs-docs.yml
@@ -17,17 +17,20 @@ jobs:
       CONFIG: >
         {"index_name": "ghaction",
         "stop_urls": ["https://docs.humansignal.com/guide/index.html", "https://docs.humansignal.com/guide/notion-faq.html", "https://labelstud.io/sdk/index.html"], 
-        "selectors_exclude": [".home-page-index"], 
-        "start_urls": ["https://docs.humansignal.com/guide", "https://docs.humansignal.com/templates", "https://docs.humansignal.com/tags", "https://labelstud.io/sdk/"],
+        "selectors_exclude": [".home-page-index"],
+        "sitemap_urls": ["https://docs.humansignal.com/guide/sitemap-docs.xml", "https://labelstud.io/sitemap-blog.xml"],
         "selectors": {
-        "lvl0": ".content h1, .ResourcesBannerHeading",
-        "lvl1": ".content h2, .ResourcesContent h2",
-        "lvl2": ".content h3, .ResourcesContent h3",
-        "lvl3": ".content h4, .ResourcesContent h4",
-        "lvl4": ".content h5, .ResourcesContent h5",
-        "lvl5": ".content h6, .ResourcesContent h6", 
-        "content": ".content-markdown > *"
-        }}
+            "default": {
+              "lvl0": ".content h1, .ResourcesBannerHeading, .BlogTitle",
+              "lvl1": ".content h2, .ResourcesContent h1, .ResourcesContent h2",
+              "lvl2": ".content h3, .ResourcesContent h3",
+              "lvl3": ".content h4, .ResourcesContent h4",
+              "lvl4": ".content h5, .ResourcesContent h5",
+              "lvl5": ".content h6, .ResourcesContent h6", 
+              "content": ".content-markdown > *, .ResourcesContent > .Text"
+            }
+          }
+        }
     name: Index Algolia
     steps:
       - name: Algolia Docsearch Action

--- a/.github/workflows/algolia-crawler-hs-docs.yml
+++ b/.github/workflows/algolia-crawler-hs-docs.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - "docs/**"
       - ".github/workflows/algolia-crawler-hs-docs.yml"
+  pull_request:
+    branches:
+      - develop
 
 jobs:
   algolia_indexer:

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -1,0 +1,35 @@
+name: Algolia Indexer for Label Studio Docs
+
+on:
+  push:
+    branches: ["develop"]
+    paths:
+      - "docs/**"
+      - ".github/workflows/algolia-crawler-ls-docs.yml"
+
+jobs:
+  algolia_indexer:
+    runs-on: ubuntu-latest
+    env:
+      APPLICATION_ID: "HELLEDAKPT"
+      API_KEY: ${{ secrets.ALGOLIA_ADMIN_API_KEY }}
+      INDEX_NAME: "ghactionls"
+      CONFIG: >
+        {"index_name": "ghactionls",
+        "stop_urls": [], 
+        "selectors_exclude": [".home-page-index"], 
+        "start_urls": ["https://labelstud.io/guide", "https://labelstud.io/templates", "https://labelstud.io/tags", "https://labelstud.io/blog/categories/tutorials/"],
+        "selectors": {
+        "lvl0": ".content h1, .ResourcesBannerHeading, .BlogTitle",
+        "lvl1": ".content h2, .ResourcesContent h2",
+        "lvl2": ".content h3, .ResourcesContent h3",
+        "lvl3": ".content h4, .ResourcesContent h4",
+        "lvl4": ".content h5, .ResourcesContent h5",
+        "lvl5": ".content h6, .ResourcesContent h6", 
+        "content": ".content-markdown > *"
+        }}
+    name: Index Algolia
+    steps:
+      - name: Algolia Docsearch Action
+        id: algolia
+        uses: adapttive/algolia-docsearch-action@1.1.1

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -22,7 +22,27 @@ jobs:
           "index_name": "labelstudiodocs",
           "stop_urls": [], 
           "selectors_exclude": [".home-page-index"], 
-          
+          "start_urls": [
+            {
+              "url": "https://labelstud.io/guide",
+              "selectors_key": "docs"
+              
+            },
+            {
+              "url": "https://labelstud.io/templates",
+              "selectors_key": "docs"
+              
+            },
+            {
+              "url": "https://labelstud.io/tags",
+              "selectors_key": "docs"
+              
+            },
+            {
+              "url": "https://labelstud.io/blog/openai-structured-outputs-with-label-studio/**",
+              "selectors_key": "docs"
+            }
+          ],
           "sitemap_urls": ["https://labelstud.io/sitemap-tutorials.xml"],
           "selectors": {
             "docs": {

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -22,17 +22,16 @@ jobs:
           "index_name": "labelstudiodocs",
           "stop_urls": ["https://labelstud.io/guide/index.html", "https://labelstud.io/sdk/index.html"], 
           "selectors_exclude": [".home-page-index"], 
-          
           "sitemap_urls": ["https://labelstud.io/sitemap-tutorials.xml", "https://deploy-preview-6570--heartex-docs.netlify.app/guide/sitemap-docs.xml"],
           "selectors": {
             "default": {
               "lvl0": ".content h1, .ResourcesBannerHeading, .BlogTitle",
-              "lvl1": ".ResourcesContent h1, .ResourcesContent h2",
-              "lvl2": ".ResourcesContent h3",
-              "lvl3": ".ResourcesContent h4",
-              "lvl4": ".ResourcesContent h5",
-              "lvl5": ".ResourcesContent h6", 
-              "content": ".ResourcesContent > .Text"
+              "lvl1": ".content h2, .ResourcesContent h1, .ResourcesContent h2",
+              "lvl2": ".content h3, .ResourcesContent h3",
+              "lvl3": ".content h4, .ResourcesContent h4",
+              "lvl4": ".content h5, .ResourcesContent h5",
+              "lvl5": ".content h6, .ResourcesContent h6", 
+              "content": ".content-markdown > *, .ResourcesContent > .Text"
             }
           }
         }

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - "docs/**"
       - ".github/workflows/algolia-crawler-ls-docs.yml"
+  pull_request:
+    branches:
+      - develop
 
 jobs:
   algolia_indexer:

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -20,7 +20,7 @@ jobs:
       CONFIG: >
         {
           "index_name": "labelstudiodocs",
-          "stop_urls": [], 
+          "stop_urls": ["https://labelstud.io/guide/index.html", "https://labelstud.io/sdk/index.html"], 
           "selectors_exclude": [".home-page-index"], 
           "start_urls": [
             {
@@ -30,7 +30,7 @@ jobs:
             {
               "url": "https://labelstud.io/templates",
               "selectors_key": "docs"
-            },
+            }
             {
               "url": "https://labelstud.io/tags",
               "selectors_key": "docs"

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -24,15 +24,15 @@ jobs:
           "selectors_exclude": [".home-page-index"], 
           "start_urls": [
           {
-              "url": "https://labelstud.io/guide",
+              "url": "https://labelstud.io/guide"
               
             },
             {
-              "url": "https://labelstud.io/templates",
+              "url": "https://labelstud.io/templates"
               
             },
             {
-              "url": "https://labelstud.io/tags",
+              "url": "https://labelstud.io/tags"
               
             },
             {

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -22,23 +22,7 @@ jobs:
           "index_name": "labelstudiodocs",
           "stop_urls": ["https://labelstud.io/guide/index.html", "https://labelstud.io/sdk/index.html"], 
           "selectors_exclude": [".home-page-index"], 
-          "start_urls": [
-            {
-              "url": "https://labelstud.io/guide",
-              "selectors_key": "docs"
-            },
-            {
-              "url": "https://labelstud.io/templates",
-              "selectors_key": "docs"
-            },
-            {
-              "url": "https://labelstud.io/tags",
-              "selectors_key": "docs"
-            },
-            {
-              "url": "https://labelstud.io/blog/categories/tutorials"
-            }
-          ],
+          
           "sitemap_urls": ["https://labelstud.io/sitemap-tutorials.xml"],
           "selectors": {
             "docs": {

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -18,19 +18,38 @@ jobs:
       API_KEY: ${{ secrets.ALGOLIA_ADMIN_API_KEY }}
       INDEX_NAME: "labelstudiodocs"
       CONFIG: >
-        {"index_name": "labelstudiodocs",
-        "stop_urls": [], 
-        "selectors_exclude": [".home-page-index"], 
-        "start_urls": ["https://labelstud.io/blog/categories/tutorials/"],
-        "selectors": {
-        "lvl0": ".content h1, .ResourcesBannerHeading, .BlogTitle",
-        "lvl1": ".content h2, .ResourcesContent h2",
-        "lvl2": ".content h3, .ResourcesContent h3",
-        "lvl3": ".content h4, .ResourcesContent h4",
-        "lvl4": ".content h5, .ResourcesContent h5",
-        "lvl5": ".content h6, .ResourcesContent h6", 
-        "content": ".content-markdown > *"
-        }}
+        {
+          "index_name": "labelstudiodocs",
+          "stop_urls": [], 
+          "selectors_exclude": [".home-page-index"], 
+          "start_urls": [
+            {
+              "url": "https://labelstud.io/blog/openai-structured-outputs-with-label-studio/",
+              "selectors_key": "blog"
+            },
+          ],
+
+          "selectors": {
+            "default": {
+              "lvl0": ".content h1, .ResourcesBannerHeading",
+              "lvl1": ".content h2, .ResourcesContent h2",
+              "lvl2": ".content h3, .ResourcesContent h3",
+              "lvl3": ".content h4, .ResourcesContent h4",
+              "lvl4": ".content h5, .ResourcesContent h5",
+              "lvl5": ".content h6, .ResourcesContent h6", 
+              "content": ".content-markdown > *"
+            },
+            "blog": {
+              "lvl0": ".BlogTitle",
+              "lvl1": ".ResourcesContent h1, .ResourcesContent h2",
+              "lvl2": ".ResourcesContent h3",
+              "lvl3": ".ResourcesContent h4",
+              "lvl4": ".ResourcesContent h5",
+              "lvl5": ".ResourcesContent h6", 
+              "content": ".ResourcesContent > .Text"
+            }
+          }
+        }
     name: Index Algolia
     steps:
       - name: Algolia Docsearch Action

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -30,11 +30,11 @@ jobs:
             {
               "url": "https://labelstud.io/templates",
               "selectors_key": "docs"
-            }
+            },
             {
               "url": "https://labelstud.io/tags",
               "selectors_key": "docs"
-            },
+            }
           ],
           "sitemap_urls": ["https://labelstud.io/sitemap-tutorials.xml"],
           "selectors": {

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -21,7 +21,7 @@ jobs:
         {"index_name": "labelstudiodocs",
         "stop_urls": [], 
         "selectors_exclude": [".home-page-index"], 
-        "start_urls": ["https://labelstud.io/guide", "https://labelstud.io/templates", "https://labelstud.io/tags", "https://labelstud.io/blog/categories/tutorials/"],
+        "start_urls": ["https://labelstud.io/blog/categories/tutorials/"],
         "selectors": {
         "lvl0": ".content h1, .ResourcesBannerHeading, .BlogTitle",
         "lvl1": ".content h2, .ResourcesContent h2",

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -26,7 +26,7 @@ jobs:
             {
               "url": "https://labelstud.io/blog/openai-structured-outputs-with-label-studio/",
               "selectors_key": "blog"
-            },
+            }
           ],
 
           "selectors": {

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -34,6 +34,9 @@ jobs:
             {
               "url": "https://labelstud.io/tags",
               "selectors_key": "docs"
+            },
+            {
+              "url": "https://labelstud.io/blog/categories/tutorials",
             }
           ],
           "sitemap_urls": ["https://labelstud.io/sitemap-tutorials.xml"],

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -22,7 +22,7 @@ jobs:
           "index_name": "labelstudiodocs",
           "stop_urls": ["https://labelstud.io/guide/index.html", "https://labelstud.io/sdk/index.html"], 
           "selectors_exclude": [".home-page-index"], 
-          "sitemap_urls": ["https://labelstud.io/sitemap-tutorials.xml", "https://deploy-preview-6570--heartex-docs.netlify.app/guide/sitemap-docs.xml"],
+          "sitemap_urls": ["https://labelstud.io/sitemap-blog.xml", "https://deploy-preview-6570--heartex-docs.netlify.app/guide/sitemap-docs.xml"],
           "selectors": {
             "default": {
               "lvl0": ".content h1, .ResourcesBannerHeading, .BlogTitle",

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -34,12 +34,14 @@ jobs:
             {
               "url": "https://labelstud.io/tags"
               
-            },
+            }
+          ],
+          "sitemaps": [
             {
               "url": "https://labelstud.io/sitemap-tutorials.xml",
               "selectors_key": "blog",
             }
-          ],
+          ]
           "selectors": {
             "default": {
               "lvl0": ".content h1, .ResourcesBannerHeading",

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -23,7 +23,7 @@ jobs:
           "stop_urls": [], 
           "selectors_exclude": [".home-page-index"], 
           
-          "sitemaps": ["https://labelstud.io/sitemap-tutorials.xml"],
+          "sitemap_urls": ["https://labelstud.io/sitemap-tutorials.xml"],
           "selectors": {
             "docs": {
               "lvl0": ".content h1, .ResourcesBannerHeading",

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -36,7 +36,7 @@ jobs:
               
             },
             {
-              "url": "https://labelstud.io/blog/openai-structured-outputs-with-label-studio/**",
+              "url": "https://labelstud.io/sitemap-tutorials.xml",
               "selectors_key": "blog",
               "tags": ["tutorials"]
             }

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -38,7 +38,6 @@ jobs:
             {
               "url": "https://labelstud.io/sitemap-tutorials.xml",
               "selectors_key": "blog",
-              "tags": ["tutorials"]
             }
           ],
           "selectors": {

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -23,19 +23,10 @@ jobs:
           "stop_urls": ["https://labelstud.io/guide/index.html", "https://labelstud.io/sdk/index.html"], 
           "selectors_exclude": [".home-page-index"], 
           
-          "sitemap_urls": ["https://labelstud.io/sitemap-tutorials.xml"],
+          "sitemap_urls": ["https://labelstud.io/sitemap-tutorials.xml", "https://deploy-preview-6570--heartex-docs.netlify.app/guide/sitemap-docs.xml"],
           "selectors": {
-            "docs": {
-              "lvl0": ".content h1, .ResourcesBannerHeading",
-              "lvl1": ".content h2, .ResourcesContent h2",
-              "lvl2": ".content h3, .ResourcesContent h3",
-              "lvl3": ".content h4, .ResourcesContent h4",
-              "lvl4": ".content h5, .ResourcesContent h5",
-              "lvl5": ".content h6, .ResourcesContent h6", 
-              "content": ".content-markdown > *"
-            },
             "default": {
-              "lvl0": ".BlogTitle",
+              "lvl0": ".content h1, .ResourcesBannerHeading, .BlogTitle",
               "lvl1": ".ResourcesContent h1, .ResourcesContent h2",
               "lvl2": ".ResourcesContent h3",
               "lvl3": ".ResourcesContent h4",

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -23,12 +23,24 @@ jobs:
           "stop_urls": [], 
           "selectors_exclude": [".home-page-index"], 
           "start_urls": [
+          {
+              "url": "https://labelstud.io/guide",
+              
+            },
             {
-              "url": "https://labelstud.io/blog/openai-structured-outputs-with-label-studio/",
-              "selectors_key": "blog"
+              "url": "https://labelstud.io/templates",
+              
+            },
+            {
+              "url": "https://labelstud.io/tags",
+              
+            },
+            {
+              "url": "https://labelstud.io/blog/openai-structured-outputs-with-label-studio/**",
+              "selectors_key": "blog",
+              "tags": ["tutorials"]
             }
           ],
-
           "selectors": {
             "default": {
               "lvl0": ".content h1, .ResourcesBannerHeading",

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -39,9 +39,9 @@ jobs:
           "sitemaps": [
             {
               "url": "https://labelstud.io/sitemap-tutorials.xml",
-              "selectors_key": "blog",
+              "selectors_key": "blog"
             }
-          ]
+          ],
           "selectors": {
             "default": {
               "lvl0": ".content h1, .ResourcesBannerHeading",

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -14,11 +14,11 @@ jobs:
   algolia_indexer:
     runs-on: ubuntu-latest
     env:
-      APPLICATION_ID: "HELLEDAKPT"
+      APPLICATION_ID: "M7RXTHKYPM"
       API_KEY: ${{ secrets.ALGOLIA_ADMIN_API_KEY }}
-      INDEX_NAME: "ghactionls"
+      INDEX_NAME: "labelstudiodocs"
       CONFIG: >
-        {"index_name": "ghactionls",
+        {"index_name": "labelstudiodocs",
         "stop_urls": [], 
         "selectors_exclude": [".home-page-index"], 
         "start_urls": ["https://labelstud.io/guide", "https://labelstud.io/templates", "https://labelstud.io/tags", "https://labelstud.io/blog/categories/tutorials/"],

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -22,7 +22,7 @@ jobs:
           "index_name": "labelstudiodocs",
           "stop_urls": ["https://labelstud.io/guide/index.html", "https://labelstud.io/sdk/index.html"], 
           "selectors_exclude": [".home-page-index"], 
-          "sitemap_urls": ["https://labelstud.io/sitemap-blog.xml", "https://deploy-preview-6570--heartex-docs.netlify.app/guide/sitemap-docs.xml"],
+          "sitemap_urls": ["https://labelstud.io/sitemap-blog.xml", "https://labelstud.io/guide/sitemap-docs.xml"],
           "selectors": {
             "default": {
               "lvl0": ".content h1, .ResourcesBannerHeading, .BlogTitle",

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -26,22 +26,15 @@ jobs:
             {
               "url": "https://labelstud.io/guide",
               "selectors_key": "docs"
-              
             },
             {
               "url": "https://labelstud.io/templates",
               "selectors_key": "docs"
-              
             },
             {
               "url": "https://labelstud.io/tags",
               "selectors_key": "docs"
-              
             },
-            {
-              "url": "https://labelstud.io/blog/openai-structured-outputs-with-label-studio/**",
-              "selectors_key": "docs"
-            }
           ],
           "sitemap_urls": ["https://labelstud.io/sitemap-tutorials.xml"],
           "selectors": {

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -36,7 +36,7 @@ jobs:
               "selectors_key": "docs"
             },
             {
-              "url": "https://labelstud.io/blog/categories/tutorials",
+              "url": "https://labelstud.io/blog/categories/tutorials"
             }
           ],
           "sitemap_urls": ["https://labelstud.io/sitemap-tutorials.xml"],

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -22,20 +22,7 @@ jobs:
           "index_name": "labelstudiodocs",
           "stop_urls": [], 
           "selectors_exclude": [".home-page-index"], 
-          "start_urls": [
-          {
-              "url": "https://labelstud.io/guide"
-              
-            },
-            {
-              "url": "https://labelstud.io/templates"
-              
-            },
-            {
-              "url": "https://labelstud.io/tags"
-              
-            }
-          ],
+          
           "sitemaps": [
             {
               "url": "https://labelstud.io/sitemap-tutorials.xml",

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -23,14 +23,9 @@ jobs:
           "stop_urls": [], 
           "selectors_exclude": [".home-page-index"], 
           
-          "sitemaps": [
-            {
-              "url": "https://labelstud.io/sitemap-tutorials.xml",
-              "selectors_key": "blog"
-            }
-          ],
+          "sitemaps": ["https://labelstud.io/sitemap-tutorials.xml"],
           "selectors": {
-            "default": {
+            "docs": {
               "lvl0": ".content h1, .ResourcesBannerHeading",
               "lvl1": ".content h2, .ResourcesContent h2",
               "lvl2": ".content h3, .ResourcesContent h3",
@@ -39,7 +34,7 @@ jobs:
               "lvl5": ".content h6, .ResourcesContent h6", 
               "content": ".content-markdown > *"
             },
-            "blog": {
+            "default": {
               "lvl0": ".BlogTitle",
               "lvl1": ".ResourcesContent h1, .ResourcesContent h2",
               "lvl2": ".ResourcesContent h3",

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -103,7 +103,7 @@ theme: v2
 
 sitemap:
   path:
-    - sitemap-docs.xml
+    - guide/sitemap-docs.xml
 
 search:
   path: search.xml

--- a/docs/themes/v2/source/js/header.js
+++ b/docs/themes/v2/source/js/header.js
@@ -41,7 +41,7 @@
 
     const appId = siteVersion == "enterprise" ? 'M7RXTHKYPM' : "HELLEDAKPT";
     const apiKey = siteVersion == "enterprise" ? '8ed23cbc92e0806140603fb62236efee' : '1d0410ef855a968fbc40669df1c4a73e'
-    const indexName = siteVersion == "enterprise" ? 'ghaction' : 'labelstud'
+    const indexName = siteVersion == "enterprise" ? 'ghaction' : 'ghactionls'
     
     if(searchInput) {
 

--- a/docs/themes/v2/source/js/header.js
+++ b/docs/themes/v2/source/js/header.js
@@ -1,8 +1,9 @@
-(function() {
+(function () {
   const pageHeader = document.querySelector(".page-header");
   const pageSidebar = document.querySelector(".page-sidebar");
   const navToggleButtons = pageHeader.querySelectorAll("button");
-  const sideBarToggleButtons = pageSidebar && pageSidebar.querySelectorAll("button");
+  const sideBarToggleButtons =
+    pageSidebar && pageSidebar.querySelectorAll("button");
   const hamburgerButton = pageHeader.querySelector(".hamburger-button");
 
   const toggleMenu = (e) => {
@@ -12,58 +13,84 @@
     const arrow = button.querySelector("svg");
     const arrowStyles = getComputedStyle(arrow);
 
-    arrow.style.setProperty('transform', arrowStyles.transform === "none" ? "matrix(-1, 0, 0, -1, 0, 0)" : "none");
-    menu.style.setProperty('display', menuStyles.display === "flex" ? "none" : "flex");
-  }
+    arrow.style.setProperty(
+      "transform",
+      arrowStyles.transform === "none" ? "matrix(-1, 0, 0, -1, 0, 0)" : "none"
+    );
+    menu.style.setProperty(
+      "display",
+      menuStyles.display === "flex" ? "none" : "flex"
+    );
+  };
 
-  navToggleButtons && navToggleButtons.forEach(button => button.addEventListener("click", toggleMenu));
-  sideBarToggleButtons && sideBarToggleButtons.forEach(button => button.addEventListener("click", toggleMenu));
+  navToggleButtons &&
+    navToggleButtons.forEach((button) =>
+      button.addEventListener("click", toggleMenu)
+    );
+  sideBarToggleButtons &&
+    sideBarToggleButtons.forEach((button) =>
+      button.addEventListener("click", toggleMenu)
+    );
 
-  const githubstarsContainer  = document.querySelector(".github-stars-count");
+  const githubstarsContainer = document.querySelector(".github-stars-count");
 
-  if(githubstarsContainer) {
+  if (githubstarsContainer) {
     fetch("https://api.github.com/repos/heartexlabs/label-studio")
-    .then((response) => response.json()
-    .then((data) => {
-      let stars = "";
-      if(data.stargazers_count) stars = data.stargazers_count.toLocaleString('en-US')
-      if(stars) githubstarsContainer.textContent = stars;
-    }))
-    .catch((err) => {
-      console.log(err)
-    });
+      .then((response) =>
+        response.json().then((data) => {
+          let stars = "";
+          if (data.stargazers_count)
+            stars = data.stargazers_count.toLocaleString("en-US");
+          if (stars) githubstarsContainer.textContent = stars;
+        })
+      )
+      .catch((err) => {
+        console.log(err);
+      });
   }
 
-  window.addEventListener('load', (event) => {
+  window.addEventListener("load", (event) => {
     const searchInput = document.querySelector("#docsearch-input");
 
     const siteVersion = searchInput.dataset.siteVersion;
 
-    const appId = siteVersion == "enterprise" ? 'M7RXTHKYPM' : "HELLEDAKPT";
-    const apiKey = siteVersion == "enterprise" ? '8ed23cbc92e0806140603fb62236efee' : '1d0410ef855a968fbc40669df1c4a73e'
-    const indexName = siteVersion == "enterprise" ? 'ghaction' : 'ghactionls'
-    
-    if(searchInput) {
+    const appId = "M7RXTHKYPM";
+    const apiKey = "8ed23cbc92e0806140603fb62236efee";
+    const indexName =
+      siteVersion == "enterprise" ? "ghaction" : "labelstudiodocs";
 
+    if (searchInput) {
       window.docsearch({
-        container: '#docsearch-input',
-        inputSelector: '#docsearch-input',
+        container: "#docsearch-input",
+        inputSelector: "#docsearch-input",
         appId,
         apiKey,
         indexName,
         algoliaOptions: { hitsPerPage: 10 },
       });
-    
+
       const handleFocusSearch = (e) => {
-        if (document.activeElement.localName === 'body' && e.code !== "Space" && e.code !== "MetaLeft" && !e.altKey && !e.shiftKey && !e.ctrlKey && !e.metaKey) {
+        if (
+          document.activeElement.localName === "body" &&
+          e.code !== "Space" &&
+          e.code !== "MetaLeft" &&
+          !e.altKey &&
+          !e.shiftKey &&
+          !e.ctrlKey &&
+          !e.metaKey
+        ) {
           searchInput.focus();
         }
 
-        if(document.activeElement.localName === 'body' && e.code === "KeyK" && (e.metaKey || e.ctrlKey)) {
+        if (
+          document.activeElement.localName === "body" &&
+          e.code === "KeyK" &&
+          (e.metaKey || e.ctrlKey)
+        ) {
           searchInput.focus();
         }
-      }
-    
+      };
+
       window.addEventListener("keydown", handleFocusSearch);
     }
   });
@@ -74,26 +101,33 @@
 
     hamburgerButton.classList.toggle("active");
 
-    nav.style.setProperty('display', navStyle.display=== "flex" ? "none" : "flex");
+    nav.style.setProperty(
+      "display",
+      navStyle.display === "flex" ? "none" : "flex"
+    );
+  });
 
-  })
-
-  if (window.matchMedia( "(hover: none)" ).matches) {
+  if (window.matchMedia("(hover: none)").matches) {
     const toggleQuickNav = (e) => {
-      if (e.target.tagName.toLowerCase() !== 'a') {
+      if (e.target.tagName.toLowerCase() !== "a") {
         const component = e.currentTarget;
         const menu = component.querySelector("ul");
         const menuStyles = getComputedStyle(menu);
 
-        menu.style.setProperty('display', menuStyles.display=== "flex" ? "none" : "flex");
+        menu.style.setProperty(
+          "display",
+          menuStyles.display === "flex" ? "none" : "flex"
+        );
       }
-    }
-  
-    const toggleQuicNavButton = document.querySelector(".page-header-content-switcher");
-    toggleQuicNavButton.addEventListener("click", toggleQuickNav)
- }
+    };
 
-  pageSidebar.addEventListener('scroll', function() {
-    localStorage.setItem('labelstudio_scrollPosition', this.scrollTop);
+    const toggleQuicNavButton = document.querySelector(
+      ".page-header-content-switcher"
+    );
+    toggleQuicNavButton.addEventListener("click", toggleQuickNav);
+  }
+
+  pageSidebar.addEventListener("scroll", function () {
+    localStorage.setItem("labelstudio_scrollPosition", this.scrollTop);
   });
 })();


### PR DESCRIPTION
Move Label Studio docs to Algolia crawler and include LS blog in the search results

https://deploy-preview-6570--heartex-docs.netlify.app/guide/
https://deploy-preview-6570--label-studio-docs-new-theme.netlify.app/guide/