### PR TITLE
feat: UTC-1: Using less expensive MD5 password hasher for tests

### DIFF
--- a/label_studio/tests/conftest.py
+++ b/label_studio/tests/conftest.py
@@ -51,7 +51,7 @@ from .utils import (
 boto3.set_stream_logger('botocore.credentials', logging.DEBUG)
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(autouse=True)
 def set_test_password_hasher(settings):
     """
     Set the password hasher to less expensive MD5 for testing purposes.
@@ -69,7 +69,7 @@ def label_stream_history_limit(settings):
     settings.LABEL_STREAM_HISTORY_LIMIT = 1
 
 
-@pytest.fixture(autouse=True, scope='session')
+@pytest.fixture(autouse=True)
 def disable_sentry(settings):
     settings.SENTRY_RATE = 0
     settings.SENTRY_DSN = None

--- a/label_studio/tests/conftest.py
+++ b/label_studio/tests/conftest.py
@@ -51,18 +51,26 @@ from .utils import (
 boto3.set_stream_logger('botocore.credentials', logging.DEBUG)
 
 
+@pytest.fixture(scope='session', autouse=True)
+def set_test_password_hasher(settings):
+    """
+    Set the password hasher to less expensive MD5 for testing purposes.
+    """
+    settings.PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher']
+
+
 @pytest.fixture(autouse=False)
-def enable_csrf():
+def enable_csrf(settings):
     settings.USE_ENFORCE_CSRF_CHECKS = True
 
 
 @pytest.fixture(autouse=False)
-def label_stream_history_limit():
+def label_stream_history_limit(settings):
     settings.LABEL_STREAM_HISTORY_LIMIT = 1
 
 
-@pytest.fixture(autouse=True)
-def disable_sentry():
+@pytest.fixture(autouse=True, scope='session')
+def disable_sentry(settings):
     settings.SENTRY_RATE = 0
     settings.SENTRY_DSN = None
 
@@ -88,7 +96,7 @@ def aws_credentials():
     os.environ['AWS_SESSION_TOKEN'] = 'testing'
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope='session')
 def azure_credentials():
     """Mocked Azure credentials"""
     os.environ['AZURE_BLOB_ACCOUNT_NAME'] = 'testing'
@@ -680,7 +688,7 @@ def async_import_off():
         yield
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope='session')
 def set_feature_flag_envvar():
     """
     Automatically set the environment variable for all tests, including Tavern tests.


### PR DESCRIPTION
<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->

MD5 Password Hasher is less expensive than Django's default one, this PR overrides the default one with MD5 for tests.