### PR TITLE
fix: DIA-2026: allow annotators/reviewers to view jwt settings

### DIFF
--- a/label_studio/jwt_auth/models.py
+++ b/label_studio/jwt_auth/models.py
@@ -34,11 +34,19 @@ class JWTSettings(models.Model):
     created_at = models.DateTimeField(_('created at'), auto_now_add=True)
     updated_at = models.DateTimeField(_('updated at'), auto_now=True)
 
-    def has_permission(self, user):
-        """Check if user has permission to modify JWT settings"""
+    def has_view_permission(self, user):
+        """Any member of the organization can view JWT settings."""
+        return self.organization.has_permission(user)
+    
+    def has_modify_permission(self, user):
+        """Only organization owners/admins can modify JWT settings."""
         if not self.organization.has_permission(user):
             return False
         return user.is_owner or (hasattr(user, 'is_administrator') and user.is_administrator)
+    
+    def has_permission(self, user):
+        """Only organization owners/admins can modify JWT settings."""
+        return self.has_modify_permission(user)
 
 
 class LSTokenBackend(TokenBackend):

--- a/label_studio/jwt_auth/models.py
+++ b/label_studio/jwt_auth/models.py
@@ -37,13 +37,13 @@ class JWTSettings(models.Model):
     def has_view_permission(self, user):
         """Any member of the organization can view JWT settings."""
         return self.organization.has_permission(user)
-    
+
     def has_modify_permission(self, user):
         """Only organization owners/admins can modify JWT settings."""
         if not self.organization.has_permission(user):
             return False
         return user.is_owner or (hasattr(user, 'is_administrator') and user.is_administrator)
-    
+
     def has_permission(self, user):
         """Only organization owners/admins can modify JWT settings."""
         return self.has_modify_permission(user)

--- a/label_studio/jwt_auth/views.py
+++ b/label_studio/jwt_auth/views.py
@@ -47,8 +47,8 @@ class TokenExistsError(APIException):
 )
 class JWTSettingsAPI(CreateAPIView):
     queryset = JWTSettings.objects.all()
-    permission_required = all_permissions.organizations_change
     serializer_class = JWTSettingsSerializer
+    permission_required = all_permissions.organizations_view
 
     def get(self, request, *args, **kwargs):
         jwt_settings = request.user.active_organization.jwt

--- a/label_studio/jwt_auth/views.py
+++ b/label_studio/jwt_auth/views.py
@@ -54,16 +54,18 @@ class JWTSettingsAPI(CreateAPIView):
         jwt_settings = request.user.active_organization.jwt
         # Check if user has view permission
         if not jwt_settings.has_view_permission(request.user):
-            return Response({"detail": "You do not have permission to view JWT settings"}, 
-                           status=status.HTTP_403_FORBIDDEN)
+            return Response(
+                {"detail": "You do not have permission to view JWT settings"}, status=status.HTTP_403_FORBIDDEN
+            )
         return Response(self.get_serializer(jwt_settings).data)
 
     def post(self, request, *args, **kwargs):
         jwt_settings = request.user.active_organization.jwt
         # Check if user has modify permission
         if not jwt_settings.has_modify_permission(request.user):
-            return Response({"detail": "You do not have permission to modify JWT settings"}, 
-                           status=status.HTTP_403_FORBIDDEN)
+            return Response(
+                {"detail": "You do not have permission to modify JWT settings"}, status=status.HTTP_403_FORBIDDEN
+            )
         serializer = self.get_serializer(data=request.data, instance=jwt_settings)
         serializer.is_valid(raise_exception=True)
         serializer.save()

--- a/label_studio/jwt_auth/views.py
+++ b/label_studio/jwt_auth/views.py
@@ -52,10 +52,18 @@ class JWTSettingsAPI(CreateAPIView):
 
     def get(self, request, *args, **kwargs):
         jwt_settings = request.user.active_organization.jwt
+        # Check if user has view permission
+        if not jwt_settings.has_view_permission(request.user):
+            return Response({"detail": "You do not have permission to view JWT settings"}, 
+                           status=status.HTTP_403_FORBIDDEN)
         return Response(self.get_serializer(jwt_settings).data)
 
     def post(self, request, *args, **kwargs):
         jwt_settings = request.user.active_organization.jwt
+        # Check if user has modify permission
+        if not jwt_settings.has_modify_permission(request.user):
+            return Response({"detail": "You do not have permission to modify JWT settings"}, 
+                           status=status.HTTP_403_FORBIDDEN)
         serializer = self.get_serializer(data=request.data, instance=jwt_settings)
         serializer.is_valid(raise_exception=True)
         serializer.save()

--- a/label_studio/jwt_auth/views.py
+++ b/label_studio/jwt_auth/views.py
@@ -55,7 +55,7 @@ class JWTSettingsAPI(CreateAPIView):
         # Check if user has view permission
         if not jwt_settings.has_view_permission(request.user):
             return Response(
-                {"detail": "You do not have permission to view JWT settings"}, status=status.HTTP_403_FORBIDDEN
+                {'detail': 'You do not have permission to view JWT settings'}, status=status.HTTP_403_FORBIDDEN
             )
         return Response(self.get_serializer(jwt_settings).data)
 
@@ -64,7 +64,7 @@ class JWTSettingsAPI(CreateAPIView):
         # Check if user has modify permission
         if not jwt_settings.has_modify_permission(request.user):
             return Response(
-                {"detail": "You do not have permission to modify JWT settings"}, status=status.HTTP_403_FORBIDDEN
+                {'detail': 'You do not have permission to modify JWT settings'}, status=status.HTTP_403_FORBIDDEN
             )
         serializer = self.get_serializer(data=request.data, instance=jwt_settings)
         serializer.is_valid(raise_exception=True)

--- a/label_studio/tests/jwt_auth/test_models.py
+++ b/label_studio/tests/jwt_auth/test_models.py
@@ -21,7 +21,7 @@ def test_jwt_settings_permissions():
 
     # Any member should be able to view
     assert org.jwt.has_view_permission(user)
-    
+
     # Only owners and administrators can modify
     user.is_owner = True
     user.save()

--- a/label_studio/tests/jwt_auth/test_models.py
+++ b/label_studio/tests/jwt_auth/test_models.py
@@ -19,13 +19,19 @@ def test_jwt_settings_permissions():
         organization=org,
     )
 
+    # Any member should be able to view
+    assert org.jwt.has_view_permission(user)
+    
+    # Only owners and administrators can modify
     user.is_owner = True
     user.save()
-    assert org.jwt.has_permission(user) is True
+    assert org.jwt.has_modify_permission(user)
+    assert org.jwt.has_permission(user)
 
     user.is_owner = False
     user.save()
-    assert org.jwt.has_permission(user) is False
+    assert not org.jwt.has_modify_permission(user)
+    assert not org.jwt.has_permission(user)
 
 
 @mock_feature_flag(flag_name='fflag__feature_develop__prompts__dia_1829_jwt_token_auth', value=True)


### PR DESCRIPTION
-------

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->

Allow annotators/reviewers to view JWT settings, so that they can view their API keys