### PR TITLE
chore: Update the base tailwind config to only target src directories of main libraries

### DIFF
--- a/web/libs/ui/src/tailwind.config.js
+++ b/web/libs/ui/src/tailwind.config.js
@@ -4,11 +4,11 @@ import tokens from "./tokens/tokens";
 module.exports = {
   content: [
     "./apps/**/*.{js,jsx,ts,tsx}",
-    "./libs/app-common/**/*.{js,jsx,ts,tsx}",
-    "./libs/core/**/*.{js,jsx,ts,tsx}",
-    "./libs/editor/**/*.{js,jsx,ts,tsx}",
-    "./libs/datamanager/**/*.{js,jsx,ts,tsx}",
-    "./libs/ui/**/*.{js,jsx,ts,tsx}",
+    "./libs/app-common/src/**/*.{js,jsx,ts,tsx}",
+    "./libs/core/src/**/*.{js,jsx,ts,tsx}",
+    "./libs/editor/src/**/*.{js,jsx,ts,tsx}",
+    "./libs/datamanager/src/**/*.{js,jsx,ts,tsx}",
+    "./libs/ui/src/**/*.{js,jsx,ts,tsx}",
     "./libs/storybook/**/*.{js,jsx,ts,tsx}",
   ],
   theme: {


### PR DESCRIPTION
The CI started to take longer and was timing out due to what I believe is a match on a lot of files for Tailwind. In editor for example, there are tests with dependencies for both cypress and codecept in node_modules living within the tests subdirectory, which likely is what was causing this to take too long.