### PR TITLE
chore: rewrite LSO PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,83 +1,24 @@
-### PR fulfills these requirements
-- [ ] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
-- [ ] Tests for the changes have been added/updated (for bug fixes/features)
-- [ ] Docs have been added/updated (for bug fixes/features)
-- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
-- [ ] Self-reviewed and ran all changes on a local instance (for bug fixes/features)
+<!--
 
+This description MUST be filled out for a PR to receive a review. Its primary
+purposes are:
 
+ - to enable your reviewer to review your code easily, and
+ - to convince your reviewer that your code works as intended.
 
-#### Change has impacts in these area(s)
-_(check all that apply)_
-- [ ] Product design
-- [ ] Backend (Database)
-- [ ] Backend (API)
-- [ ] Frontend
+Some pointers to think about when filling out your PR description:
+ - Reason for change: Description of problem and solution
+ - Screenshots: All visible changes should include screenshots.
+ - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
+ - Testing: Description of how this is being verified
+ - Risks: Are there any known risks associated with this change, eg to security or performance?
+ - Reviewer notes: Any info to help reviewers approve the PR
+ - General notes: Any info to help onlookers understand the code, or callouts to significant portions.
 
+You may use AI tools such as Copilot Actions to assist with writing your PR description
+(see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot);
+however, an AI summary isn't enough by itself. You'll need to provide your reviewer with
+strong evidence that your code works as intended, which requires actually running the code and
+showing that it works.
 
-
-### Describe the reason for change
-_(link to issue, supportive screenshots etc.)_
-
-
-
-#### What does this fix?
-_(if this is a bug fix)_
-
-
-
-#### What is the new behavior?
-_(if this is a breaking or feature change)_
-
-
-
-#### What is the current behavior?
-_(if this is a breaking or feature change)_
-
-
-
-#### What libraries were added/updated?
-_(list all with version changes)_
-
-
-
-#### Does this change affect performance?
-_(if so describe the impacts positive or negative)_
-
-
-
-#### Does this change affect security?
-_(if so describe the impacts positive or negative)_
-
-
-
-#### What alternative approaches were there?
-_(briefly list any if applicable)_
-
-
-
-#### What feature flags were used to cover this change?
-_(briefly list any if applicable)_
-
-
-
-### Does this PR introduce a breaking change?
-_(check only one)_
-- [ ] Yes, and covered entirely by feature flag(s)
-- [ ] Yes, and covered partially by feature flag(s)
-- [ ] No
-- [ ] Not sure (briefly explain the situation below)
-
-
-
-### What level of testing was included in the change?
-_(check all that apply)_
-- [ ] e2e
-- [ ] integration
-- [ ] unit
-
-
-
-### Which logical domain(s) does this change affect?
-_(for bug fixes/features, be as precise as possible. ex. Authentication, Annotation History, Review Stream etc.)_
-
+-->


### PR DESCRIPTION
Based on our LSE pilot of using a simple, flexible, comment-only template for new PRs, let's generalize that approach to our open source repo as well. 