### PR TITLE
fix: DIA-1934: [FE] Popup warning is missing when user clicks 'Revoke' button on account settings page

### DIFF
--- a/web/libs/core/src/pages/AccountSettings/sections/PersonalJWTToken.tsx
+++ b/web/libs/core/src/pages/AccountSettings/sections/PersonalJWTToken.tsx
@@ -13,7 +13,7 @@ import styles from "./PersonalJWTToken.module.scss";
  * each one of these eventually has to be migrated to core/ui
  */
 import { API } from "/apps/labelstudio/src/providers/ApiProvider";
-import { modal } from "/apps/labelstudio/src/components/Modal/Modal";
+import { modal, confirm } from "/apps/labelstudio/src/components/Modal/Modal";
 import { Button } from "/apps/labelstudio/src/components/Button/Button";
 import { Input, Label } from "/apps/labelstudio/src/components/Form/Elements";
 import { Tooltip } from "/apps/labelstudio/src/components/Tooltip/Tooltip";
@@ -106,7 +106,15 @@ export function PersonalJWTToken() {
 
   const revoke = useCallback(
     async (token: string) => {
-      await revokeToken.mutateAsync({ token });
+      confirm({
+        title: "Revoke Token",
+        body: "Are you sure you want to delete this access token? Any application using this token will need a new token to be able to access Label Studio",
+        okText: "Revoke",
+        buttonLook: "danger",
+        onOk: async () => {
+          await revokeToken.mutateAsync({ token });
+        },
+      });
     },
     [revokeToken],
   );

--- a/web/libs/core/src/pages/AccountSettings/sections/PersonalJWTToken.tsx
+++ b/web/libs/core/src/pages/AccountSettings/sections/PersonalJWTToken.tsx
@@ -108,7 +108,7 @@ export function PersonalJWTToken() {
     async (token: string) => {
       confirm({
         title: "Revoke Token",
-        body: "Are you sure you want to delete this access token? Any application using this token will need a new token to be able to access Label Studio",
+        body: `Are you sure you want to delete this access token? Any application using this token will need a new token to be able to access ${window?.APP_SETTINGS?.app_name || "Label Studio"}`,
         okText: "Revoke",
         buttonLook: "danger",
         onOk: async () => {

--- a/web/libs/core/src/pages/AccountSettings/sections/PersonalJWTToken.tsx
+++ b/web/libs/core/src/pages/AccountSettings/sections/PersonalJWTToken.tsx
@@ -108,7 +108,9 @@ export function PersonalJWTToken() {
     async (token: string) => {
       confirm({
         title: "Revoke Token",
-        body: `Are you sure you want to delete this access token? Any application using this token will need a new token to be able to access ${window?.APP_SETTINGS?.app_name || "Label Studio"}`,
+        body: `Are you sure you want to delete this access token? Any application using this token will need a new token to be able to access ${
+          window?.APP_SETTINGS?.app_name || "Label Studio"
+        }`,
         okText: "Revoke",
         buttonLook: "danger",
         onOk: async () => {


### PR DESCRIPTION
### PR fulfills these requirements
- [ ] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [ ] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [ ] Backend (API)
- [ ] Frontend



### Describe the reason for change
_(link to issue, supportive screenshots etc.)_



#### What does this fix?
_(if this is a bug fix)_



#### What is the new behavior?
_(if this is a breaking or feature change)_



#### What is the current behavior?
_(if this is a breaking or feature change)_



#### What libraries were added/updated?
_(list all with version changes)_



#### Does this change affect performance?
_(if so describe the impacts positive or negative)_



#### Does this change affect security?
_(if so describe the impacts positive or negative)_



#### What alternative approaches were there?
_(briefly list any if applicable)_



#### What feature flags were used to cover this change?
_(briefly list any if applicable)_



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [ ] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
_(for bug fixes/features, be as precise as possible. ex. Authentication, Annotation History, Review Stream etc.)_