### PR TITLE
refactor: LEAP-1308: REVERT Remove Stale Feature Flag - ff_back_dev_3865_filters_anno_171222_short

### DIFF
--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -27,6 +27,7 @@ STALE_FEATURE_FLAGS = {
     'fflag_fix_back_lsdv_1044_check_annotations_24012023_short': False,
     'fflag_fix_front_dev_4075_taxonomy_overlap_281222_short': True,
     'fflag_fix_front_dev_3730_shortcuts_initial_input_22122022_short': True,
+    'ff_back_dev_3865_filters_anno_171222_short': True,
     'fflag_feat_front_dev_3873_labeling_ui_improvements_short': True,
     'fflag_feat_back_dev_3756_queue_enrollment_min_short': False,
     'fflag_fix_front_dev_3666_max_usages_on_region_creation_171122_short': True,


### PR DESCRIPTION
Reverts HumanSignal/label-studio#6744

LSE selenium test are failing, just in case creating this.