### PR TITLE
feat: OPTIC-2161: Give Select a way to override the display value completely

### DIFF
--- a/web/libs/storybook/select/select.stories.tsx
+++ b/web/libs/storybook/select/select.stories.tsx
@@ -143,6 +143,34 @@ const meta: Meta<typeof Select> = {
             {...args}
           />
         </div>
+        <div>
+          <Select
+            options={[
+              { label: "Yes", value: true },
+              { label: "No", value: false },
+            ]}
+            label="Boolean values with displayValueOverride"
+            displayValueOverride={(selectedOptions, placeholder) => {
+              if (selectedOptions.length > 0) {
+                return selectedOptions.map((option) => `${option.label} and such`).join(", ");
+              }
+              return placeholder;
+            }}
+            multiple={true}
+            {...args}
+          />
+        </div>
+        <div>
+          <Select
+            options={[
+              { label: "Yes", value: true },
+              { label: "No", value: false },
+            ]}
+            label="Boolean values with displayValueOverride"
+            displayValueOverride={() => "Always show this"}
+            {...args}
+          />
+        </div>
       </>
     );
   },

--- a/web/libs/storybook/select/select.stories.tsx
+++ b/web/libs/storybook/select/select.stories.tsx
@@ -149,8 +149,8 @@ const meta: Meta<typeof Select> = {
               { label: "Yes", value: true },
               { label: "No", value: false },
             ]}
-            label="Boolean values with displayValueOverride"
-            displayValueOverride={(selectedOptions, placeholder) => {
+            label="Boolean values with renderSelected"
+            renderSelected={(selectedOptions, placeholder) => {
               if (selectedOptions.length > 0) {
                 return selectedOptions.map((option) => `${option.label} and such`).join(", ");
               }
@@ -166,8 +166,8 @@ const meta: Meta<typeof Select> = {
               { label: "Yes", value: true },
               { label: "No", value: false },
             ]}
-            label="Boolean values with displayValueOverride"
-            displayValueOverride={() => "Always show this"}
+            label="Boolean values with renderSelected"
+            renderSelected={() => "Always show this"}
             {...args}
           />
         </div>

--- a/web/libs/ui/src/lib/select/select.tsx
+++ b/web/libs/ui/src/lib/select/select.tsx
@@ -192,6 +192,32 @@ export const Select = forwardRef(
       setValue(defaultValue);
     }, [selectedOptions, defaultValue]);
 
+    const displayValue = useMemo(() => {
+      return (
+        <>
+          {selectedOptions?.length ? (
+            <>
+              {selectedOptions?.map((option, index) => {
+                if (selectedValueRenderer) {
+                  return (
+                    <React.Fragment key={`${option?.value}_${index}`}>{selectedValueRenderer(option)}</React.Fragment>
+                  );
+                }
+                const optionValue = option?.value ?? option;
+                return (
+                  <span key={`${optionValue}_${index}`} className="truncate only:w-full">
+                    {option?.label ?? optionValue}
+                  </span>
+                );
+              })}
+            </>
+          ) : (
+            <span className="truncate w-full">{props?.placeholder ?? ""}</span>
+          )}
+        </>
+      );
+    }, [selectedOptions, props?.placeholder, selectedValueRenderer]);
+
     const combobox = (
       <Popover open={isOpen} onOpenChange={setIsOpen}>
         <PopoverTrigger asChild={true} disabled={disabled}>
@@ -220,33 +246,7 @@ export const Select = forwardRef(
               className="flex flex-1 text-left gap-2 max-w-full w-[calc(100%-1rem-0.5rem)]"
               data-testid="select-display-value"
             >
-              {displayValueOverride ? (
-                displayValueOverride?.(selectedOptions, props?.placeholder)
-              ) : (
-                <>
-                  {selectedOptions?.length ? (
-                    <>
-                      {selectedOptions?.map((option, index) => {
-                        if (selectedValueRenderer) {
-                          return (
-                            <React.Fragment key={`${option?.value}_${index}`}>
-                              {selectedValueRenderer(option)}
-                            </React.Fragment>
-                          );
-                        }
-                        const optionValue = option?.value ?? option;
-                        return (
-                          <span key={`${optionValue}_${index}`} className="truncate only:w-full">
-                            {option?.label ?? optionValue}
-                          </span>
-                        );
-                      })}
-                    </>
-                  ) : (
-                    <span className="truncate w-full">{props?.placeholder ?? ""}</span>
-                  )}
-                </>
-              )}
+              {displayValueOverride ? displayValueOverride?.(selectedOptions, props?.placeholder) : displayValue}
             </span>
             {isOpen ? (
               <IconChevron className="h-4 w-4 shrink-0 opacity-50 pointer-events-none" />

--- a/web/libs/ui/src/lib/select/select.tsx
+++ b/web/libs/ui/src/lib/select/select.tsx
@@ -74,7 +74,7 @@ export const Select = forwardRef(
       onSearch,
       selectedValueRenderer,
       selectFirstIfEmpty,
-      displayValueOverride,
+      renderSelected,
       ...props
     }: SelectProps<T, A>,
     _ref: ForwardedRef<HTMLSelectElement>,
@@ -246,7 +246,7 @@ export const Select = forwardRef(
               className="flex flex-1 text-left gap-2 max-w-full w-[calc(100%-1rem-0.5rem)]"
               data-testid="select-display-value"
             >
-              {displayValueOverride ? displayValueOverride?.(selectedOptions, props?.placeholder) : displayValue}
+              {renderSelected ? renderSelected?.(selectedOptions, props?.placeholder) : displayValue}
             </span>
             {isOpen ? (
               <IconChevron className="h-4 w-4 shrink-0 opacity-50 pointer-events-none" />

--- a/web/libs/ui/src/lib/select/select.tsx
+++ b/web/libs/ui/src/lib/select/select.tsx
@@ -220,7 +220,9 @@ export const Select = forwardRef(
               className="flex flex-1 text-left gap-2 max-w-full w-[calc(100%-1rem-0.5rem)]"
               data-testid="select-display-value"
             >
-              {displayValueOverride ? displayValueOverride?.(selectedOptions, props?.placeholder) : (
+              {displayValueOverride ? (
+                displayValueOverride?.(selectedOptions, props?.placeholder)
+              ) : (
                 <>
                   {selectedOptions?.length ? (
                     <>

--- a/web/libs/ui/src/lib/select/select.tsx
+++ b/web/libs/ui/src/lib/select/select.tsx
@@ -74,6 +74,7 @@ export const Select = forwardRef(
       onSearch,
       selectedValueRenderer,
       selectFirstIfEmpty,
+      displayValueOverride,
       ...props
     }: SelectProps<T, A>,
     _ref: ForwardedRef<HTMLSelectElement>,
@@ -219,26 +220,30 @@ export const Select = forwardRef(
               className="flex flex-1 text-left gap-2 max-w-full w-[calc(100%-1rem-0.5rem)]"
               data-testid="select-display-value"
             >
-              {selectedOptions?.length ? (
+              {displayValueOverride ? displayValueOverride?.(selectedOptions, props?.placeholder) : (
                 <>
-                  {selectedOptions?.map((option, index) => {
-                    if (selectedValueRenderer) {
-                      return (
-                        <React.Fragment key={`${option?.value}_${index}`}>
-                          {selectedValueRenderer(option)}
-                        </React.Fragment>
-                      );
-                    }
-                    const optionValue = option?.value ?? option;
-                    return (
-                      <span key={`${optionValue}_${index}`} className="truncate only:w-full">
-                        {option?.label ?? optionValue}
-                      </span>
-                    );
-                  })}
+                  {selectedOptions?.length ? (
+                    <>
+                      {selectedOptions?.map((option, index) => {
+                        if (selectedValueRenderer) {
+                          return (
+                            <React.Fragment key={`${option?.value}_${index}`}>
+                              {selectedValueRenderer(option)}
+                            </React.Fragment>
+                          );
+                        }
+                        const optionValue = option?.value ?? option;
+                        return (
+                          <span key={`${optionValue}_${index}`} className="truncate only:w-full">
+                            {option?.label ?? optionValue}
+                          </span>
+                        );
+                      })}
+                    </>
+                  ) : (
+                    <span className="truncate w-full">{props?.placeholder ?? ""}</span>
+                  )}
                 </>
-              ) : (
-                <span className="truncate w-full">{props?.placeholder ?? ""}</span>
               )}
             </span>
             {isOpen ? (

--- a/web/libs/ui/src/lib/select/types.ts
+++ b/web/libs/ui/src/lib/select/types.ts
@@ -70,7 +70,7 @@ export type SelectProps<T, A extends SelectOption<T>[]> = {
   size?: "small" | "medium" | "large";
   onSearch?: (value: string) => void;
   selectFirstIfEmpty?: boolean;
-  displayValueOverride?: (selectedOptions?: A[number][], placeholder?: string) => React.ReactNode | string;
+  renderSelected?: (selectedOptions?: A[number][], placeholder?: string) => React.ReactNode | string;
 } & SelectVirtualizedProps &
   Omit<React.SelectHTMLAttributes<HTMLSelectElement>, "value" | "placeholder">;
 

--- a/web/libs/ui/src/lib/select/types.ts
+++ b/web/libs/ui/src/lib/select/types.ts
@@ -70,6 +70,7 @@ export type SelectProps<T, A extends SelectOption<T>[]> = {
   size?: "small" | "medium" | "large";
   onSearch?: (value: string) => void;
   selectFirstIfEmpty?: boolean;
+  displayValueOverride?: (selectedOptions?: A[number][], placeholder?: string) => React.ReactNode | string;
 } & SelectVirtualizedProps &
   Omit<React.SelectHTMLAttributes<HTMLSelectElement>, "value" | "placeholder">;
 


### PR DESCRIPTION
This pull request introduces a new `displayValueOverride` prop to the `Select` component, allowing developers to customize how selected values are displayed. It also includes updates to the `Select` component and its associated stories to demonstrate this new functionality.

<img width="566" alt="Screenshot 2025-05-06 at 1 18 42 PM" src="https://github.com/user-attachments/assets/88d233aa-1e64-436a-9ac8-1051365f3b1f" />

### Enhancements to `Select` Component:

* **Added `displayValueOverride` Prop**: A new optional prop, `displayValueOverride`, was introduced to allow custom rendering of selected values in the `Select` component. This prop takes a function that receives `selectedOptions` and an optional `placeholder`, and returns a custom display value. (`web/libs/ui/src/lib/select/types.ts` - [[1]](diffhunk://#diff-c04973e3a3095798cf15be72420af0687bc8cc748028e26fd47b27d4c3c37d5dR73) `web/libs/ui/src/lib/select/select.tsx` - [[2]](diffhunk://#diff-567459e612a12d17fb4237f0381f79f4148ad291939afbf005a1c02e398fe942R77)

* **Integrated `displayValueOverride` in Rendering Logic**: Updated the rendering logic of the `Select` component to use the `displayValueOverride` function if provided. If not, the default rendering logic is applied. (`web/libs/ui/src/lib/select/select.tsx` - [[1]](diffhunk://#diff-567459e612a12d17fb4237f0381f79f4148ad291939afbf005a1c02e398fe942R223-R224) [[2]](diffhunk://#diff-567459e612a12d17fb4237f0381f79f4148ad291939afbf005a1c02e398fe942R246-R247)

### Storybook Updates:

* **Added Examples for `displayValueOverride`**: New examples were added to the `Select` component's Storybook to demonstrate the usage of `displayValueOverride`. These examples showcase custom display logic, such as appending text to selected options or overriding the display value entirely. (`web/libs/storybook/select/select.stories.tsx` - [web/libs/storybook/select/select.stories.tsxR146-R173](diffhunk://#diff-d276d7c9492791bd2cd5819bc7d8227747ea5b3df3a30ecb0b749f97b86b27d8R146-R173))