### PR TITLE
fix: FIT-155: Launch in playground doesn't load config from URL

### DIFF
--- a/docs/source/playground/index.ejs
+++ b/docs/source/playground/index.ejs
@@ -454,7 +454,7 @@ meta_description: Label Studio interactive demo and playground for data labeling
     const urlParams = new URLSearchParams(window.location.search);
     const config = urlParams.get('config');
     if (config) {
-      return config;
+      return encodeConfig(config);
     }
     const startTemplate = document.getElementById('start-template');
     return encodeConfig(startTemplate.innerHTML);


### PR DESCRIPTION
Fix an issue that prevents the launch in playground url from opening.