### PR TITLE
feat: OPTIC-1479: Improve memory usage of Image tag

### DIFF
--- a/web/libs/editor/src/tags/object/Image/ImageEntity.js
+++ b/web/libs/editor/src/tags/object/Image/ImageEntity.js
@@ -1,4 +1,4 @@
-import { types } from "mobx-state-tree";
+import { types, getParent } from "mobx-state-tree";
 import { FileLoader } from "../../../utils/FileLoader";
 import { clamp } from "../../../utils/utilities";
 import { FF_IMAGE_MEMORY_USAGE, isFF } from "../../../utils/feature-flags";
@@ -86,12 +86,12 @@ export const ImageEntity = types
           // Get from the image tag
           const crossOrigin = self.imageCrossOrigin;
           if (crossOrigin) img.crossOrigin = crossOrigin;
-          img.src = self.src;
           img.onload = () => {
             self.setCurrentSrc(self.src);
             self.setDownloaded(true);
             self.setProgress(1);
             self.setDownloading(false);
+            self.setImageLoaded(true);
             resolve();
           };
           img.onerror = () => {
@@ -99,6 +99,7 @@ export const ImageEntity = types
             self.setDownloading(false);
             resolve();
           };
+          img.src = self.src;
         });
         return;
       }

--- a/web/libs/editor/src/tags/object/Image/ImageEntity.js
+++ b/web/libs/editor/src/tags/object/Image/ImageEntity.js
@@ -66,6 +66,15 @@ export const ImageEntity = types
     /** Is image loaded using `<img/>` tag and cached by the browser */
     imageLoaded: false,
   }))
+  .views((self) => ({
+    get parent() {
+      // Get the ImageEntityMixin
+      return getParent(self, 2);
+    },
+    get imageCrossOrigin() {
+      return self.parent?.imageCrossOrigin ?? "anonymous";
+    },
+  }))
   .actions((self) => ({
     preload() {
       if (self.ensurePreloaded() || !self.src) return;
@@ -74,6 +83,9 @@ export const ImageEntity = types
         self.setDownloading(true);
         new Promise((resolve) => {
           const img = new Image();
+          // Get from the image tag
+          const crossOrigin = self.imageCrossOrigin;
+          if (crossOrigin) img.crossOrigin = crossOrigin;
           img.src = self.src;
           img.onload = () => {
             self.setCurrentSrc(self.src);

--- a/web/libs/editor/src/tags/object/Image/ImageEntity.js
+++ b/web/libs/editor/src/tags/object/Image/ImageEntity.js
@@ -1,7 +1,7 @@
 import { types } from "mobx-state-tree";
 import { FileLoader } from "../../../utils/FileLoader";
 import { clamp } from "../../../utils/utilities";
-import { FF_IMAGE_MEMORY_USAGE, isFF } from "libs/editor/src/utils/feature-flags";
+import { FF_IMAGE_MEMORY_USAGE, isFF } from "../../../utils/feature-flags";
 
 const fileLoader = new FileLoader();
 

--- a/web/libs/editor/src/utils/feature-flags.ts
+++ b/web/libs/editor/src/utils/feature-flags.ts
@@ -218,6 +218,8 @@ export const FF_LEAP_1173 = "fflag_feat_front_leap_1173_disable_postpone_skip_sh
 
 export const FF_PER_FIELD_COMMENTS = "fflag_feat_all_leap_1430_per_field_comments_100924_short";
 
+export const FF_IMAGE_MEMORY_USAGE = "fflag_feat_front_optic_1479_improve_image_tag_memory_usage_short";
+
 Object.assign(window, {
   APP_SETTINGS: {
     ...(window.APP_SETTINGS ?? {}),


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [X] Frontend



### Describe the reason for change
Through other investigations it was surfaced that there was an unnecessary handling of image data in memory, which included caching raw data in a Map. Storing information in a Map is dangerous for unintended memory growth to occur as Map's do not get garbage collected very easily, most times not. Further to this, there is no clear use case to not just using the browser as normal to load image data from the provided urls directly, allowing the browser heuristics to effeciently manage the memory and caching of these image requests.



#### Does this change affect performance?
Separately fetching data of the image to cache and produce a base64 DataURL is not more efficient than using the browser's baseline primitives directly. This in small sample sizes would be no difference, but larger sample sizes with greater number and filesize of images would lead to improved memory usage and performance within the application.



#### What feature flags were used to cover this change?
- `fflag_feat_front_optic_1479_improve_image_tag_memory_usage_short`



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)


### Which logical domain(s) does this change affect?
ImageEntity (ImageMixin -> Image tag)

