### PR TITLE
feat: OPTIC-1367: Find opportunities for property cache

### DIFF
--- a/label_studio/core/mixins.py
+++ b/label_studio/core/mixins.py
@@ -3,6 +3,7 @@
 import logging
 
 from django.db.models.query import QuerySet
+from django.utils.functional import cached_property
 from rest_framework.generics import get_object_or_404
 
 logger = logging.getLogger(__name__)
@@ -16,7 +17,11 @@ class DummyModelMixin:
 class GetParentObjectMixin:
     parent_queryset = None
 
-    def get_parent_object(self):
+    @cached_property
+    def parent_object(self):
+        return self._get_parent_object()
+
+    def _get_parent_object(self):
         """
         The same as get_object method from DRF, but for the parent object
         For example if you want to get project inside /api/projects/ID/tasks handler

--- a/label_studio/organizations/api.py
+++ b/label_studio/organizations/api.py
@@ -196,12 +196,12 @@ class OrganizationMemberDetailAPI(GetParentObjectMixin, generics.RetrieveDestroy
         return api_settings.DEFAULT_PERMISSION_CLASSES
 
     def get_queryset(self):
-        return OrganizationMember.objects.filter(organization=self.get_parent_object())
+        return OrganizationMember.objects.filter(organization=self.parent_object)
 
     def get_serializer_context(self):
         return {
             **super().get_serializer_context(),
-            'organization': self.get_parent_object(),
+            'organization': self.parent_object,
         }
 
     def get(self, request, pk, user_pk):
@@ -213,7 +213,7 @@ class OrganizationMemberDetailAPI(GetParentObjectMixin, generics.RetrieveDestroy
         return Response(serializer.data)
 
     def delete(self, request, pk=None, user_pk=None):
-        org = self.get_parent_object()
+        org = self.parent_object
         if org != request.user.active_organization:
             raise PermissionDenied('You can delete members only for your current active organization')
 

--- a/label_studio/organizations/mixins.py
+++ b/label_studio/organizations/mixins.py
@@ -1,5 +1,8 @@
+from django.utils.functional import cached_property
+
+
 class OrganizationMixin:
-    @property
+    @cached_property
     def active_members(self):
         return self.members
 

--- a/label_studio/organizations/models.py
+++ b/label_studio/organizations/models.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.db import models, transaction
 from django.db.models import Count, Q
 from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 logger = logging.getLogger(__name__)
@@ -46,11 +47,11 @@ class OrganizationMember(OrganizationMemberMixin, models.Model):
         user_pk = user_or_user_pk.pk if isinstance(user_or_user_pk, User) else user_or_user_pk
         return OrganizationMember.objects.get(user=user_pk, organization=organization_pk)
 
-    @property
+    @cached_property
     def is_deleted(self):
         return bool(self.deleted_at)
 
-    @property
+    @cached_property
     def is_owner(self):
         return self.user.id == self.organization.created_by.id
 
@@ -181,11 +182,11 @@ class Organization(OrganizationMixin, models.Model):
             return org_verify
         return settings.VERIFY_SSL_CERTS
 
-    @property
+    @cached_property
     def secure_mode(self):
         return False
 
-    @property
+    @cached_property
     def members(self):
         return OrganizationMember.objects.filter(organization=self)
 

--- a/label_studio/projects/api.py
+++ b/label_studio/projects/api.py
@@ -620,7 +620,7 @@ class ProjectSummaryResetAPI(GetParentObjectMixin, generics.CreateAPIView):
 
     @swagger_auto_schema(auto_schema=None)
     def post(self, *args, **kwargs):
-        project = self.get_parent_object()
+        project = self.parent_object
         summary = project.summary
         start_job_async_or_sync(
             recalculate_created_annotations_and_labels_from_scratch,
@@ -776,11 +776,11 @@ class ProjectTaskListAPI(GetParentObjectMixin, generics.ListCreateAPIView, gener
 
     def get_serializer_context(self):
         context = super(ProjectTaskListAPI, self).get_serializer_context()
-        context['project'] = self.get_parent_object()
+        context['project'] = self.parent_object
         return context
 
     def perform_create(self, serializer):
-        project = self.get_parent_object()
+        project = self.parent_object
         instance = serializer.save(project=project)
         emit_webhooks_for_instance(
             self.request.user.active_organization, project, WebhookAction.TASKS_CREATED, [instance]

--- a/label_studio/tasks/api.py
+++ b/label_studio/tasks/api.py
@@ -539,7 +539,7 @@ class AnnotationsListAPI(GetParentObjectMixin, generics.ListCreateAPIView):
             pass
 
     def perform_create(self, ser):
-        task = self.get_parent_object()
+        task = self.parent_object
         # annotator has write access only to annotations and it can't be checked it after serializer.save()
         user = self.request.user
 

--- a/label_studio/users/models.py
+++ b/label_studio/users/models.py
@@ -12,6 +12,7 @@ from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from organizations.models import Organization
 from rest_framework.authtoken.models import Token
@@ -130,7 +131,7 @@ class User(UserMixin, AbstractBaseUser, PermissionsMixin, UserLastActivityMixin)
             models.Index(fields=['date_joined']),
         ]
 
-    @property
+    @cached_property
     def avatar_url(self):
         if self.avatar:
             if settings.CLOUD_FILE_STORAGE_ENABLED:
@@ -148,11 +149,11 @@ class User(UserMixin, AbstractBaseUser, PermissionsMixin, UserLastActivityMixin)
         annotations = self.active_organization_annotations()
         return annotations.values_list('project').distinct().count()
 
-    @property
+    @cached_property
     def own_organization(self) -> Optional[Organization]:
         return fast_first(Organization.objects.filter(created_by=self))
 
-    @property
+    @cached_property
     def has_organization(self):
         return Organization.objects.filter(created_by=self).exists()
 


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [ ] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Backend (Database)
- [x] Backend (API)
- [ ] Frontend



### Describe the reason for change
We are proactively trying to use cached_property to address performance issues and standardize caching methodologies of properties.
I changed `@property` methods that looked low risk and I understood its usage.
`self.get_parent_object()` was the only piece of code that I identified was being called two times in the same request in `OrganizationMemberDetailAPI`.


### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
_(for bug fixes/features, be as precise as possible. ex. Authentication, Annotation History, Review Stream etc.)_

