### PR TITLE
docs: Fix formatting in Taxonomy tag params

### DIFF
--- a/docs/source/tags/taxonomy.md
+++ b/docs/source/tags/taxonomy.md
@@ -30,7 +30,7 @@ Use with the following data types: audio, image, HTML, paragraphs, text, time se
 | [placeholder=] | <code>string</code> |  | What to display as prompt on the input |
 | [perRegion] | <code>boolean</code> |  | Use this tag to classify specific regions instead of the whole object |
 | [perItem] | <code>boolean</code> |  | Use this tag to classify specific items inside the object instead of the whole object |
-| [labeling] | <code>boolean</code> |  | Use taxonomy to label regions in text. Only supported with <Text> and <HyperText> object tags. |
+| [labeling] | <code>boolean</code> |  | Use taxonomy to label regions in text. Only supported with `<Text>` and `<HyperText>` object tags. |
 | [legacy] | <code>boolean</code> |  | Use this tag to enable the legacy version of the Taxonomy tag. The legacy version supports the ability for annotators to add labels as needed. However, when true, the `apiUrl` parameter is not usable. |
 
 ### Example

--- a/web/libs/editor/src/tags/control/Taxonomy/Taxonomy.jsx
+++ b/web/libs/editor/src/tags/control/Taxonomy/Taxonomy.jsx
@@ -85,7 +85,7 @@ import { errorBuilder } from "../../../core/DataValidator/ConfigValidator";
  * @param {string} [placeholder=]         - What to display as prompt on the input
  * @param {boolean} [perRegion]           - Use this tag to classify specific regions instead of the whole object
  * @param {boolean} [perItem]             - Use this tag to classify specific items inside the object instead of the whole object
- * @param {boolean} [labeling]            - Use taxonomy to label regions in text. Only supported with <Text> and <HyperText> object tags.
+ * @param {boolean} [labeling]            - Use taxonomy to label regions in text. Only supported with `<Text>` and `<HyperText>` object tags.
  * @param {boolean} [legacy]              - Use this tag to enable the legacy version of the Taxonomy tag. The legacy version supports the ability for annotators to add labels as needed. However, when true, the `apiUrl` parameter is not usable.
  */
 const TagAttrs = types.model({


### PR DESCRIPTION
The labeling param on the Taxonomy tag was not formatted correctly