### PR TITLE
fix: OPTIC-972: Hover effect over selected filter element is not applied

### DIFF
--- a/web/libs/datamanager/src/components/Common/Select/Select.scss
+++ b/web/libs/datamanager/src/components/Common/Select/Select.scss
@@ -60,6 +60,7 @@
     &_selected:hover,
     &_selected.select-dm__option_focused {
       background-color: hsl(var(--accent_color), 10%);
+      color: var(--accent_color);
     }
   }
 


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
improving hover effect of filter dropdown option where so its more readable
option in blue is a selected option with mouse hover
<img width="461" alt="image" src="https://github.com/user-attachments/assets/a4b56f4b-bbbc-4a84-874f-97d552576a9c">
