### PR TITLE
fix: Extend cache labels action timeout

### DIFF
--- a/label_studio/data_manager/actions/cache_labels.py
+++ b/label_studio/data_manager/actions/cache_labels.py
@@ -76,6 +76,7 @@ def cache_labels(project, queryset, request, **kwargs):
         queryset,
         organization_id=project.organization_id,
         request_data=request.data,
+        job_timeout=60*60*5  # max allowed duration is 5 hours
     )
     return {'response_code': 200}
 


### PR DESCRIPTION
The cache labels action is an experimental data manager action. It can take a long time, typically between 2 to 4 hours, for large projects that have more than 100,000 tasks and 100,000 annotations.

#### Change has impacts in these area(s)
- [ ] Product design
- [ ] Backend (Database)
- [x] Backend (API)
- [ ] Frontend
