### PR TITLE
feat: OPTIC-1658: Add searchable select as an input for Set Ground Truth action

### DIFF
--- a/web/libs/datamanager/src/stores/Action.js
+++ b/web/libs/datamanager/src/stores/Action.js
@@ -13,6 +13,8 @@ const ActionFormField = types.model("ActionForm", {
   value: types.maybeNull(types.union(types.string, types.array(types.string))),
   options: types.maybeNull(types.union(types.array(types.string), types.array(SelectOptions))),
   type: types.enumeration(["input", "number", "checkbox", "radio", "toggle", "select", "range"]),
+  searchable: types.optional(types.boolean, false),
+  placeholder: types.optional(types.string, ""),
 });
 
 const ActionFormCoulmn = types.model("ActionFormCoulmn", {


### PR DESCRIPTION
This pull request introduces enhancements to the `ActionFormField` model in the `web/libs/datamanager/src/stores/Action.js` file. The changes add new properties to improve form field configurability.

Form Fields need Placeholder and searchable optional fields

### Enhancements to the `ActionFormField` model:
* Added a `searchable` property of type `boolean`, defaulting to `false`, to indicate whether the form field supports search functionality.
* Added a `placeholder` property of type `string`, defaulting to an empty string, to allow specifying placeholder text for the form field.