### PR TITLE
docs: Add note about Academic on-prem restriction

### DIFF
--- a/docs/source/guide/install_enterprise_docker.md
+++ b/docs/source/guide/install_enterprise_docker.md
@@ -19,6 +19,9 @@ See [Secure Label Studio](security.html) for more details about security and har
 
 To install Label Studio Community Edition, see [Install Label Studio](https://labelstud.io/guide/install). This page is specific to the Enterprise version of Label Studio.
 
+!!! note
+    On-prem Label Studio Enterprise is not supported for Academic licenses. 
+
 {% insertmd includes/deploy.md %}
 
 ## Install Label Studio Enterprise using Docker

--- a/docs/source/guide/install_enterprise_docker.md
+++ b/docs/source/guide/install_enterprise_docker.md
@@ -20,7 +20,7 @@ See [Secure Label Studio](security.html) for more details about security and har
 To install Label Studio Community Edition, see [Install Label Studio](https://labelstud.io/guide/install). This page is specific to the Enterprise version of Label Studio.
 
 !!! note
-    On-prem Label Studio Enterprise is not supported for Academic licenses. 
+    On-prem deployments of Label Studio Enterprise are not supported for Academic licenses.  
 
 {% insertmd includes/deploy.md %}
 

--- a/docs/source/guide/install_enterprise_k8s.md
+++ b/docs/source/guide/install_enterprise_k8s.md
@@ -24,7 +24,7 @@ Your Kubernetes cluster can be self-hosted or installed somewhere such as Amazon
 </div>
 
 !!! note
-    On-prem Label Studio Enterprise is not supported for Academic licenses.  
+    On-prem deployments of Label Studio Enterprise are not supported for Academic licenses. 
 
 This high-level architecture diagram that outlines the main components of a Label Studio Enterprise deployment.
 

--- a/docs/source/guide/install_enterprise_k8s.md
+++ b/docs/source/guide/install_enterprise_k8s.md
@@ -23,6 +23,9 @@ Your Kubernetes cluster can be self-hosted or installed somewhere such as Amazon
 
 </div>
 
+!!! note
+    On-prem Label Studio Enterprise is not supported for Academic licenses.  
+
 This high-level architecture diagram that outlines the main components of a Label Studio Enterprise deployment.
 
 <img src="/images/LSE_k8s_scheme.png"/>


### PR DESCRIPTION
Adding a couple notes clarifying that Academic licenses are not available for on-prem installs