### PR TITLE
fix: FIT-14: Playground preview panel should not be fullscreen

### DIFF
--- a/web/apps/playground/src/components/PreviewPanel/PreviewPanel.tsx
+++ b/web/apps/playground/src/components/PreviewPanel/PreviewPanel.tsx
@@ -79,6 +79,7 @@ export const PreviewPanel: FC<PreviewPanelProps> = memo(
               forceBottomPanel: true,
               collapsibleBottomPanel: true,
               defaultCollapsedBottomPanel: true,
+              fullscreen: false,
             },
             onStorageInitialized: (LS: any) => {
               const initAnnotation = () => {


### PR DESCRIPTION
In the production build of playground, it was loading the Editor in the PreviewPanel with fullscreen true, this is to make sure it is false as it cannot visually work with those styles as is.