### PR TITLE
chore: Add CODEOWNERS for `editor`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,4 @@ docker-compose*   @HumanSignal/devops
 docs/.npmignore   @hlomzik @Gondragos @nicholasrq
 docs/package.json @hlomzik @Gondragos @nicholasrq
 docs/yarn.lock    @hlomzik @Gondragos @nicholasrq
+web/libs/editor   @hlomzik @Gondragos @nicholasrq

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 deploy/           @HumanSignal/devops
 Dockerfile*       @HumanSignal/devops
 docker-compose*   @HumanSignal/devops
-docs/.npmignore   @hlomzik @Gondragos @nicholasrq
-docs/package.json @hlomzik @Gondragos @nicholasrq
-docs/yarn.lock    @hlomzik @Gondragos @nicholasrq
-web/libs/editor   @hlomzik @Gondragos @nicholasrq
+docs/.npmignore   @hlomzik @Gondragos @nick-skriabin
+docs/package.json @hlomzik @Gondragos @nick-skriabin
+docs/yarn.lock    @hlomzik @Gondragos @nick-skriabin
+web/libs/editor   @hlomzik @Gondragos @nick-skriabin


### PR DESCRIPTION
Code owners have been designated based on their foundational knowledge, depth of involvement and the extent of contributions made in that area of the codebase.
