### PR TITLE
chore: FIT-30: Multi select selected options shouldn't be highlighted along with having the checkboxes

### DIFF
--- a/web/libs/ui/src/lib/select/select.tsx
+++ b/web/libs/ui/src/lib/select/select.tsx
@@ -458,7 +458,7 @@ const Option = ({
             "hover:data-[disabled=true]:cursor-not-allowed",
             "duration-150 ease-out",
           ],
-          (!multiple && isOptionSelected) && ["bg-primary-emphasis"],
+          !multiple && isOptionSelected && ["bg-primary-emphasis"],
         )}
         data-disabled={disabled}
       >

--- a/web/libs/ui/src/lib/select/select.tsx
+++ b/web/libs/ui/src/lib/select/select.tsx
@@ -458,7 +458,7 @@ const Option = ({
             "hover:data-[disabled=true]:cursor-not-allowed",
             "duration-150 ease-out",
           ],
-          isOptionSelected && ["bg-primary-emphasis"],
+          (!multiple && isOptionSelected) && ["bg-primary-emphasis"],
         )}
         data-disabled={disabled}
       >


### PR DESCRIPTION
This pull request includes a small but important change to the `Option` component in `web/libs/ui/src/lib/select/select.tsx`. The change ensures that the `bg-primary-emphasis` class is applied only when the `isOptionSelected` condition is true and the `multiple` prop is false.

before:
![image (32)](https://github.com/user-attachments/assets/530d93b3-615d-4027-8507-5669bfe807d6)

after:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/8f3e9db6-d7c9-493e-87b3-b31dc5a88c35" />
