### PR TITLE
chore: remove unsupported version of python from test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'


### PR DESCRIPTION
3.9 isn't supported by django 5; let's pull it from our automated tests.