### PR TITLE
fix: FIT-35: LSO: Annotated by column user pic is always faded

### DIFF
--- a/web/libs/datamanager/src/components/CellViews/Annotators/Annotators.jsx
+++ b/web/libs/datamanager/src/components/CellViews/Annotators/Annotators.jsx
@@ -18,6 +18,7 @@ export const Annotators = (cell) => {
   const extra = userList.length - renderable.length;
   const userPickBadge = cn("userpic-badge");
   const annotatorsCN = cn("annotators");
+  const isEnterprise = window.APP_SETTINGS.billing?.enterprise;
 
   return (
     <div className={annotatorsCN.toString()}>
@@ -26,7 +27,7 @@ export const Annotators = (cell) => {
         const { annotated, reviewed, review } = item;
 
         const userpicIsFaded =
-          (isDefined(annotated) && annotated === false) || (isDefined(reviewed) && reviewed === false);
+          (isDefined(annotated) && annotated === false) || (isDefined(reviewed) && reviewed === false && isEnterprise);
         const suppressStats = column.alias === "comment_authors";
 
         return (


### PR DESCRIPTION
This pull request updates the `Annotators` component in `Annotators.jsx` to introduce conditional behavior based on whether the application is running in an enterprise environment. The most important changes involve adding a new `isEnterprise` variable and modifying the logic for determining when user pictures should be faded.

### Updates to `Annotators` component:

* Introduced a new `isEnterprise` variable to check if the application is operating in an enterprise environment by accessing `window.APP_SETTINGS.billing?.enterprise`.
* Adjusted the `userpicIsFaded` logic to only fade user pictures for unreviewed items if the application is in an enterprise environment.