### PR TITLE
docs: fix spacing in tags in case it’s an array

### DIFF
--- a/docs/themes/v2/layout/templates.ejs
+++ b/docs/themes/v2/layout/templates.ejs
@@ -4,10 +4,11 @@
 
 <div class="templates-grid">
   <% page.cards.forEach(function(card) { %>
+    <% const tags = typeof card.categories === "object" ? card.categories.join(", ") : card.categories %>
     <div class="templates-card">
       <img src="<%= card.image %>" alt="" />
       <a href="<%= card.url %>"><%- partial("component/heading", {text: card.title, size: "XXSmall", tag: "span" }) %></a>
-      <%- partial("component/text", {text: card.categories, tag: "p", size: "Small"}) %>
+      <%- partial("component/text", {text: tags, tag: "p", size: "Small"}) %>
     </div>
   <% }); %>
 </div>


### PR DESCRIPTION
Currently, the categories and written in two differents ways:

As an array:
```
categories:
  - "A"
  - "B"
  - "C"
```

and as a string:
```
categories: a, b, c
```

This commit makes sure we account for both cases

### Testing

https://deploy-preview-7568--label-studio-docs-new-theme.netlify.app/templates/
https://deploy-preview-7568--heartex-docs.netlify.app/plugins/

