### PR TITLE
fix: DIA-1689: Fix empty parsed_label_config in projects

### DIFF
--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -889,8 +889,12 @@ class Project(ProjectMixin, models.Model):
 
     def get_parsed_config(self, autosave_cache=True):
         if self.parsed_label_config is None:
-            self.parsed_label_config = parse_config(self.label_config)
-            self.save(update_fields=['parsed_label_config'])
+            try:
+                self.parsed_label_config = parse_config(self.label_config)
+                self.save(update_fields=['parsed_label_config'])
+            except Exception as e:
+                logger.error(f'Error parsing label config for project {self.id}: {e}', exc_info=True)
+                return {}
 
         return self.parsed_label_config
 

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -890,9 +890,7 @@ class Project(ProjectMixin, models.Model):
     def get_parsed_config(self, autosave_cache=True):
         if self.parsed_label_config is None:
             self.parsed_label_config = parse_config(self.label_config)
-
-            # if autosave_cache:
-            #    Project.objects.filter(id=self.id).update(parsed_label_config=self.parsed_label_config)
+            self.save(update_fields=['parsed_label_config'])
 
         return self.parsed_label_config
 

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -696,7 +696,7 @@ class Project(ProjectMixin, models.Model):
         return {'deleted_predictions': count}
 
     def get_updated_weights(self):
-        outputs = self.get_parsed_config(autosave_cache=False)
+        outputs = self.get_parsed_config()
         control_weights = {}
         exclude_control_types = ('Filter',)
 
@@ -887,7 +887,7 @@ class Project(ProjectMixin, models.Model):
     def max_tasks_file_size():
         return settings.TASKS_MAX_FILE_SIZE
 
-    def get_parsed_config(self, autosave_cache=True):
+    def get_parsed_config(self):
         if self.parsed_label_config is None:
             try:
                 self.parsed_label_config = parse_config(self.label_config)


### PR DESCRIPTION
Users see 500 errors when interacting with subsets API: some of the project.parsed_label_configs are empty