### PR TITLE
fix: FIT-155: Improve playground inline preview collapsed panel by default

### DIFF
--- a/docs/themes/v2/source/js/code-blocks-enhancements.js
+++ b/docs/themes/v2/source/js/code-blocks-enhancements.js
@@ -106,7 +106,7 @@ function showRenderEditor(config) {
 
     const inlinePlayground = document.querySelector("#main-preview");
 
-    if (inlinePlayground) editorIframe(code, inlinePlayground, true);
+    if (inlinePlayground) editorIframe(code, inlinePlayground, "inline", true);
   };
 
   const enhanceCodeBlocks = (codeBlock) => {


### PR DESCRIPTION
The arguments for displaying the editor iframe were incorrect and were therefore not properly setting the inline preview to being preview-inline which shows the playground with default bottom panel collapsed for the preview only panel.