### PR TITLE
chore: FIT-12: Datamanager App.jsx to App.tsx

### DIFF
--- a/web/libs/datamanager/src/components/App/App.tsx
+++ b/web/libs/datamanager/src/components/App/App.tsx
@@ -8,28 +8,47 @@ import { DataManager } from "../DataManager/DataManager";
 import { Labeling } from "../Label/Label";
 import "./App.scss";
 
-class ErrorBoundary extends React.Component {
-  state = {
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = {
     error: null,
   };
 
-  componentDidCatch(error) {
+  componentDidCatch(error: Error): void {
     this.setState({ error });
   }
 
-  render() {
-    return this.state.error ? <div className="error">{this.state.error}</div> : this.props.children;
+  render(): React.ReactNode {
+    return this.state.error ? <div className="error">{this.state.error.toString()}</div> : this.props.children;
   }
+}
+
+interface AppComponentProps {
+  app: {
+    SDK: {
+      mode: string;
+    };
+    crashed: boolean;
+    loading: boolean;
+    isLabeling: boolean;
+  };
 }
 
 /**
  * Main Component
- * @param {{app: import("../../stores/AppStore").AppStore} param0
  */
-const AppComponent = ({ app }) => {
+const AppComponent: React.FC<AppComponentProps> = ({ app }) => {
   const rootCN = cn("root");
   const rootClassName = rootCN.mod({ mode: app.SDK.mode }).toString();
   const crashCN = cn("crash");
+
   return (
     <ErrorBoundary>
       <Provider store={app}>


### PR DESCRIPTION
This pull request refactors the `App` component in `web/libs/datamanager/src/components/App/App.tsx` (renamed from `App.jsx`) by migrating the codebase to TypeScript. The key changes include adding TypeScript interfaces, updating the `ErrorBoundary` class for type safety, and defining props for the `AppComponent`.

### TypeScript Migration:

* Converted the file from `.jsx` to `.tsx` and updated imports accordingly.
* Added `ErrorBoundaryProps` and `ErrorBoundaryState` interfaces to define the types for props and state in the `ErrorBoundary` class. Updated the `componentDidCatch` and `render` methods to include proper TypeScript return types.
* Defined a new `AppComponentProps` interface to type-check the `app` prop in the `AppComponent`. Updated the `AppComponent` to use `React.FC` with the defined props interface.