### PR TITLE
refactor: OPTIC-1270: Remove Stale Feature Flag - fflag_feat_front_prod_309_choice_hint_080523_short

### DIFF
--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -14,7 +14,6 @@ STALE_FEATURE_FLAGS = {
     'fflag_fix_back_lsdv_4648_annotator_filter_29052023_short': True,
     'fflag_feat_back_lsdv_5035_use_created_at_from_draft_for_annotation_256052023_short': True,
     'fflag_feat_front_lsdv_3025_outliner_filter_short': False,
-    'fflag_feat_front_prod_309_choice_hint_080523_short': True,
     'fflag_fix_front_lsdv_4992_hide_all_regions_04052023_short': True,
     'ff_back_dev_4664_remove_storage_file_on_export_delete_29032023_short': False,
     'fflag_feat_front_lops_86_datasets_storage_edit_short': False,

--- a/web/libs/editor/src/components/Taxonomy/Taxonomy.tsx
+++ b/web/libs/editor/src/components/Taxonomy/Taxonomy.tsx
@@ -5,7 +5,7 @@ import { LsChevron } from "../../assets/icons";
 import { Tooltip } from "../../common/Tooltip/Tooltip";
 import { useToggle } from "../../hooks/useToggle";
 import type { CNTagName } from "../../utils/bem";
-import { FF_DEV_4075, FF_PROD_309, isFF } from "../../utils/feature-flags";
+import { FF_DEV_4075, isFF } from "../../utils/feature-flags";
 import { isArraysEqual } from "../../utils/utilities";
 import TreeStructure from "../TreeStructure/TreeStructure";
 
@@ -160,8 +160,6 @@ type HintTooltipProps = {
 };
 
 export const HintTooltip: React.FC<HintTooltipProps> = ({ title, wrapper: Wrapper, children, ...rest }) => {
-  if (!isFF(FF_PROD_309)) return children;
-
   const content = Wrapper ? <Wrapper>{children}</Wrapper> : children;
 
   if (title) {

--- a/web/libs/editor/src/tags/control/Choice.jsx
+++ b/web/libs/editor/src/tags/control/Choice.jsx
@@ -12,7 +12,7 @@ import Tree from "../../core/Tree";
 import Types from "../../core/Types";
 import { AnnotationMixin } from "../../mixins/AnnotationMixin";
 import { TagParentMixin } from "../../mixins/TagParentMixin";
-import { FF_DEV_3391, FF_PROD_309, isFF } from "../../utils/feature-flags";
+import { FF_DEV_3391, isFF } from "../../utils/feature-flags";
 import { Block, Elem } from "../../utils/bem";
 import "./Choice/Choice.scss";
 import { LsChevron } from "../../assets/icons";
@@ -54,7 +54,7 @@ const TagAttrs = types.model({
   style: types.maybeNull(types.string),
   html: types.maybeNull(types.string),
   color: types.maybeNull(types.string),
-  ...(isFF(FF_PROD_309) ? { hint: types.maybeNull(types.string) } : {}),
+  hint: types.maybeNull(types.string),
 });
 
 const Model = types

--- a/web/libs/editor/src/utils/feature-flags.ts
+++ b/web/libs/editor/src/utils/feature-flags.ts
@@ -229,11 +229,6 @@ export const FF_LSDV_4992 = "fflag_fix_front_lsdv_4992_hide_all_regions_04052023
 export const FF_LSDV_4998 = "fflag_fix_front_lsdv_4998_missed_dynamic_children_030523_short";
 
 /**
- * Add ability to show hints while hover over the choice
- */
-export const FF_PROD_309 = "fflag_feat_front_prod_309_choice_hint_080523_short";
-
-/**
  * Fix delay on double-click interactions in Image Segmentation
  * @link https://app.launchdarkly.com/default/production/features/fflag_fix_front_lsdv_5248_double_click_delay_280823_short
  */

--- a/web/libs/editor/tests/integration/feature-flags.ts
+++ b/web/libs/editor/tests/integration/feature-flags.ts
@@ -2,7 +2,6 @@ import * as FLAGS from "../../src/utils/feature-flags";
 
 export const CURRENT_FLAGS = {
   [FLAGS.FF_DEV_1170]: true,
-  [FLAGS.FF_PROD_309]: true,
   [FLAGS.FF_LSDV_4930]: true,
   [FLAGS.FF_LSDV_4992]: true,
   [FLAGS.FF_DEV_2715]: true,


### PR DESCRIPTION


### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
Removing a feature flag that has been stale for a while allows us to remove another feature flag that appears to be related in LD.
