### PR TITLE
fix: broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Label Studio is an open source data labeling tool. It lets you label data types 
 
 ![Gif of Label Studio annotating different types of data](/images/annotation_examples.gif)
 
-Have a custom dataset? You can customize Label Studio to fit your needs. Read an [introductory blog post](https://towardsdatascience.com/introducing-label-studio-a-swiss-army-knife-of-data-labeling-140c1be92881) to learn more. 
+Have a custom dataset? You can customize Label Studio to fit your needs. Read an [introductory blog post](https://medium.com/data-science/introducing-label-studio-a-swiss-army-knife-of-data-labeling-140c1be92881) to learn more. 
 
 ## Try out Label Studio
 


### PR DESCRIPTION
The link to the blog post in the README leads to a 404, so I fixed it by pointing to the updated URL in Towards Data Science's blog archive in Medium

Screenshots: 
## Before
<img width="1224" alt="image" src="https://github.com/user-attachments/assets/31c53c82-f889-40d7-9136-acb667039fd7" />

## After
<img width="1224" alt="image" src="https://github.com/user-attachments/assets/e25a507b-8941-4eab-ac9a-e156707928dd" />
