### PR TITLE
feat: Add option to reverse zoom scroll direction in settings

### DIFF
--- a/web/libs/editor/src/components/AnnotationsCarousel/__tests__/sampleData.js
+++ b/web/libs/editor/src/components/AnnotationsCarousel/__tests__/sampleData.js
@@ -5999,6 +5999,7 @@ const store = {
     imageFullSize: false,
     enableAutoSave: false,
     showLabels: true,
+    reverseZoomScrollDirection: true,
     showLineNumbers: false,
     showAnnotationsPanel: true,
     showPredictionsPanel: true,

--- a/web/libs/editor/src/components/ImageView/ImageView.jsx
+++ b/web/libs/editor/src/components/ImageView/ImageView.jsx
@@ -772,10 +772,11 @@ export default observer(
         e.evt.preventDefault();
       }
       if (e.evt) {
-        const { item } = this.props;
+        const { item, store } = this.props;
         const stage = item.stageRef;
-
-        item.handleZoom(e.evt.deltaY, stage.getPointerPosition());
+        const isReverseScroll = store.settings.reverseZoomScrollDirection;
+        const delta = e.evt.deltaY * (isReverseScroll ? -1 : 1);
+        item.handleZoom(delta, stage.getPointerPosition());
       }
     };
 

--- a/web/libs/editor/src/core/settings/editorsettings.js
+++ b/web/libs/editor/src/core/settings/editorsettings.js
@@ -54,6 +54,15 @@ export default {
     onChangeEvent: "toggleSelectAfterCreate",
     defaultValue: false,
   },
+  enableReverseZoomScrollDirection: {
+    newUI: {
+      title: "Reverse zoom scroll direction",
+      description: "When enabled, ctrl + scroll up zooms in and scroll down zooms out"
+    },
+    description: "Use standard zoom direction (scroll up to zoom in)",
+    onChangeEvent: "toggleReverseZoomScrollDirection",
+    defaultValue: true,
+  },
   showLineNumbers: {
     newUI: {
       tags: "Text Tag",

--- a/web/libs/editor/src/stores/SettingsStore.js
+++ b/web/libs/editor/src/stores/SettingsStore.js
@@ -32,6 +32,11 @@ const SettingsModel = types
      */
     continuousLabeling: false,
 
+    /**
+     * Scroll zoom direction
+     */
+    reverseZoomScrollDirection: types.optional(types.boolean, true),
+
     // select regions after creating them
     selectAfterCreate: false,
 
@@ -135,6 +140,10 @@ const SettingsModel = types
       //   // TODO there is no showLables in the regions right now
       //   return typeof r.showLabels === "boolean" && r.setShowLables(self.showLabels);
       // });
+    },
+
+    toggleReverseZoomScrollDirection() {
+      self.reverseZoomScrollDirection = !self.reverseZoomScrollDirection;
     },
 
     toggleShowLineNumbers() {


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
When labeling images, the current zoom behavior is not intuitive, as it's reversed from common applications.
Link to the issue: #6729 

label studio:

- ctrl + scroll up == zoom out
- ctrl + scroll down == zoom in

other software:

- ctrl + scroll up == zoom in
- ctrl + scroll down == zoom out


#### What does this fix?
_(if this is a bug fix)_



#### What is the new behavior?
I added a new parameter into the configuration modal “Reverse zoom scroll direction”, so users can toggle to choose which scrolling direction they want. 

They could switch to the new setting, or keep using the previous one if they are used to it.

![image](https://github.com/user-attachments/assets/8cfd690d-b869-4ff5-a5c8-514f0703a5e3)



#### What is the current behavior?
Currently, Ctrl+scroll up zooms out and Ctrl+scroll down zooms in.



#### What libraries were added/updated?
No new libraries were added or updated.


#### Does this change affect performance?
No, it does not impact performance.



#### Does this change affect security?
No, it does not affect security.



#### What alternative approaches were there?
Changing the scroll direction without setting parameter.



#### What feature flags were used to cover this change?
feature



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [x] unit



### Which logical domain(s) does this change affect?
Image Annotation Interface, shortcuts.

