### PR TITLE
fix: OPTIC-1850: 'n is not a function' RUNTIME error occur on ls-develop when user tries to create a project

### DIFF
--- a/web/apps/labelstudio/src/pages/CreateProject/CreateProject.jsx
+++ b/web/apps/labelstudio/src/pages/CreateProject/CreateProject.jsx
@@ -117,7 +117,9 @@ export const CreateProject = ({ onClose, redirect = true }) => {
 
   // name intentionally skipped from deps:
   // this should trigger only once when we got project loaded
-  React.useEffect(() => project && !name && setName(project.title), [project]);
+  React.useEffect(() => {
+    project && !name && setName(project.title);
+  }, [project]);
 
   const projectBody = React.useMemo(
     () => ({

--- a/web/libs/core/src/pages/AccountSettings/sections/PersonalInfo.tsx
+++ b/web/libs/core/src/pages/AccountSettings/sections/PersonalInfo.tsx
@@ -92,7 +92,9 @@ export const PersonalInfo = () => {
     [user?.id],
   );
 
-  useEffect(() => setIsInProgress(userInProgress), [userInProgress]);
+  useEffect(() => {
+    setIsInProgress(userInProgress);
+  }, [userInProgress]);
 
   useEffect(() => {
     setFname(user?.first_name);

--- a/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.tsx
+++ b/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.tsx
@@ -60,8 +60,12 @@ const DraftState: FC<{
   const [hasUnsavedChanges, setChanges] = useState(false);
 
   // turn it on when changes just made; off when they we saved
-  useEffect(() => setChanges(true), [annotation.history.history.length]);
-  useEffect(() => setChanges(false), [annotation.draftSaved]);
+  useEffect(() => {
+    setChanges(true);
+  }, [annotation.history.history.length]);
+  useEffect(() => {
+    setChanges(false);
+  }, [annotation.draftSaved]);
 
   if (!hasChanges && !annotation.versions.draft) return null;
 


### PR DESCRIPTION
due to the upgrade to react 18 - we need to make sure that if a useEffect function only gets a destroy function when appropriate. we have use cases that shouldnt be returning to useEffect so we update it here