### PR TITLE
fix: OPTIC-1780: Ignoring PermissionDenied exceptions in Sentry

### DIFF
--- a/label_studio/core/settings/base.py
+++ b/label_studio/core/settings/base.py
@@ -388,6 +388,17 @@ SENTRY_REDIS_ENABLED = False
 FRONTEND_SENTRY_DSN = get_env('FRONTEND_SENTRY_DSN', None)
 FRONTEND_SENTRY_RATE = get_env('FRONTEND_SENTRY_RATE', 0.01)
 FRONTEND_SENTRY_ENVIRONMENT = get_env('FRONTEND_SENTRY_ENVIRONMENT', 'stage.opensource')
+SENTRY_IGNORED_EXCEPTIONS = [
+    'Http404',
+    'NotAuthenticated',
+    'AuthenticationFailed',
+    'NotFound',
+    'XMLSyntaxError',
+    'FileUpload.DoesNotExist',
+    'Forbidden',
+    'KeyboardInterrupt',
+    'PermissionDenied',
+]
 
 ROOT_URLCONF = 'core.urls'
 WSGI_APPLICATION = 'core.wsgi.application'

--- a/label_studio/core/utils/sentry.py
+++ b/label_studio/core/utils/sentry.py
@@ -9,16 +9,7 @@ def event_processor(event, hint):
     # skip specified exceptions
     exceptions = event.get('exception', {}).get('values', [{}])
     last = exceptions[-1]
-    if last.get('type') in [
-        'Http404',
-        'NotAuthenticated',
-        'AuthenticationFailed',
-        'NotFound',
-        'XMLSyntaxError',
-        'FileUpload.DoesNotExist',
-        'Forbidden',
-        'KeyboardInterrupt',
-    ]:
+    if last.get('type') in settings.SENTRY_IGNORED_EXCEPTIONS:
         return None
 
     # sentry ignored factory class


### PR DESCRIPTION
<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->

This pull request includes changes to centralize the management of ignored exceptions for Sentry in the `label_studio` project. The most important changes are the addition of a new setting for ignored exceptions and the refactoring of the event processor to use this new setting.

Centralization of ignored exceptions:

* [`label_studio/core/settings/base.py`](diffhunk://#diff-6a0734f20b03b8a742088661655e0c27d3c4e240c7a200f8d8ae95239a476e9fR391-R401): Added a new setting `SENTRY_IGNORED_EXCEPTIONS` to list exceptions that should be ignored by Sentry.

Refactoring to use the new setting:

* [`label_studio/core/utils/sentry.py`](diffhunk://#diff-30273d292318821417bcd1a66643c2f7d2442968fcc886812d86827a672efff9L12-R12): Modified the `event_processor` function to reference `settings.SENTRY_IGNORED_EXCEPTIONS` instead of hardcoding the list of ignored exceptions.

* Ignoring now `PermissionDenied` exception
