### PR TITLE
fix: OPTIC-2122: Selected choice in View All page is broken for light mode

### DIFF
--- a/web/libs/editor/src/tags/control/Choice/Choice.scss
+++ b/web/libs/editor/src/tags/control/Choice/Choice.scss
@@ -82,8 +82,22 @@ body :global(.ant-checkbox-checked .ant-checkbox-inner) {
   border-color: var(--color-primary-surface);
 }
 
+
 body :global(.ant-checkbox-checked)::after {
   border: 1px solid var(--color-primary-surface);
+}
+
+body :global(.ant-checkbox-checked.ant-checkbox-disabled .ant-checkbox-inner) {
+  background-color: var(--color-primary-surface) !important;
+  border-color: var(--color-primary-border) !important;
+}
+
+body :global(.ant-checkbox-checked.ant-checkbox-disabled .ant-checkbox-inner::after) {
+  border-color: var(--color-primary-surface-content);
+}
+
+body :global(.ant-checkbox.ant-checkbox-disabled .ant-checkbox-inner) {
+  border-color: var(--color-neutral-border) !important;
 }
 
 :global(.ant-checkbox-wrapper span + span) {


### PR DESCRIPTION
### Reason for change
The selected choice in the 'view all' page was not readable in light mode due to black checkmark on a blue background. This issue appears to have been introduced with the dark mode implementation. The fix ensures that the selected checkbox remains visible in both light and dark modes by adapting the disabled state styling of the `ant-checkbox` component.

### Screenshots
**Before:**
<img width="272" alt="image" src="https://github.com/user-attachments/assets/f904c358-2c52-4821-bf60-1b207bb0f6c5" />

**After:**
<img width="288" alt="image" src="https://github.com/user-attachments/assets/e95ac01c-4ccf-4f43-b2e2-1552d1da67fc" />

### Testing
1. Navigate to https://develop.appx.humansignal.com/ and log in with an admin account.
2. Create a new project using the 'Image Classification' label configuration.
3. Import tasks using the provided JSON file: https://data.heartex.net/q/c41eb19145.json
4. Open Quick View for any task.
5. Select one of the choices in the annotation interface.
6. Submit the annotation.
7. Click the 'View all' button.
8. **Verify in Light Mode:** Confirm that the selected checkbox is displayed with white text on a blue background.
9. Switch to Dark Mode (if applicable in the environment).
10. **Verify in Dark Mode:** Confirm that the selected checkbox is still clearly visible (it should retain a readable contrast, similar to the original dark mode styling).

### Reviewer notes
- Please verify the fix in both Light and Dark mode themes to ensure readability.
- Ensure that the change does not negatively impact the appearance or functionality of the checkbox in other contexts.

### General notes
The fix targets the styling of the disabled state of the `ant-checkbox` component to ensure consistent visibility across different themes.