### PR TITLE
docs: Fix syntax highlight bug in included markdown files

### DIFF
--- a/docs/_multiconfig.yml
+++ b/docs/_multiconfig.yml
@@ -1,3 +1,4 @@
+url: https://labelstud.io/
 theme_config:
   tier: opensource
   root_domain: labelstud.io
@@ -19,7 +20,6 @@ author: Heartex
 language: en
 timezone: null
 google_analytics: UA-129877673-4
-url: https://labelstud.io/
 root: /
 permalink: ':year/:month/:day/:title/'
 permalink_defaults: null
@@ -57,6 +57,9 @@ markdown:
   breaks: false
   smartLists: true
   smartypants: true
+marked:
+  gfm: true
+  breaks: false
 index_generator:
   path: ''
   per_page: 10
@@ -73,7 +76,7 @@ plugins:
 theme: v2
 sitemap:
   path:
-    - sitemap-docs.xml
+    - guide/sitemap-docs.xml
 search:
   path: search.xml
   field: all

--- a/docs/package.json
+++ b/docs/package.json
@@ -29,7 +29,6 @@
     "hexo-generator-sitemap": "^3.0.1",
     "hexo-generator-tag": "^0.2.0",
     "hexo-include": "^1.1.0",
-    "hexo-include-markdown": "^1.0.2",
     "hexo-insert-markdown": "^1.4.4",
     "hexo-ipynb": "^0.2.4",
     "hexo-jupyter-notebook": "0.0.3",

--- a/docs/source/guide/export.md
+++ b/docs/source/guide/export.md
@@ -20,8 +20,7 @@ Image annotations exported in JSON format use percentages of overall image size,
 !!! note
     Some export formats export only the annotations and not the data from the task. For more information, see the [export formats supported by Label Studio](#Export-formats-supported-by-Label-Studio).
 
-
-<!-- md annotation_ids.md -->
+{% insertmd includes/annotation_ids.md %}
 
 <div class="opensource-only">
 
@@ -192,12 +191,9 @@ Results are stored in a tab-separated tabular file with column names specified b
 
 Export object detection annotations in the YOLOv3 and YOLOv4 format. Supports object detection labeling projects that use the `RectangleLabels` tag. 
 
-
 {% insertmd includes/task_format.md %}
 
-
-<!-- md image_units.md -->
-
+{% insertmd includes/image_units.md %}
 
 ## Manually convert JSON annotations to another format
 You can run the [Label Studio converter tool](https://github.com/HumanSignal/label-studio-converter) on a directory or file of completed JSON annotations using the command line or Python to convert the completed annotations from Label Studio JSON format into another format. 

--- a/docs/source/guide/install.md
+++ b/docs/source/guide/install.md
@@ -20,7 +20,7 @@ Install Label Studio on premises or in the cloud. Choose the installation method
 
 Label Studio is also available an [enterprise product](https://heartex.com/), which you can explore instantly through a [free trial](https://humansignal.com/free-trial).
 
-<!-- md deploy.md -->
+{% insertmd includes/deploy.md %}
 
 ### Web browser support
 
@@ -228,5 +228,3 @@ label-studio start path/to/old/project
 The most important change to be aware of is changes to rename "completions" to "annotations". See the [updated JSON format for completed tasks](export.html#Raw_JSON_format_of_completed_tasks).
 
 If you customized the Label Studio Frontend, see the [Frontend reference guide](frontend_reference.html) for required updates to maintain compatibility with version 1.0.0.
-
-

--- a/docs/source/guide/install_enterprise_docker.md
+++ b/docs/source/guide/install_enterprise_docker.md
@@ -19,7 +19,7 @@ See [Secure Label Studio](security.html) for more details about security and har
 
 To install Label Studio Community Edition, see [Install Label Studio](https://labelstud.io/guide/install). This page is specific to the Enterprise version of Label Studio.
 
-<!-- md deploy.md -->
+{% insertmd includes/deploy.md %}
 
 ## Install Label Studio Enterprise using Docker
 

--- a/docs/source/guide/install_requirements.md
+++ b/docs/source/guide/install_requirements.md
@@ -8,8 +8,7 @@ meta_title: Requirements to Install and Upgrade
 meta_description: "Label Studio documentation: Requirements to install and upgrade Label Studio." 
 ---
 
-<!-- md deploy.md -->
-
+{% insertmd includes/deploy.md %}
 
 ## Install prerequisite
 

--- a/docs/source/guide/labeling.md
+++ b/docs/source/guide/labeling.md
@@ -444,5 +444,4 @@ OR
 
 1. Press CTRL button and start drawing bounding box over another one. 
 
-
-<!-- md annotation_ids.md -->
+{% insertmd includes/annotation_ids.md %}

--- a/docs/source/guide/release_notes.md
+++ b/docs/source/guide/release_notes.md
@@ -19,6 +19,120 @@ meta_description: Review new features, enhancements, and bug fixes for on-premis
     Before upgrading, review the steps outlined in [Upgrade Label Studio Enterprise](upgrade_enterprise) and ensure that you complete the recommended tests after each upgrade. 
 
 <div class="release-note"><button class="release-note-toggle"></button>
+<a name="2191md"></a>
+
+## Label Studio Enterprise 2.19.1
+
+<div class="onprem-highlight">Bug fixes </div>
+
+*Jan 02, 2025*
+
+Helm Chart version: 1.7.4
+
+### Bug fixes
+- Fixed an issue where, in some cases, project roles were reset on SAML SSO login. 
+- Fixed an issue affecting Redis credentials with special characters. 
+
+
+
+
+
+
+</div><div class="release-note"><button class="release-note-toggle"></button>
+<a name="2190md"></a>
+
+## Label Studio Enterprise 2.19.0
+
+<div class="onprem-highlight">Paginated multi-image labeling and a new Task Reservation setting </div>
+
+*Dec 17, 2024*
+
+Helm Chart version: 1.7.3
+
+### New features
+
+#### Paginated multi-image labeling
+
+Paginated multi-image labeling allows you to label an album of images within a single task. When enabled, a page navigation tool is available within the labeling interface. 
+
+While you can use paginated multi-image labeling with any series of related images, it can also be especially useful for for document annotation. 
+
+For example, you can pre-process a PDF to convert it into image files, and then use the pagination toolbar to navigate the PDF. For more information, see our [Multi-Page Document Annotation template](/templates/multi-page-document-annotation).
+
+To enable this feature, use the `valueList` parameter on the [`<Image> tag`](/tags/image).
+
+![Screenshot of multi-page annotation](/images/releases/2-19-mig.png)
+
+#### Set task reservation time
+
+There is a new project setting under **Annotation > Task Reservation**.
+
+You can use this setting to determine how many minutes a task can be reserved by a user. You can also use it for projects that have become stalled due to too many reserved tasks. For more information, see [Project settings - Task Reservation](https://docs.humansignal.com/guide/project_settings_lse#lock-tasks).
+
+By default, the task reservation time is set to one day (1440 minutes). This setting is only available when task distribution is set to **Auto**.
+
+![Screenshot of multi-page annotation](/images/releases/2-19-reservation.png)
+
+### Enhancements
+
+- When using the **Send Test Request** action for a connected ML backend model, you will now see more descriptive error messages.
+
+- The placeholder text within labeling configuration previews is now more descriptive of what should appear, rather than providing example text strings.
+
+- Improved the inter-annotator agreement API so that it is more performant and can better handle a high number of annotators.
+
+- Improved Annotator Performance Report page load time.
+
+- TextArea elements have been updated to reflect the look and feel of other labeling elements.
+
+### Bug fixes
+
+- Fixed an issue where SSO/SAML users were not being redirected back to the originally requested URL.
+
+- Fixed an issue where a timeout on the inter-annotator agreement API would cause missing data in the Annotator Summary table on the Members page.
+
+- Fixed an issue where the default date format used when exporting to CSV was incompatible with Google Sheets.
+
+- Fixed an issue where commas in comment text breaking were causing errors when exporting to CSV from the Annotator Performance report.
+
+- Fixed an issue that was causing 404 errors in the Activity Log.
+
+- Fixed an issue where users were unable to deselect tools from the toolbar by clicking them a second time.
+
+- Fixed an issue where users were presented with Reviewer actions even if the annotation was still in Draft state.
+
+- Fixed an issue with the Source Storage editor in which some fields were overlapping in the user interface.
+
+- Fixed an issue with the Data Manager filters when the columns are different from those in the labeling config and when `$undefined$` is present in the task data.
+
+- Fixed an issue where filter options in the Data Manager would disappear on hover.
+
+- Fixed an issue which caused XML comments to incorrectly be considered in the label config validation.
+
+- Fixed an issue causing an error when marking a comment as read.
+
+- Fixed an issue where an error message would appear when selecting or unselecting the **Get the latest news & tips from Heidi** option on the Account Settings page.
+
+- Fixed an issue where annotators were seeing a tooltip message stating that the project was not ready yet, even though the project had already been completed.
+
+- Fixed an issue where project-level roles did not affect role upgrades performed at the Organization level.
+
+
+### Feature flag updates
+
+The following feature flags have been removed:
+
+- `fflag_feat_front_dev_2984_dm_draggable_columns_short`
+- `fflag-feat-front-dev-2982-label-weights-settings`
+- `ff_back_2070_inner_id_12052022_short`
+
+
+
+
+
+
+
+</div><div class="release-note"><button class="release-note-toggle"></button>
 <a name="2180md"></a>
 
 ## Label Studio Enterprise 2.18.0

--- a/docs/source/guide/troubleshooting.md
+++ b/docs/source/guide/troubleshooting.md
@@ -214,7 +214,7 @@ Check that you are using the correct annotation units.
 
 {% details <b>Image annotation units</b> %}
 
-<!-- md image_units.md -->
+{% insertmd includes/image_units.md %}
 
 {% enddetails %}
 

--- a/docs/source/includes/nested-classification.md
+++ b/docs/source/includes/nested-classification.md
@@ -1,20 +1,3 @@
-<!-- Unfortunately included md files doesn't support code highlighting, do it manually -->
-<script src="/js/highlight.min.js"></script>
-<script>
-    hljs.highlightAll();
-    $(function() {
-      $('.code-badge-language').each(function (o, v) {
-        console.log(o)
-        if ($(v).html() === 'undefined')
-          $(v).html('')
-        if ($(v).html() === 'bash')
-          $(v).html('shell')
-        if ($(v).html() === 'html')
-          $(v).html('xml')
-      })
-    });
-</script>
-
 ## Enhance classification templates with nested choices
 
 You can add conditional or nested choices to any classification template. If you want classification options to appear only if certain conditions are met, such as specific choices being selected by annotators, adapt one of these conditional and nested classification examples. 

--- a/docs/source/templates/audio_classification.md
+++ b/docs/source/templates/audio_classification.md
@@ -79,7 +79,7 @@ If you want to make the classification section visually distinct from the rest o
 </View>
 ```
 
-<!-- md nested-classification.md -->
+{% insertmd includes/nested-classification.md %}
 
 ## Related tags
 

--- a/docs/source/templates/image_classification.md
+++ b/docs/source/templates/image_classification.md
@@ -75,7 +75,7 @@ If you want the classification choices to appear to the left of the image, you c
 
 ```
 
-<!-- md nested-classification.md -->
+{% insertmd includes/nested-classification.md %}
 
 ## Related tags
 

--- a/docs/source/templates/intent_classification.md
+++ b/docs/source/templates/intent_classification.md
@@ -63,7 +63,7 @@ Use the [Choices](/tags/choices.html) control tag to classify the intent for eac
 ```
 Because of the `perRegion="true"` argument, each choice applies to a different segment labeled as a segment. The `required="true"` argument ensures that each labeled audio segment has a choice selected before the annotation can be submitted.
 
-<!-- md nested-classification.md -->
+{% insertmd includes/nested-classification.md %}
 
 ## Related tags
 

--- a/docs/source/templates/sentiment_analysis.md
+++ b/docs/source/templates/sentiment_analysis.md
@@ -125,7 +125,7 @@ Don't forget to close the original [View](/tags/view.html) tag:
 </View>
 ```
 
-<!-- md nested-classification.md -->
+{% insertmd includes/nested-classification.md %}
 
 ## Related tags
 - [Text](/tags/text.html)


### PR DESCRIPTION
Markdown pages including other markdown files using https://github.com/tea3/hexo-include-markdown
and the `<!-- md nested-classification.md -->` syntax don’t support syntax highlighting.

Solution is to switch to https://github.com/bennycode/hexo-insert-markdown and use this syntax instead:

`{% insertmd includes/nested-classification.md %}`
