### PR TITLE
fix: OPTIC-1407: Optimize the tasks API paginated prediction and annotation totals

### DIFF
--- a/label_studio/data_manager/api.py
+++ b/label_studio/data_manager/api.py
@@ -230,8 +230,8 @@ class TaskPagination(PageNumberPagination):
             total_annotations=Sum('total_annotations') - Sum('cancelled_annotations'),
             total_predictions=Sum('total_predictions'),
         )
-        self.total_annotations = totals['total_annotations']
-        self.total_predictions = totals['total_predictions']
+        self.total_annotations = totals.get('total_annotations', 0)
+        self.total_predictions = totals.get('total_predictions', 0)
         return super().paginate_queryset(queryset, request, view)
 
     def paginate_queryset(self, queryset, request, view=None):

--- a/label_studio/data_manager/api.py
+++ b/label_studio/data_manager/api.py
@@ -224,7 +224,7 @@ class TaskPagination(PageNumberPagination):
         self.total_predictions = Prediction.objects.filter(task_id__in=queryset).count()
         self.total_annotations = Annotation.objects.filter(task_id__in=queryset, was_cancelled=False).count()
         return super().paginate_queryset(queryset, request, view)
-    
+
     def paginate_totals_queryset(self, queryset, request, view=None):
         totals = queryset.values('id', 'total_predictions', 'total_annotations', 'cancelled_annotations').aggregate(
             total_annotations=Sum('total_annotations') - Sum('cancelled_annotations'),

--- a/label_studio/data_manager/api.py
+++ b/label_studio/data_manager/api.py
@@ -234,19 +234,16 @@ class TaskPagination(PageNumberPagination):
         # the default value of the aggregate function is None
         self.total_annotations = totals['total_annotations'] or 0
         self.total_predictions = totals['total_predictions'] or 0
-        print(f"paginate_totals_queryset: total_annotations: {self.total_annotations}, total_predictions: {self.total_predictions}")
         return super().paginate_queryset(queryset, request, view)
 
     def paginate_queryset(self, queryset, request, view=None):
         if flag_set('fflag_fix_back_optic_1407_optimize_tasks_api_pagination_counts'):
             return self.paginate_totals_queryset(queryset, request, view)
-        elif flag_set('fflag_fix_back_leap_24_tasks_api_optimization_05092023_short'):
+        if flag_set('fflag_fix_back_leap_24_tasks_api_optimization_05092023_short'):
             return self.async_paginate_queryset(queryset, request, view)
-        else:
-            return self.sync_paginate_queryset(queryset, request, view)
+        return self.sync_paginate_queryset(queryset, request, view)
 
     def get_paginated_response(self, data):
-        print(f"paginated_response: total_annotations: {self.total_annotations}, total_predictions: {self.total_predictions}")
         return Response(
             {
                 'total_annotations': self.total_annotations,

--- a/label_studio/data_manager/api.py
+++ b/label_studio/data_manager/api.py
@@ -230,8 +230,11 @@ class TaskPagination(PageNumberPagination):
             total_annotations=Sum('total_annotations') - Sum('cancelled_annotations'),
             total_predictions=Sum('total_predictions'),
         )
-        self.total_annotations = totals.get('total_annotations', 0)
-        self.total_predictions = totals.get('total_predictions', 0)
+        # if the total is None, set it to 0
+        # the default value of the aggregate function is None
+        self.total_annotations = totals['total_annotations'] or 0
+        self.total_predictions = totals['total_predictions'] or 0
+        print(f"paginate_totals_queryset: total_annotations: {self.total_annotations}, total_predictions: {self.total_predictions}")
         return super().paginate_queryset(queryset, request, view)
 
     def paginate_queryset(self, queryset, request, view=None):
@@ -243,6 +246,7 @@ class TaskPagination(PageNumberPagination):
             return self.sync_paginate_queryset(queryset, request, view)
 
     def get_paginated_response(self, data):
+        print(f"paginated_response: total_annotations: {self.total_annotations}, total_predictions: {self.total_predictions}")
         return Response(
             {
                 'total_annotations': self.total_annotations,

--- a/label_studio/tests/data_manager/test_api_tasks.py
+++ b/label_studio/tests/data_manager/test_api_tasks.py
@@ -4,7 +4,6 @@ import json
 
 import pytest
 from projects.models import Project
-from tasks.functions import update_tasks_counters
 
 from ..utils import make_annotation, make_prediction, make_task, project_id  # noqa
 
@@ -121,8 +120,6 @@ def test_views_total_counters(tasks_count, annotations_count, predictions_count,
 
         for _ in range(0, predictions_count):
             make_prediction({'result': []}, task_id)
-
-    update_tasks_counters(project.tasks.all())
 
     response = business_client.get(f'/api/tasks?fields=all&view={view_id}')
 

--- a/label_studio/tests/data_manager/test_api_tasks.py
+++ b/label_studio/tests/data_manager/test_api_tasks.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 from projects.models import Project
+from tasks.functions import update_tasks_counters
 
 from ..utils import make_annotation, make_prediction, make_task, project_id  # noqa
 
@@ -120,6 +121,8 @@ def test_views_total_counters(tasks_count, annotations_count, predictions_count,
 
         for _ in range(0, predictions_count):
             make_prediction({'result': []}, task_id)
+
+    update_tasks_counters(project.tasks.all())
 
     response = business_client.get(f'/api/tasks?fields=all&view={view_id}')
 


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [X] Backend (Database)
- [X] Backend (API)
- [ ] Frontend



### Describe the reason for change
At larger counts of tasks and annotations, these 2 queries would become incredibly inefficient and cause slowdowns. This PR instead uses the task column values to do aggregation and simple SUM's on the values to produce the same output.







#### Does this change affect performance?
Improves performance about 15-20x when looking at volumes of data where there are greater than 500K tasks, and 500K annotations per project.



#### What alternative approaches were there?
- Moving the original subquery to a JOIN, which is difficult to do without dropping down to raw SQL.
- Similarily this query while an improvement could possibly benefit further from moving this subquery to a JOIN. Same point of why not, it would likely require dropping out of the ORM to achieve as it really likes to use subqueries (which do tend to be faster in most cases, just not at certain scale)



#### What feature flags were used to cover this change?
- `fflag_fix_back_optic_1407_optimize_tasks_api_pagination_counts`



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [x] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Tasks List API

