### PR TITLE
fix: OPTIC-1585: Change Annotations => Submitted Annotations to match its real meaning

### DIFF
--- a/web/libs/datamanager/src/components/DataManager/DataManager.jsx
+++ b/web/libs/datamanager/src/components/DataManager/DataManager.jsx
@@ -55,7 +55,8 @@ const ProjectSummary = summaryInjector((props) => {
       <span style={{ display: "flex", alignItems: "center", fontSize: 12 }}>
         <Space size="compact">
           <span>
-            Tasks: <span title="Filtered tasks">{props.totalFoundTasks}</span> / <span title="Total tasks in the project">{props.totalTasks}</span>
+            Tasks: <span title="Filtered tasks">{props.totalFoundTasks}</span> /{" "}
+            <span title="Total tasks in the project">{props.totalTasks}</span>
           </span>
           <span>Submitted annotations: {props.totalAnnotations}</span>
           <span>Predictions: {props.totalPredictions}</span>

--- a/web/libs/datamanager/src/components/DataManager/DataManager.jsx
+++ b/web/libs/datamanager/src/components/DataManager/DataManager.jsx
@@ -55,9 +55,9 @@ const ProjectSummary = summaryInjector((props) => {
       <span style={{ display: "flex", alignItems: "center", fontSize: 12 }}>
         <Space size="compact">
           <span>
-            Tasks: {props.totalFoundTasks} / {props.totalTasks}
+            Tasks: <span title="Filtered tasks">{props.totalFoundTasks}</span> / <span title="Total tasks in the project">{props.totalTasks}</span>
           </span>
-          <span>Annotations: {props.totalAnnotations}</span>
+          <span>Submitted annotations: {props.totalAnnotations}</span>
           <span>Predictions: {props.totalPredictions}</span>
         </Space>
       </span>


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/2af564d6-8a06-42ac-9b00-e32f8786d168)


#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [x] Frontend



### Describe the reason for change
It’s very confusing to see Annotations on the bottom panel in the data manager. Because it’s not total annotations, but Submitted annotations only. 



#### What does this fix?
Renames Annotations => Submitted annotations
