### PR TITLE
feat: block sentry in frontend side

### DIFF
--- a/label_studio/templates/base.html
+++ b/label_studio/templates/base.html
@@ -28,10 +28,12 @@
   {% block app-scripts %}
   {% endblock %}
 
-  <script
-   src="https://browser.sentry-cdn.com/5.17.0/bundle.min.js"
-   integrity="sha384-lowBFC6YTkvMIWPORr7+TERnCkZdo5ab00oH5NkFLeQUAmBTLGwJpFjF6djuxJ/5"
-   crossorigin="anonymous"></script>
+  {% if settings.FRONTEND_SENTRY_DSN %}
+    <script
+    src="https://browser.sentry-cdn.com/5.17.0/bundle.min.js"
+    integrity="sha384-lowBFC6YTkvMIWPORr7+TERnCkZdo5ab00oH5NkFLeQUAmBTLGwJpFjF6djuxJ/5"
+    crossorigin="anonymous"></script>
+  {% endif %}
 
   <script nonce="{{request.csp_nonce}}">
     window.exports = () => {};

--- a/web/apps/labelstudio/src/config/Sentry.ts
+++ b/web/apps/labelstudio/src/config/Sentry.ts
@@ -5,7 +5,7 @@ import { Integrations } from "@sentry/tracing";
 import { Route } from "react-router-dom";
 
 export const initSentry = (history: RouterHistory) => {
-  if (APP_SETTINGS.debug === false && APP_SETTINGS.frontend_sentry_dsn) {
+  if (APP_SETTINGS.debug === false && APP_SETTINGS.sentry_dsn) {
     setTags();
     Sentry.init({
       dsn: APP_SETTINGS.sentry_dsn,

--- a/web/apps/labelstudio/src/config/Sentry.ts
+++ b/web/apps/labelstudio/src/config/Sentry.ts
@@ -5,10 +5,10 @@ import { Integrations } from "@sentry/tracing";
 import { Route } from "react-router-dom";
 
 export const initSentry = (history: RouterHistory) => {
-  if (APP_SETTINGS.debug === false) {
+  if (APP_SETTINGS.debug === false && APP_SETTINGS.frontend_sentry_dsn) {
     setTags();
     Sentry.init({
-      dsn: "https://5f51920ff82a4675a495870244869c6b@o227124.ingest.sentry.io/5838868",
+      dsn: APP_SETTINGS.frontend_sentry_dsn,
       integrations: [
         new Integrations.BrowserTracing({
           routingInstrumentation: ReactSentry.reactRouterV5Instrumentation(history),

--- a/web/apps/labelstudio/src/config/Sentry.ts
+++ b/web/apps/labelstudio/src/config/Sentry.ts
@@ -8,7 +8,7 @@ export const initSentry = (history: RouterHistory) => {
   if (APP_SETTINGS.debug === false && APP_SETTINGS.frontend_sentry_dsn) {
     setTags();
     Sentry.init({
-      dsn: APP_SETTINGS.frontend_sentry_dsn,
+      dsn: APP_SETTINGS.sentry_dsn,
       integrations: [
         new Integrations.BrowserTracing({
           routingInstrumentation: ReactSentry.reactRouterV5Instrumentation(history),


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)


#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend

### Describe the reason for change
https://github.com/HumanSignal/label-studio/issues/4421

In airgapped environment, frontend tries to get the file from sentry cdn, but it hangs, so page won't load.
Setting `FRONTEND_SENTRY_DSN` won't fix this problemn.

#### What does this fix?

When `FRONTEND_SENTRY_DSN` is set empty,
it disables
* sentry initialization
* fetching from sentry cdn 


### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)


