### PR TITLE
chore: FIT-14: Clear any old labelStudio:settings which may conflict from the old playground

### DIFF
--- a/web/apps/playground/src/components/PreviewPanel/PreviewPanel.tsx
+++ b/web/apps/playground/src/components/PreviewPanel/PreviewPanel.tsx
@@ -17,6 +17,10 @@ type PreviewPanelProps = {
   onAnnotationUpdate?: (annotation: any) => void;
 };
 
+// Clear localStorage of any LabelStudio:settings as it may cause issues with fullscreen mode
+// if coming from the old playground
+localStorage.removeItem("labelStudio:settings");
+
 export const PreviewPanel: FC<PreviewPanelProps> = memo(
   ({ onAnnotationUpdate }) => {
     const config = useAtomValue(configAtom);


### PR DESCRIPTION
To ensure there are no oddities in the display of the PreviewPanel, we need to ensure there are no leftover localStorage of shared settings between the old playground to the new one.