### PR TITLE
fix: OPTIC-2146: PerRegion TextArea input is barely visible in dark mode

### DIFF
--- a/web/libs/editor/src/tags/control/TextArea/TextArea.scss
+++ b/web/libs/editor/src/tags/control/TextArea/TextArea.scss
@@ -77,8 +77,19 @@
     padding: 8px;
     box-sizing: border-box;
     border-radius: 4px;
-    border: 1px solid transparent;
+    border: 1px solid var(--color-neutral-border);
     background-color: var(--color-neutral-surface);
+    color: var(--color-neutral-content);
+
+
+    &:hover {
+      border: 1px solid var(--color-neutral-border-bold);
+      background-color: var(--color-neutral-surface-hover);
+    }
+
+    &:focus {
+      background-color: var(--color-neutral-surface);
+    }
 
     &::placeholder {
       color: var(--color-neutral-content-subtler);
@@ -88,7 +99,8 @@
   &_outliner &__input:focus {
     background-color: var(--color-neutral-background);
     box-sizing: border-box;
-    border-color: var(--color-neutral-border);
-    box-shadow: 0 0 0 3px var(--color-neutral-border);
+    border-color: var(--color-neutral-border-bold);
+    background-color: var(--color-neutral-surface-hover);
+    box-shadow: 0 0 0 4px var(--color-primary-focus-outline);
   }
 }

--- a/web/libs/editor/src/tags/control/TextArea/TextArea.scss
+++ b/web/libs/editor/src/tags/control/TextArea/TextArea.scss
@@ -97,7 +97,6 @@
   }
 
   &_outliner &__input:focus {
-    background-color: var(--color-neutral-background);
     box-sizing: border-box;
     border-color: var(--color-neutral-border-bold);
     background-color: var(--color-neutral-surface-hover);

--- a/web/libs/editor/src/tags/control/TextArea/TextArea.scss
+++ b/web/libs/editor/src/tags/control/TextArea/TextArea.scss
@@ -87,10 +87,6 @@
       background-color: var(--color-neutral-surface-hover);
     }
 
-    &:focus {
-      background-color: var(--color-neutral-surface);
-    }
-
     &::placeholder {
       color: var(--color-neutral-content-subtler);
     }


### PR DESCRIPTION
### Reason for change
The text entered into the perRegion TextArea input field was barely visible when the application was in Dark Mode. This was due to the text color not having sufficient contrast against the background color of the textarea. The fix involves updating the CSS for the textarea input in Dark Mode to ensure the text is clearly visible. Specifically, the text color is now explicitly set to a color that provides better contrast against the dark background.

Other improvements were made to ensure the default, hover and focus states of the TextArea input match the overall look and feel of the application (border-color, focus outline, etc).

### Screenshots
**Before:**
<img width="989" alt="image" src="https://github.com/user-attachments/assets/2f0c5b5a-3259-4522-9d23-60c52543e10f" />

**After:**
<img width="845" alt="image" src="https://github.com/user-attachments/assets/7ba72796-12a3-41b1-83ec-1b52bde5ce44" />

### Rollout strategy
No specific rollout strategy is required for this change as it is a small visual fix. 

### Testing
The following steps were performed to verify the fix (data provided didn't work for Quick View):
1. Logged in as OWNER to LSE.
2. Navigated to a project using the Optical Character Recognition template.
3. Opened the Labeling configuration and toggled Advanced Mode ON.
4. Added a region.
5. Selected the region and entered text into the TextArea under the corresponding region.
6. Confirmed that the entered text is now clearly visible against the dark background of the TextArea.

### Risks
The risk associated with this change is minimal as it only involves a CSS modification to improve text visibility. There are no anticipated functional regressions.

### Reviewer notes
Please verify that the CSS changes in `web/libs/editor/src/tags/control/TextArea/TextArea.scss` correctly address the contrast issue in Dark Mode and do not introduce any unintended visual side effects in other themes or parts of the application.