### PR TITLE
refactor: OPTIC-1510: remove a batch of ff

### DIFF
--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -23,7 +23,6 @@ STALE_FEATURE_FLAGS = {
     'fflag_feat_front_lsdv_4661_full_uri_resolve_15032023_short': True,
     'fflag_feat_front_lsdv_4659_skipduplicates_060323_short': True,
     'fflag_fix_font_lsdv_1148_hotkeys_namespaces_01022023_short': True,
-    'fflag_fix_back_lsdv_1044_check_annotations_24012023_short': False,
     'ff_back_dev_3865_filters_anno_171222_short': True,
     'fflag_feat_front_dev_3873_labeling_ui_improvements_short': True,
     'fflag_feat_back_dev_3756_queue_enrollment_min_short': False,

--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -21,7 +21,6 @@ STALE_FEATURE_FLAGS = {
     'fflag_fix_back_lsdv_4929_limit_exports_10042023_short': True,
     'fflag_feat_front_lsdv_4620_richtext_opimization_060423_short': True,
     'fflag_feat_front_lsdv_4661_full_uri_resolve_15032023_short': True,
-    'fflag_feat_front_lsdv_4659_skipduplicates_060323_short': True,
     'ff_back_dev_3865_filters_anno_171222_short': True,
     'fflag_feat_front_dev_3873_labeling_ui_improvements_short': True,
     'fflag_feat_back_dev_3756_queue_enrollment_min_short': False,

--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -17,7 +17,6 @@ STALE_FEATURE_FLAGS = {
     'ff_back_dev_4664_remove_storage_file_on_export_delete_29032023_short': False,
     'fflag_feat_front_lops_86_datasets_storage_edit_short': False,
     'fflag_fix_front_lsdv_4881_timeseries_points_missing_140423_short': True,
-    'fflag_feat_front_lsdv_4712_skipduplicates_editing_110423_short': True,
     'fflag_fix_back_lsdv_4929_limit_exports_10042023_short': True,
     'fflag_feat_front_lsdv_4620_richtext_opimization_060423_short': True,
     'ff_back_dev_3865_filters_anno_171222_short': True,

--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -22,7 +22,6 @@ STALE_FEATURE_FLAGS = {
     'fflag_feat_front_lsdv_4620_richtext_opimization_060423_short': True,
     'fflag_feat_front_lsdv_4661_full_uri_resolve_15032023_short': True,
     'fflag_feat_front_lsdv_4659_skipduplicates_060323_short': True,
-    'fflag_fix_font_lsdv_1148_hotkeys_namespaces_01022023_short': True,
     'ff_back_dev_3865_filters_anno_171222_short': True,
     'fflag_feat_front_dev_3873_labeling_ui_improvements_short': True,
     'fflag_feat_back_dev_3756_queue_enrollment_min_short': False,

--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -24,7 +24,6 @@ STALE_FEATURE_FLAGS = {
     'fflag_feat_front_lsdv_4659_skipduplicates_060323_short': True,
     'fflag_fix_font_lsdv_1148_hotkeys_namespaces_01022023_short': True,
     'fflag_fix_back_lsdv_1044_check_annotations_24012023_short': False,
-    'fflag_fix_front_dev_4075_taxonomy_overlap_281222_short': True,
     'ff_back_dev_3865_filters_anno_171222_short': True,
     'fflag_feat_front_dev_3873_labeling_ui_improvements_short': True,
     'fflag_feat_back_dev_3756_queue_enrollment_min_short': False,

--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -20,7 +20,6 @@ STALE_FEATURE_FLAGS = {
     'fflag_feat_front_lsdv_4712_skipduplicates_editing_110423_short': True,
     'fflag_fix_back_lsdv_4929_limit_exports_10042023_short': True,
     'fflag_feat_front_lsdv_4620_richtext_opimization_060423_short': True,
-    'fflag_feat_front_lsdv_4661_full_uri_resolve_15032023_short': True,
     'ff_back_dev_3865_filters_anno_171222_short': True,
     'fflag_feat_front_dev_3873_labeling_ui_improvements_short': True,
     'fflag_feat_back_dev_3756_queue_enrollment_min_short': False,

--- a/label_studio/io_storages/functions.py
+++ b/label_studio/io_storages/functions.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Dict, Iterable, List, Union
 
-from core.feature_flags import flag_set
 from io_storages.base_models import ImportStorage
 
 from .azure_blob.api import AzureBlobExportStorageListAPI, AzureBlobImportStorageListAPI
@@ -51,11 +50,10 @@ def get_storage_by_url(url: Union[str, List, Dict], storage_objects: Iterable[Im
             return storage_object
 
     # url is list or dict
-    if flag_set('fflag_feat_front_lsdv_4661_full_uri_resolve_15032023_short', user='auto'):
-        if isinstance(url, dict) or isinstance(url, list):
-            for storage_object in storage_objects:
-                if storage_object.can_resolve_url(url):
-                    # note: only first found storage_object will be used for link resolving
-                    # probably we need to use more advanced can_resolve_url mechanics
-                    # that takes into account not only prefixes, but bucket path too
-                    return storage_object
+    if isinstance(url, dict) or isinstance(url, list):
+        for storage_object in storage_objects:
+            if storage_object.can_resolve_url(url):
+                # note: only first found storage_object will be used for link resolving
+                # probably we need to use more advanced can_resolve_url mechanics
+                # that takes into account not only prefixes, but bucket path too
+                return storage_object

--- a/label_studio/projects/functions/next_task.py
+++ b/label_studio/projects/functions/next_task.py
@@ -265,9 +265,6 @@ def skipped_queue(next_task, prepared_tasks, project, user, queue_info):
 def postponed_queue(next_task, prepared_tasks, project, user, queue_info):
     if not next_task:
         q = Q(task__project=project, task__isnull=False, was_postponed=True, task__is_labeled=False)
-        if flag_set('fflag_fix_back_lsdv_1044_check_annotations_24012023_short', user):
-            q &= ~Q(task__annotations__completed_by=user)
-
         postponed_tasks = user.drafts.filter(q).order_by('updated_at').values_list('task__pk', flat=True)
         if postponed_tasks.exists():
             preserved_order = Case(*[When(pk=pk, then=pos) for pos, pk in enumerate(postponed_tasks)])

--- a/web/libs/editor/src/components/Taxonomy/Taxonomy.module.scss
+++ b/web/libs/editor/src/components/Taxonomy/Taxonomy.module.scss
@@ -115,12 +115,8 @@
   pointer-events: none;
   display: flex;
   padding-left: 43px;
-  padding-right: 60px;
-
-  &.taxonomy__measure_ff_dev4075 {
-    padding-right: 8px;
-    line-height: 2em;
-  }
+  padding-right: 8px;
+  line-height: 2em;
 }
 
 ;

--- a/web/libs/editor/src/components/Taxonomy/Taxonomy.tsx
+++ b/web/libs/editor/src/components/Taxonomy/Taxonomy.tsx
@@ -5,7 +5,6 @@ import { LsChevron } from "../../assets/icons";
 import { Tooltip } from "../../common/Tooltip/Tooltip";
 import { useToggle } from "../../hooks/useToggle";
 import type { CNTagName } from "../../utils/bem";
-import { FF_DEV_4075, isFF } from "../../utils/feature-flags";
 import { isArraysEqual } from "../../utils/utilities";
 import TreeStructure from "../TreeStructure/TreeStructure";
 
@@ -237,13 +236,9 @@ const Item: React.FC<RowProps> = ({ style, item, dimensionCallback, maxWidth, is
     <div ref={itemContainer} style={{ paddingLeft: padding, maxWidth, ...style, width: "fit-content" }}>
       {!isAddingItem ? (
         <>
-          <div
-            className={[styles.taxonomy__measure, isFF(FF_DEV_4075) ? styles.taxonomy__measure_ff_dev4075 : false]
-              .filter(Boolean)
-              .join(" ")}
-          >
+          <div className={styles.taxonomy__measure}>
             <label>{name}</label>
-            {isFF(FF_DEV_4075) && !isFiltering && (
+            {!isFiltering && (
               <div className={styles.taxonomy__extra}>
                 <span className={styles.taxonomy__extra_count}>{childCount}</span>
               </div>
@@ -270,7 +265,6 @@ const Item: React.FC<RowProps> = ({ style, item, dimensionCallback, maxWidth, is
               />
               <label
                 htmlFor={id}
-                style={isFF(FF_DEV_4075) ? {} : { maxWidth: `${labelMaxWidth}px` }}
                 onClick={isEditable ? onClick : undefined}
                 title={title}
                 className={disabled ? styles.taxonomy__collapsable : undefined}

--- a/web/libs/editor/src/components/TreeStructure/TreeStructure.tsx
+++ b/web/libs/editor/src/components/TreeStructure/TreeStructure.tsx
@@ -1,7 +1,6 @@
 import type React from "react";
 import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
 import { VariableSizeList } from "react-window";
-import { FF_DEV_4075, isFF } from "../../utils/feature-flags";
 
 type ExtendedData = Readonly<{
   id: string;
@@ -170,7 +169,7 @@ const TreeStructure = ({
       (rowRef) => {
         const key = `${index}`;
         const scrollbarWidth = scrollableElement?.offsetWidth - scrollableElement?.clientWidth || 0;
-        const itemWidth = (isFF(FF_DEV_4075) ? rowRef.scrollWidth : rowRef.offsetWidth) + scrollbarWidth + 5;
+        const itemWidth = rowRef.scrollWidth + scrollbarWidth + 5;
         const itemHeight = rowRef.scrollHeight;
 
         if (width < itemWidth) {

--- a/web/libs/editor/src/core/Hotkey.ts
+++ b/web/libs/editor/src/core/Hotkey.ts
@@ -5,7 +5,7 @@ import { createElement, Fragment } from "react";
 import { Tooltip } from "../common/Tooltip/Tooltip";
 import Hint from "../components/Hint/Hint";
 import { Block, Elem } from "../utils/bem";
-import { FF_LSDV_1148, FF_MULTI_OBJECT_HOTKEYS, isFF } from "../utils/feature-flags";
+import { FF_MULTI_OBJECT_HOTKEYS, isFF } from "../utils/feature-flags";
 import { isDefined, isMacOS } from "../utils/utilities";
 import defaultKeymap from "./settings/keymap.json";
 
@@ -170,13 +170,9 @@ export const Hotkey = (namespace = "global", description = "Hotkeys") => {
         const keys = getKeys(key);
 
         for (const key of keys) {
-          if (isFF(FF_LSDV_1148)) {
-            removeKeyHandlerRef(scope, key);
-            keymaster.unbind(key, scope);
-            rebindKeyHandlers(scope, key);
-          } else {
-            keymaster.unbind(key, scope);
-          }
+          removeKeyHandlerRef(scope, key);
+          keymaster.unbind(key, scope);
+          rebindKeyHandlers(scope, key);
           delete _hotkeys_desc[key];
         }
       }
@@ -229,9 +225,7 @@ export const Hotkey = (namespace = "global", description = "Hotkeys") => {
             func(...args);
           };
 
-          if (isFF(FF_LSDV_1148)) {
-            addKeyHandlerRef(scope, keyName, handler);
-          }
+          addKeyHandlerRef(scope, keyName, handler);
           keymaster(keyName, scope, handler);
         });
     },
@@ -264,13 +258,9 @@ export const Hotkey = (namespace = "global", description = "Hotkeys") => {
           .map((s) => s.trim())
           .filter(Boolean)
           .forEach((scope) => {
-            if (isFF(FF_LSDV_1148)) {
-              removeKeyHandlerRef(scope, key);
-              keymaster.unbind(keyName, scope);
-              rebindKeyHandlers(scope, key);
-            } else {
-              keymaster.unbind(keyName, scope);
-            }
+            removeKeyHandlerRef(scope, key);
+            keymaster.unbind(keyName, scope);
+            rebindKeyHandlers(scope, key);
           });
 
         delete _hotkeys_map[keyName];

--- a/web/libs/editor/src/regions/TextAreaRegion.jsx
+++ b/web/libs/editor/src/regions/TextAreaRegion.jsx
@@ -9,7 +9,6 @@ import { guidGenerator } from "../core/Helpers";
 
 import styles from "./TextAreaRegion/TextAreaRegion.scss";
 import { HtxTextBox } from "../components/HtxTextBox/HtxTextBox";
-import { FF_LSDV_4712, isFF } from "../utils/feature-flags";
 import { cn } from "../utils/bem";
 
 const Model = types
@@ -40,7 +39,7 @@ const Model = types
   }))
   .actions((self) => ({
     setValue(val) {
-      if (isFF(FF_LSDV_4712) && (self._value === val || !self.parent.validateText(val))) return;
+      if (self._value === val || !self.parent.validateText(val)) return;
 
       self._value = val;
       self.parent.onChange();

--- a/web/libs/editor/src/tags/control/TextArea/TextArea.jsx
+++ b/web/libs/editor/src/tags/control/TextArea/TextArea.jsx
@@ -17,7 +17,7 @@ import ProcessAttrsMixin from "../../../mixins/ProcessAttrs";
 import { ReadOnlyControlMixin } from "../../../mixins/ReadOnlyMixin";
 import RequiredMixin from "../../../mixins/Required";
 import { HtxTextAreaRegion, TextAreaRegionModel } from "../../../regions/TextAreaRegion";
-import { FF_LEAD_TIME, FF_LSDV_4583, FF_LSDV_4659, isFF } from "../../../utils/feature-flags";
+import { FF_LEAD_TIME, FF_LSDV_4583, isFF } from "../../../utils/feature-flags";
 import ControlBase from "../Base";
 import ClassificationBase from "../ClassificationBase";
 import "./TextAreaRegionView";
@@ -87,11 +87,7 @@ const TagAttrs = types.model({
   maxsubmissions: types.maybeNull(types.string),
   editable: types.optional(types.boolean, false),
   transcription: false,
-  ...(isFF(FF_LSDV_4659)
-    ? {
-        skipduplicates: types.optional(types.boolean, false),
-      }
-    : {}),
+  skipduplicates: types.optional(types.boolean, false),
 });
 
 const Model = types
@@ -236,7 +232,7 @@ const Model = types
       },
 
       validateText(text) {
-        if (isFF(FF_LSDV_4659) && self.skipduplicates && self.hasResult(text)) {
+        if (self.skipduplicates && self.hasResult(text)) {
           self.uniqueModal();
           return false;
         }

--- a/web/libs/editor/src/tags/control/TextArea/TextAreaRegionView.jsx
+++ b/web/libs/editor/src/tags/control/TextArea/TextAreaRegionView.jsx
@@ -11,7 +11,6 @@ import styles from "../../../components/HtxTextBox/HtxTextBox.module.scss";
 import Registry from "../../../core/Registry";
 import { PER_REGION_MODES } from "../../../mixins/PerRegion";
 import { Block, Elem } from "../../../utils/bem";
-import { FF_LSDV_4712, isFF } from "../../../utils/feature-flags";
 
 import "./TextArea.scss";
 
@@ -23,29 +22,23 @@ const HtxTextAreaResultLine = forwardRef(
     const isTextarea = rows > 1;
     const [stateValue, setStateValue] = useState(value ?? "");
 
-    if (isFF(FF_LSDV_4712)) {
-      useEffect(() => {
-        if (value !== stateValue) {
-          setStateValue(value);
-        }
-      }, [value]);
-    }
+    useEffect(() => {
+      if (value !== stateValue) {
+        setStateValue(value);
+      }
+    }, [value]);
 
     const displayValue = useMemo(() => {
       if (collapsed) {
         return (value ?? "").split(/\n/)[0] ?? "";
       }
 
-      return isFF(FF_LSDV_4712) ? stateValue : value;
-    }, [value, collapsed, ...(isFF(FF_LSDV_4712) ? [stateValue] : [])]);
+      return stateValue;
+    }, [value, collapsed, stateValue]);
 
-    const changeHandler = isFF(FF_LSDV_4712)
-      ? useCallback((e) => {
-          setStateValue(e.target.value);
-        }, [])
-      : (e) => {
-          if (!collapsed) onChange(idx, e.target.value);
-        };
+    const changeHandler = useCallback((e) => {
+      setStateValue(e.target.value);
+    }, []);
 
     const blurHandler = useCallback(
       (e) => {
@@ -69,19 +62,15 @@ const HtxTextAreaResultLine = forwardRef(
       onFocus,
     };
 
-    if (isFF(FF_LSDV_4712)) {
-      inputProps.onBlur = blurHandler;
-    }
+    inputProps.onBlur = blurHandler;
 
-    if (isFF(FF_LSDV_4712) || isTextarea) {
-      inputProps.onKeyDown = (e) => {
-        if ((e.key === "Enter" && !e.shiftKey) || e.key === "Escape") {
-          e.preventDefault();
-          e.stopPropagation();
-          e.target?.blur?.();
-        }
-      };
-    }
+    inputProps.onKeyDown = (e) => {
+      if ((e.key === "Enter" && !e.shiftKey) || e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        e.target?.blur?.();
+      }
+    };
 
     return (
       <Elem name="item">
@@ -143,7 +132,7 @@ const HtxTextAreaResult = observer(({ item, control, firstResultInputRef, onFocu
         ref={idx === 0 ? firstResultInputRef : null}
         onFocus={onFocus}
         collapsed={collapsed}
-        validate={isFF(FF_LSDV_4712) ? item.from_name.validateText : null}
+        validate={item.from_name.validateText}
       />
     );
   });

--- a/web/libs/editor/src/utils/feature-flags.ts
+++ b/web/libs/editor/src/utils/feature-flags.ts
@@ -72,12 +72,6 @@ export const FF_DEV_3873 = "fflag_feat_front_dev_3873_labeling_ui_improvements_s
 export const FF_DEV_3793 = "fflag_fix_front_dev_3793_relative_coords_short";
 
 /**
- * Fixing issue with overlapping taxonomy items during searching
- * @link https://app.launchdarkly.com/default/community/features/fflag_fix_front_dev_4075_taxonomy_overlap_281222_short
- */
-export const FF_DEV_4075 = "fflag_fix_front_dev_4075_taxonomy_overlap_281222_short";
-
-/**
  * Label stream ablation experiment for solving overlap issue
  * @link https://app.launchdarkly.com/default/production/features/fflag_fix_back_dev_4174_overlap_issue_experiments_10012023_short
  */

--- a/web/libs/editor/src/utils/feature-flags.ts
+++ b/web/libs/editor/src/utils/feature-flags.ts
@@ -90,12 +90,6 @@ export const FF_LSDV_E_278 = "fflag_feat_front_lsdv_e_278_contextual_scrolling_s
 export const FF_LLM_EPIC = "fflag_feat_all_lsdv_e_294_llm_annotations_180723_long";
 
 /**
- * Fix logic of namespaces inside Hotkeys
- * @link https://app.launchdarkly.com/default/production/features/fflag_fix_font_lsdv_1148_hotkeys_namespaces_01022023_short
- */
-export const FF_LSDV_1148 = "fflag_fix_font_lsdv_1148_hotkeys_namespaces_01022023_short";
-
-/**
  * Multi-image segmentation support via `valueList`
  */
 export const FF_LSDV_4583 = "fflag_feat_front_lsdv_4583_multi_image_segmentation_short";
@@ -109,7 +103,7 @@ export const FF_LSDV_4583_6 = "fflag_feat_front_lsdv_4583_6_images_preloading_sh
  * Removing interrupting from the draft saving
  *
  * Without this flag we have a situation when changes in history leading to the empty results break functionality of adding comments and make the draft saving process indicator stay forever.
- * @link https://app.launchdarkly.com/default/production/features/fflag_fix_font_lsdv_1148_hotkeys_namespaces_01022023_short
+ * @link https://app.launchdarkly.com/default/production/features/fflag_fix_font_lsdv_3009_draft_saving_stuck_130223_short
  */
 export const FF_LSDV_3009 = "fflag_fix_font_lsdv_3009_draft_saving_stuck_130223_short";
 

--- a/web/libs/editor/src/utils/feature-flags.ts
+++ b/web/libs/editor/src/utils/feature-flags.ts
@@ -114,12 +114,6 @@ export const FF_LSDV_3009 = "fflag_fix_font_lsdv_3009_draft_saving_stuck_130223_
 export const FF_LEAD_TIME = "fflag_fix_front_lsdv_4600_lead_time_27072023_short";
 
 /**
- * Adds "skipDuplicates" parameter for <TextArea /> to prevent adding duplicate entries
- * @link https://app.launchdarkly.com/default/production/features/fflag_feat_front_lsdv_4659_skipduplicates_060323_short
- */
-export const FF_LSDV_4659 = "fflag_feat_front_lsdv_4659_skipduplicates_060323_short";
-
-/**
  * Reworking of RichText to optimize its work with DOM and decrease response time with a large number of regions.
  * It also fixes scenarios of working with hidden regions
  * and edge cases for creating spans inside other spans.

--- a/web/libs/editor/src/utils/feature-flags.ts
+++ b/web/libs/editor/src/utils/feature-flags.ts
@@ -142,15 +142,6 @@ export const FF_OUTLINER_OPTIM = "fflag_feat_front_lsdv_4620_outliner_optimizati
 export const FF_LSDV_4711 = "fflag_fix_all_lsdv_4711_cors_errors_accessing_task_data_short";
 
 /**
- * Preventing creating duplicates in TextArea results with "skipDuplicates" parameter during editing.
- * It also prevent creating new history steps on every change during editing textarea results.
- *
- * @see FF_LSDV_4659: To enable `skipDuplicates` parameter
- * @link https://app.launchdarkly.com/default/production/features/fflag_feat_front_lsdv_4712_skipduplicates_editing_110423_short
- */
-export const FF_LSDV_4712 = "fflag_feat_front_lsdv_4712_skipduplicates_editing_110423_short";
-
-/**
  * Fixing issue with missed steps in timeseries with optimized data and zoom
  *
  * @link https://app.launchdarkly.com/default/production/features/fflag_fix_front_lsdv_4881_timeseties_points_missing_140423_short

--- a/web/libs/editor/tests/e2e/setup/feature-flags.js
+++ b/web/libs/editor/tests/e2e/setup/feature-flags.js
@@ -5,7 +5,6 @@
 module.exports = {
   fflag_feat_front_lsdv_4659_skipduplicates_060323_short: true,
   fflag_feat_front_lsdv_4712_skipduplicates_editing_110423_short: true,
-  fflag_fix_font_lsdv_1148_hotkeys_namespaces_01022023_short: true,
   fflag_fix_front_lsdv_4881_timeseries_points_missing_140423_short: true,
   fflag_fix_front_lsdv_4930_selection_tool_fixes_240423_short: true,
   fflag_feat_front_lsdv_4620_richtext_opimization_060423_short: true,

--- a/web/libs/editor/tests/e2e/setup/feature-flags.js
+++ b/web/libs/editor/tests/e2e/setup/feature-flags.js
@@ -3,7 +3,6 @@
  */
 
 module.exports = {
-  fflag_feat_front_lsdv_4659_skipduplicates_060323_short: true,
   fflag_feat_front_lsdv_4712_skipduplicates_editing_110423_short: true,
   fflag_fix_front_lsdv_4881_timeseries_points_missing_140423_short: true,
   fflag_fix_front_lsdv_4930_selection_tool_fixes_240423_short: true,

--- a/web/libs/editor/tests/e2e/setup/feature-flags.js
+++ b/web/libs/editor/tests/e2e/setup/feature-flags.js
@@ -3,7 +3,6 @@
  */
 
 module.exports = {
-  fflag_feat_front_lsdv_4712_skipduplicates_editing_110423_short: true,
   fflag_fix_front_lsdv_4881_timeseries_points_missing_140423_short: true,
   fflag_fix_front_lsdv_4930_selection_tool_fixes_240423_short: true,
   fflag_feat_front_lsdv_4620_richtext_opimization_060423_short: true,

--- a/web/libs/editor/tests/e2e/tests/regression-tests/hotkey.test.js
+++ b/web/libs/editor/tests/e2e/tests/regression-tests/hotkey.test.js
@@ -19,7 +19,6 @@ Scenario("Hotkeys on re-initing lsf", async ({ I, LabelStudio, AtAudioView, AtSi
 
   LabelStudio.setFeatureFlags({
     ff_front_dev_2715_audio_3_280722_short: true,
-    fflag_fix_font_lsdv_1148_hotkeys_namespaces_01022023_short: true,
   });
   I.amOnPage("/");
 

--- a/web/libs/editor/tests/e2e/tests/taxonomy.test.js
+++ b/web/libs/editor/tests/e2e/tests/taxonomy.test.js
@@ -8,7 +8,6 @@ Before(({ LabelStudio }) => {
     fflag_fix_front_dev_3617_taxonomy_memory_leaks_fix: true,
     ff_front_dev_1536_taxonomy_user_labels_150222_long: true,
     ff_front_1170_outliner_030222_short: true,
-    fflag_fix_front_dev_4075_taxonomy_overlap_281222_short: true,
   });
 });
 

--- a/web/libs/frontend-test/src/feature-flags.ts
+++ b/web/libs/frontend-test/src/feature-flags.ts
@@ -72,12 +72,6 @@ export const FF_DEV_3793 = "fflag_fix_front_dev_3793_relative_coords_short";
 export const FF_DEV_4174 = "fflag_fix_back_dev_4174_overlap_issue_experiments_10012023_short";
 
 /**
- * Fix logic of namespaces inside Hotkeys
- * @link https://app.launchdarkly.com/default/production/features/fflag_fix_font_lsdv_1148_hotkeys_namespaces_01022023_short
- */
-export const FF_LSDV_1148 = "fflag_fix_font_lsdv_1148_hotkeys_namespaces_01022023_short";
-
-/**
  * Default Audio v3 to use multichannel mode if the track has 2 or more channels.
  * @link https://app.launchdarkly.com/default/production/features/fflag_feat_front_lsdv_3028_audio_v3_multichannel_default_17022023_short
  *
@@ -98,7 +92,7 @@ export const FF_LSDV_4583_6 = "fflag_feat_front_lsdv_4583_6_images_preloading_sh
  * Removing interrupting from the draft saving
  *
  * Without this flag we have a situation when changes in history leading to the empty results break functionality of adding comments and make the draft saving process indicator stay forever.
- * @link https://app.launchdarkly.com/default/production/features/fflag_fix_font_lsdv_1148_hotkeys_namespaces_01022023_short
+ * @link https://app.launchdarkly.com/default/production/features/fflag_fix_font_lsdv_3009_draft_saving_stuck_130223_short
  */
 export const FF_LSDV_3009 = "fflag_fix_font_lsdv_3009_draft_saving_stuck_130223_short";
 

--- a/web/libs/frontend-test/src/feature-flags.ts
+++ b/web/libs/frontend-test/src/feature-flags.ts
@@ -66,12 +66,6 @@ export const FF_DEV_3666 = "fflag_fix_front_dev_3666_max_usages_on_region_creati
 export const FF_DEV_3793 = "fflag_fix_front_dev_3793_relative_coords_short";
 
 /**
- * Fixing issue with overlapping taxonomy items during searching
- * @link https://app.launchdarkly.com/default/community/features/fflag_fix_front_dev_4075_taxonomy_overlap_281222_short
- */
-export const FF_DEV_4075 = "fflag_fix_front_dev_4075_taxonomy_overlap_281222_short";
-
-/**
  * Label stream ablation experiment for solving overlap issue
  * @link https://app.launchdarkly.com/default/production/features/fflag_fix_back_dev_4174_overlap_issue_experiments_10012023_short
  */

--- a/web/libs/frontend-test/src/feature-flags.ts
+++ b/web/libs/frontend-test/src/feature-flags.ts
@@ -97,13 +97,6 @@ export const FF_LSDV_4583_6 = "fflag_feat_front_lsdv_4583_6_images_preloading_sh
 export const FF_LSDV_3009 = "fflag_fix_font_lsdv_3009_draft_saving_stuck_130223_short";
 
 /**
- * Adding "skipDuplicates" parameter for <TextArea /> to preventing adding duplicate entries
- *
- * @link https://app.launchdarkly.com/default/production/features/fflag_feat_front_lsdv_4659_skipduplicates_060323_short
- */
-export const FF_LSDV_4659 = "fflag_feat_front_lsdv_4659_skipduplicates_060323_short";
-
-/**
  * Fixing issues related to selection tool functional (selecting hidden regions, onClick in Konva, interaction with regions inside selection area)
  *
  * @link https://app.launchdarkly.com/default/production/features/fflag_fix_front_lsdv_4930_selection_tool_fixes_240423_short


### PR DESCRIPTION
Review commit by commit
A group of simple FF that were stale an we dice to remove them in the same pull request to avoid the conflict when merge.

`fflag_fix_front_dev_4075_taxonomy_overlap_281222_short` as  True,

`fflag_fix_back_lsdv_1044_check_annotations_24012023_short` as False,

`fflag_fix_font_lsdv_1148_hotkeys_namespaces_01022023_short` as True,

`fflag_feat_front_lsdv_4659_skipduplicates_060323_short` as True
 (skipduplicates_editing is referenced somehow here, so I take it down also in the last commit)

`fflag_feat_front_lsdv_4661_full_uri_resolve_15032023_short` as  True
(white spaces here are relevant)

`fflag_feat_front_lsdv_4712_skipduplicates_editing_110423_short` as True

All of this are LSO only.

You may want to review commit by commit and with whitespace option enabled.
First commit is empty since I create a ticket to group this work

    