### PR TITLE
docs: Add Django upgrade to 2.20 release notes

### DIFF
--- a/docs/source/guide/release_notes/onprem/2.20.0.md
+++ b/docs/source/guide/release_notes/onprem/2.20.0.md
@@ -39,7 +39,7 @@ Optimized the API calls made from the frontend within the members management and
 
 ### Breaking changes
 
-This release includes an upgrade to Django 5. This means we now require PostgreSQL version 13+. 
+This release includes an upgrade to Django 5. As part of this change, Label Studio now requires PostgreSQL version 13+. 
 
 ### Bug fixes
 

--- a/docs/source/guide/release_notes/onprem/2.20.0.md
+++ b/docs/source/guide/release_notes/onprem/2.20.0.md
@@ -37,6 +37,9 @@ Optimized the API calls made from the frontend within the members management and
 
 - Updated the default settings for CSRF cookie to be more secure and added an environment setting to control cookie age.
 
+### Breaking changes
+
+This release includes an upgrade to Django 5. This means we now require PostgreSQL version 13+. 
 
 ### Bug fixes
 


### PR DESCRIPTION
Added a section about Django 5 and PostgreSql to the on-prem release notes