### PR TITLE
fix: `InactivitySessionTimeoutMiddleware`: Check for `last_login` (allow Django admin login + access)

### DIFF
--- a/label_studio/core/middleware.py
+++ b/label_studio/core/middleware.py
@@ -211,8 +211,9 @@ class InactivitySessionTimeoutMiddleWare(CommonMiddleware):
         current_time = time.time()
         last_login = request.session['last_login'] if 'last_login' in request.session else 0
 
-        # Check if this request is too far from when the login happened
-        if (current_time - last_login) > settings.MAX_SESSION_AGE:
+        # Check if this request is too far from when the login happened,
+        # but only when last_login was set before
+        if last_login and (current_time - last_login) > settings.MAX_SESSION_AGE:
             logger.info(
                 f'Request is too far from last login {current_time - last_login:.0f} > {settings.MAX_SESSION_AGE}; logout'
             )

--- a/label_studio/core/middleware.py
+++ b/label_studio/core/middleware.py
@@ -214,7 +214,7 @@ class InactivitySessionTimeoutMiddleWare(CommonMiddleware):
         # Check if this request is too far from when the login happened,
         # but only when last_login was set before
         if last_login and (current_time - last_login) > settings.MAX_SESSION_AGE:
-            logger.info(
+            logger.warn(
                 f'Request is too far from last login {current_time - last_login:.0f} > {settings.MAX_SESSION_AGE}; logout'
             )
             logout(request)

--- a/label_studio/tests/test_django_admin_login.py
+++ b/label_studio/tests/test_django_admin_login.py
@@ -1,0 +1,25 @@
+from django.urls import reverse
+
+
+def test_django_admin_login(admin_user, client, live_server):
+    response = client.get(reverse("admin:index"))
+
+    # Make sure we are redirected to the django admin login page
+    assert response.status_code == 302
+    assert response.url.startswith(reverse("admin:login"))
+
+    credentials = {"username": admin_user.email, "password": "password"}
+    response = client.post(response.url, credentials)
+
+    # We should be redirected to the django index
+    assert response.status_code == 302
+    assert response.url.startswith(reverse("admin:index"))
+
+    # No last_login key has been set in the session as we do not
+    # login via the regular /users/login page
+    assert not "last_login" in client.session
+
+    # And our logged in session will still be valid
+    response = client.get(reverse("admin:index"))
+
+    assert response.status_code == 200


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)

Note: I do not (yet) understand what should be the `TICKET-ID` and how to decide the commit message with this prefix `DEV-XXXX`, therefore I left it empty for now and just added the commit message. (Suggestion: Add documentation for outside collaborators how they can determine this).

#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [ ] Frontend

Not really sure which one to choose.

### Describe the reason for change
Allows login into the Django admin "Out-of-the-box", and makes sure no `last_login` comparison is made when never logged in. See also the issue [Admin Page - Not letting login #4083 ](https://github.com/HumanSignal/label-studio/issues/4083)

#### What does this fix?
Allow users to login via the Django admin login screen (`/admin/login`)

#### What is the new behavior?
The `InactivitySessionTimeoutMiddleware` won't automatically logout a user when `last_login` is not set in the user session.

#### What is the current behavior?
The `InactivitySessionTimeoutMiddleware` logs out all users which do not have the `last_login` value set > 0 in the user session.

#### What libraries were added/updated?
N/A

#### Does this change affect performance?
No

#### Does this change affect security?
No

#### What alternative approaches were there?
I suggest to completely remove the `InactivitySessionTimeoutMiddleware` in a future release. Session expiration time can be set out of the box via the [SESSION_COOKIE_AGE](https://docs.djangoproject.com/en/5.1/ref/settings/#session-cookie-age).

If manual extension / adjustion of the session time is required, you can use the [.set_expiry()](https://docs.djangoproject.com/en/5.1/topics/http/sessions/#django.contrib.sessions.backends.base.SessionBase.set_expiry) method. (In the `/users/login` view for example).

#### What feature flags were used to cover this change?
N/A

### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [X] integration
- [ ] unit

### Which logical domain(s) does this change affect?
_(for bug fixes/features, be as precise as possible. ex. Authentication, Annotation History, Review Stream etc.)_
Authentication
