### PR TITLE
fix: DIA-2122: allow all LSO users to modify JWT settings

### DIFF
--- a/label_studio/core/utils/common.py
+++ b/label_studio/core/utils/common.py
@@ -750,3 +750,17 @@ def empty(*args, **kwargs):
 def get_ttl_hash(seconds: int = 60) -> int:
     """Return the same value within `seconds` time period"""
     return round(time.time() / seconds)
+
+def is_enterprise():
+    """Determine if the current Label Studio instance is Enterprise (LSE) or open-source (LSO).
+
+    Returns
+    -------
+    bool
+        True if running Label Studio Enterprise, False if running open-source Label Studio
+    """
+    try:
+        import label_studio_enterprise
+        return True
+    except ImportError:
+        return False

--- a/label_studio/core/utils/common.py
+++ b/label_studio/core/utils/common.py
@@ -752,17 +752,17 @@ def get_ttl_hash(seconds: int = 60) -> int:
     return round(time.time() / seconds)
 
 
-def is_enterprise():
-    """Determine if the current Label Studio instance is Enterprise (LSE) or open-source (LSO).
+def is_community():
+    """Determine if the current Label Studio instance is the community edition (aka LSO).
 
     Returns
     -------
     bool
-        True if running Label Studio Enterprise, False if running open-source Label Studio
+        True if running open-source Label Studio, False otherwise.
     """
     try:
         import label_studio_enterprise  # noqa: F401
 
-        return True
-    except ImportError:
         return False
+    except ImportError:
+        return True

--- a/label_studio/core/utils/common.py
+++ b/label_studio/core/utils/common.py
@@ -751,6 +751,7 @@ def get_ttl_hash(seconds: int = 60) -> int:
     """Return the same value within `seconds` time period"""
     return round(time.time() / seconds)
 
+
 def is_enterprise():
     """Determine if the current Label Studio instance is Enterprise (LSE) or open-source (LSO).
 
@@ -760,7 +761,8 @@ def is_enterprise():
         True if running Label Studio Enterprise, False if running open-source Label Studio
     """
     try:
-        import label_studio_enterprise
+        import label_studio_enterprise  # noqa: F401
+
         return True
     except ImportError:
         return False

--- a/label_studio/jwt_auth/models.py
+++ b/label_studio/jwt_auth/models.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from typing import Any
 
 from annoying.fields import AutoOneToOneField
+from core.utils.common import is_enterprise
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from organizations.models import Organization
@@ -39,9 +40,19 @@ class JWTSettings(models.Model):
         return self.organization.has_permission(user)
 
     def has_modify_permission(self, user):
-        """Only organization owners/admins can modify JWT settings."""
+        """Determine who can modify JWT settings.
+        
+        In label studio enterprise: Only organization owners/admins can modify JWT settings.
+        In label studio open-source: Any organization member can modify JWT settings.
+        """
         if not self.organization.has_permission(user):
             return False
+
+        # open-source
+        if not is_enterprise():
+            return True
+
+        # enterprise
         is_owner = user.is_owner if hasattr(user, 'is_owner') else (user.id == self.organization.created_by.id)
         is_administrator = hasattr(user, 'is_administrator') and user.is_administrator
         return is_owner or is_administrator

--- a/label_studio/jwt_auth/models.py
+++ b/label_studio/jwt_auth/models.py
@@ -41,7 +41,7 @@ class JWTSettings(models.Model):
 
     def has_modify_permission(self, user):
         """Determine who can modify JWT settings.
-        
+
         In label studio enterprise: Only organization owners/admins can modify JWT settings.
         In label studio open-source: Any organization member can modify JWT settings.
         """

--- a/label_studio/jwt_auth/models.py
+++ b/label_studio/jwt_auth/models.py
@@ -49,7 +49,7 @@ class JWTSettings(models.Model):
             return False
 
         # open-source
-        if not is_enterprise():
+        if is_community():
             return True
 
         # enterprise

--- a/label_studio/jwt_auth/models.py
+++ b/label_studio/jwt_auth/models.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from typing import Any
 
 from annoying.fields import AutoOneToOneField
-from core.utils.common import is_enterprise
+from core.utils.common import is_community
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from organizations.models import Organization

--- a/label_studio/tests/jwt_auth/test_models.py
+++ b/label_studio/tests/jwt_auth/test_models.py
@@ -1,9 +1,11 @@
 import pytest
 from jwt_auth.models import LSAPIToken, LSTokenBackend
 from organizations.models import OrganizationMember
+from organizations.tests.factories import OrganizationFactory
 from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.settings import api_settings as simple_jwt_settings
 from rest_framework_simplejwt.token_blacklist.models import BlacklistedToken, OutstandingToken
+from users.models import User
 
 from ..utils import mock_feature_flag
 from .utils import create_user_with_token_settings
@@ -12,26 +14,56 @@ from .utils import create_user_with_token_settings
 @mock_feature_flag(flag_name='fflag__feature_develop__prompts__dia_1829_jwt_token_auth', value=True)
 @pytest.mark.django_db
 def test_jwt_settings_permissions():
-    user = create_user_with_token_settings(api_tokens_enabled=True, legacy_api_tokens_enabled=False)
-    org = user.active_organization
-    OrganizationMember.objects.create(
-        user=user,
-        organization=org,
-    )
+    org = OrganizationFactory()
+    user = org.created_by
 
     # Any member should be able to view
     assert org.jwt.has_view_permission(user)
 
-    # Only owners and administrators can modify
-    user.is_owner = True
-    user.save()
+    # Any LSO member should be able to modify
+    # (tests for enterprise handled in enterprise test suite)
     assert org.jwt.has_modify_permission(user)
     assert org.jwt.has_permission(user)
 
-    user.is_owner = False
-    user.save()
-    assert not org.jwt.has_modify_permission(user)
-    assert not org.jwt.has_permission(user)
+
+@mock_feature_flag(flag_name='fflag__feature_develop__prompts__dia_1829_jwt_token_auth', value=True)
+@pytest.mark.django_db
+def test_non_owner_user_can_modify_jwt_settings():
+    """Test that a regular non-owner user who is added to an organization can modify JWT settings"""
+    org = OrganizationFactory()
+    non_owner = User.objects.create(email='regular_user@example.com')
+
+    OrganizationMember.objects.create(
+        user=non_owner,
+        organization=org,
+    )
+    non_owner.active_organization = org
+    non_owner.save()
+
+    assert org.jwt.has_view_permission(non_owner)
+    assert org.jwt.has_modify_permission(non_owner)
+    assert org.jwt.has_permission(non_owner)
+
+
+@mock_feature_flag(flag_name='fflag__feature_develop__prompts__dia_1829_jwt_token_auth', value=True)
+@pytest.mark.django_db
+def test_user_from_other_org_cannot_access_jwt_settings():
+    """Test that users from other organizations cannot view or modify JWT settings"""
+    org1 = OrganizationFactory()
+    org1_owner = org1.created_by
+
+    org2 = OrganizationFactory()
+    org2_owner = org2.created_by
+
+    # Verify org1 owner cannot view or modify JWT settings of org2
+    assert not org2.jwt.has_view_permission(org1_owner)
+    assert not org2.jwt.has_modify_permission(org1_owner)
+    assert not org2.jwt.has_permission(org1_owner)
+    
+    # Verify org2 owner cannot view or modify JWT settings of org1
+    assert not org1.jwt.has_view_permission(org2_owner)
+    assert not org1.jwt.has_modify_permission(org2_owner)
+    assert not org1.jwt.has_permission(org2_owner)
 
 
 @mock_feature_flag(flag_name='fflag__feature_develop__prompts__dia_1829_jwt_token_auth', value=True)

--- a/label_studio/tests/jwt_auth/test_models.py
+++ b/label_studio/tests/jwt_auth/test_models.py
@@ -59,7 +59,7 @@ def test_user_from_other_org_cannot_access_jwt_settings():
     assert not org2.jwt.has_view_permission(org1_owner)
     assert not org2.jwt.has_modify_permission(org1_owner)
     assert not org2.jwt.has_permission(org1_owner)
-    
+
     # Verify org2 owner cannot view or modify JWT settings of org1
     assert not org1.jwt.has_view_permission(org2_owner)
     assert not org1.jwt.has_modify_permission(org2_owner)


### PR DESCRIPTION
-------

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->

Changes JWT settings permissions, so that in the case of LSO all users will be able to change JWT permissions.

Added test cases for this, and the LSE cases already have tests in LSE to verify that the functionality works properly there (i.e. that only owners/admins can change JWT settings).