### PR TITLE
fix: DIA-1803: Stop using deprecated utcnow

### DIFF
--- a/label_studio/core/utils/common.py
+++ b/label_studio/core/utils/common.py
@@ -14,7 +14,7 @@ import time
 import traceback as tb
 import uuid
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import wraps
 from typing import Any, Callable, Generator, Iterable, Mapping, Optional
 
@@ -261,7 +261,7 @@ def datetime_to_timestamp(dt):
 
 
 def timestamp_now():
-    return datetime_to_timestamp(datetime.utcnow())
+    return datetime_to_timestamp(datetime.now(timezone.utc))
 
 
 def find_first_one_to_one_related_field_by_prefix(instance, prefix):

--- a/label_studio/core/utils/common.py
+++ b/label_studio/core/utils/common.py
@@ -39,7 +39,8 @@ from django.db.models.signals import (
     pre_migrate,
     pre_save,
 )
-from django.db.utils import OperationalError, timezone
+from django.db.utils import OperationalError
+from django.utils import timezone
 from django.utils.crypto import get_random_string
 from django.utils.module_loading import import_string
 from django_filters.rest_framework import DjangoFilterBackend

--- a/label_studio/core/utils/common.py
+++ b/label_studio/core/utils/common.py
@@ -14,7 +14,6 @@ import time
 import traceback as tb
 import uuid
 from collections import defaultdict
-from datetime import datetime, timezone
 from functools import wraps
 from typing import Any, Callable, Generator, Iterable, Mapping, Optional
 
@@ -40,7 +39,7 @@ from django.db.models.signals import (
     pre_migrate,
     pre_save,
 )
-from django.db.utils import OperationalError
+from django.db.utils import OperationalError, timezone
 from django.utils.crypto import get_random_string
 from django.utils.module_loading import import_string
 from django_filters.rest_framework import DjangoFilterBackend
@@ -261,7 +260,7 @@ def datetime_to_timestamp(dt):
 
 
 def timestamp_now():
-    return datetime_to_timestamp(datetime.now(timezone.utc))
+    return datetime_to_timestamp(timezone.now())
 
 
 def find_first_one_to_one_related_field_by_prefix(instance, prefix):

--- a/label_studio/io_storages/azure_blob/models.py
+++ b/label_studio/io_storages/azure_blob/models.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from typing import Union
 from urllib.parse import urlparse
 
@@ -15,6 +15,7 @@ from django.conf import settings
 from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from io_storages.base_models import (
     ExportStorage,
@@ -144,7 +145,7 @@ class AzureBlobImportStorageBase(AzureBlobStorageMixin, ImportStorage):
         container = r.netloc
         blob = r.path.lstrip('/')
 
-        expiry = datetime.now(timezone.utc) + timedelta(minutes=self.presign_ttl)
+        expiry = timezone.now() + timedelta(minutes=self.presign_ttl)
 
         sas_token = generate_blob_sas(
             account_name=self.get_account_name(),

--- a/label_studio/io_storages/azure_blob/models.py
+++ b/label_studio/io_storages/azure_blob/models.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Union
 from urllib.parse import urlparse
 
@@ -144,7 +144,7 @@ class AzureBlobImportStorageBase(AzureBlobStorageMixin, ImportStorage):
         container = r.netloc
         blob = r.path.lstrip('/')
 
-        expiry = datetime.utcnow() + timedelta(minutes=self.presign_ttl)
+        expiry = datetime.now(timezone.utc) + timedelta(minutes=self.presign_ttl)
 
         sas_token = generate_blob_sas(
             account_name=self.get_account_name(),


### PR DESCRIPTION
get rid of datetime.utcnow() which was deprecated in Python 3.12