### PR TITLE
refactor: OPTIC-1678: ff clean up left overs

### DIFF
--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -38,7 +38,6 @@ STALE_FEATURE_FLAGS = {
     'fflag_fix_front_dev_3793_relative_coords_short': True,
     'ff_front_dev_2715_audio_3_280722_short': True,
     # Feb 5
-    'fflag_fix_back_optic_1526_project_members_prefetch_short': True,
     'fflag_feat_front_optic_1351_use_new_projects_counts_api_short': True,
     'fflag_feature_all_optic_1421_cold_start_v2': False,
     'fflag_fix_back_optic_1407_optimize_tasks_api_pagination_counts': True,
@@ -51,6 +50,5 @@ STALE_FEATURE_FLAGS = {
     # Feb 6
     'fflag_feat_dia_1528_gemini_models_support_vertex_ai_support_short': True,
     'fflag_feat_all_dia_1576_prompts_easy_breezy_onboarding_short_async_presets_ks': False,
-    'fflag__feature_develop__prompts__dia_1362_custom_llm_endpoint': True,
     'fflag_front_dia_1150_ddisco_sneak_preview': False,
 }

--- a/web/libs/editor/src/core/feature-flags/flags.json
+++ b/web/libs/editor/src/core/feature-flags/flags.json
@@ -3,7 +3,6 @@
   "ff_front_DEV_1713_audio_ui_150222_short": false,
   "ff_front_dev_2715_audio_3_280722_short": true,
   "fflag_fix_front_dev_3391_interactive_view_all": false,
-  "fflag_fix_front_dev_3617_taxonomy_memory_leaks_fix": true,
   "fflag_feat_front_dev_3873_labeling_ui_improvements_short": true,
   "fflag_feat_front_lsdv_4620_richtext_opimization_060423_short": true,
   "fflag_fix_front_lsdv_4620_memory_leaks_100723_short": false


### PR DESCRIPTION
Clean up references to:

fflag_fix_back_optic_1526_project_members_prefetch_short;
fflag_fix_front_dev_3617_taxonomy_memory_leaks_fix;
fflag__feature_develop__prompts__dia_1362_custom_llm_endpoint; 