### PR TITLE
fix: OPTIC-1859: Incomplete string escaping causing warnings for dependabot for design-tokens-converter

### DIFF
--- a/web/tools/design-tokens-converter/design-tokens-converter.mjs
+++ b/web/tools/design-tokens-converter/design-tokens-converter.mjs
@@ -526,11 +526,11 @@ function processCornerRadiusTokens(cornerRadiusObj, result, variables) {
 function processColorTokens(colorObj, parentPath, result, variables) {
   for (const key in colorObj) {
     if (typeof colorObj[key] === "object" && !Array.isArray(colorObj[key])) {
-      const newPath = parentPath ? `${parentPath}-${key.replace("$", "")}` : key.replace("$", "");
+      const newPath = parentPath ? `${parentPath}-${key.replace(/\$/g, "")}` : key.replace(/\$/g, "");
 
       // If this is a color token with value and type
       if (colorObj[key].$type === "color" && colorObj[key].$value) {
-        const name = parentPath ? `${parentPath}-${key.replace("$", "")}` : key.replace("$", "");
+        const name = parentPath ? `${parentPath}-${key.replace(/\$/g, "")}` : key.replace(/\$/g, "");
         const value = colorObj[key].$value;
         const cssVarName = `--color-${name.replace(/\$/g, "")}`;
 


### PR DESCRIPTION
This addresses a concern of non sanitized inputs in the design tokens converter. It actually is not a problem because this code is run offline and the resultant is reviewed and then committed. But the fix is not a bad idea to address the concern and bolster the code.

**Copilot**
Potential fix for [https://github.com/HumanSignal/label-studio/security/code-scanning/791](https://github.com/HumanSignal/label-studio/security/code-scanning/791)

To fix the problem, we need to ensure that all occurrences of the `$` character in the `key` string are replaced. This can be achieved by using a regular expression with the global flag (`g`). This change will ensure that every instance of the `$` character is replaced, not just the first one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
