### PR TITLE
feat: OPTIC-1755: Let error logs go to Sentry

### DIFF
--- a/label_studio/core/utils/sentry.py
+++ b/label_studio/core/utils/sentry.py
@@ -2,8 +2,12 @@ from django.conf import settings
 
 
 def event_processor(event, hint):
-    # skip all transactions without errors
+    # skip all transactions without exceptions, unless it's a log record
     if 'exc_info' not in hint:
+
+        if 'log_record' in hint:
+            return event
+
         return None
 
     # skip specified exceptions


### PR DESCRIPTION
<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->

We were filtering out the new logs added in https://github.com/HumanSignal/label-studio-enterprise/pull/7085 because they didn't have exceptions. This PR allows error logs to go through the normal process.
