### PR TITLE
fix: OPTIC-2145: Audio tracker line is not visible in dark mode

### DIFF
--- a/web/libs/editor/src/lib/AudioUltra/Cursor/Cursor.ts
+++ b/web/libs/editor/src/lib/AudioUltra/Cursor/Cursor.ts
@@ -58,7 +58,7 @@ export class Cursor extends Events<CursorEvents> {
   private focusId = "";
 
   id = "cursor";
-  color = rgba("rgba(65, 60, 74, 0.16)");
+  color = "var(--color-neutral-border)";
   x: number;
   y: number;
   offsetX = 0;


### PR DESCRIPTION
### Reason for change
The audio tracker line in the Quick View is not visible when Dark Mode is enabled, making it difficult for users to navigate the audio data. This change updates the color of the tracker line to use a theme-aware variable, ensuring it is visible in both Light and Dark Modes.

### Screenshots
Before:
<img width="456" alt="image" src="https://github.com/user-attachments/assets/4f1e6185-a3ba-408d-9088-2c42d48762d4" />
<img width="329" alt="image" src="https://github.com/user-attachments/assets/8f9d836d-551d-4b92-8cfc-f0bc1bb98c73" />


After:
<img width="473" alt="image" src="https://github.com/user-attachments/assets/a0228f1d-4bba-4d82-8ee3-e06216e0dbe2" />
<img width="525" alt="image" src="https://github.com/user-attachments/assets/eca4b8df-6b6f-4bde-a524-da80bb7eef92" />


### Rollout strategy
This is a small visual change and does not require a specific rollout strategy.

### Testing
1. Set the application theme to Dark Mode.
2. Open an audio project and navigate to the Data Manager page.
3. Click on a task to open it in Quick View.
4. Hover over the waveform area to display the audio tracker under the cursor.
5. Verify that the audio tracker line is clearly visible.
6. Set the application theme to Light Mode. 
7. Refresh the page to reload the audio player's styles.
8. Repeat steps 2-5 and confirm the audio tracker line is still visible.

### Risks
There are no anticipated risks associated with this minor visual correction.

### Reviewer notes
Please verify that the color variable `var(--color-neutral-border)` ensures sufficient contrast for the audio tracker line to be visible in both Light and Dark Mode themes.

### General notes
The fix involves changing a hardcoded color value to a CSS variable that adapts to the current theme.