### PR TITLE
fix: OPTIC-1832: Missing tokens scss variables import

### DIFF
--- a/web/apps/labelstudio/src/themes/default/variables.scss
+++ b/web/apps/labelstudio/src/themes/default/variables.scss
@@ -1,3 +1,4 @@
+@import './tokens';
 @import './colors';
 @import './layout';
 @import './typography';


### PR DESCRIPTION
With the introduction of the Figma design tokens, the import was missing for the app default theme, and thus broke some of the styles that were relying on the existence of these tokens. Very simple fix, just needed to include the import.