### PR TITLE
refactor: OPTIC-1542: remove a buch of stale feature flags

### DIFF
--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -17,7 +17,6 @@ STALE_FEATURE_FLAGS = {
     'fflag_feat_front_lsdv_4620_richtext_opimization_060423_short': True,
     'fflag_feat_front_dev_3873_labeling_ui_improvements_short': True,
     'fflag_feat_back_dev_3756_queue_enrollment_min_short': False,
-    'fflag_fix_front_dev_3666_max_usages_on_region_creation_171122_short': True,
     'ff_front_dev_2432_auto_save_polygon_draft_210622_short': True,
     'ff_front_1170_outliner_030222_short': True,
     'fflag_fix_front_lsdv_4620_memory_leaks_100723_short': False,

--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -18,7 +18,6 @@ STALE_FEATURE_FLAGS = {
     'fflag_feat_front_dev_3873_labeling_ui_improvements_short': True,
     'fflag_feat_back_dev_3756_queue_enrollment_min_short': False,
     'fflag_fix_front_dev_3666_max_usages_on_region_creation_171122_short': True,
-    'fflag_fix_front_dev_3617_taxonomy_memory_leaks_fix': True,
     'ff_front_dev_2432_auto_save_polygon_draft_210622_short': True,
     'ff_front_1170_outliner_030222_short': True,
     'fflag_fix_front_lsdv_4620_memory_leaks_100723_short': False,

--- a/web/apps/labelstudio/src/pages/CreateProject/Config/Preview.jsx
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/Preview.jsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Spinner } from "../../../components";
 import { cn } from "../../../utils/bem";
-import { FF_DEV_3617, isFF } from "../../../utils/feature-flags";
 import "./Config.scss";
 import { EMPTY_CONFIG } from "./Template";
 import { API_CONFIG } from "../../../config/ApiConfig";
@@ -75,7 +74,7 @@ export const Preview = ({ config, data, error, loading, project }) => {
         task,
         interfaces: ["side-column"],
         // with SharedStore we should use more late event
-        [isFF(FF_DEV_3617) ? "onStorageInitialized" : "onLabelStudioLoad"](LS) {
+        onStorageInitialized(LS) {
           LS.settings.bottomSidePanel = true;
 
           const initAnnotation = () => {
@@ -86,12 +85,8 @@ export const Preview = ({ config, data, error, loading, project }) => {
             setStoreReady(true);
           };
 
-          if (isFF(FF_DEV_3617)) {
-            // and even then we need to wait a little even after the store is initialized
-            setTimeout(initAnnotation);
-          } else {
-            initAnnotation();
-          }
+          // and even then we need to wait a little even after the store is initialized
+          setTimeout(initAnnotation);
         },
       });
 

--- a/web/apps/labelstudio/src/utils/feature-flags.ts
+++ b/web/apps/labelstudio/src/utils/feature-flags.ts
@@ -9,12 +9,6 @@ export const FF_DEV_1658 = "ff_front_dev_1658_notification_center_170222_short";
 // Model version selector per model backend
 export const FF_DEV_1682 = "ff_front_dev_1682_model_version_dropdown_070622_short";
 
-/**
- * Addresses the memory leak issue in Taxonomy with Repeater
- * @link https://app.launchdarkly.com/default/production/features/fflag_fix_front_dev_3617_taxonomy_memory_leaks_fix
- */
-export const FF_DEV_3617 = "fflag_fix_front_dev_3617_taxonomy_memory_leaks_fix";
-
 // Fixes how presigned urls are generated and accessed to remove possibility of CORS errors.
 export const FF_LSDV_4711 = "fflag_fix_all_lsdv_4711_cors_errors_accessing_task_data_short";
 // Enables "Enterprise Awareness" features

--- a/web/libs/editor/src/mixins/DrawingTool.js
+++ b/web/libs/editor/src/mixins/DrawingTool.js
@@ -3,7 +3,7 @@ import { types } from "mobx-state-tree";
 import Utils from "../utils";
 import throttle from "lodash.throttle";
 import { MIN_SIZE } from "../tools/Base";
-import { FF_DEV_3666, FF_DEV_3793, isFF } from "../utils/feature-flags";
+import { FF_DEV_3793, isFF } from "../utils/feature-flags";
 import { RELATIVE_STAGE_HEIGHT, RELATIVE_STAGE_WIDTH } from "../components/ImageView/Image";
 
 const DrawingTool = types
@@ -175,12 +175,7 @@ const DrawingTool = types
       },
 
       canStartDrawing() {
-        return (
-          !self.isIncorrectControl() &&
-          (!isFF(FF_DEV_3666) || !self.isIncorrectLabel()) &&
-          self.canStart() &&
-          !self.annotation.isDrawing
-        );
+        return !self.isIncorrectControl() && !self.isIncorrectLabel() && self.canStart() && !self.annotation.isDrawing;
       },
 
       startDrawing(x, y) {

--- a/web/libs/editor/src/mixins/SelectedModel.js
+++ b/web/libs/editor/src/mixins/SelectedModel.js
@@ -2,7 +2,6 @@ import { types } from "mobx-state-tree";
 
 import Tree from "../core/Tree";
 import { isDefined } from "../utils/utilities";
-import { FF_DEV_3666, isFF } from "../utils/feature-flags";
 
 const SelectedModelMixin = types
   .model()
@@ -82,13 +81,7 @@ const SelectedModelMixin = types
     },
 
     checkMaxUsages() {
-      if (isFF(FF_DEV_3666)) {
-        return self.tiedChildren.filter((c) => !c.canBeUsed());
-      }
-      const list = self.tiedChildren.filter((c) => !c.canBeUsed());
-
-      if (list.length) list.forEach((c) => c.setSelected(false));
-      return list;
+      return self.tiedChildren.filter((c) => !c.canBeUsed());
     },
 
     selectFirstVisible() {

--- a/web/libs/editor/src/stores/Annotation/store.js
+++ b/web/libs/editor/src/stores/Annotation/store.js
@@ -9,7 +9,7 @@ import Types from "../../core/Types";
 import { StoreExtender } from "../../mixins/SharedChoiceStore/extender";
 import { ViewModel } from "../../tags/visual";
 import Utils from "../../utils";
-import { FF_DEV_3034, FF_DEV_3391, FF_DEV_3617, FF_SIMPLE_INIT, isFF } from "../../utils/feature-flags";
+import { FF_DEV_3034, FF_DEV_3391, FF_SIMPLE_INIT, isFF } from "../../utils/feature-flags";
 import { emailFromCreatedBy } from "../../utils/utilities";
 import { Annotation } from "./Annotation";
 import { HistoryItem } from "./HistoryItem";
@@ -563,4 +563,4 @@ const AnnotationStoreModel = types
     };
   });
 
-export default types.compose("AnnotationStore", AnnotationStoreModel, ...(isFF(FF_DEV_3617) ? [StoreExtender] : []));
+export default types.compose("AnnotationStore", AnnotationStoreModel, StoreExtender);

--- a/web/libs/editor/src/tags/control/Taxonomy/Taxonomy.jsx
+++ b/web/libs/editor/src/tags/control/Taxonomy/Taxonomy.jsx
@@ -19,13 +19,7 @@ import SelectedChoiceMixin from "../../../mixins/SelectedChoiceMixin";
 import { SharedStoreMixin } from "../../../mixins/SharedChoiceStore/mixin";
 import VisibilityMixin from "../../../mixins/Visibility";
 import { parseValue } from "../../../utils/data";
-import {
-  FF_LEAP_218,
-  FF_LSDV_4583,
-  FF_TAXONOMY_ASYNC,
-  FF_TAXONOMY_LABELING,
-  isFF,
-} from "../../../utils/feature-flags";
+import { FF_LEAP_218, FF_LSDV_4583, FF_TAXONOMY_ASYNC, FF_TAXONOMY_LABELING, isFF } from "../../../utils/feature-flags";
 import ControlBase from "../Base";
 import ClassificationBase from "../ClassificationBase";
 

--- a/web/libs/editor/src/tags/control/Taxonomy/Taxonomy.jsx
+++ b/web/libs/editor/src/tags/control/Taxonomy/Taxonomy.jsx
@@ -20,7 +20,6 @@ import { SharedStoreMixin } from "../../../mixins/SharedChoiceStore/mixin";
 import VisibilityMixin from "../../../mixins/Visibility";
 import { parseValue } from "../../../utils/data";
 import {
-  FF_DEV_3617,
   FF_LEAP_218,
   FF_LSDV_4583,
   FF_TAXONOMY_ASYNC,
@@ -218,7 +217,7 @@ const Model = types
     pid: types.optional(types.string, guidGenerator),
 
     type: "taxonomy",
-    [isFF(FF_DEV_3617) ? "_children" : "children"]: Types.unionArray(["choice"]),
+    _children: Types.unionArray(["choice"]),
   })
   .volatile(() => ({
     maxUsagesReached: false,
@@ -227,22 +226,17 @@ const Model = types
     _api: "", // will be filled after the first load in updateValue()
     _items: [], // items loaded via API
   }))
-  .views((self) =>
-    isFF(FF_DEV_3617)
-      ? {
-          get children() {
-            return self._children;
-          },
-          set children(val) {
-            self._children = val;
-          },
-          get isLabeling() {
-            return isFF(FF_TAXONOMY_LABELING) && self.labeling;
-          },
-        }
-      : {},
-  )
   .views((self) => ({
+    get children() {
+      return self._children;
+    },
+    set children(val) {
+      self._children = val;
+    },
+    get isLabeling() {
+      return isFF(FF_TAXONOMY_LABELING) && self.labeling;
+    },
+
     get userLabels() {
       return self.annotation.store.userLabels;
     },
@@ -362,7 +356,7 @@ const Model = types
 
       const children = ChildrenSnapshots.get(self.name) ?? [];
 
-      if (isFF(FF_DEV_3617) && self.store && children.length !== self.children.length) {
+      if (self.store && children.length !== self.children.length) {
         // we have to update it during config parsing to let other code work
         // with correctly added children.
         // looks like there are no obstacles to do it in the same tick
@@ -559,16 +553,14 @@ const Model = types
     };
   })
   .preProcessSnapshot((sn) => {
-    if (isFF(FF_DEV_3617)) {
-      const children = sn._children ?? sn.children;
+    const children = sn._children ?? sn.children;
 
-      if (children && !ChildrenSnapshots.has(sn.name)) {
-        ChildrenSnapshots.set(sn.name, children);
-      }
-
-      delete sn._children;
-      delete sn.children;
+    if (children && !ChildrenSnapshots.has(sn.name)) {
+      ChildrenSnapshots.set(sn.name, children);
     }
+
+    delete sn._children;
+    delete sn.children;
 
     return sn;
   });
@@ -582,7 +574,7 @@ const TaxonomyModel = types.compose(
   AnnotationMixin,
   RequiredMixin,
   Model,
-  ...(isFF(FF_DEV_3617) ? [SharedStoreMixin] : []),
+  SharedStoreMixin,
   PerRegionMixin,
   ...(isFF(FF_LSDV_4583) ? [PerItemMixin] : []),
   ...(isFF(FF_TAXONOMY_LABELING) ? [TaxonomyLabelingResult] : []),
@@ -614,7 +606,7 @@ const HtxTaxonomy = observer(({ item }) => {
   // they are indicated by loading icon on the item itself
   const firstLoad = item.isLoadedByApi ? !item.items.length : true;
 
-  if (item.loading && isFF(FF_DEV_3617) && firstLoad) {
+  if (item.loading && isFF(FF_TAXONOMY_ASYNC) && firstLoad) {
     return (
       <div className={className} style={visibleStyle}>
         <div className={styles.taxonomy__loading}>

--- a/web/libs/editor/src/tags/object/Base.js
+++ b/web/libs/editor/src/tags/object/Base.js
@@ -2,7 +2,7 @@ import { types } from "mobx-state-tree";
 import isMatch from "lodash.ismatch";
 import InfoModal from "../../components/Infomodal/Infomodal";
 import { AnnotationMixin } from "../../mixins/AnnotationMixin";
-import { FF_DEV_3391, FF_DEV_3666, isFF } from "../../utils/feature-flags";
+import { FF_DEV_3391, isFF } from "../../utils/feature-flags";
 import { BaseTag } from "../TagBase";
 
 const ObjectBase = types
@@ -73,12 +73,8 @@ const ObjectBase = types
       const allStates = self.states() || [];
       let exceeded;
 
-      if (isFF(FF_DEV_3666)) {
-        exceeded = allStates.reduce(checkAndCollect, []).filter((e) => e.selected);
-        exceeded.forEach((e) => e.setSelected(false));
-      } else {
-        exceeded = allStates.reduce(checkAndCollect, []);
-      }
+      exceeded = allStates.reduce(checkAndCollect, []).filter((e) => e.selected);
+      exceeded.forEach((e) => e.setSelected(false));
 
       const states = self.activeStates() || [];
 

--- a/web/libs/editor/src/tags/object/Base.js
+++ b/web/libs/editor/src/tags/object/Base.js
@@ -71,9 +71,7 @@ const ObjectBase = types
       // `checkMaxUsages` may unselect labels with already reached `maxUsages`
       const checkAndCollect = (list, s) => (s.checkMaxUsages ? list.concat(s.checkMaxUsages()) : list);
       const allStates = self.states() || [];
-      let exceeded;
-
-      exceeded = allStates.reduce(checkAndCollect, []).filter((e) => e.selected);
+      const exceeded = allStates.reduce(checkAndCollect, []).filter((e) => e.selected);
       exceeded.forEach((e) => e.setSelected(false));
 
       const states = self.activeStates() || [];

--- a/web/libs/editor/src/tags/object/Image/Image.js
+++ b/web/libs/editor/src/tags/object/Image/Image.js
@@ -16,7 +16,6 @@ import ToolsManager from "../../../tools/Manager";
 import { parseValue } from "../../../utils/data";
 import {
   FF_DEV_3377,
-  FF_DEV_3666,
   FF_DEV_3793,
   FF_LSDV_4583,
   FF_LSDV_4583_6,
@@ -1106,15 +1105,8 @@ const Model = types
     },
 
     checkLabels() {
-      let labelStates;
-
-      if (isFF(FF_DEV_3666)) {
-        // there should be at least one available label or none of them should be selected
-        labelStates = self.activeStates() || [];
-      } else {
-        // there is should be at least one state selected for *labels object
-        labelStates = (self.states() || []).filter((s) => s.type.includes("labels"));
-      }
+      // there should be at least one available label or none of them should be selected
+      const labelStates = self.activeStates() || [];
       const selectedStates = self.getAvailableStates();
 
       return selectedStates.length !== 0 || labelStates.length === 0;

--- a/web/libs/editor/src/tags/object/Paragraphs/model.js
+++ b/web/libs/editor/src/tags/object/Paragraphs/model.js
@@ -9,7 +9,7 @@ import { SyncableMixin } from "../../../mixins/Syncable";
 import { ParagraphsRegionModel } from "../../../regions/ParagraphsRegion";
 import Utils from "../../../utils";
 import { parseValue } from "../../../utils/data";
-import { FF_DEV_2669, FF_DEV_2918, FF_DEV_3666, FF_LSDV_E_278, isFF } from "../../../utils/feature-flags";
+import { FF_DEV_2669, FF_DEV_2918, FF_LSDV_E_278, isFF } from "../../../utils/feature-flags";
 import messages from "../../../utils/messages";
 import { clamp, isDefined, isValidObjectURL } from "../../../utils/utilities";
 import ObjectBase from "../Base";
@@ -516,7 +516,7 @@ const ParagraphsLoadingModel = types.model().actions((self) => ({
 
   addRegions(ranges) {
     const areas = [];
-    const states = isFF(FF_DEV_3666) ? self.getAvailableStates() : self.activeStates();
+    const states = self.getAvailableStates();
 
     if (states.length === 0) return;
 
@@ -540,7 +540,7 @@ const ParagraphsLoadingModel = types.model().actions((self) => ({
     if (isFF(FF_DEV_2918)) {
       return self.addRegions([range])[0];
     }
-    const states = isFF(FF_DEV_3666) ? self.getAvailableStates() : self.activeStates();
+    const states = self.getAvailableStates();
 
     if (states.length === 0) return;
 

--- a/web/libs/editor/src/tools/Brush.jsx
+++ b/web/libs/editor/src/tools/Brush.jsx
@@ -9,7 +9,6 @@ import { DrawingTool } from "../mixins/DrawingTool";
 import { Tool } from "../components/Toolbar/Tool";
 import { Range } from "../common/Range/Range";
 import { NodeViews } from "../components/Node/Node";
-import { FF_DEV_3666, isFF } from "../utils/feature-flags";
 
 const MIN_SIZE = 1;
 const MAX_SIZE = 50;
@@ -213,7 +212,7 @@ const _Tool = types
 
           self.addPoint(x, y);
         } else {
-          if (isFF(FF_DEV_3666) && !self.canStartDrawing()) return;
+          if (!self.canStartDrawing()) return;
           if (self.tagTypes.stateTypes === self.control.type && !self.control.isSelected) return;
           self.annotation.history.freeze();
           self.mode = "drawing";

--- a/web/libs/editor/src/tools/KeyPoint.js
+++ b/web/libs/editor/src/tools/KeyPoint.js
@@ -4,7 +4,7 @@ import BaseTool from "./Base";
 import ToolMixin from "../mixins/Tool";
 import { NodeViews } from "../components/Node/Node";
 import { DrawingTool } from "../mixins/DrawingTool";
-import { FF_DEV_3666, FF_DEV_3793, isFF } from "../utils/feature-flags";
+import { FF_DEV_3793, isFF } from "../utils/feature-flags";
 
 const _Tool = types
   .model("KeyPointTool", {
@@ -29,7 +29,7 @@ const _Tool = types
   }))
   .actions((self) => ({
     clickEv(ev, [x, y]) {
-      if (isFF(FF_DEV_3666) && !self.canStartDrawing()) return;
+      if (!self.canStartDrawing()) return;
 
       const c = self.control;
 

--- a/web/libs/editor/src/utils/feature-flags.ts
+++ b/web/libs/editor/src/utils/feature-flags.ts
@@ -51,12 +51,6 @@ export const FF_DEV_3377 = "fflag_fix_front_dev_3377_image_regions_shift_on_resi
 export const FF_DEV_3391 = "fflag_fix_front_dev_3391_interactive_view_all";
 
 /**
- * Addresses the memory leak issue in Taxonomy with Repeater
- * @link https://app.launchdarkly.com/default/production/features/fflag_fix_front_dev_3617_taxonomy_memory_leaks_fix
- */
-export const FF_DEV_3617 = "fflag_fix_front_dev_3617_taxonomy_memory_leaks_fix";
-
-/**
  * Fixing maxUsages prop of *labels on region creation.
  * @link https://app.launchdarkly.com/default/test/features/fflag_fix_front_dev_3666_max_usages_on_region_creation_171122_short
  */

--- a/web/libs/editor/src/utils/feature-flags.ts
+++ b/web/libs/editor/src/utils/feature-flags.ts
@@ -51,12 +51,6 @@ export const FF_DEV_3377 = "fflag_fix_front_dev_3377_image_regions_shift_on_resi
 export const FF_DEV_3391 = "fflag_fix_front_dev_3391_interactive_view_all";
 
 /**
- * Fixing maxUsages prop of *labels on region creation.
- * @link https://app.launchdarkly.com/default/test/features/fflag_fix_front_dev_3666_max_usages_on_region_creation_171122_short
- */
-export const FF_DEV_3666 = "fflag_fix_front_dev_3666_max_usages_on_region_creation_171122_short";
-
-/**
  * Fixing "Auto Detect" tool undo functionality and bugs with skipNextUndoState.
  * @link https://app.launchdarkly.com/default/production/features/fflag_fix_front_dev_1284_auto_detect_undo_281022_short
  */

--- a/web/libs/editor/tests/e2e/tests/maxUsage.test.js
+++ b/web/libs/editor/tests/e2e/tests/maxUsage.test.js
@@ -140,9 +140,6 @@ Data(maxUsageImageToolsDataTable).Scenario(
     }
 
     I.amOnPage("/");
-    LabelStudio.setFeatureFlags({
-      fflag_fix_front_dev_3666_max_usages_on_region_creation_171122_short: true,
-    });
     LabelStudio.init({
       config: createImageToolsConfig({ maxUsage }),
       data: {
@@ -174,9 +171,6 @@ Data(maxUsageImageToolsDataTable).Scenario(
     const shape = shapes[shapeName];
 
     I.amOnPage("/");
-    LabelStudio.setFeatureFlags({
-      fflag_fix_front_dev_3666_max_usages_on_region_creation_171122_short: true,
-    });
     LabelStudio.init({
       config: createImageLabelsConfig({ maxUsage }),
       data: {
@@ -207,7 +201,6 @@ Data(maxUsageDataTable).Scenario(
     const { maxUsage } = current;
 
     LabelStudio.setFeatureFlags({
-      fflag_fix_front_dev_3666_max_usages_on_region_creation_171122_short: true,
       ff_front_dev_2715_audio_3_280722_short: true,
     });
     I.amOnPage("/");
@@ -248,9 +241,6 @@ Data(maxUsageDataTable).Scenario(
     const { maxUsage } = current;
 
     I.amOnPage("/");
-    LabelStudio.setFeatureFlags({
-      fflag_fix_front_dev_3666_max_usages_on_region_creation_171122_short: true,
-    });
     LabelStudio.init({
       config: `
 <View>
@@ -286,9 +276,6 @@ Data(maxUsageDataTable).Scenario(
     const { maxUsage } = current;
 
     I.amOnPage("/");
-    LabelStudio.setFeatureFlags({
-      fflag_fix_front_dev_3666_max_usages_on_region_creation_171122_short: true,
-    });
     LabelStudio.init({
       config: `
 <View>
@@ -322,9 +309,6 @@ Data(maxUsageDataTable).Scenario(
     const { maxUsage } = current;
 
     I.amOnPage("/");
-    LabelStudio.setFeatureFlags({
-      fflag_fix_front_dev_3666_max_usages_on_region_creation_171122_short: true,
-    });
     LabelStudio.init({
       config: `
 <View>

--- a/web/libs/editor/tests/e2e/tests/taxonomy.test.js
+++ b/web/libs/editor/tests/e2e/tests/taxonomy.test.js
@@ -5,7 +5,6 @@ Feature("Taxonomy");
 Before(({ LabelStudio }) => {
   LabelStudio.setFeatureFlags({
     fflag_feat_front_lsdv_5451_async_taxonomy_110823_short: false,
-    fflag_fix_front_dev_3617_taxonomy_memory_leaks_fix: true,
     ff_front_dev_1536_taxonomy_user_labels_150222_long: true,
     ff_front_1170_outliner_030222_short: true,
   });

--- a/web/libs/frontend-test/src/feature-flags.ts
+++ b/web/libs/frontend-test/src/feature-flags.ts
@@ -51,12 +51,6 @@ export const FF_DEV_3377 = "fflag_fix_front_dev_3377_image_regions_shift_on_resi
 export const FF_DEV_3391 = "fflag_fix_front_dev_3391_interactive_view_all";
 
 /**
- * Addresses the memory leak issue in Taxonomy with Repeater
- * @link https://app.launchdarkly.com/default/production/features/fflag_fix_front_dev_3617_taxonomy_memory_leaks_fix
- */
-export const FF_DEV_3617 = "fflag_fix_front_dev_3617_taxonomy_memory_leaks_fix";
-
-/**
  * Fixing maxUsages prop of *labels on region creation.
  * @link https://app.launchdarkly.com/default/test/features/fflag_fix_front_dev_3666_max_usages_on_region_creation_171122_short
  */

--- a/web/libs/frontend-test/src/feature-flags.ts
+++ b/web/libs/frontend-test/src/feature-flags.ts
@@ -50,12 +50,6 @@ export const FF_DEV_3377 = "fflag_fix_front_dev_3377_image_regions_shift_on_resi
 // Refactoring to use separate trees for every annotation to allow real annotations in View All
 export const FF_DEV_3391 = "fflag_fix_front_dev_3391_interactive_view_all";
 
-/**
- * Fixing maxUsages prop of *labels on region creation.
- * @link https://app.launchdarkly.com/default/test/features/fflag_fix_front_dev_3666_max_usages_on_region_creation_171122_short
- */
-export const FF_DEV_3666 = "fflag_fix_front_dev_3666_max_usages_on_region_creation_171122_short";
-
 // Use only relative coords internally to improve performance and reduce bugs
 export const FF_DEV_3793 = "fflag_fix_front_dev_3793_relative_coords_short";
 


### PR DESCRIPTION
Removing two feature flags that have long been stale.

fflag_fix_front_dev_3666_max_usages_on_region_creation_171122_short: True,
fflag_fix_front_dev_3617_taxonomy_memory_leaks_fix: True,

No LSE code related.

You know the drill, review commit by commit.