### PR TITLE
fix: DIA-1942: Fix Information exposure through an exception

### DIFF
--- a/label_studio/jwt_auth/views.py
+++ b/label_studio/jwt_auth/views.py
@@ -176,7 +176,7 @@ class LSTokenBlacklistView(TokenViewBase):
             # .blacklist() on the token under the hood
             serializer.is_valid(raise_exception=True)
         except TokenError as e:
-            logger.error("Token error occurred: %s", str(e), exc_info=True)
+            logger.error('Token error occurred: %s', str(e), exc_info=True)
             return Response({'detail': 'Token is invalid or already blacklisted.'}, status=status.HTTP_404_NOT_FOUND)
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/label_studio/jwt_auth/views.py
+++ b/label_studio/jwt_auth/views.py
@@ -176,6 +176,7 @@ class LSTokenBlacklistView(TokenViewBase):
             # .blacklist() on the token under the hood
             serializer.is_valid(raise_exception=True)
         except TokenError as e:
-            return Response({'detail': str(e)}, status=status.HTTP_404_NOT_FOUND)
+            logger.error("Token error occurred: %s", str(e), exc_info=True)
+            return Response({'detail': 'Token is invalid or already blacklisted.'}, status=status.HTTP_404_NOT_FOUND)
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/label_studio/jwt_auth/views.py
+++ b/label_studio/jwt_auth/views.py
@@ -176,7 +176,7 @@ class LSTokenBlacklistView(TokenViewBase):
             # .blacklist() on the token under the hood
             serializer.is_valid(raise_exception=True)
         except TokenError as e:
-            logger.error('Token error occurred: %s', str(e), exc_info=True)
+            logger.error('Token error occurred while trying to blacklist a token: %s', str(e), exc_info=True)
             return Response({'detail': 'Token is invalid or already blacklisted.'}, status=status.HTTP_404_NOT_FOUND)
 
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Potential fix for [https://github.com/HumanSignal/label-studio/security/code-scanning/788](https://github.com/HumanSignal/label-studio/security/code-scanning/788)

To fix the problem, we should log the detailed exception message on the server and return a generic error message to the user. This approach ensures that sensitive information is not exposed to external users while still allowing developers to access the necessary details for debugging.

- Modify the `except` block to log the exception using the `logger` and return a generic error message to the user.
- Ensure that the logging captures the full stack trace for debugging purposes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
