### PR TITLE
chore: Allow retries on Audio Regions test suite temporarily while a fix is investigated

### DIFF
--- a/web/libs/editor/tests/integration/e2e/audio/audio_regions.cy.ts
+++ b/web/libs/editor/tests/integration/e2e/audio/audio_regions.cy.ts
@@ -1,7 +1,16 @@
 import { AudioView, Labels, LabelStudio, Relations } from "@humansignal/frontend-test/helpers/LSF";
 import { audioOneRegionResult, audioWithLabelsConfig, audioWithLabelsData } from "../../data/audio/audio_regions";
 
-describe("Audio regions", () => {
+// This test suite has exhibited flakiness in the past, so we are going to run it with retries
+// while we investigate the root cause.
+const suiteConfig = {
+  retries: {
+    runMode: 3,
+    openMode: 0,
+  },
+};
+
+describe("Audio regions", suiteConfig, () => {
   it("Should have indication of selected state", () => {
     LabelStudio.params()
       .config(audioWithLabelsConfig)


### PR DESCRIPTION
There has been a very intermittent failure occurring in this Audio Regions test suite on CI, which is consistently passing on local environments. For now we will opt to retry tests that fail in this suite up to 3 times, which overall does not affect the test runtime given these tests run within 2 seconds each.