### PR TITLE
docs: Add BrushLabels support for COCO export

### DIFF
--- a/docs/source/guide/export.md
+++ b/docs/source/guide/export.md
@@ -121,7 +121,7 @@ Export your brush mask labels as NumPy 2d arrays and PNG images. Each label outp
 
 ### COCO
 
-A popular machine learning format used by the [COCO dataset](http://cocodataset.org/#home) for object detection and image segmentation tasks. Supports bounding box and polygon image labeling projects that use the `RectangleLabels` or `PolygonLabels` tags.
+A popular machine learning format used by the [COCO dataset](http://cocodataset.org/#home) for object detection and image segmentation tasks. Supports bounding box and polygon image labeling projects that use the `BrushLabels`, `RectangleLabels`, or `PolygonLabels` tags.
 
 ### CoNLL2003
 


### PR DESCRIPTION
Small doc update to reflect this PR: https://github.com/HumanSignal/label-studio-sdk/pull/429

Add COCO export for BrushLabels as Polygons