### PR TITLE
fix: LEAP-1928: support deletions of annotations and tasks in pausing code

### DIFF
--- a/label_studio/data_manager/actions/basic.py
+++ b/label_studio/data_manager/actions/basic.py
@@ -65,7 +65,7 @@ def delete_tasks(project, queryset, **kwargs):
         reload = True
 
     # Execute actions after delete tasks
-    Task.after_bulk_delete_actions(tasks_ids_list)
+    Task.after_bulk_delete_actions(tasks_ids_list, project)
 
     return {'processed_items': count, 'reload': reload, 'detail': 'Deleted ' + str(count) + ' tasks'}
 

--- a/label_studio/tasks/mixins.py
+++ b/label_studio/tasks/mixins.py
@@ -21,7 +21,7 @@ class TaskMixin:
         pass
 
     @staticmethod
-    def after_bulk_delete_actions(tasks_ids):
+    def after_bulk_delete_actions(tasks_ids, project):
         """
         Actions to execute after bulk task deletion
         """

--- a/label_studio/tests/webhooks/test_webhooks.py
+++ b/label_studio/tests/webhooks/test_webhooks.py
@@ -352,7 +352,7 @@ def test_webhooks_for_action_delete_tasks_annotations(configured_project, busine
 
 # ACTION: DELETE TASKS
 @pytest.mark.django_db
-def test_webhooks_for_action_delete_tasks_annotations(configured_project, business_client, organization_webhook):
+def test_webhooks_for_action_delete_tasks(configured_project, business_client, organization_webhook):
     webhook = organization_webhook
     with requests_mock.Mocker(real_http=True) as m:
         m.register_uri('POST', webhook.url)


### PR DESCRIPTION
Prepwork for LSE change - just start passing Project to the `after_bulk_delete_actions` function which does nothing on LSO.