### PR TITLE
fix: OPTIC-2120: LSO: All Projects navigation bar is transparent

### DIFF
--- a/web/apps/labelstudio/src/pages/Projects/Projects.scss
+++ b/web/apps/labelstudio/src/pages/Projects/Projects.scss
@@ -31,7 +31,8 @@
   }
 
   &__pages {
-    background-color: transparent;
+    background: var(--color-neutral-background);
+    border-top: 1px solid var(--color-neutral-border);
     bottom: 0;
     width: 100%;
     position: sticky;


### PR DESCRIPTION
This pull request updates the styling of the `Projects` page in the `web/apps/labelstudio` application to enhance visual consistency and improve the user interface.

<img width="874" alt="image" src="https://github.com/user-attachments/assets/3b1f3417-a0c9-4015-8151-105a9bca50d5" />


Styling updates:

* [`web/apps/labelstudio/src/pages/Projects/Projects.scss`](diffhunk://#diff-224df041218b6857b9353bb0b3f2853a3c4667b2d9851bd9637c631e071c8db6L34-R35): Changed the `background-color` of the `__pages` class from `transparent` to a variable `--color-neutral-background` for better theme consistency. Added a top border with `--color-neutral-border` to visually separate sections.