### PR TITLE
fix: DIA-2096: don't use is_owner in LSO

### DIFF
--- a/label_studio/jwt_auth/models.py
+++ b/label_studio/jwt_auth/models.py
@@ -42,7 +42,9 @@ class JWTSettings(models.Model):
         """Only organization owners/admins can modify JWT settings."""
         if not self.organization.has_permission(user):
             return False
-        return user.is_owner or (hasattr(user, 'is_administrator') and user.is_administrator)
+        is_owner = user.is_owner if hasattr(user, 'is_owner') else (user.id == self.organization.created_by.id)
+        is_administrator = (hasattr(user, 'is_administrator') and user.is_administrator)
+        return is_owner or is_administrator
 
     def has_permission(self, user):
         """Only organization owners/admins can modify JWT settings."""

--- a/label_studio/jwt_auth/models.py
+++ b/label_studio/jwt_auth/models.py
@@ -43,7 +43,7 @@ class JWTSettings(models.Model):
         if not self.organization.has_permission(user):
             return False
         is_owner = user.is_owner if hasattr(user, 'is_owner') else (user.id == self.organization.created_by.id)
-        is_administrator = (hasattr(user, 'is_administrator') and user.is_administrator)
+        is_administrator = hasattr(user, 'is_administrator') and user.is_administrator
         return is_owner or is_administrator
 
     def has_permission(self, user):


### PR DESCRIPTION
-------

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->

Don't use is_owner in LSO when trying to determine whether we can get the JWT settings, since this attr isn't available.