### PR TITLE
fix: OPTIC-1287: Project config validation should ignore xml comments

### DIFF
--- a/label_studio/core/label_config.py
+++ b/label_studio/core/label_config.py
@@ -76,7 +76,9 @@ def _fix_choices(config):
     return config
 
 
-def remove_xml_comments(config_string):
+def remove_xml_comments(config_string: str | None) -> str | None:
+    if config_string is None:
+        return None
     return re.sub(r'<!--[\s\S]*?-->', '', config_string)
 
 
@@ -92,7 +94,7 @@ def parse_config_to_json(config_string):
     return config
 
 
-def validate_label_config(config_string):
+def validate_label_config(config_string: str | None) -> None:
     # xml and schema
     config_string = remove_xml_comments(config_string)
     try:

--- a/label_studio/core/label_config.py
+++ b/label_studio/core/label_config.py
@@ -101,7 +101,7 @@ def parse_config_to_json(config_string: Union[str, None]) -> Tuple[Union[Ordered
         raise etree.ParseError('xml is empty or incorrect')
     config = xmljson.badgerfish.data(xml)
     config = _fix_choices(config)
-    return config, etree.tostring(xml, encoding='unicode')
+    return config, etree.tostring(xml)
 
 
 def validate_label_config(config_string: Union[str, None]) -> None:

--- a/label_studio/core/label_config.py
+++ b/label_studio/core/label_config.py
@@ -4,11 +4,11 @@ import json
 import logging
 import re
 from collections import OrderedDict, defaultdict
-from typing import Union
+from typing import Tuple, Union
 from urllib.parse import urlencode
 
-import defusedxml.ElementTree as etree
 import jsonschema
+import lxml.etree as etree
 import numpy as np
 import pandas as pd
 import xmljson
@@ -77,31 +77,28 @@ def _fix_choices(config):
     return config
 
 
-def remove_xml_comments(config_string: Union[str, None]) -> Union[str, None]:
+def parse_config_to_xml(config_string: Union[str, None]) -> Union[etree.Element, None]:
     if config_string is None:
         return None
-    parser = etree.XMLParser(remove_comments=True)
-    xml = etree.fromstring(config_string, parser=parser)
-    return etree.tostring(xml, encoding='unicode')
+    return etree.fromstring(config_string, parser=etree.XMLParser(remove_comments=True))
 
 
-def parse_config_to_json(config_string: Union[str, None]) -> Union[OrderedDict, None]:
+def parse_config_to_json(config_string: Union[str, None]) -> Tuple[Union[OrderedDict, None], Union[str, None]]:
     try:
-        xml = etree.fromstring(config_string, forbid_dtd=False)
+        xml = parse_config_to_xml(config_string)
     except TypeError:
         raise etree.ParseError('can only parse strings')
     if xml is None:
         raise etree.ParseError('xml is empty or incorrect')
     config = xmljson.badgerfish.data(xml)
     config = _fix_choices(config)
-    return config
+    return config, etree.tostring(xml, encoding='unicode')
 
 
 def validate_label_config(config_string: Union[str, None]) -> None:
     # xml and schema
-    config_string = remove_xml_comments(config_string)
     try:
-        config = parse_config_to_json(config_string)
+        config, cleaned_config_string = parse_config_to_json(config_string)
         jsonschema.validate(config, _LABEL_CONFIG_SCHEMA_DATA)
     except (etree.ParseError, ValueError) as exc:
         raise LabelStudioValidationErrorSentryIgnored(str(exc))
@@ -116,13 +113,13 @@ def validate_label_config(config_string: Union[str, None]) -> None:
         raise LabelStudioValidationErrorSentryIgnored(error_message)
 
     # unique names in config # FIXME: 'name =' (with spaces) won't work
-    all_names = re.findall(r'name="([^"]*)"', config_string)
+    all_names = re.findall(r'name="([^"]*)"', cleaned_config_string)
     if len(set(all_names)) != len(all_names):
         raise LabelStudioValidationErrorSentryIgnored('Label config contains non-unique names')
 
     # toName points to existent name
     names = set(all_names)
-    toNames = re.findall(r'toName="([^"]*)"', config_string)
+    toNames = re.findall(r'toName="([^"]*)"', cleaned_config_string)
     for toName_ in toNames:
         for toName in toName_.split(','):
             if toName not in names:
@@ -131,7 +128,7 @@ def validate_label_config(config_string: Union[str, None]) -> None:
 
 def extract_data_types(label_config):
     # load config
-    xml = etree.fromstring(label_config, forbid_dtd=False)
+    xml = parse_config_to_xml(label_config)
     if xml is None:
         raise etree.ParseError('Project config is empty or incorrect')
 
@@ -195,16 +192,11 @@ def get_all_object_tag_names(label_config):
 
 
 def config_line_stipped(c):
-    tree = etree.fromstring(c, forbid_dtd=False)
-    comments = tree.xpath('//comment()')
+    xml = parse_config_to_xml(c)
+    if xml is None:
+        return None
 
-    for c in comments:
-        p = c.getparent()
-        if p is not None:
-            p.remove(c)
-        c = etree.tostring(tree, method='html').decode('utf-8')
-
-    return c.replace('\n', '').replace('\r', '')
+    return etree.tostring(xml, encoding='unicode').replace('\n', '').replace('\r', '')
 
 
 def get_task_from_labeling_config(config):
@@ -253,7 +245,7 @@ def data_examples(mode):
 def generate_sample_task_without_check(label_config, mode='upload', secure_mode=False):
     """Generate sample task only"""
     # load config
-    xml = etree.fromstring(label_config, forbid_dtd=False)
+    xml = parse_config_to_xml(label_config)
     if xml is None:
         raise etree.ParseError('Project config is empty or incorrect')
 

--- a/label_studio/core/label_config.py
+++ b/label_studio/core/label_config.py
@@ -4,6 +4,7 @@ import json
 import logging
 import re
 from collections import OrderedDict, defaultdict
+from typing import Union 
 from urllib.parse import urlencode
 
 import defusedxml.ElementTree as etree
@@ -76,13 +77,13 @@ def _fix_choices(config):
     return config
 
 
-def remove_xml_comments(config_string: str | None) -> str | None:
+def remove_xml_comments(config_string: Union[str, None]) -> Union[str, None]:
     if config_string is None:
         return None
     return re.sub(r'<!--[\s\S]*?-->', '', config_string)
 
 
-def parse_config_to_json(config_string):
+def parse_config_to_json(config_string: Union[str, None]) -> Union[OrderedDict, None]:
     try:
         xml = etree.fromstring(config_string, forbid_dtd=False)
     except TypeError:
@@ -94,7 +95,7 @@ def parse_config_to_json(config_string):
     return config
 
 
-def validate_label_config(config_string: str | None) -> None:
+def validate_label_config(config_string: Union[str, None]) -> None:
     # xml and schema
     config_string = remove_xml_comments(config_string)
     try:

--- a/label_studio/core/label_config.py
+++ b/label_studio/core/label_config.py
@@ -7,8 +7,8 @@ from collections import OrderedDict, defaultdict
 from typing import Tuple, Union
 from urllib.parse import urlencode
 
+import defusedxml.ElementTree as etree
 import jsonschema
-import lxml.etree as etree
 import numpy as np
 import pandas as pd
 import xmljson
@@ -77,11 +77,17 @@ def _fix_choices(config):
     return config
 
 
-def parse_config_to_xml(config_string: Union[str, None]) -> Union[etree.Element, None]:
+def parse_config_to_xml(config_string: Union[str, None]) -> Union[OrderedDict, None]:
     if config_string is None:
         return None
-    return etree.fromstring(config_string, parser=etree.XMLParser(remove_comments=True))
 
+    xml = etree.fromstring(config_string, forbid_dtd=True)
+
+    # Remove comments
+    for comment in xml.findall('.//comment'):
+        comment.getparent().remove(comment)
+
+    return xml
 
 def parse_config_to_json(config_string: Union[str, None]) -> Tuple[Union[OrderedDict, None], Union[str, None]]:
     try:

--- a/label_studio/core/label_config.py
+++ b/label_studio/core/label_config.py
@@ -76,6 +76,10 @@ def _fix_choices(config):
     return config
 
 
+def remove_xml_comments(config_string):
+    return re.sub(r'<!--[\s\S]*?-->', '', config_string)
+
+
 def parse_config_to_json(config_string):
     try:
         xml = etree.fromstring(config_string, forbid_dtd=False)
@@ -90,6 +94,7 @@ def parse_config_to_json(config_string):
 
 def validate_label_config(config_string):
     # xml and schema
+    config_string = remove_xml_comments(config_string)
     try:
         config = parse_config_to_json(config_string)
         jsonschema.validate(config, _LABEL_CONFIG_SCHEMA_DATA)

--- a/label_studio/core/label_config.py
+++ b/label_studio/core/label_config.py
@@ -77,8 +77,10 @@ def _fix_choices(config):
     return config
 
 
-def parse_config_to_xml(config_string: Union[str, None]) -> Union[OrderedDict, None]:
+def parse_config_to_xml(config_string: Union[str, None], raise_on_empty: bool = False) -> Union[OrderedDict, None]:
     if config_string is None:
+        if raise_on_empty:
+            raise TypeError('config_string is None')
         return None
 
     xml = etree.fromstring(config_string, forbid_dtd=True)
@@ -91,7 +93,7 @@ def parse_config_to_xml(config_string: Union[str, None]) -> Union[OrderedDict, N
 
 def parse_config_to_json(config_string: Union[str, None]) -> Tuple[Union[OrderedDict, None], Union[str, None]]:
     try:
-        xml = parse_config_to_xml(config_string)
+        xml = parse_config_to_xml(config_string, raise_on_empty=True)
     except TypeError:
         raise etree.ParseError('can only parse strings')
     if xml is None:

--- a/label_studio/core/label_config.py
+++ b/label_studio/core/label_config.py
@@ -101,7 +101,7 @@ def parse_config_to_json(config_string: Union[str, None]) -> Tuple[Union[Ordered
         raise etree.ParseError('xml is empty or incorrect')
     config = xmljson.badgerfish.data(xml)
     config = _fix_choices(config)
-    return config, etree.tostring(xml)
+    return config, etree.tostring(xml, encoding='unicode')
 
 
 def validate_label_config(config_string: Union[str, None]) -> None:

--- a/label_studio/core/label_config.py
+++ b/label_studio/core/label_config.py
@@ -4,7 +4,7 @@ import json
 import logging
 import re
 from collections import OrderedDict, defaultdict
-from typing import Union 
+from typing import Union
 from urllib.parse import urlencode
 
 import defusedxml.ElementTree as etree

--- a/label_studio/core/label_config.py
+++ b/label_studio/core/label_config.py
@@ -91,6 +91,7 @@ def parse_config_to_xml(config_string: Union[str, None], raise_on_empty: bool = 
 
     return xml
 
+
 def parse_config_to_json(config_string: Union[str, None]) -> Tuple[Union[OrderedDict, None], Union[str, None]]:
     try:
         xml = parse_config_to_xml(config_string, raise_on_empty=True)

--- a/label_studio/core/label_config.py
+++ b/label_studio/core/label_config.py
@@ -80,7 +80,9 @@ def _fix_choices(config):
 def remove_xml_comments(config_string: Union[str, None]) -> Union[str, None]:
     if config_string is None:
         return None
-    return re.sub(r'<!--[\s\S]*?-->', '', config_string)
+    parser = etree.XMLParser(remove_comments=True)
+    xml = etree.fromstring(config_string, parser=parser)
+    return etree.tostring(xml, encoding='unicode')
 
 
 def parse_config_to_json(config_string: Union[str, None]) -> Union[OrderedDict, None]:

--- a/label_studio/tests/config_validation.tavern.yml
+++ b/label_studio/tests/config_validation.tavern.yml
@@ -1403,3 +1403,36 @@ stages:
     url: '{django_live_url}/api/projects/{pk}/import'
   response:
     status_code: 201
+
+---
+test_name: Validation should ignore xml comments
+strict: false
+marks:
+- usefixtures:
+  - django_live_url
+
+stages:
+- # Signup to the system
+  id: signup
+  type: ref
+- name: create project
+  request:
+    method: POST
+    url: '{django_live_url}/api/projects'
+    json:
+      label_config: <View> <Text name="text" value="$text"/><Taxonomy name="taxonomy" toName="text"><Choice value="A"><Choice value="A_1"/><Choice value="A_2"/></Choice><Choice value="B"/></Taxonomy></View>
+  response:
+    save:
+      json:
+        pk: id
+    status_code: 201
+- name: validate config will not throw config contains non-unique names error
+  request:
+    headers:
+      content-type: application/json
+    json:
+      label_config: '<View> <Text name="text" value="$text"/><Taxonomy name="taxonomy" toName="text"><Choice value="C"><Choice value="A_1"/><Choice value="A_2"/></Choice><Choice value="B"/></Taxonomy></View><!-- Custom script draft --><!-- const taxonomy = document.querySelector(`[name="taxonomy"]`);-->'
+    method: POST
+    url: '{django_live_url}/api/projects/{pk}/validate'
+  response:
+    status_code: 200


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [X] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [X] Backend (API)
- [ ] Frontend



### Describe the reason for change
When using xml comments which may contain code samples that have a name property like`<!--document.querySelector('[name="field"]')-->` that also occurs in the label config xml `<Taxonomy name="field">` it would fail to validate stating that Config cannot contain non-unique names. This is not correct as the values do not occur within the Label config portion of the xml.


### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [X] unit



### Which logical domain(s) does this change affect?
Project Config Validation

