### PR TITLE
fix: FIT-155: Better handling for config encoding/decoding in docs playground

### DIFF
--- a/docs/source/playground/index.ejs
+++ b/docs/source/playground/index.ejs
@@ -442,6 +442,14 @@ meta_description: Label Studio interactive demo and playground for data labeling
     return "https://label-studio-playground.netlify.app/";
   }
 
+  function normalizeNewlines(text) {
+    return text.replace(/(\r\n|\n|\r)/gm, "\n");
+  }
+
+  function encodeConfig(text) {
+    return encodeURIComponent(normalizeNewlines(text));
+  }
+
   function getStartingConfigValue() {
     const urlParams = new URLSearchParams(window.location.search);
     const config = urlParams.get('config');
@@ -449,7 +457,7 @@ meta_description: Label Studio interactive demo and playground for data labeling
       return config;
     }
     const startTemplate = document.getElementById('start-template');
-    return encodeURIComponent(startTemplate.innerHTML.replace(/(\r\n|\n|\r)/gm, "<br>"));
+    return encodeConfig(startTemplate.innerHTML);
   }
 
   const labelStudioPlaygroundUrl = getLabelStudioPlaygroundUrl();
@@ -666,11 +674,10 @@ meta_description: Label Studio interactive demo and playground for data labeling
       }
 
       try {
-        value = encodeURIComponent(value.replace(/(\r\n|\n|\r)/gm, "<br>"))
+        labelStudioPlayground.src = labelStudioPlaygroundUrl + '?config=' + encodeConfig(value);
       } catch (e) {
         console.error('Error encoding template config', e);
       }
-      labelStudioPlayground.src = labelStudioPlaygroundUrl + '?config=' + value;
     }
 
     $('.use-template').on('click', function () {

--- a/docs/source/playground/index.ejs
+++ b/docs/source/playground/index.ejs
@@ -443,7 +443,7 @@ meta_description: Label Studio interactive demo and playground for data labeling
   }
 
   function normalizeNewlines(text) {
-    return text.replace(/(\r\n|\n|\r)/gm, "\n");
+    return text.replace(/(\r\n|\r)/gm, "\n");
   }
 
   function encodeConfig(text) {

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -10,7 +10,13 @@ function getLabelStudioPlaygroundUrl() {
   return "https://label-studio-playground.netlify.app/";
 }
 
-const labelStudioPlaygroundUrl = getLabelStudioPlaygroundUrl();
+function normalizeNewlines(text) {
+  return text.replace(/(\r\n|\n|\r)/gm, "\n");
+}
+
+function encodeConfig(text) {
+  return encodeURIComponent(normalizeNewlines(text));
+}
 
 function editorIframe(config, modal, id) {
   // generate new iframe
@@ -26,9 +32,9 @@ function editorIframe(config, modal, id) {
     iframe.style.display = "block";
   });
 
-  const templateValue = encodeURIComponent(config.replace(/(\r\n|\n|\r)/gm, "<br>"));
+  const templateValue = encodeConfig(config);
 
-  iframe.src = `${labelStudioPlaygroundUrl}?config=${templateValue}&mode=preview`;
+  iframe.src = `${getLabelStudioPlaygroundUrl()}?config=${templateValue}&mode=preview`;
 }
 
 function showRenderEditor(config) {
@@ -90,7 +96,7 @@ function showRenderEditor(config) {
     const htmlTemplate = `
     <div class="playground-buttons">
       <button class="code-block-open-preview">Open Preview</button>
-      <a href="/playground/?config=${encodeURIComponent(code)}" target="_blank" rel="noreferrer noopener">Launch in Playground</a>
+      <a href="/playground/?config=${encodeConfig(code)}" target="_blank" rel="noreferrer noopener">Launch in Playground</a>
     </div>
     `;
     pre.insertAdjacentHTML("beforeend", htmlTemplate);

--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -11,7 +11,7 @@ function getLabelStudioPlaygroundUrl() {
 }
 
 function normalizeNewlines(text) {
-  return text.replace(/(\r\n|\n|\r)/gm, "\n");
+  return text.replace(/(\r\n|\r)/gm, "\n");
 }
 
 function encodeConfig(text) {


### PR DESCRIPTION
Normalize newlines, and encode the config with standard newlines.
Also fixes an issue with the collision of a redefinition of labelStudioPlaygroundUrl which is possible due to the templates and included scripts.