### PR TITLE
ci: OPTIC-1357: biomejs level error sin ci

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Run biome
         working-directory: ${{ env.FRONTEND_MONOREPO_DIR }}
         run: |
-          yarn biome check .
+          yarn biome check . --diagnostic-level=error


### PR DESCRIPTION
Currently, warnings make it very difficult to find errors when Biome fails.
We enable warnings for rules that are in the process of being activated.