### PR TITLE
refactor: OPTIC-1644: Remove another set of FF

### DIFF
--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -18,7 +18,7 @@ STALE_FEATURE_FLAGS = {
     'ff_front_dev_2432_auto_save_polygon_draft_210622_short': True,
     'ff_front_1170_outliner_030222_short': True,
     'fflag_fix_front_lsdv_4620_memory_leaks_100723_short': False,
-    'fflag_fix_back_lsdv_5410_temporary_disable_auto_inference_jobs_short': True,
+    'fflag_feat_optic_198_multi_select_users_short': True,
     'fflag_feat_front_prod_292_archive_workspaces_short': True,
     'fflag_feat_all_lsdv_4915_async_task_import_13042023_short': True,
     'fflag_fix_all_lsdv_4971_async_reimport_09052023_short': True,

--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -18,7 +18,6 @@ STALE_FEATURE_FLAGS = {
     'ff_front_dev_2432_auto_save_polygon_draft_210622_short': True,
     'ff_front_1170_outliner_030222_short': True,
     'fflag_fix_front_lsdv_4620_memory_leaks_100723_short': False,
-    'fflag_feat_front_prod_292_archive_workspaces_short': True,
     'fflag_feat_all_lsdv_4915_async_task_import_13042023_short': True,
     'fflag_fix_all_lsdv_4971_async_reimport_09052023_short': True,
     # Jan 16

--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -18,7 +18,6 @@ STALE_FEATURE_FLAGS = {
     'ff_front_dev_2432_auto_save_polygon_draft_210622_short': True,
     'ff_front_1170_outliner_030222_short': True,
     'fflag_fix_front_lsdv_4620_memory_leaks_100723_short': False,
-    'fflag_feat_optic_198_multi_select_users_short': True,
     'fflag_fix_back_lsdv_5410_temporary_disable_auto_inference_jobs_short': True,
     'fflag_feat_front_prod_292_archive_workspaces_short': True,
     'fflag_feat_all_lsdv_4915_async_task_import_13042023_short': True,

--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -18,7 +18,6 @@ STALE_FEATURE_FLAGS = {
     'ff_front_dev_2432_auto_save_polygon_draft_210622_short': True,
     'ff_front_1170_outliner_030222_short': True,
     'fflag_fix_front_lsdv_4620_memory_leaks_100723_short': False,
-    'fflag_feat_optic_198_multi_select_users_short': True,
     'fflag_feat_front_prod_292_archive_workspaces_short': True,
     'fflag_feat_all_lsdv_4915_async_task_import_13042023_short': True,
     'fflag_fix_all_lsdv_4971_async_reimport_09052023_short': True,


### PR DESCRIPTION
A collection of feature flags that will be removed from the codebase. 

These are feature flags that have been stale for a long time. Each feature flag will be removed in a separate commit.  Only LSE code


    'fflag_feat_optic_198_multi_select_users_short': True,
    'fflag_fix_back_lsdv_5410_temporary_disable_auto_inference_jobs_short': True,
    'fflag_feat_front_prod_292_archive_workspaces_short': True,

