### PR TITLE
refactor: OPTIC-1621: Remove Stale Feature Flag - fflag_perf_back_lsdv_4695_update_prediction_query_to_use_direct_project_relation

### DIFF
--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -3,7 +3,6 @@ STALE_FEATURE_FLAGS = {
     'fflag_feat_front_optic_66_lazy_chart_evaluation_19092023_short': False,
     'fflag_fix_back_leap_24_tasks_api_optimization_05092023_short': False,
     'fflag_feat_optic_2_ensure_draft_saved_short': True,
-    'fflag_perf_back_lsdv_4695_update_prediction_query_to_use_direct_project_relation': True,
     'fflag_feat_front_lsdv_4620_outliner_optimization_310723_short': True,
     'fflag_fix_front_lsdv_4600_lead_time_27072023_short': False,
     'fflag_feat_front_lops_e_10_updated_ux_short': False,

--- a/label_studio/projects/functions/__init__.py
+++ b/label_studio/projects/functions/__init__.py
@@ -15,13 +15,7 @@ def annotate_finished_task_number(queryset):
 
 
 def annotate_total_predictions_number(queryset):
-    if flag_set(
-        'fflag_perf_back_lsdv_4695_update_prediction_query_to_use_direct_project_relation',
-        user='auto',
-    ):
-        predictions = Prediction.objects.filter(project=OuterRef('id')).values('id')
-    else:
-        predictions = Prediction.objects.filter(task__project=OuterRef('id')).values('id')
+    predictions = Prediction.objects.filter(project=OuterRef('id')).values('id')
     return queryset.annotate(total_predictions_number=SQCount(predictions))
 
 

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -5,7 +5,6 @@ import logging
 from typing import Any, Mapping, Optional
 
 from annoying.fields import AutoOneToOneField
-from core.feature_flags import flag_set
 from core.label_config import (
     check_control_in_config_by_regex,
     check_toname_in_config_by_regex,
@@ -327,13 +326,7 @@ class Project(ProjectMixin, models.Model):
 
     @property
     def has_any_predictions(self):
-        if flag_set(
-            'fflag_perf_back_lsdv_4695_update_prediction_query_to_use_direct_project_relation',
-            user='auto',
-        ):
-            return Prediction.objects.filter(Q(project=self.id)).exists()
-        else:
-            return Prediction.objects.filter(Q(task__project=self.id)).exists()
+        return Prediction.objects.filter(Q(project=self.id)).exists()
 
     @property
     def business(self):
@@ -933,14 +926,7 @@ class Project(ProjectMixin, models.Model):
         :param extended: Boolean, if True, returns additional information. Default is False.
         :return: Dict or list containing model versions and their count predictions.
         """
-        if flag_set(
-            'fflag_perf_back_lsdv_4695_update_prediction_query_to_use_direct_project_relation',
-            user='auto',
-        ):
-            predictions = Prediction.objects.filter(project=self)
-        else:
-            predictions = Prediction.objects.filter(task__project=self)
-        # model_versions = set(predictions.values_list('model_version', flat=True).distinct())
+        predictions = Prediction.objects.filter(project=self)
 
         if extended:
             model_versions = list(

--- a/label_studio/tasks/api.py
+++ b/label_studio/tasks/api.py
@@ -778,13 +778,7 @@ class PredictionAPI(viewsets.ModelViewSet):
     filterset_fields = ['task', 'task__project', 'project']
 
     def get_queryset(self):
-        if flag_set(
-            'fflag_perf_back_lsdv_4695_update_prediction_query_to_use_direct_project_relation',
-            user='auto',
-        ):
-            return Prediction.objects.filter(project__organization=self.request.user.active_organization)
-        else:
-            return Prediction.objects.filter(task__project__organization=self.request.user.active_organization)
+        return Prediction.objects.filter(project__organization=self.request.user.active_organization)
 
 
 @method_decorator(name='get', decorator=swagger_auto_schema(auto_schema=None))

--- a/label_studio/tasks/models.py
+++ b/label_studio/tasks/models.py
@@ -933,15 +933,8 @@ class Prediction(models.Model):
         return timesince(self.created_at)
 
     def has_permission(self, user):
-        if flag_set(
-            'fflag_perf_back_lsdv_4695_update_prediction_query_to_use_direct_project_relation',
-            user='auto',
-        ):
-            user.project = self.project  # link for activity log
-            return self.project.has_permission(user)
-        else:
-            user.project = self.task.project  # link for activity log
-            return self.task.project.has_permission(user)
+        user.project = self.project  # link for activity log
+        return self.project.has_permission(user)
 
     @classmethod
     def prepare_prediction_result(cls, result, project):
@@ -1009,13 +1002,8 @@ class Prediction(models.Model):
                 update_fields = {'project_id'}.union(update_fields)
 
         # "result" data can come in different forms - normalize them to JSON
-        if flag_set(
-            'fflag_perf_back_lsdv_4695_update_prediction_query_to_use_direct_project_relation',
-            user='auto',
-        ):
-            self.result = self.prepare_prediction_result(self.result, self.project)
-        else:
-            self.result = self.prepare_prediction_result(self.result, self.task.project)
+        self.result = self.prepare_prediction_result(self.result, self.project)
+
         if update_fields is not None:
             update_fields = {'result'}.union(update_fields)
         # set updated_at field of task to now()


### PR DESCRIPTION
Removing stale feature flag

fflag_perf_back_lsdv_4695_update_prediction_query_to_use_direct_project_relation -> True