### PR TITLE
fix: FIT-133: Locked region can be edited on Timeline

### DIFF
--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
@@ -218,6 +218,7 @@ const useDataTree = ({ regions, rootClass, footer }: any) => {
       },
       className: rootClass.elem("node").mod(mods).toClassName(),
       title: (data: any) => <RootTitle {...data} />,
+      locked: item.locked,
     };
   }, []);
 

--- a/web/libs/editor/src/components/Timeline/Types.ts
+++ b/web/libs/editor/src/components/Timeline/Types.ts
@@ -101,6 +101,7 @@ export interface TimelineRegion {
   sequence: TimelineRegionKeyframe[];
   /** is this timeline region with spans */
   timeline?: boolean;
+  locked?: boolean;
 }
 
 export interface TimelineRegionKeyframe {

--- a/web/libs/editor/src/components/Timeline/Views/Frames/Frames.tsx
+++ b/web/libs/editor/src/components/Timeline/Views/Frames/Frames.tsx
@@ -177,7 +177,7 @@ export const Frames: FC<TimelineViewProps> = ({
         const target = e.target as Element;
         // every region has `data-id` attribute, so looking for them
         const regionRow = target.closest("[data-id]") as HTMLElement | null;
-        if (regionRow) {
+        if (regionRow && !regionRow.dataset?.locked) {
           const [start, end] = [regionRow.dataset?.start, regionRow.dataset?.end];
           if (start === String(frame) || end === String(frame)) {
             regionRow.style.cursor = "col-resize";

--- a/web/libs/editor/src/components/Timeline/Views/Frames/Keypoints.scss
+++ b/web/libs/editor/src/components/Timeline/Views/Frames/Keypoints.scss
@@ -73,6 +73,10 @@
     border-radius: 2px;
     transform: translate3d(-50%, -50%, 0) rotate(45deg);
     background-color: var(--point-color);
+
+    &_locked {
+      display: none;
+    }
   }
 
   &_timeline &__point {

--- a/web/libs/editor/src/components/Timeline/Views/Frames/Keypoints.tsx
+++ b/web/libs/editor/src/components/Timeline/Views/Frames/Keypoints.tsx
@@ -17,7 +17,7 @@ export interface KeypointsProps {
 
 export const Keypoints: FC<KeypointsProps> = ({ idx, region, startOffset, renderable, onSelectRegion }) => {
   const { step, seekOffset, visibleWidth, length } = useContext(TimelineContext);
-  const { label, color, visible, sequence, selected, timeline } = region;
+  const { label, color, visible, sequence, selected, timeline, locked } = region;
 
   const extraSteps = useMemo(() => {
     return Math.round(visibleWidth / 2);
@@ -50,14 +50,14 @@ export const Keypoints: FC<KeypointsProps> = ({ idx, region, startOffset, render
   const lifespans = useMemo(() => {
     if (!renderable) return [];
 
-    return visualizeLifespans(sequence, step).map((span) => {
+    return visualizeLifespans(sequence, step, locked).map((span) => {
       span.points = span.points.filter(({ frame }) => {
         return frame >= minVisibleKeypointPosition && frame <= maxVisibleKeypointPosition;
       });
 
       return span;
     });
-  }, [sequence, start, step, renderable, minVisibleKeypointPosition, maxVisibleKeypointPosition]);
+  }, [sequence, start, step, renderable, minVisibleKeypointPosition, maxVisibleKeypointPosition, locked]);
 
   const onSelectRegionHandler = useCallback(
     (e: MouseEvent<HTMLDivElement>, select?: boolean) => {
@@ -78,6 +78,7 @@ export const Keypoints: FC<KeypointsProps> = ({ idx, region, startOffset, render
       data-id={region.id}
       data-start={range[0]}
       data-end={range[1]}
+      data-locked={locked || undefined}
     >
       <Elem name="label" onClick={onSelectRegionHandler}>
         <Elem name="name">{label}</Elem>
@@ -134,10 +135,11 @@ interface LifespanItemProps {
   visible: boolean;
   isLast: boolean;
   points: number[];
+  locked?: boolean;
 }
 
 const LifespanItem: FC<LifespanItemProps> = memo(
-  ({ mainOffset, width, start, step, offset, enabled, visible, isLast, points }) => {
+  ({ mainOffset, width, start, step, offset, enabled, visible, isLast, points, locked }) => {
     const left = mainOffset + offset + step / 2;
     const right = isLast && enabled ? 0 : "auto";
     const finalWidth = isLast && enabled ? "auto" : width;
@@ -150,7 +152,7 @@ const LifespanItem: FC<LifespanItemProps> = memo(
         {points.map((frame, i) => {
           const left = (frame - start) * step;
 
-          return <Elem key={i} name="point" style={{ left }} mod={{ last: !!left }} />;
+          return <Elem key={i} name="point" style={{ left }} mod={{ last: !!left, locked }} />;
         })}
       </Elem>
     );

--- a/web/libs/editor/src/components/Timeline/Views/Frames/Minimap.tsx
+++ b/web/libs/editor/src/components/Timeline/Views/Frames/Minimap.tsx
@@ -11,11 +11,11 @@ export const Minimap: FC<any> = () => {
   const [step, setStep] = useState(0);
 
   const visualization = useMemo(() => {
-    return regions.map(({ id, color, sequence }) => {
+    return regions.map(({ id, color, sequence, locked }) => {
       return {
         id,
         color,
-        lifespans: visualizeLifespans(sequence, step),
+        lifespans: visualizeLifespans(sequence, step, locked),
       };
     });
   }, [step, regions]);

--- a/web/libs/editor/src/components/Timeline/Views/Frames/Utils.ts
+++ b/web/libs/editor/src/components/Timeline/Views/Frames/Utils.ts
@@ -7,9 +7,10 @@ export interface Lifespan {
   enabled: boolean;
   start: number;
   points: TimelineRegionKeyframe[];
+  locked?: boolean;
 }
 
-export const visualizeLifespans = (keyframes: TimelineRegionKeyframe[], step: number) => {
+export const visualizeLifespans = (keyframes: TimelineRegionKeyframe[], step: number, locked = false) => {
   if (keyframes.length === 0) return [];
 
   const lifespans: Lifespan[] = [];
@@ -29,6 +30,7 @@ export const visualizeLifespans = (keyframes: TimelineRegionKeyframe[], step: nu
         enabled: point.enabled,
         start: point.frame,
         points: [point],
+        locked,
       });
     } else if (prevPoint?.enabled) {
       lastSpan.width = (point.frame - lastSpan.points[0].frame) * step;

--- a/web/libs/editor/src/regions/TimelineRegion.js
+++ b/web/libs/editor/src/regions/TimelineRegion.js
@@ -112,6 +112,7 @@ const Model = types
      *        In first two cases we need to update undo history only once
      */
     setRange([start, end], { mode } = {}) {
+      if (self.locked) return;
       if (mode === "new") {
         // we need to update existing history item while drawing a new region
         self.parent.annotation.history.setReplaceNextUndoState();

--- a/web/libs/editor/src/tags/object/Video/HtxVideo.jsx
+++ b/web/libs/editor/src/tags/object/Video/HtxVideo.jsx
@@ -462,6 +462,7 @@ const HtxVideoView = ({ item, store }) => {
       selected: reg.selected || reg.inSelection,
       sequence,
       timeline,
+      locked: reg.locked,
     };
   });
 


### PR DESCRIPTION
This pull request introduces a "locked" property to timeline regions and integrates it across various components to ensure locked regions are visually and functionally distinct. The changes primarily focus on preventing interactions with locked regions and updating the UI accordingly.

locked timeline regions will not be allowed to resize. when locked the draggable handles will be made invisible 
<img width="745" alt="image" src="https://github.com/user-attachments/assets/eca7f3b3-d10b-45d8-8422-b0f1a20a6d6b" />

### Core Functionality Updates:
* Added a `locked` property to the `TimelineRegion` interface and related data structures, allowing regions to be marked as locked. (`web/libs/editor/src/components/Timeline/Types.ts` - [[1]](diffhunk://#diff-92cf542126f556c3070de22992593fbae5a77f0dea843a49252de5df6231a326R104) `web/libs/editor/src/components/Timeline/Views/Frames/Utils.ts` - [[2]](diffhunk://#diff-8e97a15b638b9322404dc3d3b88e94ff575bff5a63cacee14bf2a614ced0c1deR10-R13) [[3]](diffhunk://#diff-8e97a15b638b9322404dc3d3b88e94ff575bff5a63cacee14bf2a614ced0c1deR33)
* Updated the `setRange` method in `TimelineRegion` to prevent modifications to locked regions. (`web/libs/editor/src/regions/TimelineRegion.js` - [web/libs/editor/src/regions/TimelineRegion.jsR115](diffhunk://#diff-35b086492f07067eb4474348009793bcdf88ed70319ae88730a115ba6ab45f64R115))

### UI Enhancements:
* Modified the `Keypoints` component to pass the `locked` property and visually differentiate locked points using a new `_locked` CSS modifier. (`web/libs/editor/src/components/Timeline/Views/Frames/Keypoints.tsx` - [[1]](diffhunk://#diff-bfb636deae87abacd4751d9a336dde763d56f9231a014a7e06a9aa16ad18aedeL20-R20) [[2]](diffhunk://#diff-bfb636deae87abacd4751d9a336dde763d56f9231a014a7e06a9aa16ad18aedeL53-R60) [[3]](diffhunk://#diff-bfb636deae87abacd4751d9a336dde763d56f9231a014a7e06a9aa16ad18aedeR81) [[4]](diffhunk://#diff-bfb636deae87abacd4751d9a336dde763d56f9231a014a7e06a9aa16ad18aedeR138-R142) [[5]](diffhunk://#diff-bfb636deae87abacd4751d9a336dde763d56f9231a014a7e06a9aa16ad18aedeL153-R155); `web/libs/editor/src/components/Timeline/Views/Frames/Keypoints.scss` - [[6]](diffhunk://#diff-d5dd97365c4c448b4f5c2a60fe5bf7901d85e9823991fffb8ae8feb2cf12f4deR76-R79)
* Updated the `Frames` component to disable cursor interactions for locked regions. (`web/libs/editor/src/components/Timeline/Views/Frames/Frames.tsx` - [web/libs/editor/src/components/Timeline/Views/Frames/Frames.tsxL180-R180](diffhunk://#diff-ef363a06b49e2e4e16f484d20809bc9408c204a58173456976c854f430759599L180-R180))

### Data Flow Adjustments:
* Ensured the `locked` property is propagated through the data tree and passed to components such as `Keypoints` and `Minimap`. (`web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx` - [[1]](diffhunk://#diff-f4db8bd107bcd19f6cfa67c1b88e801a4a5608c73b12b2bae96fea65b34bec08R221) `web/libs/editor/src/components/Timeline/Views/Frames/Minimap.tsx` - [[2]](diffhunk://#diff-b1ac41acdf9d6eec069763039d3999a8fcba44b2acb9ae963512b2bb554e2048L14-R18) `web/libs/editor/src/tags/object/Video/HtxVideo.jsx` - [[3]](diffhunk://#diff-fbc54e8f061e27eec42b31d12ee5728c7db585f76572d1cedd3a73be3d8a1bdaR465)