### PR TITLE
chore: OPTIC-2163: Allow inclusion of all libs related frontend code for Tailwind classes

### DIFF
--- a/web/libs/ui/src/tailwind.config.js
+++ b/web/libs/ui/src/tailwind.config.js
@@ -2,12 +2,7 @@ import tokens from "./tokens/tokens";
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: [
-    "./apps/**/*.{js,jsx,ts,tsx}",
-    "./libs/ui/src/**/*.{js,jsx,ts,tsx}",
-    "./libs/core/src/**/*.{js,jsx,ts,tsx}",
-    "./libs/storybook/**/*.{js,jsx,ts,tsx}",
-  ],
+  content: ["./apps/**/*.{js,jsx,ts,tsx}", "./libs/**/*.{js,jsx,ts,tsx}"],
   theme: {
     extend: {
       colors: {

--- a/web/libs/ui/src/tailwind.config.js
+++ b/web/libs/ui/src/tailwind.config.js
@@ -2,7 +2,15 @@ import tokens from "./tokens/tokens";
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ["./apps/**/*.{js,jsx,ts,tsx}", "./libs/**/*.{js,jsx,ts,tsx}"],
+  content: [
+    "./apps/**/*.{js,jsx,ts,tsx}",
+    "./libs/app-common/**/*.{js,jsx,ts,tsx}",
+    "./libs/core/**/*.{js,jsx,ts,tsx}",
+    "./libs/editor/**/*.{js,jsx,ts,tsx}",
+    "./libs/datamanager/**/*.{js,jsx,ts,tsx}",
+    "./libs/ui/**/*.{js,jsx,ts,tsx}",
+    "./libs/storybook/**/*.{js,jsx,ts,tsx}",
+  ],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
This pull request simplifies the configuration of the Tailwind CSS `content` property in `web/libs/ui/src/tailwind.config.js`.

This allows Tailwind to pick up all classnames across the application, including `editor` and `datamanager`, for its JIT compiler, unblocking its full potential.

* [`web/libs/ui/src/tailwind.config.js`](diffhunk://#diff-78a475fe09afce02fe6e47b2b8c24cdc9a72f52ce23edad68fe7ca94d1d32852L5-R5): Consolidated the `content` property paths by replacing individual directory specifications with a single wildcard pattern (`"./libs/**/*.{js,jsx,ts,tsx}"`), reducing redundancy and improving maintainability.