### PR TITLE
fix: FIT-145: Taxonomy items not visible dark mode using arrow keys

### DIFF
--- a/web/libs/editor/src/tags/control/Taxonomy/Taxonomy.scss
+++ b/web/libs/editor/src/tags/control/Taxonomy/Taxonomy.scss
@@ -49,8 +49,8 @@ body :global(.ant-select-tree) {
   color: var(--color-neutral-content);
 }
 
-body :global(.ant-select-tree .ant-select-tree-node-content-wrapper:hover) {
-  background-color: var(--color-primary-emphasis-subtle) !important;
+body :global(.ant-select-tree .ant-select-tree-treenode .ant-select-tree-node-content-wrapper:hover) {
+  background-color: var(--color-primary-emphasis-subtle);
   color: var(--color-neutral-content);
 }
 

--- a/web/libs/editor/src/tags/control/Taxonomy/Taxonomy.scss
+++ b/web/libs/editor/src/tags/control/Taxonomy/Taxonomy.scss
@@ -50,7 +50,13 @@ body :global(.ant-select-tree) {
 }
 
 body :global(.ant-select-tree .ant-select-tree-node-content-wrapper:hover) {
-  background-color: var(--color-primary-emphasis-subtle);
+  background-color: var(--color-primary-emphasis-subtle) !important;
+  color: var(--color-neutral-content);
+}
+
+
+body :global(.ant-select-tree .ant-select-tree-treenode.ant-select-tree-treenode-active .ant-select-tree-node-content-wrapper) {
+  background: var(--color-primary-emphasis-subtle);
   color: var(--color-neutral-content);
 }
 
@@ -81,4 +87,8 @@ body :global(.ant-select-multiple .ant-select-selection-item-remove) {
 
 body :global(.ant-select-arrow) {
   color: var(--color-neutral-icon);
+}
+
+body :global(.ant-empty-description) {
+  color: var(--color-neutral-content-subtler);
 }


### PR DESCRIPTION
### Reason for change

This PR addresses an issue where taxonomy items were not visible in Dark mode when navigating the taxonomy tree using arrow key hotkeys. 

The changes primarily involve updates to `Taxonomy.scss` to improve the visual feedback for active and hovered items:

* **Hovered Node Selector Updated:** The CSS selector for hovered tree nodes was made more specific by adding `.ant-select-tree-treenode`, ensuring only the node wrappers inside tree nodes are targeted.
* **Active Node Styling Added:** New styles were introduced for active tree nodes (`.ant-select-tree-treenode-active`), setting a distinct background color and text color to properly highlight the active node.
* **Empty Description Styling Added:** A new style was added for `.ant-empty-description`, setting its color to a subtler neutral content color for consistency.

These modifications ensure that the active taxonomy item is clearly visible in Dark mode, resolving the reported accessibility and usability issue.

### Screenshots

Before:
<img width="275" alt="image" src="https://github.com/user-attachments/assets/9a421b22-811d-4e3c-91c0-eab59fd6c821" />
<img width="252" alt="image" src="https://github.com/user-attachments/assets/f7efd8f4-22a1-4161-a7e7-0fb603211059" />
<img width="261" alt="image" src="https://github.com/user-attachments/assets/491f2ece-ecd3-4e98-b1d6-3753069d1085" />
<img width="259" alt="image" src="https://github.com/user-attachments/assets/186dcfdf-cef8-4028-9cad-99bc6b15eb28" />


After:
<img width="309" alt="image" src="https://github.com/user-attachments/assets/37271c76-6986-419b-96c8-d8595b9a1ca5" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/aee0cef7-a615-4368-8f94-2113fb38f264" />
<img width="302" alt="image" src="https://github.com/user-attachments/assets/2ee367ae-99c3-44c6-9f58-a2aa43bd4b4c" />
<img width="288" alt="image" src="https://github.com/user-attachments/assets/71dc85ab-9094-4677-8415-f895998a7fa4" />


### Rollout strategy

This change does not require a specific rollout strategy beyond a standard deployment. It's a CSS fix that directly addresses a visual bug and does not introduce any new features or breaking changes.

### Testing

The fix has been verified by following the steps to reproduce the original bug:

1.  Log in as OWNER to LSE in Dark mode.
2.  Create a project and import some data.
3.  Open any task in Quick View.
4.  Click on the Taxonomy dropdown.
5.  Navigate through the taxonomy tree using the Arrow down keyboard button.
6. Also, make a search for an element that does not exist to see the empty state.
7. Switch to Light mode and go through steps 4-6.

### Risks

No significant risks are anticipated with this change. It is a targeted CSS adjustment and does not impact core functionality, security, or performance.

### Reviewer notes

Please pay attention to the changes in `Taxonomy.scss`, specifically the new styles for `.ant-select-tree-treenode-active` and the more specific selector for hovered nodes. Ensure the visual changes align with expectations for Dark mode visibility.

### General notes

This PR directly addresses the reported bug and improves the user experience for users navigating taxonomy trees in Dark mode. The changes are confined to styling and do not alter any underlying logic.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
