### PR TITLE
chore: OPTIC-1956: Update Menubar to have the proper new import of pages from app-common

### DIFF
--- a/web/apps/labelstudio/src/components/Menubar/Menubar.jsx
+++ b/web/apps/labelstudio/src/components/Menubar/Menubar.jsx
@@ -27,7 +27,7 @@ import "./MenuContent.scss";
 import "./MenuSidebar.scss";
 import { FF_HOMEPAGE } from "../../utils/feature-flags";
 import { IconHome } from "@humansignal/ui";
-import { pages } from "@humansignal/core";
+import { pages } from "@humansignal/app-common";
 import { isFF } from "../../utils/feature-flags";
 
 export const MenubarContext = createContext();


### PR DESCRIPTION
This pull request includes a change to the import statement in the `Menubar.jsx` file to ensure the correct module is being used.

* [`web/apps/labelstudio/src/components/Menubar/Menubar.jsx`](diffhunk://#diff-e7879b6adc8fea7d0c6bbe05245ab6dc5dc66f11347b27a2e3842ce36ade779cL30-R30): Changed the import source for `pages` from `@humansignal/core` to `@humansignal/app-common` to align with the updated module structure.