### PR TITLE
fix: OPTIC-1490: Safely reference content_type of the response so it does not error

### DIFF
--- a/label_studio/core/utils/contextlog.py
+++ b/label_studio/core/utils/contextlog.py
@@ -271,7 +271,7 @@ class ContextLog(object):
         else:
             namespace = request.resolver_match.namespace if request.resolver_match else None
             status_code = response.status_code
-            content_type = response.content_type if 'content_type' in response else None
+            content_type = response.content_type if hasattr(response, 'content_type') else None
             response_content = self._get_response_content(response)
 
         payload = {

--- a/label_studio/core/utils/contextlog.py
+++ b/label_studio/core/utils/contextlog.py
@@ -271,7 +271,7 @@ class ContextLog(object):
         else:
             namespace = request.resolver_match.namespace if request.resolver_match else None
             status_code = response.status_code
-            content_type = response.content_type
+            content_type = response.content_type if 'content_type' in response else None
             response_content = self._get_response_content(response)
 
         payload = {

--- a/label_studio/core/utils/contextlog.py
+++ b/label_studio/core/utils/contextlog.py
@@ -271,7 +271,7 @@ class ContextLog(object):
         else:
             namespace = request.resolver_match.namespace if request.resolver_match else None
             status_code = response.status_code
-            content_type = response.content_type if hasattr(response, 'content_type') else None
+            content_type = getattr(response, 'content_type', None)
             response_content = self._get_response_content(response)
 
         payload = {


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [X] Backend (API)
- [ ] Frontend



### Describe the reason for change
There will be cases where the response has no content_type, which is the case of NotFound response objects. This just makes sure it is present before reading it.



### Which logical domain(s) does this change affect?
ContextLog

