### PR TITLE
chore: FIT-14: Fix webpack build for standalone apps

### DIFF
--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -65,7 +65,7 @@ const optimizer = () => {
     result.minimizer = undefined;
   }
 
-  if (process.env.MODE.startsWith("standalone")) {
+  if (process.env.MODE?.startsWith("standalone")) {
     result.runtimeChunk = false;
     result.splitChunks = { cacheGroups: { default: false } };
   }
@@ -84,7 +84,7 @@ module.exports = composePlugins(
   withReact({ svgr: true }),
   (config) => {
     // LS entrypoint
-    if (!process.env.MODE.startsWith("standalone")) {
+    if (!process.env.MODE?.startsWith("standalone")) {
       config.entry = {
         main: {
           import: path.resolve(__dirname, "apps/labelstudio/src/main.tsx"),
@@ -270,7 +270,7 @@ module.exports = composePlugins(
       mode,
       plugins,
       optimization: optimizer(),
-      devServer: process.env.MODE.startsWith("standalone")
+      devServer: process.env.MODE?.startsWith("standalone")
         ? {}
         : {
             // Port for the Webpack dev server


### PR DESCRIPTION
This pull request updates the `webpack.config.js` file to handle cases where the `MODE` environment variable might be undefined. The changes ensure safer access to `process.env.MODE` by using optional chaining (`?.`).

### Improvements to environment variable handling:

* Updated the condition in the `optimizer` function to use `process.env.MODE?.startsWith("standalone")`, preventing potential runtime errors if `MODE` is undefined. (`[web/webpack.config.jsL68-R68](diffhunk://#diff-1ace8d4ea714744aae05de2cab449346ded75cf8646e36fcd8eb5d1cd66f4d03L68-R68)`)
* Modified the entry point configuration in the `composePlugins` section to safely check if `process.env.MODE` starts with "standalone" using optional chaining. (`[web/webpack.config.jsL87-R87](diffhunk://#diff-1ace8d4ea714744aae05de2cab449346ded75cf8646e36fcd8eb5d1cd66f4d03L87-R87)`)
* Adjusted the `devServer` configuration to use optional chaining for the `process.env.MODE.startsWith("standalone")` condition, ensuring robust handling of undefined values. (`[web/webpack.config.jsL273-R273](diffhunk://#diff-1ace8d4ea714744aae05de2cab449346ded75cf8646e36fcd8eb5d1cd66f4d03L273-R273)`)