### PR TITLE
fix: OPTIC-2157: Actions Menu Disappears at High Browser Zoom Levels

### DIFF
--- a/web/libs/core/src/lib/utils/dom.ts
+++ b/web/libs/core/src/lib/utils/dom.ts
@@ -160,7 +160,6 @@ export const alignElements = (
     offsetLeft = pos.horizontalRight;
     resultAlign[1] = "right";
   }
-  console.log("offsetTop", offsetTop, openUpwardForShortViewport, elem, target, resultAlign);
 
   const { scrollY, scrollX } = window;
 

--- a/web/libs/core/src/lib/utils/dom.ts
+++ b/web/libs/core/src/lib/utils/dom.ts
@@ -96,6 +96,7 @@ export const alignElements = (
   align: Align = "bottom-left",
   padding = 0,
   constrainHeight = false,
+  openUpwardForShortViewport = true,
 ) => {
   let offsetLeft = 0;
   let offsetTop = 0;
@@ -139,9 +140,9 @@ export const alignElements = (
       break;
   }
 
-  if (offsetTop < window.scrollX) {
+  if (offsetTop < window.scrollY || !openUpwardForShortViewport) {
     offsetTop = pos.bottom + padding;
-    maxHeight = window.scrollX + window.innerHeight - offsetTop;
+    maxHeight = window.scrollY + window.innerHeight - offsetTop;
     resultAlign[0] = "bottom";
   }
   // If the dropdown has more space on the top, then we should align it to the top
@@ -159,6 +160,7 @@ export const alignElements = (
     offsetLeft = pos.horizontalRight;
     resultAlign[1] = "right";
   }
+  console.log("offsetTop", offsetTop, openUpwardForShortViewport, elem, target, resultAlign);
 
   const { scrollY, scrollX } = window;
 

--- a/web/libs/core/src/lib/utils/dom.ts
+++ b/web/libs/core/src/lib/utils/dom.ts
@@ -124,17 +124,17 @@ export const alignElements = (
     case "bottom-center":
       offsetTop = pos.bottom + padding;
       offsetLeft = pos.horizontalCenter;
-      maxHeight = window.scrollX + window.innerHeight - offsetTop;
+      maxHeight = window.scrollY + window.innerHeight - offsetTop;
       break;
     case "bottom-left":
       offsetTop = pos.bottom + padding;
       offsetLeft = pos.horizontalLeft;
-      maxHeight = window.scrollX + window.innerHeight - offsetTop;
+      maxHeight = window.scrollY + window.innerHeight - offsetTop;
       break;
     case "bottom-right":
       offsetTop = pos.bottom + padding;
       offsetLeft = pos.horizontalRight;
-      maxHeight = window.scrollX + window.innerHeight - offsetTop;
+      maxHeight = window.scrollY + window.innerHeight - offsetTop;
       break;
     default:
       break;

--- a/web/libs/datamanager/src/components/Common/Dropdown/DropdownComponent.jsx
+++ b/web/libs/datamanager/src/components/Common/Dropdown/DropdownComponent.jsx
@@ -10,162 +10,164 @@ import { DropdownTrigger } from "./DropdownTrigger";
 
 let lastIndex = 1;
 
-export const Dropdown = React.forwardRef(({ animated = true, visible = false, ...props }, ref) => {
-  const rootName = cn("dropdown-dm");
+export const Dropdown = React.forwardRef(
+  ({ animated = true, visible = false, constrainHeight = false, ...props }, ref) => {
+    const rootName = cn("dropdown-dm");
 
-  /**@type {import('react').RefObject<HTMLElement>} */
-  const dropdown = React.useRef();
-  const { triggerRef } = React.useContext(DropdownContext) ?? {};
-  const isInline = triggerRef === undefined;
+    /**@type {import('react').RefObject<HTMLElement>} */
+    const dropdown = React.useRef();
+    const { triggerRef } = React.useContext(DropdownContext) ?? {};
+    const isInline = triggerRef === undefined;
 
-  const { children, align, openUpwardForShortViewport } = props;
-  const [currentVisible, setVisible] = React.useState(visible);
-  const [offset, setOffset] = React.useState({});
-  const [visibility, setVisibility] = React.useState(visible ? "visible" : null);
+    const { children, align, openUpwardForShortViewport } = props;
+    const [currentVisible, setVisible] = React.useState(visible);
+    const [offset, setOffset] = React.useState({});
+    const [visibility, setVisibility] = React.useState(visible ? "visible" : null);
 
-  const calculatePosition = React.useCallback(() => {
-    const dropdownEl = dropdown.current;
-    const parent = triggerRef?.current ?? dropdownEl.parentNode;
-    const { left, top } = alignElements(
-      parent,
-      dropdownEl,
-      align ?? "bottom-left",
-      0,
-      false,
-      openUpwardForShortViewport ?? true,
+    const calculatePosition = React.useCallback(() => {
+      const dropdownEl = dropdown.current;
+      const parent = triggerRef?.current ?? dropdownEl.parentNode;
+      const { left, top } = alignElements(
+        parent,
+        dropdownEl,
+        align ?? "bottom-left",
+        0,
+        constrainHeight,
+        openUpwardForShortViewport ?? true,
+      );
+
+      setOffset({ left, top });
+    }, [triggerRef, align, openUpwardForShortViewport]);
+
+    const dropdownIndex = React.useMemo(() => {
+      return lastIndex++;
+    }, []);
+
+    const performAnimation = React.useCallback(
+      async (visible = false) => {
+        if (props.enabled === false && visible === true) return;
+
+        return new Promise((resolve) => {
+          const menu = dropdown.current;
+
+          if (animated !== false) {
+            aroundTransition(menu, {
+              transition: () => {
+                setVisibility(visible ? "appear" : "disappear");
+              },
+              beforeTransition: () => {
+                setVisibility(visible ? "before-appear" : "before-disappear");
+              },
+              afterTransition: () => {
+                setVisibility(visible ? "visible" : null);
+                resolve();
+              },
+            });
+          } else {
+            setVisibility(visible ? "visible" : null);
+            resolve();
+          }
+        });
+      },
+      [animated],
     );
 
-    setOffset({ left, top });
-  }, [triggerRef, align, openUpwardForShortViewport]);
+    const close = React.useCallback(async () => {
+      if (currentVisible === false) return;
 
-  const dropdownIndex = React.useMemo(() => {
-    return lastIndex++;
-  }, []);
+      props.onToggle?.(false);
+      await performAnimation(false);
+      setVisible(false);
+    }, [currentVisible, performAnimation, props]);
 
-  const performAnimation = React.useCallback(
-    async (visible = false) => {
-      if (props.enabled === false && visible === true) return;
+    const open = React.useCallback(async () => {
+      if (currentVisible === true) return;
 
-      return new Promise((resolve) => {
-        const menu = dropdown.current;
+      props.onToggle?.(true);
+      await performAnimation(true);
+      setVisible(true);
+    }, [currentVisible, performAnimation, props]);
 
-        if (animated !== false) {
-          aroundTransition(menu, {
-            transition: () => {
-              setVisibility(visible ? "appear" : "disappear");
-            },
-            beforeTransition: () => {
-              setVisibility(visible ? "before-appear" : "before-disappear");
-            },
-            afterTransition: () => {
-              setVisibility(visible ? "visible" : null);
-              resolve();
-            },
-          });
-        } else {
-          setVisibility(visible ? "visible" : null);
-          resolve();
-        }
-      });
-    },
-    [animated],
-  );
+    const toggle = React.useCallback(async () => {
+      const newState = !currentVisible;
 
-  const close = React.useCallback(async () => {
-    if (currentVisible === false) return;
+      if (newState) {
+        open();
+      } else {
+        close();
+      }
+    }, [close, currentVisible, open]);
 
-    props.onToggle?.(false);
-    await performAnimation(false);
-    setVisible(false);
-  }, [currentVisible, performAnimation, props]);
+    React.useEffect(() => {
+      if (!ref) return;
 
-  const open = React.useCallback(async () => {
-    if (currentVisible === true) return;
+      ref.current = {
+        dropdown: dropdown.current,
+        visible: visibility !== null,
+        toggle,
+        open,
+        close,
+      };
+    }, [close, open, ref, toggle, dropdown, visibility]);
 
-    props.onToggle?.(true);
-    await performAnimation(true);
-    setVisible(true);
-  }, [currentVisible, performAnimation, props]);
+    React.useEffect(() => {
+      setVisible(visible);
+    }, [visible]);
 
-  const toggle = React.useCallback(async () => {
-    const newState = !currentVisible;
+    React.useEffect(() => {
+      if (!isInline && visibility === "before-appear") {
+        calculatePosition();
+      }
+    }, [visibility, calculatePosition, isInline]);
 
-    if (newState) {
-      open();
-    } else {
-      close();
-    }
-  }, [close, currentVisible, open]);
+    React.useEffect(() => {
+      if (props.enabled === false) performAnimation(false);
+    }, [props.enabled]);
 
-  React.useEffect(() => {
-    if (!ref) return;
+    const content =
+      children.props && children.props.type === "Menu"
+        ? React.cloneElement(children, {
+            ...children.props,
+            className: rootName.elem("menu").mix(children.props.className),
+          })
+        : children;
 
-    ref.current = {
-      dropdown: dropdown.current,
-      visible: visibility !== null,
-      toggle,
-      open,
-      close,
+    const visibilityClasses = React.useMemo(() => {
+      switch (visibility) {
+        case "before-appear":
+          return "before-appear";
+        case "appear":
+          return "appear before-appear";
+        case "before-disappear":
+          return "before-disappear";
+        case "disappear":
+          return "disappear before-disappear";
+        case "visible":
+          return "visible";
+        default:
+          return visible ? "visible" : null;
+      }
+    }, [visibility, visible]);
+
+    const compositeStyles = {
+      ...(props.style ?? {}),
+      ...(offset ?? {}),
+      zIndex: 1000 + dropdownIndex,
     };
-  }, [close, open, ref, toggle, dropdown, visibility]);
+    const result = (
+      <div
+        ref={dropdown}
+        className={clsx(rootName.toString(), rootName.mix([props.className, visibilityClasses]).toString())}
+        style={compositeStyles}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {content}
+      </div>
+    );
 
-  React.useEffect(() => {
-    setVisible(visible);
-  }, [visible]);
-
-  React.useEffect(() => {
-    if (!isInline && visibility === "before-appear") {
-      calculatePosition();
-    }
-  }, [visibility, calculatePosition, isInline]);
-
-  React.useEffect(() => {
-    if (props.enabled === false) performAnimation(false);
-  }, [props.enabled]);
-
-  const content =
-    children.props && children.props.type === "Menu"
-      ? React.cloneElement(children, {
-          ...children.props,
-          className: rootName.elem("menu").mix(children.props.className),
-        })
-      : children;
-
-  const visibilityClasses = React.useMemo(() => {
-    switch (visibility) {
-      case "before-appear":
-        return "before-appear";
-      case "appear":
-        return "appear before-appear";
-      case "before-disappear":
-        return "before-disappear";
-      case "disappear":
-        return "disappear before-disappear";
-      case "visible":
-        return "visible";
-      default:
-        return visible ? "visible" : null;
-    }
-  }, [visibility, visible]);
-
-  const compositeStyles = {
-    ...(props.style ?? {}),
-    ...(offset ?? {}),
-    zIndex: 1000 + dropdownIndex,
-  };
-  const result = (
-    <div
-      ref={dropdown}
-      className={clsx(rootName.toString(), rootName.mix([props.className, visibilityClasses]).toString())}
-      style={compositeStyles}
-      onClick={(e) => e.stopPropagation()}
-    >
-      {content}
-    </div>
-  );
-
-  return props.inline === true ? result : ReactDOM.createPortal(result, document.body);
-});
+    return props.inline === true ? result : ReactDOM.createPortal(result, document.body);
+  },
+);
 
 Dropdown.displayName = "Dropdown";
 

--- a/web/libs/datamanager/src/components/Common/Dropdown/DropdownComponent.jsx
+++ b/web/libs/datamanager/src/components/Common/Dropdown/DropdownComponent.jsx
@@ -24,7 +24,6 @@ export const Dropdown = React.forwardRef(({ animated = true, visible = false, ..
   const [visibility, setVisibility] = React.useState(visible ? "visible" : null);
 
   const calculatePosition = React.useCallback(() => {
-    console.log("calculatePosition", openUpwardForShortViewport);
     const dropdownEl = dropdown.current;
     const parent = triggerRef?.current ?? dropdownEl.parentNode;
     const { left, top } = alignElements(

--- a/web/libs/datamanager/src/components/Common/Dropdown/DropdownComponent.jsx
+++ b/web/libs/datamanager/src/components/Common/Dropdown/DropdownComponent.jsx
@@ -36,7 +36,7 @@ export const Dropdown = React.forwardRef(({ animated = true, visible = false, ..
     );
 
     setOffset({ left, top });
-  }, [triggerRef, align, openUpwardForShortViewport]);
+  }, [triggerRef, align, openUpwardForShortViewport, constrainHeight]);
 
   const dropdownIndex = React.useMemo(() => {
     return lastIndex++;

--- a/web/libs/datamanager/src/components/Common/Dropdown/DropdownComponent.jsx
+++ b/web/libs/datamanager/src/components/Common/Dropdown/DropdownComponent.jsx
@@ -10,164 +10,162 @@ import { DropdownTrigger } from "./DropdownTrigger";
 
 let lastIndex = 1;
 
-export const Dropdown = React.forwardRef(
-  ({ animated = true, visible = false, constrainHeight = false, ...props }, ref) => {
-    const rootName = cn("dropdown-dm");
+export const Dropdown = React.forwardRef(({ animated = true, visible = false, ...props }, ref) => {
+  const rootName = cn("dropdown-dm");
 
-    /**@type {import('react').RefObject<HTMLElement>} */
-    const dropdown = React.useRef();
-    const { triggerRef } = React.useContext(DropdownContext) ?? {};
-    const isInline = triggerRef === undefined;
+  /**@type {import('react').RefObject<HTMLElement>} */
+  const dropdown = React.useRef();
+  const { triggerRef } = React.useContext(DropdownContext) ?? {};
+  const isInline = triggerRef === undefined;
 
-    const { children, align, openUpwardForShortViewport } = props;
-    const [currentVisible, setVisible] = React.useState(visible);
-    const [offset, setOffset] = React.useState({});
-    const [visibility, setVisibility] = React.useState(visible ? "visible" : null);
+  const { children, align, openUpwardForShortViewport, constrainHeight = false } = props;
+  const [currentVisible, setVisible] = React.useState(visible);
+  const [offset, setOffset] = React.useState({});
+  const [visibility, setVisibility] = React.useState(visible ? "visible" : null);
 
-    const calculatePosition = React.useCallback(() => {
-      const dropdownEl = dropdown.current;
-      const parent = triggerRef?.current ?? dropdownEl.parentNode;
-      const { left, top } = alignElements(
-        parent,
-        dropdownEl,
-        align ?? "bottom-left",
-        0,
-        constrainHeight,
-        openUpwardForShortViewport ?? true,
-      );
-
-      setOffset({ left, top });
-    }, [triggerRef, align, openUpwardForShortViewport]);
-
-    const dropdownIndex = React.useMemo(() => {
-      return lastIndex++;
-    }, []);
-
-    const performAnimation = React.useCallback(
-      async (visible = false) => {
-        if (props.enabled === false && visible === true) return;
-
-        return new Promise((resolve) => {
-          const menu = dropdown.current;
-
-          if (animated !== false) {
-            aroundTransition(menu, {
-              transition: () => {
-                setVisibility(visible ? "appear" : "disappear");
-              },
-              beforeTransition: () => {
-                setVisibility(visible ? "before-appear" : "before-disappear");
-              },
-              afterTransition: () => {
-                setVisibility(visible ? "visible" : null);
-                resolve();
-              },
-            });
-          } else {
-            setVisibility(visible ? "visible" : null);
-            resolve();
-          }
-        });
-      },
-      [animated],
+  const calculatePosition = React.useCallback(() => {
+    const dropdownEl = dropdown.current;
+    const parent = triggerRef?.current ?? dropdownEl.parentNode;
+    const { left, top } = alignElements(
+      parent,
+      dropdownEl,
+      align ?? "bottom-left",
+      0,
+      constrainHeight,
+      openUpwardForShortViewport ?? true,
     );
 
-    const close = React.useCallback(async () => {
-      if (currentVisible === false) return;
+    setOffset({ left, top });
+  }, [triggerRef, align, openUpwardForShortViewport]);
 
-      props.onToggle?.(false);
-      await performAnimation(false);
-      setVisible(false);
-    }, [currentVisible, performAnimation, props]);
+  const dropdownIndex = React.useMemo(() => {
+    return lastIndex++;
+  }, []);
 
-    const open = React.useCallback(async () => {
-      if (currentVisible === true) return;
+  const performAnimation = React.useCallback(
+    async (visible = false) => {
+      if (props.enabled === false && visible === true) return;
 
-      props.onToggle?.(true);
-      await performAnimation(true);
-      setVisible(true);
-    }, [currentVisible, performAnimation, props]);
+      return new Promise((resolve) => {
+        const menu = dropdown.current;
 
-    const toggle = React.useCallback(async () => {
-      const newState = !currentVisible;
+        if (animated !== false) {
+          aroundTransition(menu, {
+            transition: () => {
+              setVisibility(visible ? "appear" : "disappear");
+            },
+            beforeTransition: () => {
+              setVisibility(visible ? "before-appear" : "before-disappear");
+            },
+            afterTransition: () => {
+              setVisibility(visible ? "visible" : null);
+              resolve();
+            },
+          });
+        } else {
+          setVisibility(visible ? "visible" : null);
+          resolve();
+        }
+      });
+    },
+    [animated],
+  );
 
-      if (newState) {
-        open();
-      } else {
-        close();
-      }
-    }, [close, currentVisible, open]);
+  const close = React.useCallback(async () => {
+    if (currentVisible === false) return;
 
-    React.useEffect(() => {
-      if (!ref) return;
+    props.onToggle?.(false);
+    await performAnimation(false);
+    setVisible(false);
+  }, [currentVisible, performAnimation, props]);
 
-      ref.current = {
-        dropdown: dropdown.current,
-        visible: visibility !== null,
-        toggle,
-        open,
-        close,
-      };
-    }, [close, open, ref, toggle, dropdown, visibility]);
+  const open = React.useCallback(async () => {
+    if (currentVisible === true) return;
 
-    React.useEffect(() => {
-      setVisible(visible);
-    }, [visible]);
+    props.onToggle?.(true);
+    await performAnimation(true);
+    setVisible(true);
+  }, [currentVisible, performAnimation, props]);
 
-    React.useEffect(() => {
-      if (!isInline && visibility === "before-appear") {
-        calculatePosition();
-      }
-    }, [visibility, calculatePosition, isInline]);
+  const toggle = React.useCallback(async () => {
+    const newState = !currentVisible;
 
-    React.useEffect(() => {
-      if (props.enabled === false) performAnimation(false);
-    }, [props.enabled]);
+    if (newState) {
+      open();
+    } else {
+      close();
+    }
+  }, [close, currentVisible, open]);
 
-    const content =
-      children.props && children.props.type === "Menu"
-        ? React.cloneElement(children, {
-            ...children.props,
-            className: rootName.elem("menu").mix(children.props.className),
-          })
-        : children;
+  React.useEffect(() => {
+    if (!ref) return;
 
-    const visibilityClasses = React.useMemo(() => {
-      switch (visibility) {
-        case "before-appear":
-          return "before-appear";
-        case "appear":
-          return "appear before-appear";
-        case "before-disappear":
-          return "before-disappear";
-        case "disappear":
-          return "disappear before-disappear";
-        case "visible":
-          return "visible";
-        default:
-          return visible ? "visible" : null;
-      }
-    }, [visibility, visible]);
-
-    const compositeStyles = {
-      ...(props.style ?? {}),
-      ...(offset ?? {}),
-      zIndex: 1000 + dropdownIndex,
+    ref.current = {
+      dropdown: dropdown.current,
+      visible: visibility !== null,
+      toggle,
+      open,
+      close,
     };
-    const result = (
-      <div
-        ref={dropdown}
-        className={clsx(rootName.toString(), rootName.mix([props.className, visibilityClasses]).toString())}
-        style={compositeStyles}
-        onClick={(e) => e.stopPropagation()}
-      >
-        {content}
-      </div>
-    );
+  }, [close, open, ref, toggle, dropdown, visibility]);
 
-    return props.inline === true ? result : ReactDOM.createPortal(result, document.body);
-  },
-);
+  React.useEffect(() => {
+    setVisible(visible);
+  }, [visible]);
+
+  React.useEffect(() => {
+    if (!isInline && visibility === "before-appear") {
+      calculatePosition();
+    }
+  }, [visibility, calculatePosition, isInline]);
+
+  React.useEffect(() => {
+    if (props.enabled === false) performAnimation(false);
+  }, [props.enabled]);
+
+  const content =
+    children.props && children.props.type === "Menu"
+      ? React.cloneElement(children, {
+          ...children.props,
+          className: rootName.elem("menu").mix(children.props.className),
+        })
+      : children;
+
+  const visibilityClasses = React.useMemo(() => {
+    switch (visibility) {
+      case "before-appear":
+        return "before-appear";
+      case "appear":
+        return "appear before-appear";
+      case "before-disappear":
+        return "before-disappear";
+      case "disappear":
+        return "disappear before-disappear";
+      case "visible":
+        return "visible";
+      default:
+        return visible ? "visible" : null;
+    }
+  }, [visibility, visible]);
+
+  const compositeStyles = {
+    ...(props.style ?? {}),
+    ...(offset ?? {}),
+    zIndex: 1000 + dropdownIndex,
+  };
+  const result = (
+    <div
+      ref={dropdown}
+      className={clsx(rootName.toString(), rootName.mix([props.className, visibilityClasses]).toString())}
+      style={compositeStyles}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {content}
+    </div>
+  );
+
+  return props.inline === true ? result : ReactDOM.createPortal(result, document.body);
+});
 
 Dropdown.displayName = "Dropdown";
 

--- a/web/libs/datamanager/src/components/Common/Dropdown/DropdownComponent.jsx
+++ b/web/libs/datamanager/src/components/Common/Dropdown/DropdownComponent.jsx
@@ -24,6 +24,7 @@ export const Dropdown = React.forwardRef(({ animated = true, visible = false, ..
   const [visibility, setVisibility] = React.useState(visible ? "visible" : null);
 
   const calculatePosition = React.useCallback(() => {
+    console.log("calculatePosition", openUpwardForShortViewport);
     const dropdownEl = dropdown.current;
     const parent = triggerRef?.current ?? dropdownEl.parentNode;
     const { left, top } = alignElements(
@@ -31,11 +32,12 @@ export const Dropdown = React.forwardRef(({ animated = true, visible = false, ..
       dropdownEl,
       align ?? "bottom-left",
       0,
+      false,
       openUpwardForShortViewport ?? true,
     );
 
     setOffset({ left, top });
-  }, [triggerRef]);
+  }, [triggerRef, align, openUpwardForShortViewport]);
 
   const dropdownIndex = React.useMemo(() => {
     return lastIndex++;


### PR DESCRIPTION
This pull request introduces changes to improve the alignment logic for dropdown elements in scenarios with limited viewport height. It adds a new parameter, `openUpwardForShortViewport`, to control whether dropdowns should open upward when there is insufficient space below. Debugging `console.log` statements have also been added for troubleshooting.

<img width="363" alt="image" src="https://github.com/user-attachments/assets/0b58bdb5-74c5-4b90-a766-3966ea709e99" />


### Alignment logic enhancements:
* [`web/libs/core/src/lib/utils/dom.ts`](diffhunk://#diff-5bcd905e2119e59538abf86ccee7613a1c338b995755a2dd89dd950164742bb6R99): Added a new parameter `openUpwardForShortViewport` to the `alignElements` function, defaulting to `true`. Updated the alignment logic to consider this parameter when determining whether to align dropdowns upward or downward. [[1]](diffhunk://#diff-5bcd905e2119e59538abf86ccee7613a1c338b995755a2dd89dd950164742bb6R99) [[2]](diffhunk://#diff-5bcd905e2119e59538abf86ccee7613a1c338b995755a2dd89dd950164742bb6L142-R145)

### Debugging improvements:
* [`web/libs/core/src/lib/utils/dom.ts`](diffhunk://#diff-5bcd905e2119e59538abf86ccee7613a1c338b995755a2dd89dd950164742bb6R163): Added a `console.log` statement to log alignment calculations, including `offsetTop`, `openUpwardForShortViewport`, and other related variables.
* [`web/libs/datamanager/src/components/Common/Dropdown/DropdownComponent.jsx`](diffhunk://#diff-70cc7355435ba12d350d0a0c3c9575cdce72a1dd4a37726b07d54248b7a06e74R27-R40): Added a `console.log` statement to log the value of `openUpwardForShortViewport` during position calculation in the `Dropdown` component.