### PR TITLE
fix: LEAP-1409: Add preserving hidden filters during filter operations

### DIFF
--- a/web/libs/datamanager/src/stores/Tabs/store.js
+++ b/web/libs/datamanager/src/stores/Tabs/store.js
@@ -27,7 +27,10 @@ const dataCleanup = (tab, columnIds) => {
   if (!data) return { ...tab };
 
   if (data.filters) {
-    data.filters.items = data.filters.items.filter(({ filter }) => {
+    data._originalFilters = [];
+    data.filters.items = data.filters.items.filter((item) => {
+      const { filter } = item;
+      data._originalFilters.push(item);
       return columnIds.includes(filter.replace(/^filter:/, ""));
     });
   }
@@ -305,11 +308,16 @@ export const TabStore = types
         return view;
       }
       const viewSnapshot = getSnapshot(view);
+      let originalFilters = [];
+      if (result.filters) {
+        originalFilters = result.filters.items;
+      }
       const newViewSnapshot = {
         ...viewSnapshot,
         ...result,
         saved: true,
         filters: viewSnapshot.filters,
+        _originalFilters: originalFilters,
         conjunction: viewSnapshot.conjunction,
       };
 


### PR DESCRIPTION
Ensure hidden filters are retained and correctly processed in filter-related operations. Introduced `_originalFilters` to store and manage filters not editable by the user, preventing their loss during requests.

### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
We have columns in Data Manager. For some user roles the list of columns is reduced. We can have filters over these columns set by other users. But we cannot do anything with these filters as they are dependent on  the non existing for the current user columns.

The previous solution was just filter this filters out of the models. But this approach causes the problem: we do not save this filtered out filters when we adding / deleting / editing other filters an columns.

Storing these filtered out filters somewhere and restoring them on creating a request should help with that.




#### What alternative approaches were there?
1. Solve this on the backend. But we may lose consistency and orderliness. There is not enough control.
2. We could keep these filters in the model but just hide them. In that case we have problem with fixing current logic, that was written with assuming that we do not need these filters and everything else, related to them (f.e. colums in the model). It's hard to fixx all places like that. 


### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
`Data Manager`, 'Filers'

