### PR TITLE
fix: FIT-136: Duration field at Info panel is not optimized for Dark mode

### DIFF
--- a/web/libs/editor/src/components/SidePanels/DetailsPanel/TimelineRegionEditor.module.scss
+++ b/web/libs/editor/src/components/SidePanels/DetailsPanel/TimelineRegionEditor.module.scss
@@ -12,7 +12,7 @@
 
 .input {
   display: block;
-  border: 1px solid var(--sand_300);
+  border: 1px solid var(--color-neutral-border);
   border-radius: 4px;
   padding: 0 0 0 8px;
   width: 80px;
@@ -20,7 +20,12 @@
   text-align: right;
 
   &[readonly] {
-    background-color: var(--sand_100);
+    background-color: var(--color-neutral-border);
     color: var(--color-neutral-content-subtler);
+    cursor: default;
+
+    &:focus {
+      outline: none;
+    }
   }
 }

--- a/web/libs/editor/src/components/SidePanels/DetailsPanel/TimelineRegionEditor.module.scss
+++ b/web/libs/editor/src/components/SidePanels/DetailsPanel/TimelineRegionEditor.module.scss
@@ -20,8 +20,7 @@
   text-align: right;
 
   &[readonly] {
-    background-color: var(--color-neutral-border);
-    color: var(--color-neutral-content-subtler);
+    color: var(--color-neutral-content-subtlest);
     cursor: default;
 
     &:focus {


### PR DESCRIPTION
This pull request updates the styling of the `TimelineRegionEditor` component to improve consistency and accessibility. The changes include replacing hardcoded color variables with standardized design tokens and enhancing the behavior of read-only input fields.

after update light mode
<img width="323" alt="image" src="https://github.com/user-attachments/assets/c2513f33-2b43-4095-ba54-e9e41c37f4d0" />

after update dark mode
<img width="330" alt="image" src="https://github.com/user-attachments/assets/c6bc1b6a-d4e8-4a3d-ad50-573891105f1f" />


Styling updates:

* Replaced `--sand_300` and `--sand_100` with standardized design tokens `--color-neutral-border` for border and background colors to ensure consistency across the application.

Behavior enhancements:

* Updated read-only input fields to include a `cursor: default` property and removed the focus outline for better user experience.