### PR TITLE
fix: OPTIC-1916: Filter Tag is Not Working on Label Studio

### DIFF
--- a/web/libs/editor/src/tags/control/Choice/Choice.scss
+++ b/web/libs/editor/src/tags/control/Choice/Choice.scss
@@ -18,8 +18,8 @@
     line-height: 40px;
   }
 
-  &_leaf&_hidden,
-  &_notLeaf&_hidden {
+  @at-root #{selector-append(&,_leaf,&,_hidden)},
+  #{selector-append(&,_notLeaf,&,_hidden)} {
     display: none;
   }
 

--- a/web/libs/editor/src/tags/control/Choice/Choice.scss
+++ b/web/libs/editor/src/tags/control/Choice/Choice.scss
@@ -18,8 +18,8 @@
     line-height: 40px;
   }
 
-  &_leaf &_hidden,
-  &_notLeaf &_hidden {
+  &_leaf&_hidden,
+  &_notLeaf&_hidden {
     display: none;
   }
 


### PR DESCRIPTION
The style .lsf-choice_hidden contain no styles this was introduce in a recent migration [here](https://github.com/HumanSignal/label-studio/pull/6187/files#diff-346bb02c58e7899bdebe8ea92303f9fd29f75ba3121f61fb48aa1543c24f70acL17)

The current problem is that the filter does not hide the options. But the right className is being attach

Also fixes: https://github.com/HumanSignal/label-studio/issues/7347

