### PR TITLE
chore: update Minio and remove deprecated version keyword

### DIFF
--- a/docker-compose.minio.yml
+++ b/docker-compose.minio.yml
@@ -9,7 +9,7 @@ x-logging:
 services:
   # not replicated setup for test setup, use a proper aws S3 compatible cluster in production
   minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    image: "minio/minio:${MINIO_VERSION:-RELEASE.2025-04-22T22-12-26Z}"
     command: server /data --console-address ":9009"
     restart: unless-stopped
     logging: *default-logging

--- a/docker-compose.minio.yml
+++ b/docker-compose.minio.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 # rotating logs so they do not overflow
 x-logging:
   logging: &default-logging

--- a/docker-compose.minio.yml
+++ b/docker-compose.minio.yml
@@ -9,7 +9,7 @@ x-logging:
 services:
   # not replicated setup for test setup, use a proper aws S3 compatible cluster in production
   minio:
-    image: minio/minio:RELEASE.2024-02-13T15-35-11Z
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     command: server /data --console-address ":9009"
     restart: unless-stopped
     logging: *default-logging

--- a/docker-compose.minio.yml
+++ b/docker-compose.minio.yml
@@ -9,7 +9,7 @@ x-logging:
 services:
   # not replicated setup for test setup, use a proper aws S3 compatible cluster in production
   minio:
-    image: quay.io/minio/minio:RELEASE.2024-02-13T15-35-11Z
+    image: minio/minio:RELEASE.2024-02-13T15-35-11Z
     command: server /data --console-address ":9009"
     restart: unless-stopped
     logging: *default-logging

--- a/docs/source/guide/storedata.md
+++ b/docs/source/guide/storedata.md
@@ -68,11 +68,15 @@ To configure MinIO settings, create a `.env` file. Remember to override the defa
 ````.dotenv
 MINIO_ROOT_USER=minio_admin_do_not_use_in_production
 MINIO_ROOT_PASSWORD=minio_admin_do_not_use_in_production
+
 # To automatically select the right compose file for minio you can add on of the following lines:
 # Windows
 COMPOSE_FILE=docker-compose.yml;docker-compose.minio.yml
 # Linux/Mac
 COMPOSE_FILE=docker-compose.yml:docker-compose.minio.yml
+
+# To use a specific minio version you can set the following env var
+# MINIO_VERSION=RELEASE.2025-04-22T22-12-26Z
 ````
 
 ### Connect Label Studio to local MinIO

--- a/docs/source/guide/storedata.md
+++ b/docs/source/guide/storedata.md
@@ -68,6 +68,11 @@ To configure MinIO settings, create a `.env` file. Remember to override the defa
 ````.dotenv
 MINIO_ROOT_USER=minio_admin_do_not_use_in_production
 MINIO_ROOT_PASSWORD=minio_admin_do_not_use_in_production
+# To automatically select the right compose file for minio you can add on of the following lines:
+# Windows
+COMPOSE_FILE=docker-compose.yml;docker-compose.minio.yml
+# Linux/Mac
+COMPOSE_FILE=docker-compose.yml:docker-compose.minio.yml
 ````
 
 ### Connect Label Studio to local MinIO


### PR DESCRIPTION
This PR :
* bumps the Minio compose file 
* removes the deprecated version keyword
* adds .env configurability for the Minio version

 - Reason for change: Last update was last year, since then the `version` keyword was deprecated.
   - Having the option to upgrade Minio versions without changes in git tracked files is nice.
   - Deprecation warnings are annoying.
 - Screenshots: /
 - Rollout strategy: env/minio compose update
 - Testing: Tested on Windows and Linux dev deployment
 - Risks: /
 - Reviewer notes: please take note of the new example env entries in the docs if you wish to test this locally
 - General notes: See you next year
