### PR TITLE
ci: PLT-536: rework migration script to use pg_try_advisory_xact_lock

### DIFF
--- a/label_studio/core/management/commands/locked_migrate.py
+++ b/label_studio/core/management/commands/locked_migrate.py
@@ -1,5 +1,5 @@
-import time
 import logging
+import time
 
 from django.conf import settings
 from django.core.management.commands.migrate import Command as MigrateCommand
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_LOCK_ID = getattr(settings, 'MIGRATE_LOCK_ID', 1000)
 
-LOCKED_MIGRATE_CMD_CONNECTION_ALIAS = "locked_migrate_cmd_connection"
+LOCKED_MIGRATE_CMD_CONNECTION_ALIAS = 'locked_migrate_cmd_connection'
 RETRY_INTERVAL = 5  # Time to wait between retries in seconds
 MAX_WAIT_TIME = 300  # Maximum time to wait for the lock in seconds (5 minutes)
 
@@ -27,16 +27,16 @@ class Command(MigrateCommand):
         )
 
     def handle(self, *args, **options):
-        lock_id = options.pop("migrate_lock_id")
+        lock_id = options.pop('migrate_lock_id')
 
         # Use a new, separate database connection to hold the pg_advisory_xact_lock.
-        separate_lock_connection = connections.create_connection("default")
+        separate_lock_connection = connections.create_connection('default')
         connections[LOCKED_MIGRATE_CMD_CONNECTION_ALIAS] = separate_lock_connection
         try:
             with transaction.atomic(using=LOCKED_MIGRATE_CMD_CONNECTION_ALIAS):
                 self.acquire_lock_with_retry(separate_lock_connection, lock_id)
                 super().handle(*args, **options)
-            logger.info("Migration complete, the migration lock has now been released.")
+            logger.info('Migration complete, the migration lock has now been released.')
         finally:
             # Ensure the connection is closed as we created it ourselves
             separate_lock_connection.close()
@@ -46,24 +46,22 @@ class Command(MigrateCommand):
 
         while True:
             with lock_connection.cursor() as cursor:
-                logger.info(
-                    f"Attempting to acquire the postgres advisory transaction lock with id: {lock_id}."
-                )
+                logger.info(f'Attempting to acquire the postgres advisory transaction lock with id: {lock_id}.')
 
                 # Attempt to acquire the transaction-level lock without blocking
-                cursor.execute(f"SELECT pg_try_advisory_xact_lock({lock_id})")
+                cursor.execute(f'SELECT pg_try_advisory_xact_lock({lock_id})')
                 lock_acquired = cursor.fetchone()[0]
 
                 if lock_acquired:
-                    logger.info("Acquired the transaction lock, proceeding with migration.")
+                    logger.info('Acquired the transaction lock, proceeding with migration.')
                     return  # Exit the function if the lock is acquired
 
                 # Check if the maximum wait time has been reached
                 elapsed_time = time.time() - start_time
                 if elapsed_time >= MAX_WAIT_TIME:
-                    logger.info("Could not acquire the transaction lock within the timeout period.")
-                    raise TimeoutError("Failed to acquire PostgreSQL advisory transaction lock within 5 minutes.")
+                    logger.info('Could not acquire the transaction lock within the timeout period.')
+                    raise TimeoutError('Failed to acquire PostgreSQL advisory transaction lock within 5 minutes.')
 
                 # Wait before retrying
-                logger.info(f"Lock not acquired. Retrying in {RETRY_INTERVAL} seconds...")
+                logger.info(f'Lock not acquired. Retrying in {RETRY_INTERVAL} seconds...')
                 time.sleep(RETRY_INTERVAL)

--- a/label_studio/core/management/commands/locked_migrate.py
+++ b/label_studio/core/management/commands/locked_migrate.py
@@ -1,12 +1,17 @@
+import time
 import logging
 
 from django.conf import settings
 from django.core.management.commands.migrate import Command as MigrateCommand
-from django.db import connections
+from django.db import connections, transaction
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_LOCK_ID = getattr(settings, 'MIGRATE_LOCK_ID', 1000)
+
+LOCKED_MIGRATE_CMD_CONNECTION_ALIAS = "locked_migrate_cmd_connection"
+RETRY_INTERVAL = 5  # Time to wait between retries in seconds
+MAX_WAIT_TIME = 300  # Maximum time to wait for the lock in seconds (5 minutes)
 
 
 class Command(MigrateCommand):
@@ -22,21 +27,43 @@ class Command(MigrateCommand):
         )
 
     def handle(self, *args, **options):
-        database = options['database']
-        if not options['skip_checks']:
-            self.check(databases=[database])
+        lock_id = options.pop("migrate_lock_id")
 
-        # Get the database we're operating from
-        connection = connections[database]
-        # Hook for backends needing any database preparation
-        connection.prepare_database()
+        # Use a new, separate database connection to hold the pg_advisory_xact_lock.
+        separate_lock_connection = connections.create_connection("default")
+        connections[LOCKED_MIGRATE_CMD_CONNECTION_ALIAS] = separate_lock_connection
+        try:
+            with transaction.atomic(using=LOCKED_MIGRATE_CMD_CONNECTION_ALIAS):
+                self.acquire_lock_with_retry(separate_lock_connection, lock_id)
+                super().handle(*args, **options)
+            logger.info("Migration complete, the migration lock has now been released.")
+        finally:
+            # Ensure the connection is closed as we created it ourselves
+            separate_lock_connection.close()
 
-        lock_id = options['migrate_lock_id']
-        with connection.cursor() as cursor:
-            try:
-                logger.info(f'Attempting to acquire a migration lock: {lock_id}')
-                cursor.execute(f'SELECT pg_advisory_xact_lock({lock_id})')
-                logger.info('Successfully acquired the lock. Starting migrations...')
-                MigrateCommand.handle(self, *args, **options)
-            finally:
-                logger.info('Migration lock has been released.')
+    def acquire_lock_with_retry(self, lock_connection, lock_id):
+        start_time = time.time()
+
+        while True:
+            with lock_connection.cursor() as cursor:
+                logger.info(
+                    f"Attempting to acquire the postgres advisory transaction lock with id: {lock_id}."
+                )
+
+                # Attempt to acquire the transaction-level lock without blocking
+                cursor.execute(f"SELECT pg_try_advisory_xact_lock({lock_id})")
+                lock_acquired = cursor.fetchone()[0]
+
+                if lock_acquired:
+                    logger.info("Acquired the transaction lock, proceeding with migration.")
+                    return  # Exit the function if the lock is acquired
+
+                # Check if the maximum wait time has been reached
+                elapsed_time = time.time() - start_time
+                if elapsed_time >= MAX_WAIT_TIME:
+                    logger.info("Could not acquire the transaction lock within the timeout period.")
+                    raise TimeoutError("Failed to acquire PostgreSQL advisory transaction lock within 5 minutes.")
+
+                # Wait before retrying
+                logger.info(f"Lock not acquired. Retrying in {RETRY_INTERVAL} seconds...")
+                time.sleep(RETRY_INTERVAL)


### PR DESCRIPTION
Switch to pg_try_advisory_xact_lock for locked_migrations