### PR TITLE
chore: FIT-14: Ensure production deployment of playground is resolvable as a subpath redirect

### DIFF
--- a/web/apps/playground/project.json
+++ b/web/apps/playground/project.json
@@ -10,7 +10,7 @@
       "defaultConfiguration": "production",
       "options": {
         "compiler": "babel",
-        "outputPath": "dist/apps/playground",
+        "outputPath": "dist/apps/playground/playground-assets",
         "index": "apps/playground/src/index.html",
         "baseHref": "/",
         "main": "apps/playground/src/main.tsx",
@@ -26,7 +26,8 @@
           "extractLicenses": false,
           "optimization": false,
           "sourceMap": true,
-          "vendorChunk": true
+          "vendorChunk": true,
+          "baseHref": "/"
         },
         "production": {
           "fileReplacements": [
@@ -39,7 +40,8 @@
           "sourceMap": false,
           "namedChunks": false,
           "extractLicenses": true,
-          "vendorChunk": false
+          "vendorChunk": false,
+          "baseHref": "/playground-assets/"
         }
       }
     },

--- a/web/package.json
+++ b/web/package.json
@@ -37,8 +37,8 @@
     "extract-antd-no-reset": "nx extract-antd-no-reset editor",
     "storybook:serve": "nx storybook storybook",
     "storybook:build": "nx build-storybook storybook",
-    "playground:serve": "FRONTEND_HOSTNAME=http://localhost:4200 MODE=standalone nx run playground:serve:development",
-    "playground:build": "NODE_ENV=production MODE=standalone nx run playground:build:production"
+    "playground:serve": "FRONTEND_HOSTNAME=http://localhost:4200 MODE=standalone-playground nx run playground:serve:development",
+    "playground:build": "NODE_ENV=production MODE=standalone-playground nx run playground:build:production && mv dist/apps/playground/playground-assets/index.html dist/apps/playground/index.html"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This pull request introduces updates to the `playground` application to adjust its output structure, enhance environment-specific configurations, and improve the Webpack build process. The key changes include modifying the output paths and base hrefs, updating environment variables for standalone modes, and refining Webpack's configuration logic to support the new setup.

### Changes to output structure and base hrefs:
* Updated the `outputPath` in `web/apps/playground/project.json` to include a `playground-assets` subdirectory, and added specific `baseHref` values for development (`"/"`) and production (`"/playground-assets/"`) environments. [[1]](diffhunk://#diff-40d15ca50c4943c2be44b0a86cf843695b0f8e3588fda381dda39eba88f51d91L13-R13) [[2]](diffhunk://#diff-40d15ca50c4943c2be44b0a86cf843695b0f8e3588fda381dda39eba88f51d91L29-R30) [[3]](diffhunk://#diff-40d15ca50c4943c2be44b0a86cf843695b0f8e3588fda381dda39eba88f51d91L42-R44)

### Updates to environment variables and scripts:
* Changed the `MODE` environment variable in `web/package.json` scripts from `"standalone"` to `"standalone-playground"`, and added a post-build step to move the `index.html` file to the correct directory.

### Refinements to Webpack configuration:
* Modified Webpack's `optimizer` and `entry` logic to use `process.env.MODE.startsWith("standalone")` instead of strict equality checks, ensuring compatibility with the new `standalone-playground` mode. [[1]](diffhunk://#diff-1ace8d4ea714744aae05de2cab449346ded75cf8646e36fcd8eb5d1cd66f4d03L68-R68) [[2]](diffhunk://#diff-1ace8d4ea714744aae05de2cab449346ded75cf8646e36fcd8eb5d1cd66f4d03L87-R87)
* Adjusted the `publicPath` in Webpack's output configuration to dynamically set the path based on whether the mode is `standalone-playground`.
* Updated the `devServer` configuration in Webpack to handle standalone modes using a more flexible condition.