### PR TITLE
fix: DIA-1916: [FE] User is NOT able to upload profile image on new account page

### DIFF
--- a/web/libs/core/src/lib/api-proxy/index.ts
+++ b/web/libs/core/src/lib/api-proxy/index.ts
@@ -53,7 +53,11 @@ export class APIProxy<T extends {}> {
     this.resolveMethods(options.endpoints);
   }
 
-  invoke(method: keyof typeof this.methods, params?: Record<string, any>, options?: ApiParams) {
+  invoke<T>(
+    method: keyof typeof this.methods,
+    params?: Record<string, any>,
+    options?: ApiParams,
+  ): Promise<WrappedResponse<T>> {
     if (!this.isValidMethod(method as string)) {
       throw new Error(`Method ${method.toString()} not found`);
     }

--- a/web/libs/core/src/lib/hooks/useCurrentUser.ts
+++ b/web/libs/core/src/lib/hooks/useCurrentUser.ts
@@ -1,0 +1,34 @@
+import type { APIUser } from "@humansignal/core/types/user";
+import { API } from "apps/labelstudio/src/providers/ApiProvider";
+import { useAtomValue } from "jotai";
+import { atomWithQuery, queryClientAtom } from "jotai-tanstack-query";
+import { useCallback } from "react";
+
+const currentUserAtom = atomWithQuery(() => ({
+  queryKey: ["current-user"],
+  async queryFn() {
+    return await API.invoke<APIUser>("me");
+  },
+}));
+
+export function useCurrentUser() {
+  const user = useAtomValue(currentUserAtom);
+  const queryClient = useAtomValue(queryClientAtom);
+  const refetch = useCallback(() => queryClient.invalidateQueries({ queryKey: ["current-user"] }), []);
+
+  return user.isSuccess
+    ? ({
+        user: user.data,
+        isInProgress: user.isFetching,
+        loaded: user.isSuccess,
+        error: null,
+        fetch: refetch,
+      } as const)
+    : ({
+        user: null,
+        isInProgress: user.isFetching,
+        loaded: user.isSuccess,
+        error: user.error,
+        fetch: refetch,
+      } as const);
+}

--- a/web/libs/core/src/lib/hooks/useCurrentUser.ts
+++ b/web/libs/core/src/lib/hooks/useCurrentUser.ts
@@ -14,7 +14,7 @@ const currentUserAtom = atomWithQuery(() => ({
 const currentUserUpdateAtom = atomWithMutation((get) => ({
   mutationKey: ["update-current-user"],
   async mutationFn({ pk, user }: { pk: number; user: Partial<APIUser> }) {
-    return await API.invoke("updateUser", { pk }, { body: user });
+    return await API.invoke<APIUser>("updateUser", { pk }, { body: user });
   },
 
   onSettled() {
@@ -39,12 +39,24 @@ export function useCurrentUserAtom() {
     [user.data?.id, updateUser.mutate],
   );
 
+  const updateAsync = useCallback(
+    (userUpdate: Partial<APIUser>) => {
+      if (!user.data) {
+        console.error("User is not loaded. Try fetching first.");
+        return;
+      }
+      return updateUser.mutateAsync({ pk: user.data.id, user: userUpdate });
+    },
+    [user.data?.id, updateUser.mutate],
+  );
+
   const commonResponse = {
     isInProgress: user.isFetching || updateUser.isPending,
     isUpdating: updateUser.isPending,
     loaded: user.isSuccess,
     fetch: refetch,
     update,
+    updateAsync,
   } as const;
 
   return user.isSuccess

--- a/web/libs/core/src/lib/hooks/useCurrentUser.ts
+++ b/web/libs/core/src/lib/hooks/useCurrentUser.ts
@@ -41,6 +41,7 @@ export function useCurrentUserAtom() {
 
   const commonResponse = {
     isInProgress: user.isFetching || updateUser.isPending,
+    isUpdating: updateUser.isPending,
     loaded: user.isSuccess,
     fetch: refetch,
     update,

--- a/web/libs/core/src/pages/AccountSettings/sections/PersonalInfo.tsx
+++ b/web/libs/core/src/pages/AccountSettings/sections/PersonalInfo.tsx
@@ -93,7 +93,6 @@ export const PersonalInfo = () => {
     async (e: FormEvent, isDelete = false) => {
       e.preventDefault();
       e.stopPropagation();
-      console.log("submitting");
       if (!user) return;
 
       const body = new FormData(e.currentTarget as HTMLFormElement);

--- a/web/libs/core/src/pages/AccountSettings/sections/PersonalInfo.tsx
+++ b/web/libs/core/src/pages/AccountSettings/sections/PersonalInfo.tsx
@@ -6,7 +6,7 @@ import { Userpic } from "/apps/labelstudio/src/components/Userpic/Userpic";
 import { Button } from "/apps/labelstudio/src/components/Button/Button";
 import { API, useAPI } from "apps/labelstudio/src/providers/ApiProvider";
 import styles from "../AccountSettings.module.scss";
-import { useCurrentUser } from "@humansignal/core/lib/hooks/useCurrentUser";
+import { useCurrentUserAtom } from "@humansignal/core/lib/hooks/useCurrentUser";
 import { atomWithMutation } from "jotai-tanstack-query";
 import { useAtomValue } from "jotai";
 import type { APIUser } from "@humansignal/core/types/user";
@@ -57,7 +57,7 @@ export const PersonalInfo = () => {
   const toast = useToast();
   const updateUser = useAtomValue(updateUserAtom);
   const updateUserAvatar = useAtomValue(updateUserAvatarAtom);
-  const { user, fetch: refetchUser, isInProgress: userInProgress } = useCurrentUser();
+  const { user, fetch: refetchUser, isInProgress: userInProgress } = useCurrentUserAtom();
   const [isInProgress, setIsInProgress] = useState(false);
   const userAvatarForm = useRef<HTMLFormElement>();
   const avatarRef = useRef<HTMLInputElement>();

--- a/web/libs/core/src/pages/AccountSettings/sections/PersonalInfo.tsx
+++ b/web/libs/core/src/pages/AccountSettings/sections/PersonalInfo.tsx
@@ -1,81 +1,131 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { type FormEvent, type FormEventHandler, useCallback, useEffect, useRef, useState } from "react";
 import clsx from "clsx";
-import { InputFile, useToast } from "@humansignal/ui";
+import { InputFile, ToastType, useToast } from "@humansignal/ui";
 import { Input } from "/apps/labelstudio/src/components/Form/Elements";
 import { Userpic } from "/apps/labelstudio/src/components/Userpic/Userpic";
-import { useCurrentUser } from "/apps/labelstudio/src/providers/CurrentUser";
 import { Button } from "/apps/labelstudio/src/components/Button/Button";
-import { useAPI } from "apps/labelstudio/src/providers/ApiProvider";
+import { API, useAPI } from "apps/labelstudio/src/providers/ApiProvider";
 import styles from "../AccountSettings.module.scss";
+import { useCurrentUser } from "@humansignal/core/lib/hooks/useCurrentUser";
+import { atomWithMutation } from "jotai-tanstack-query";
+import { useAtomValue } from "jotai";
+import type { APIUser } from "@humansignal/core/types/user";
 
-export const PersonalInfo = () => {
-  const api = useAPI();
-  const toast = useToast();
-  const { user, fetch, isInProgress: userInProgress } = useCurrentUser();
-  const [fname, setFName] = useState("");
-  const [lname, setLName] = useState("");
-  const [email, setEmail] = useState("");
-  const [phone, setPhone] = useState("");
-  const [isInProgress, setIsInProgress] = useState(false);
-  const userInfoForm = useRef();
-  const userAvatarForm = useRef();
-  const avatarRef = useRef();
-  const fileChangeHandler = () => userAvatarForm.current.requestSubmit();
-  const avatarFormSubmitHandler = useCallback(
-    async (e, isDelete = false) => {
-      e.preventDefault();
-      const response = await api.callApi(isDelete ? "deleteUserAvatar" : "updateUserAvatar", {
-        params: {
-          pk: user?.id,
-        },
-        body: {
-          avatar: avatarRef.current.files[0],
-        },
+const updateUserAtom = atomWithMutation(() => ({
+  mutationKey: ["update-user"],
+  async mutationFn({ userId, body }: { userId: number; body: FormData }) {
+    return await API.invoke<APIUser>(
+      "updateUser",
+      {
+        pk: userId,
+      },
+      {
+        body: Object.fromEntries(body.entries()),
+        errorFilter: () => true,
+      },
+    );
+  },
+}));
+
+const updateUserAvatarAtom = atomWithMutation(() => ({
+  mutationKey: ["update-user"],
+  async mutationFn({
+    userId,
+    body,
+    isDelete,
+  }: { userId: number; body: FormData; isDelete?: never } | { userId: number; isDelete: true; body?: never }) {
+    const method = isDelete ? "deleteUserAvatar" : "updateUserAvatar";
+    const response = await API.invoke(
+      method,
+      {
+        pk: userId,
+      },
+      {
+        body,
         headers: {
           "Content-Type": "multipart/form-data",
         },
         errorFilter: () => true,
+      },
+    );
+    return response;
+  },
+}));
+
+export const PersonalInfo = () => {
+  const api = useAPI();
+  const toast = useToast();
+  const updateUser = useAtomValue(updateUserAtom);
+  const updateUserAvatar = useAtomValue(updateUserAvatarAtom);
+  const { user, fetch: refetchUser, isInProgress: userInProgress } = useCurrentUser();
+  const [isInProgress, setIsInProgress] = useState(false);
+  const userAvatarForm = useRef<HTMLFormElement>();
+  const avatarRef = useRef<HTMLInputElement>();
+  const fileChangeHandler: FormEventHandler<HTMLInputElement> = useCallback(
+    async (e) => {
+      if (!user) return;
+
+      const input = e.currentTarget as HTMLInputElement;
+      const body = new FormData();
+      body.append("avatar", input.files?.[0] ?? "");
+      const response = await updateUserAvatar.mutateAsync({
+        body,
+        userId: user.id,
       });
-      if (!isDelete && response?.status) {
+
+      if (!response.$meta.ok) {
+        toast.show({ message: response?.response?.detail ?? "Error updating avatar", type: ToastType.error });
+      } else {
+        refetchUser();
+      }
+      input.value = "";
+    },
+    [user?.id],
+  );
+
+  const deleteUserAvatar = async () => {
+    if (!user) return;
+    await updateUserAvatar.mutateAsync({ userId: user.id, isDelete: true });
+    refetchUser();
+  };
+
+  const avatarFormSubmitHandler = useCallback(
+    async (e: FormEvent, isDelete = false) => {
+      e.preventDefault();
+      e.stopPropagation();
+      console.log("submitting");
+      if (!user) return;
+
+      const body = new FormData(e.currentTarget as HTMLFormElement);
+      const response = await updateUserAvatar.mutateAsync({
+        body,
+        userId: user.id,
+      });
+
+      if (!isDelete && !response.$meta.ok) {
         toast.show({ message: response?.response?.detail ?? "Error updating avatar", type: "error" });
       } else {
-        fetch();
+        refetchUser();
       }
-      userAvatarForm.current.reset();
+      userAvatarForm.current?.reset();
     },
     [user?.id, fetch],
   );
-  const userFormSubmitHandler = useCallback(
+
+  const userFormSubmitHandler: FormEventHandler = useCallback(
     async (e) => {
       e.preventDefault();
-      const response = await api.callApi("updateUser", {
-        params: {
-          pk: user?.id,
-        },
-        body: {
-          first_name: fname,
-          last_name: lname,
-          phone,
-        },
-        errorFilter: () => true,
-      });
-      if (response?.status) {
-        toast.show({ message: response?.response?.detail ?? "Error updating user", type: "error" });
-      } else {
-        fetch();
+      if (!user) return;
+      const body = new FormData(e.currentTarget as HTMLFormElement);
+      const response = await updateUser.mutateAsync({ userId: user.id, body: body });
+
+      refetchUser();
+      if (!response?.$meta.ok) {
+        toast.show({ message: response?.response?.detail ?? "Error updating user", type: ToastType.error });
       }
     },
-    [fname, lname, phone, user?.id],
+    [user?.id],
   );
-
-  useEffect(() => {
-    if (userInProgress) return;
-    setFName(user?.first_name);
-    setLName(user?.last_name);
-    setEmail(user?.email);
-    setPhone(user?.phone);
-    setIsInProgress(userInProgress);
-  }, [user, userInProgress]);
 
   useEffect(() => setIsInProgress(userInProgress), [userInProgress]);
 
@@ -84,7 +134,7 @@ export const PersonalInfo = () => {
       <div className={styles.sectionContent}>
         <div className={styles.flexRow}>
           <Userpic user={user} isInProgress={userInProgress} size={92} style={{ flex: "none" }} />
-          <form ref={userAvatarForm} className={styles.flex1} onSubmit={(e) => avatarFormSubmitHandler(e)}>
+          <form ref={userAvatarForm} className={styles.flex1}>
             <InputFile
               name="avatar"
               onChange={fileChangeHandler}
@@ -93,34 +143,26 @@ export const PersonalInfo = () => {
             />
           </form>
           {user?.avatar && (
-            <form onSubmit={(e) => avatarFormSubmitHandler(e, true)}>
-              <button type="submit" look="danger">
-                Delete
-              </button>
-            </form>
+            <Button type="submit" look="danger" onClick={deleteUserAvatar}>
+              Delete
+            </Button>
           )}
         </div>
-        <form ref={userInfoForm} className={styles.sectionContent} onSubmit={userFormSubmitHandler}>
+        <form onSubmit={userFormSubmitHandler} className={styles.sectionContent}>
           <div className={styles.flexRow}>
             <div className={styles.flex1}>
-              <Input label="First Name" value={fname} onChange={(e) => setFName(e.target.value)} />
+              <Input label="First Name" value={user?.first_name} name="first_name" />
             </div>
             <div className={styles.flex1}>
-              <Input label="Last Name" value={lname} onChange={(e) => setLName(e.target.value)} />
+              <Input label="Last Name" value={user?.last_name} name="last_name" />
             </div>
           </div>
           <div className={styles.flexRow}>
             <div className={styles.flex1}>
-              <Input
-                label="E-mail"
-                type="email"
-                readOnly={true}
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-              />
+              <Input label="E-mail" type="email" readOnly={true} value={user?.email} />
             </div>
             <div className={styles.flex1}>
-              <Input label="Phone" type="phone" value={phone} onChange={(e) => setPhone(e.target.value)} />
+              <Input label="Phone" type="phone" value={user?.phone} name="phone" />
             </div>
           </div>
           <div className={clsx(styles.flexRow, styles.flexEnd)}>

--- a/web/libs/core/src/pages/AccountSettings/sections/PersonalInfo.tsx
+++ b/web/libs/core/src/pages/AccountSettings/sections/PersonalInfo.tsx
@@ -1,15 +1,20 @@
-import { type FormEvent, type FormEventHandler, useCallback, useEffect, useRef, useState } from "react";
+import { type FormEventHandler, useCallback, useEffect, useRef, useState } from "react";
 import clsx from "clsx";
 import { InputFile, ToastType, useToast } from "@humansignal/ui";
-import { Input } from "/apps/labelstudio/src/components/Form/Elements";
-import { Userpic } from "/apps/labelstudio/src/components/Userpic/Userpic";
-import { Button } from "/apps/labelstudio/src/components/Button/Button";
 import { API, useAPI } from "apps/labelstudio/src/providers/ApiProvider";
 import styles from "../AccountSettings.module.scss";
 import { useCurrentUserAtom } from "@humansignal/core/lib/hooks/useCurrentUser";
 import { atomWithMutation } from "jotai-tanstack-query";
 import { useAtomValue } from "jotai";
 import type { APIUser } from "@humansignal/core/types/user";
+
+/**
+ * FIXME: This is legacy imports. We're not supposed to use such statements
+ * each one of these eventually has to be migrated to core or ui
+ */
+import { Input } from "/apps/labelstudio/src/components/Form/Elements";
+import { Userpic } from "/apps/labelstudio/src/components/Userpic/Userpic";
+import { Button } from "/apps/labelstudio/src/components/Button/Button";
 
 const updateUserAtom = atomWithMutation(() => ({
   mutationKey: ["update-user"],
@@ -59,7 +64,6 @@ export const PersonalInfo = () => {
   const updateUserAvatar = useAtomValue(updateUserAvatarAtom);
   const { user, fetch: refetchUser, isInProgress: userInProgress } = useCurrentUserAtom();
   const [isInProgress, setIsInProgress] = useState(false);
-  const userAvatarForm = useRef<HTMLFormElement>();
   const avatarRef = useRef<HTMLInputElement>();
   const fileChangeHandler: FormEventHandler<HTMLInputElement> = useCallback(
     async (e) => {
@@ -89,28 +93,6 @@ export const PersonalInfo = () => {
     refetchUser();
   };
 
-  const avatarFormSubmitHandler = useCallback(
-    async (e: FormEvent, isDelete = false) => {
-      e.preventDefault();
-      e.stopPropagation();
-      if (!user) return;
-
-      const body = new FormData(e.currentTarget as HTMLFormElement);
-      const response = await updateUserAvatar.mutateAsync({
-        body,
-        userId: user.id,
-      });
-
-      if (!isDelete && !response.$meta.ok) {
-        toast.show({ message: response?.response?.detail ?? "Error updating avatar", type: "error" });
-      } else {
-        refetchUser();
-      }
-      userAvatarForm.current?.reset();
-    },
-    [user?.id, fetch],
-  );
-
   const userFormSubmitHandler: FormEventHandler = useCallback(
     async (e) => {
       e.preventDefault();
@@ -133,7 +115,7 @@ export const PersonalInfo = () => {
       <div className={styles.sectionContent}>
         <div className={styles.flexRow}>
           <Userpic user={user} isInProgress={userInProgress} size={92} style={{ flex: "none" }} />
-          <form ref={userAvatarForm} className={styles.flex1}>
+          <form className={styles.flex1}>
             <InputFile
               name="avatar"
               onChange={fileChangeHandler}

--- a/web/libs/core/src/types/user.ts
+++ b/web/libs/core/src/types/user.ts
@@ -1,0 +1,14 @@
+export type APIUser = {
+  id: number;
+  first_name: string;
+  last_name: string;
+  username: string;
+  email: string;
+  last_activity: string;
+  avatar: string | null;
+  initials: string;
+  phone: string;
+  active_organization: number;
+  allow_newsletters: boolean;
+  date_joined: string;
+};

--- a/web/libs/ui/src/lib/InputFile/InputFile.tsx
+++ b/web/libs/ui/src/lib/InputFile/InputFile.tsx
@@ -1,15 +1,17 @@
 import { IconUpload } from "../../assets/icons";
 import clsx from "clsx";
-type InputFileProps = {
+type InputFileProps = HTMLAttributes<HTMLInputElement> & {
   name?: string;
   className?: string;
   text?: React.ReactNode | string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  accept?: string;
   props?: Record<string, any>;
 };
+
 import styles from "./InputFile.module.scss";
 import type React from "react";
-import { forwardRef, useCallback, useRef } from "react";
+import { forwardRef, type HTMLAttributes, useCallback, useRef } from "react";
 export const InputFile = forwardRef(({ name, className, text, onChange, ...props }: InputFileProps, ref: any) => {
   if (!ref) {
     ref = useRef();


### PR DESCRIPTION
Refactoring the user account page to be more concise. Fixing avatar upload in LSO and LSE.

Along with that introducing new `useCurrentUser` hook that should be preferred over the existing one. New hook uses Jotai and tanstack-query under the hood and allows better cacheing without usage of Context API. This hook is a drop-in replacement for the old one.