### PR TITLE
fix: OPTIC-1243: Version history will navigate to a LabelStudio owned url

### DIFF
--- a/web/apps/labelstudio/src/components/VersionNotifier/VersionNotifier.jsx
+++ b/web/apps/labelstudio/src/components/VersionNotifier/VersionNotifier.jsx
@@ -43,8 +43,8 @@ export const VersionProvider = ({ children }) => {
 };
 
 export const VersionNotifier = ({ showNewVersion, showCurrentVersion }) => {
-  const url = "https://pypi.org/project/label-studio/#history";
   const { newVersion, updateTime, latestVersion, version } = useContext(VersionContext) ?? {};
+  const url = `https://labelstud.io/redirect/update?version=${version}`;
 
   return newVersion && showNewVersion ? (
     <Block tag="li" name="version-notifier">


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [X] Frontend



### Describe the reason for change
To enable a more enriched experience in the future, we are updating the version history link to go to a LabelStudio owned url. For now this url will be a redirect to the same underlying pypi history page for the package, but later to be replaced by our own page with more robust information.



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### Which logical domain(s) does this change affect?
VersionNotifier

