### PR TITLE
fix: DIA-2121: Project statistics on home page for LSO displays annotator's view rather than admin's view

### DIFF
--- a/web/apps/labelstudio/src/pages/Home/HomePage.tsx
+++ b/web/apps/labelstudio/src/pages/Home/HomePage.tsx
@@ -186,8 +186,8 @@ function ProjectSimpleCard({
 }: {
   project: APIProject;
 }) {
-  const finished = project.queue_done ?? 0;
-  const total = project.queue_total ?? 0;
+  const finished = project.finished_task_number ?? 0;
+  const total = project.task_number ?? 0;
   const progress = (total > 0 ? finished / total : 0) * 100;
   const white = "#FFFFFF";
   const color = project.color && project.color !== white ? project.color : "#E1DED5";


### PR DESCRIPTION
Because we were using `queue` data instead of overall one, different admins saw different data on the Homepage. This PR addresses this issue.

This pull request includes a change to the `ProjectSimpleCard` component in the `HomePage.tsx` file. The change updates the properties used to calculate the progress of a project.

* [`web/apps/labelstudio/src/pages/Home/HomePage.tsx`](diffhunk://#diff-5beb2cd206dd6c5d34a094f966f0b306e197713ce75e3d11d4b55a1af603f4efL189-R190): Modified the properties from `project.queue_done` and `project.queue_total` to `project.finished_task_number` and `project.task_number` respectively, to reflect the updated project structure. 

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
