### PR TITLE
feat: DIA-1815: Add conditional dependencies in product tour

### DIFF
--- a/label_studio/users/product_tours/serializers.py
+++ b/label_studio/users/product_tours/serializers.py
@@ -14,7 +14,9 @@ PRODUCT_TOURS_CONFIGS_DIR = pathlib.Path(__file__).parent / 'configs'
 
 
 class UserProductTourSerializer(serializers.ModelSerializer):
+    # steps is a list of steps in the tour loaded from the yaml file
     steps = serializers.SerializerMethodField(read_only=True)
+    # awaiting is a boolean that indicates if the tour is awaiting other tours in the list of "dependencies"
     awaiting = serializers.SerializerMethodField(read_only=True)
 
     class Meta:

--- a/web/libs/core/src/lib/Tour/TourProvider.tsx
+++ b/web/libs/core/src/lib/Tour/TourProvider.tsx
@@ -131,6 +131,11 @@ export const TourProvider: React.FC<{
         return;
       }
 
+      if (response.awaiting) {
+        console.info(`Tour "${name}" is awaiting other tours`);
+        return;
+      }
+
       if (!response.steps?.length) {
         console.info(`No steps found for tour "${name}"`);
         return;


### PR DESCRIPTION
Ability to trigger product tours only if other product tours are completed using:
```yaml
dependencies:
  - another_tour

steps:
  ...
```