### PR TITLE
refactor: OPTIC-1356: Remove Stale Feature Flag

### DIFF
--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -37,7 +37,6 @@ STALE_FEATURE_FLAGS = {
     'fflag_fix_front_dev_3350_restrict_drawing_area_short': True,
     'fflag_feat_front_dev_2984_dm_draggable_columns_short': True,
     'fflag_feat_front_dev_2461_audio_paragraphs_seek_chunk_position_short': True,
-    'fflag-feat-front-dev-2982-label-weights-settings': True,
     'ff_front_dev_2432_auto_save_polygon_draft_210622_short': True,
     'ff_front_dev_2575_projects_list_performance_280622_short': True,
     'ff_front_dev_2431_delete_polygon_points_080622_short': True,


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [x] Backend (API)
- [ ] Frontend



### Describe the reason for change
Cleaning up stale feature flag fflag-feat-front-dev-2982-label-weights-settings, stale since July. Has LSE changes.






### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
_(for bug fixes/features, be as precise as possible. ex. Authentication, Annotation History, Review Stream etc.)_

