### PR TITLE
chore: OPTIC-1413: Add internal tracking of Heidi Tips

### DIFF
--- a/label_studio/users/templates/users/new-ui/user_tips.html
+++ b/label_studio/users/templates/users/new-ui/user_tips.html
@@ -1,6 +1,10 @@
 {% load filters %}
 
 <script nonce="{{request.csp_nonce}}">
+
+  window.APP_SETTINGS = window.APP_SETTINGS ?? {};
+  window.APP_SETTINGS.collect_analytics = {{ settings.COLLECT_ANALYTICS|yesno:"true,false" }};
+
   // Log event to the server, if analytics are enabled
   // This is a fallback for when the __lsa global is not defined
   // Normally this is a part of our main bundle but these pages do not use the main bundle
@@ -219,7 +223,7 @@
     _container.addEventListener('click', (event) => {
       // If the clicked element is the link, log the click
       if (event.target.hasAttribute('data-heidi-tip-link')) {
-        __lsa(getTipEvent(TIP_COLLECTION_NAME, selectedTip, event), getTipMetadata(selectedTip));
+        __lsa(getTipEvent(TIP_COLLECTION_NAME, selectedTip, 'click'), getTipMetadata(selectedTip));
       }
     });
 

--- a/label_studio/users/templates/users/new-ui/user_tips.html
+++ b/label_studio/users/templates/users/new-ui/user_tips.html
@@ -1,12 +1,45 @@
 {% load filters %}
 
 <script nonce="{{request.csp_nonce}}">
+  // Log event to the server, if analytics are enabled
+  // This is a fallback for when the __lsa global is not defined
+  // Normally this is a part of our main bundle but these pages do not use the main bundle
+  // and this allows us to log events from these pages
+  const logEvent = (eventName, metadata = {}) => {
+    if (!window.APP_SETTINGS?.collect_analytics) return;
+
+    const payload = {
+      ...metadata,
+      event: eventName,
+      url: window.location.href,
+    };
+
+    window.requestIdleCallback(() => {
+      const params = new URLSearchParams({ __: JSON.stringify(payload) });
+      const url = `/__lsa/?${params}`;
+      try {
+        if (navigator.sendBeacon) {
+          navigator.sendBeacon(url);
+        } else {
+          const img = new Image();
+          img.src = url;
+        }
+      } catch {
+        // Ignore errors here
+      }
+    });
+  };
+  if (!window.__lsa) {
+    window.__lsa = logEvent;
+  }
 
   const SERVER_ID = {{ request.server_id|json_dumps_ensure_ascii|safe }};
+  const EVENT_NAMESPACE_KEY = "heidi_tips";
   const CACHE_KEY = "heidi_live_tips_collection";
   const CACHE_FETCHED_AT_KEY = "heidi_live_tips_collection_fetched_at";
   const CACHE_STALE_TIME = 1000 * 60 * 60; // 1 hour
   const MAX_TIMEOUT = 5000; // 5 seconds
+  const TIP_COLLECTION_NAME = "authPage";
 
   const defaultTipsCollection = {
     authPage: [
@@ -130,13 +163,43 @@
   function getRandomTip() {
     const tipsCollection = loadLiveTipsCollection();
 
-    if (!tipsCollection['authPage']) return null;
+    if (!tipsCollection[TIP_COLLECTION_NAME]) return null;
 
-    const tips = tipsCollection['authPage'];
+    const tips = tipsCollection[TIP_COLLECTION_NAME];
 
     const index = Math.floor(Math.random() * tips.length);
 
     return tips[index];
+  }
+
+  function getTipCollectionEvent(collection, event) {
+    return `${EVENT_NAMESPACE_KEY}.${collection}.${event}`;
+  }
+
+  function getTipEvent(collection, tip, event) {
+    if (tip.link.params?.experiment && tip.link.params?.treatment) {
+      return `${EVENT_NAMESPACE_KEY}.${collection}.${tip.link.params?.experiment}.${tip.link.params?.treatment}.${event}`;
+    }
+    if (tip.link.params?.experiment) {
+      return `${EVENT_NAMESPACE_KEY}.${collection}.${tip.link.params?.experiment}.${event}`;
+    }
+    if (tip.link.params?.treatment) {
+      return `${EVENT_NAMESPACE_KEY}.${collection}.${tip.link.params?.treatment}.${event}`;
+    }
+
+    return getTipCollectionEvent(collection, event);
+  }
+
+  function getTipMetadata(tip) {
+    // Everything except the experiment and treatment params as those are part of the event name
+    const { experiment, treatment, ...rest } = tip.link.params ?? {};
+    return {
+      ...rest,
+      content: tip.description ?? tip.content ?? "",
+      title: tip.title,
+      href: tip.link.url,
+      label: tip.link.label,
+    };
   }
 
   document.addEventListener('DOMContentLoaded', function() {
@@ -151,10 +214,19 @@
       return;
     }
 
+    // Add the click handler to all links inside the tips container that have the data-heidi-tip-link attribute
+    // In the future if there are more than one tip, we will need to check which tip was clicked
+    _container.addEventListener('click', (event) => {
+      // If the clicked element is the link, log the click
+      if (event.target.hasAttribute('data-heidi-tip-link')) {
+        __lsa(getTipEvent(TIP_COLLECTION_NAME, selectedTip, event), getTipMetadata(selectedTip));
+      }
+    });
+
     const linkUrl = createURL(selectedTip.link.url, selectedTip.link.params)
 
     _title.innerHTML = selectedTip.title;
-    _description.innerHTML = `${selectedTip.description} <a href="${linkUrl}" target="_blank">${selectedTip.link.label}</a>`;
+    _description.innerHTML = `${selectedTip.description} <a data-heidi-tip-link href="${linkUrl}" target="_blank">${selectedTip.link.label}</a>`;
   });
 </script>
 

--- a/web/apps/labelstudio/src/components/HeidiTips/HeidiTip.tsx
+++ b/web/apps/labelstudio/src/components/HeidiTips/HeidiTip.tsx
@@ -8,7 +8,7 @@ import type { HeidiTipProps, Tip } from "./types";
 import { Tooltip } from "../Tooltip/Tooltip";
 import { createURL } from "./utils";
 
-const HeidiLink: FC<{ link: Tip["link"] }> = ({ link }) => {
+const HeidiLink: FC<{ link: Tip["link"]; onClick: () => void }> = ({ link, onClick }) => {
   const url = useMemo(() => {
     const params = link.params ?? {};
     /* if needed, add server ID here */
@@ -18,13 +18,13 @@ const HeidiLink: FC<{ link: Tip["link"] }> = ({ link }) => {
 
   return (
     /* @ts-ignore-next-line */
-    <Elem name="link" tag="a" href={url} target="_blank">
+    <Elem name="link" tag="a" href={url} target="_blank" onClick={onClick}>
       {link.label}
     </Elem>
   );
 };
 
-export const HeidiTip: FC<HeidiTipProps> = ({ tip, onDismiss }) => {
+export const HeidiTip: FC<HeidiTipProps> = ({ tip, onDismiss, onLinkClick }) => {
   const handleClick = useCallback((event: MouseEvent) => {
     event.preventDefault();
     event.stopPropagation();
@@ -48,7 +48,7 @@ export const HeidiTip: FC<HeidiTipProps> = ({ tip, onDismiss }) => {
         </Elem>
         <Elem name="text">
           {tip.content}
-          <HeidiLink link={tip.link} />
+          <HeidiLink link={tip.link} onClick={onLinkClick} />
         </Elem>
       </Elem>
       <Elem name="heidi">

--- a/web/apps/labelstudio/src/components/HeidiTips/HeidiTips.tsx
+++ b/web/apps/labelstudio/src/components/HeidiTips/HeidiTips.tsx
@@ -4,7 +4,7 @@ import { HeidiTip } from "./HeidiTip";
 import { useRandomTip } from "./hooks";
 
 export const HeidiTips: FC<HeidiTipsProps> = memo(({ collection }) => {
-  const [tip, dismiss] = useRandomTip(collection);
+  const [tip, dismiss, onLinkClick] = useRandomTip(collection);
 
-  return tip && <HeidiTip tip={tip} onDismiss={dismiss} />;
+  return tip && <HeidiTip tip={tip} onDismiss={dismiss} onLinkClick={onLinkClick} />;
 });

--- a/web/apps/labelstudio/src/components/HeidiTips/hooks.ts
+++ b/web/apps/labelstudio/src/components/HeidiTips/hooks.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import { dismissTip, getRandomTip } from "./utils";
+import { dismissTip, getRandomTip, getTipEvent, getTipMetadata } from "./utils";
 import type { Tip, TipsCollection } from "./types";
 
 export const useRandomTip = (collection: keyof TipsCollection) => {
@@ -9,5 +9,11 @@ export const useRandomTip = (collection: keyof TipsCollection) => {
     setTip(null);
   }, []);
 
-  return [tip, dismiss] as const;
+  const onLinkClick = useCallback(() => {
+    if (tip) {
+      __lsa(getTipEvent(collection, tip, "click"), getTipMetadata(tip));
+    }
+  }, [tip]);
+
+  return [tip, dismiss, onLinkClick] as const;
 };

--- a/web/apps/labelstudio/src/components/HeidiTips/types.ts
+++ b/web/apps/labelstudio/src/components/HeidiTips/types.ts
@@ -1,11 +1,17 @@
+export type TipLinkParams = Record<string, string> & {
+  experiment?: string;
+  treatment?: string;
+};
+
 export type Tip = {
   title: string;
   content: string;
+  description?: string;
   closable?: boolean;
   link: {
     url: string;
     label: string;
-    params?: Record<string, string>;
+    params?: TipLinkParams;
   };
 };
 
@@ -20,4 +26,5 @@ export type HeidiTipsProps = {
 export type HeidiTipProps = {
   tip: Tip;
   onDismiss: () => void;
+  onLinkClick: () => void;
 };

--- a/web/apps/labelstudio/src/components/HeidiTips/utils.ts
+++ b/web/apps/labelstudio/src/components/HeidiTips/utils.ts
@@ -2,6 +2,7 @@ import { defaultTipsCollection } from "./content";
 import type { Tip, TipsCollection } from "./types";
 
 const STORE_KEY = "heidi_ignored_tips";
+const EVENT_NAMESPACE_KEY = "heidi_tips";
 const CACHE_KEY = "heidi_live_tips_collection";
 const CACHE_FETCHED_AT_KEY = "heidi_live_tips_collection_fetched_at";
 const CACHE_STALE_TIME = 1000 * 60 * 60; // 1 hour
@@ -9,6 +10,37 @@ const MAX_TIMEOUT = 5000; // 5 seconds
 
 function getKey(collection: string) {
   return `${STORE_KEY}:${collection}`;
+}
+
+export function getTipCollectionEvent(collection: string, event: string) {
+  return `${EVENT_NAMESPACE_KEY}.${collection}.${event}`;
+}
+
+export function getTipEvent(collection: string, tip: Tip, event: string) {
+  if (tip.link.params?.experiment && tip.link.params?.treatment) {
+    return `${EVENT_NAMESPACE_KEY}.${collection}.${tip.link.params?.experiment}.${tip.link.params?.treatment}.${event}`;
+  }
+  if (tip.link.params?.experiment) {
+    return `${EVENT_NAMESPACE_KEY}.${collection}.${tip.link.params?.experiment}.${event}`;
+  }
+  if (tip.link.params?.treatment) {
+    return `${EVENT_NAMESPACE_KEY}.${collection}.${tip.link.params?.treatment}.${event}`;
+  }
+
+  return getTipCollectionEvent(collection, event);
+}
+
+
+export function getTipMetadata(tip: Tip) {
+  // Everything except the experiment and treatment params as those are part of the event name
+  const { experiment, treatment, ...rest } = tip.link.params ?? {};
+  return {
+    ...rest,
+    content: tip.description ?? tip.content ?? "" ,
+    title: tip.title,
+    href: tip.link.url,
+    label: tip.link.label,
+  }
 }
 
 export const loadLiveTipsCollection = () => {
@@ -89,8 +121,11 @@ export function dismissTip(collection: string) {
   const cookieExpiry = `expires=${cookieExpiryDate.toUTCString()}`;
   const cookiePath = "path=/";
   const cookieString = [cookieValue, cookieExpiry, cookiePath].join("; ");
-
   document.cookie = cookieString;
+
+  __lsa(getTipCollectionEvent(collection, "dismiss"), {
+    expires: cookieExpiryDate.getTime(),
+  });
 }
 
 export function isTipDismissed(collection: string) {

--- a/web/apps/labelstudio/src/components/HeidiTips/utils.ts
+++ b/web/apps/labelstudio/src/components/HeidiTips/utils.ts
@@ -30,17 +30,16 @@ export function getTipEvent(collection: string, tip: Tip, event: string) {
   return getTipCollectionEvent(collection, event);
 }
 
-
 export function getTipMetadata(tip: Tip) {
   // Everything except the experiment and treatment params as those are part of the event name
   const { experiment, treatment, ...rest } = tip.link.params ?? {};
   return {
     ...rest,
-    content: tip.description ?? tip.content ?? "" ,
+    content: tip.description ?? tip.content ?? "",
     title: tip.title,
     href: tip.link.url,
     label: tip.link.label,
-  }
+  };
 }
 
 export const loadLiveTipsCollection = () => {

--- a/web/libs/core/src/lib/utils/analytics.ts
+++ b/web/libs/core/src/lib/utils/analytics.ts
@@ -1,9 +1,9 @@
 type LogEventFn = (eventName: string, metadata?: Record<string, unknown>) => void;
-
 declare global {
   interface Window {
     __lsa: LogEventFn;
   }
+  const __lsa: LogEventFn;
 }
 
 const logEvent: LogEventFn = (eventName, metadata = {}) => {


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [X] Product
- [ ] Backend (Database)
- [ ] Backend (API)
- [X] Frontend



### Describe the reason for change
Adding event tracking of the Heidi Tips content to understand the usefulness.


### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### Which logical domain(s) does this change affect?
Heidi Tips

