### PR TITLE
docs: Add new tableOfContent script

### DIFF
--- a/docs/scripts/index.js
+++ b/docs/scripts/index.js
@@ -1,7 +1,9 @@
 var breadcrumb = require("./breadcrumb")(hexo);
 var removeContent = require("./removeContent")(hexo);
 var replaceContent = require("./replaceContent")(hexo);
+var tableOfContent = require("./tableOfContent")(hexo);
 
 hexo.extend.helper.register("breadcrumb", breadcrumb, { async: true });
 hexo.extend.helper.register("removeContent", removeContent, { async: true });
 hexo.extend.helper.register("replaceContent", replaceContent, { async: true });
+hexo.extend.helper.register("tableOfContent", tableOfContent, { async: true });

--- a/docs/scripts/tableOfContent.js
+++ b/docs/scripts/tableOfContent.js
@@ -1,0 +1,24 @@
+const { tocObj } = require('hexo-util');
+
+module.exports = function () {
+  return function tableOfContent(str, options = {}) {
+
+      options = Object.assign({
+        min_depth: 1,
+        max_depth: 6,
+      }, options);
+    
+      const data = tocObj(str, { min_depth: options.min_depth, max_depth: options.max_depth });
+
+    
+      if (!data.length) return '';
+    
+      let html = '';
+
+      data.forEach(item => {
+        html += `<li class="toc-list-level-${item.level}"><a href="#${item.id}">${item.text}</a></li>`
+      });
+
+      return `<ol class="toc-list">${html}</ol>`;
+  };
+};

--- a/docs/themes/v2/layout/page.ejs
+++ b/docs/themes/v2/layout/page.ejs
@@ -1,10 +1,10 @@
 <% const isEnterpriseTheme = theme.tier === "enterprise" %>
 <% const tocPageTypes = page.type === "guide" || page.type === "blog" || page.type === "templates" || page.type === "tags" %>
 
-<% const showToc = tocPageTypes %>
-
 <% const formattedContent = removeContent(page.content) %>
 <% const tocContent = replaceContent(formattedContent) %>
+<% const pageHasHeading = /<h[1-6]\b[^>]*>/i.test(formattedContent); %>
+<% const showToc = tocPageTypes && pageHasHeading %>
 
 <div class="content-grid">
   <div class="content-markdown">

--- a/docs/themes/v2/layout/page.ejs
+++ b/docs/themes/v2/layout/page.ejs
@@ -21,7 +21,7 @@
     <% if (showToc) { %>
       <div class="toc">
         <%- partial("component/text", {text: "In this article", tag: "h3", size: "Eyebrow"}) %>
-        <%- toc(tocContent, {max_depth: 3, list_number: false, class: "toc-list"}) %>
+        <%- tableOfContent(tocContent, {max_depth: 3, list_number: false, class: "toc-list"}) %>
       </div>
     <% } %>
     <div class="toc-enterprise-cta">

--- a/docs/themes/v2/layout/page.ejs
+++ b/docs/themes/v2/layout/page.ejs
@@ -1,8 +1,7 @@
 <% const isEnterpriseTheme = theme.tier === "enterprise" %>
-<% const pageContainsHeadings = page.content.includes("<h2") %>
 <% const tocPageTypes = page.type === "guide" || page.type === "blog" || page.type === "templates" || page.type === "tags" %>
 
-<% const showToc = pageContainsHeadings && tocPageTypes %>
+<% const showToc = tocPageTypes %>
 
 <% const formattedContent = removeContent(page.content) %>
 <% const tocContent = replaceContent(formattedContent) %>
@@ -21,7 +20,7 @@
     <% if (showToc) { %>
       <div class="toc">
         <%- partial("component/text", {text: "In this article", tag: "h3", size: "Eyebrow"}) %>
-        <%- tableOfContent(tocContent, {max_depth: 3, list_number: false, class: "toc-list"}) %>
+        <%- tableOfContent(tocContent, {max_depth: 3}) %>
       </div>
     <% } %>
     <div class="toc-enterprise-cta">

--- a/docs/themes/v2/source/css/styles.css
+++ b/docs/themes/v2/source/css/styles.css
@@ -1223,7 +1223,7 @@ ul {
   margin-top: 1em;
 }
 
-.toc-list-level-3 {
+.toc-list-level-2~.toc-list-level-3 {
   padding-left: 1em;
 }
 

--- a/docs/themes/v2/source/css/styles.css
+++ b/docs/themes/v2/source/css/styles.css
@@ -1223,6 +1223,10 @@ ul {
   margin-top: 1em;
 }
 
+.toc-list-level-3 {
+  padding-left: 1em;
+}
+
 .toc-list-child {
   list-style: none;
   padding-left: 0.825em;


### PR DESCRIPTION
Replace hexo `toc` helper with our own `tableOfContent` to fix page rendering when the heading levels are in the wrong order (e.g. `h3` before `h2`)

### Testing

These page should render normally now:

https://deploy-preview-6667--label-studio-docs-new-theme.netlify.app/tags/timeseries
https://deploy-preview-6667--label-studio-docs-new-theme.netlify.app/templates/generative-pairwise-human-preference

Also fixed where the toc wasn’t showing if there was no `<h2>`:

https://deploy-preview-6667--label-studio-docs-new-theme.netlify.app/tags/table

Other pages should show the toc same as before:

https://deploy-preview-6667--label-studio-docs-new-theme.netlify.app/guide/storedata


