### PR TITLE
fix: LEAP-2056: Make sure tools added once per ToolManager

### DIFF
--- a/web/libs/editor/src/tags/object/Image/Image.js
+++ b/web/libs/editor/src/tags/object/Image/Image.js
@@ -606,15 +606,15 @@ const Model = types
       if (ff.isActive(FF_DEV_3391) && !self.annotation) {
         return;
       }
-      if (self.selectioncontrol) manager.addTool("MoveTool", Tools.Selection.create({}, env));
+      if (self.selectioncontrol) manager.addTool("MoveTool", Tools.Selection.create({}, env), "MoveTool");
 
-      if (self.zoomcontrol) manager.addTool("ZoomPanTool", Tools.Zoom.create({}, env));
+      if (self.zoomcontrol) manager.addTool("ZoomPanTool", Tools.Zoom.create({}, env), "ZoomPanTool");
 
-      if (self.brightnesscontrol) manager.addTool("BrightnessTool", Tools.Brightness.create({}, env));
+      if (self.brightnesscontrol) manager.addTool("BrightnessTool", Tools.Brightness.create({}, env), "BrightnessTool");
 
-      if (self.contrastcontrol) manager.addTool("ContrastTool", Tools.Contrast.create({}, env));
+      if (self.contrastcontrol) manager.addTool("ContrastTool", Tools.Contrast.create({}, env), "ContrastTool");
 
-      if (self.rotatecontrol) manager.addTool("RotateTool", Tools.Rotate.create({}, env));
+      if (self.rotatecontrol) manager.addTool("RotateTool", Tools.Rotate.create({}, env), "RotateTool");
 
       createImageEntities();
     }


### PR DESCRIPTION
Updated calls to `manager.addTool` by adding explicit tool names as the third argument.

---

### Reason for change
Previously, calls to `manager.addTool` could result in duplicate tools being added. This fix ensures tools are only added once by specifying explicit tool names as the third argument.

### Screenshots

#### Before

<img width="1007" alt="image" src="https://github.com/user-attachments/assets/f5fabe90-d4fc-47ad-9f30-c0b44350c44a" />

#### After

<img width="1007" alt="image" src="https://github.com/user-attachments/assets/0999cf47-928a-4caf-a61a-4378146bae1a" />

### Testing
- Verified manually to ensure no duplicate tools are added after the fix.

### General notes
- This change addresses the duplication issue and improves tool management logic.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
