### PR TITLE
chore: remove unnecessary newlines in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,6 @@
 <!--
 
-This description MUST be filled out for a PR to receive a review. Its primary
-purposes are:
+This description MUST be filled out for a PR to receive a review. Its primary purposes are:
 
  - to enable your reviewer to review your code easily, and
  - to convince your reviewer that your code works as intended.
@@ -15,10 +14,6 @@ Some pointers to think about when filling out your PR description:
  - Reviewer notes: Any info to help reviewers approve the PR
  - General notes: Any info to help onlookers understand the code, or callouts to significant portions.
 
-You may use AI tools such as Copilot Actions to assist with writing your PR description
-(see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot);
-however, an AI summary isn't enough by itself. You'll need to provide your reviewer with
-strong evidence that your code works as intended, which requires actually running the code and
-showing that it works.
+You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.
 
 -->


### PR DESCRIPTION
The template looks better in the GH UI without newlines; let's remove those.