### PR TITLE
docs: ROOT-9: Allow reading multiple tasks from a JSON file in source cloud storage

### DIFF
--- a/docs/source/guide/storage.md
+++ b/docs/source/guide/storage.md
@@ -77,18 +77,9 @@ When disabled, tasks in JSON format can be loaded directly from storage buckets 
 
 <img src="/images/source-storages-treat-off.png" class="make-intense-zoom">
 
-###### On
+You may put multiple tasks inside the same JSON file, but not mix task formats inside the same file.
 
-When enabled, Label Studio automatically lists files from the storage bucket and constructs tasks. This is only possible for simple labeling tasks that involve a single media source (such as an image, text, etc.).* 
-
-<img src="/images/source-storages-treat-on.png" class="make-intense-zoom">
-
-
-#### One Task - One JSON File 
-
-If you plan to load JSON tasks from the Source Storage (`Treat every bucket object as a source file = No`), you must place only one task as the **dict** per one JSON file. Otherwise, Label Studio will not load your data properly.
-
-{% details <b>Example with tasks in separate JSON files</b> %}
+{% details <b>Example with bare tasks</b> %}
 
 
 `task_01.json`
@@ -107,11 +98,27 @@ If you plan to load JSON tasks from the Source Storage (`Treat every bucket obje
 }
 ```
 
+Or:
+
+`tasks.json`
+```
+[
+  {
+    "image": "s3://bucket/1.jpg",
+    "text": "opossums are awesome"
+  },
+  {
+    "image": "s3://bucket/2.jpg",
+    "text": "cats are awesome"
+  }
+]
+```
+
 {% enddetails %}
 
 <br>
 
-{% details <b>Example with tasks, annotations and predictions in separate JSON files</b> %}
+{% details <b>Example with tasks, annotations and predictions</b> %}
 
 `task_with_predictions_and_annotations_01.json`
 ```
@@ -137,28 +144,39 @@ If you plan to load JSON tasks from the Source Storage (`Treat every bucket obje
 }
 ```
 
+Or:
+
+`tasks_with_predictions_and_annotations.json`
+```
+[
+  {
+      "data": {
+          "image": "s3://bucket/1.jpg",
+          "text": "opossums are awesome"
+      },
+      "annotations": [...],  
+      "predictions": [...]
+  },
+  {
+      "data": {
+        "image": "s3://bucket/2.jpg",
+        "text": "cats are awesome"
+      }
+      "annotations": [...],  
+      "predictions": [...]
+  }
+]
+```
+
 {% enddetails %}
 
 <br>
 
-{% details <b>Python script to split a single JSON file with multiple tasks</b> %}
+###### On
 
- Python script to split a single JSON file containing multiple tasks into separate JSON files, each containing one task:
+When enabled, Label Studio automatically lists files from the storage bucket and constructs tasks. This is only possible for simple labeling tasks that involve a single media source (such as an image, text, etc.).* 
 
-```python
-import sys
-import json
-
-input_json = sys.argv[1]
-with open(input_json) as inp:
-    tasks = json.load(inp)
-
-for i, v in enumerate(tasks):
-    with open(f'task_{i}.json', 'w') as f:
-        json.dump(v, f)
-```
-
-{% enddetails %}
+<img src="/images/source-storages-treat-on.png" class="make-intense-zoom">
 
 
 ### Target storage

--- a/docs/source/guide/tasks.md
+++ b/docs/source/guide/tasks.md
@@ -343,7 +343,6 @@ You can then import text tasks to label that match the following JSON format:
   }]
 }]
 ```
-If you're placing JSON files in [cloud storage](storage.html), place 1 task in each JSON file in the storage bucket. If you want to upload a JSON file from your machine directly into Label Studio, you can place multiple tasks in one JSON file and import it using Label Studio GUI (Data Manager => Import button). 
 
 #### Example JSON with multiple tasks
 You can place multiple tasks in one JSON file if you're uploading the JSON file using Label Studio Import Dialog only (Data Manager => Import button), or when importing from [cloud storage](storage.html). When using cloud storage, you must ensure every task in the file is formatted the same way. 

--- a/docs/source/guide/tasks.md
+++ b/docs/source/guide/tasks.md
@@ -346,7 +346,7 @@ You can then import text tasks to label that match the following JSON format:
 If you're placing JSON files in [cloud storage](storage.html), place 1 task in each JSON file in the storage bucket. If you want to upload a JSON file from your machine directly into Label Studio, you can place multiple tasks in one JSON file and import it using Label Studio GUI (Data Manager => Import button). 
 
 #### Example JSON with multiple tasks
-You can place multiple tasks in one JSON file if you're uploading the JSON file using Label Studio Import Dialog only (Data Manager => Import button). 
+You can place multiple tasks in one JSON file if you're uploading the JSON file using Label Studio Import Dialog only (Data Manager => Import button), or when importing from [cloud storage](storage.html). When using cloud storage, you must ensure every task in the file is formatted the same way. 
 
 <br/>
 {% details <b>To place multiple tasks in one JSON file, use this JSON format example</b> %}
@@ -373,6 +373,22 @@ The "data" parameter must contain the "my_text" field defined in the text labeli
       "data":{
          "my_text":"Opossums like to forage for food."
       }
+   }
+]
+{% endcodeblock %}
+
+You can also use the bare contents of the "data" field without nesting, as long as you have no annotations or predictions.
+
+{% codeblock lang:json %}
+[
+   {
+      "my_text":"Opossums like to be aloft in trees."
+   },
+   {
+      "my_text":"Opossums are opportunistic."
+   },
+   {
+      "my_text":"Opossums like to forage for food."
    }
 ]
 {% endcodeblock %}

--- a/docs/source/guide/troubleshooting.md
+++ b/docs/source/guide/troubleshooting.md
@@ -190,7 +190,7 @@ If there is only LIST permission, Label Studio can scan the bucket for the exist
 ### Tasks don't load the way I expect
 
 If the tasks sync to Label Studio but don't appear the way that you expect, maybe with URLs instead of images or with one task where you expect to see many, check the following:
-- If you're placing JSON files in [cloud storage](storage.html), place 1 task in each JSON file in the storage bucket. If you want to upload a JSON file from local storage into Label Studio, you can place multiple tasks in one JSON file. 
+- If you're placing JSON files in [cloud storage](storage.html), ensure that if you have multiple tasks in the same file, they are all formatted the same way (for example, you cannot have 1 task with the raw contents of the `data` field and another task that contains annotations and predictions in the same file).
 - If you're syncing image or audio files, make sure **Treat every bucket object as a source file** is enabled. 
 
 ### Unable to access local storage when using Windows


### PR DESCRIPTION
update docs

Note: the ability to drop the `data` key in tasks with no annots or preds already existed, just wanted to make it more clear.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
