### PR TITLE
Fix S3 file storage import

### DIFF
--- a/label_studio/core/storage.py
+++ b/label_studio/core/storage.py
@@ -66,7 +66,10 @@ class StorageProxyMixin:
 
 
 class CustomS3Boto3Storage(StorageProxyMixin, S3Boto3Storage):
-    pass
+    def url(self, name, storage_url=False, *args, **kwargs):
+        if storage_url is True:
+            return super().url(name, *args, **kwargs)
+        return f"s3://{settings.AWS_STORAGE_BUCKET_NAME}/{name}"
 
 
 class CustomAzureStorage(StorageProxyMixin, AzureStorage):

--- a/label_studio/data_import/models.py
+++ b/label_studio/data_import/models.py
@@ -113,7 +113,7 @@ class FileUpload(models.Model):
     def read_task_from_uploaded_file(self):
         logger.debug('Read 1 task from uploaded file {}'.format(self.filepath))
         if settings.CLOUD_FILE_STORAGE_ENABLED:
-            tasks = [{'data': {settings.DATA_UNDEFINED_NAME: self.filepath}}]
+            tasks = [{'data': {settings.DATA_UNDEFINED_NAME: self.file.storage.url(self.file.name)}}]
         else:
             tasks = [{'data': {settings.DATA_UNDEFINED_NAME: self.url}}]
         return tasks


### PR DESCRIPTION
### PR fulfills these requirements

- [ ] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)

I'm not sure what I can do, I don't have a ticket id.

#### Change has impacts in these area(s)

- [ ] Product design
- [ ] Backend (Database)
- [x] Backend (API)
- [ ] Frontend

### Describe the reason for change

When using cloud storage, a task created from an imported image has a relative URL (e.g., `upload/1/d0672b53-ff-template.jpg`) that breaks when enabling cloud file storage.

<img width="1409" alt="image" src="https://github.com/user-attachments/assets/09c5065c-5314-4f3c-9e64-3bcc39749b82" />

#### What does this fix?

The fix adds `CustomS3Boto3Storage::url` and utilizes it in the `FileUpload::read_task_from_uploaded_file` to make the app correctly display imported images.

#### What is the new behavior?

When manually importing, the task URL will have `s3://BUCKER_NAME/` prefix.


#### What is the current behavior?

The task URL has no prefix (e.g., `upload/1/d0672b53-ff-template.jpg`), so it fails to display in the app.

#### What libraries were added/updated?

NA

#### Does this change affect performance?

NA

#### Does this change affect security?

NA

#### What alternative approaches were there?

The alternative was to resolve to the storage URL when displaying, but using the file storage instance was a more straightforward approach and matched the storage-imported task schema.

#### What feature flags were used to cover this change?

NA

### Does this PR introduce a breaking change?

- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [ ] No
- [x] Not sure (briefly explain the situation below)

I'm not sure what was the current setup, but it was clearly not working for cloud file storage, but I can imagine there was a working setup that might get affected, but it is not clear from the source code if there was any.

### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
_(for bug fixes/features, be as precise as possible. ex. Authentication, Annotation History, Review Stream etc.)_

