### PR TITLE
fix: DIA-2116: Export storages can be incorrectly retrieved as import storages

### DIFF
--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -30,6 +30,7 @@ from django.conf import settings
 from django.core.validators import MaxLengthValidator, MinLengthValidator
 from django.db import models, transaction
 from django.db.models import Avg, BooleanField, Case, Count, JSONField, Max, Q, Sum, Value, When
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from label_studio_sdk._extensions.label_studio_tools.core.label_config import parse_config
 from labels_manager.models import Label
@@ -997,23 +998,30 @@ class Project(ProjectMixin, models.Model):
 
         return self.get_ml_backends(state=MLBackendState.CONNECTED)
 
-    def get_all_storage_objects(self, type_='import'):
+    @cached_property
+    def get_all_import_storage_objects(self):
         from io_storages.models import get_storage_classes
 
-        if hasattr(self, '_storage_objects'):
-            return self._storage_objects
-
         storage_objects = []
-        for storage_class in get_storage_classes(type_):
+        for storage_class in get_storage_classes('import'):
             storage_objects += list(storage_class.objects.filter(project=self))
 
-        self._storage_objects = storage_objects
+        return storage_objects
+
+    @cached_property
+    def get_all_export_storage_objects(self):
+        from io_storages.models import get_storage_classes
+
+        storage_objects = []
+        for storage_class in get_storage_classes('export'):
+            storage_objects += list(storage_class.objects.filter(project=self))
+
         return storage_objects
 
     def resolve_storage_uri(self, url: str) -> Optional[Mapping[str, Any]]:
         from io_storages.functions import get_storage_by_url
 
-        storage_objects = self.get_all_storage_objects()
+        storage_objects = self.get_all_import_storage_objects
         storage = get_storage_by_url(url, storage_objects)
 
         if storage:

--- a/label_studio/tasks/models.py
+++ b/label_studio/tasks/models.py
@@ -415,7 +415,7 @@ class Task(TaskMixin, models.Model):
         project = self.project
 
         if not storage:
-            storage_objects = project.get_all_storage_objects(type_='import')
+            storage_objects = project.get_all_import_storage_objects
             storage = get_storage_by_url(url, storage_objects)
 
         if storage:
@@ -440,7 +440,7 @@ class Task(TaskMixin, models.Model):
                 protected_data[key] = value
             return protected_data
         else:
-            storage_objects = project.get_all_storage_objects(type_='import')
+            storage_objects = project.get_all_import_storage_objects
 
             # try resolve URLs via storage associated with that task
             for field in task_data:


### PR DESCRIPTION
...due to an incorrect use of caching. Replaced it with @cached_property. There was no active code that would have hit this bug, but I was about to write some for DIA-2033 :slightly_smiling_face: 

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
