### PR TITLE
fix: FIT-153: LSO - deleting a project causes us to not be able to scroll on projects page after redirection

### DIFF
--- a/web/apps/labelstudio/src/components/Modal/ModalPopup.jsx
+++ b/web/apps/labelstudio/src/components/Modal/ModalPopup.jsx
@@ -40,6 +40,7 @@ export class Modal extends React.Component {
   }
 
   componentWillUnmount() {
+    document.body.style.overflow = "";
     document.removeEventListener("keydown", this.closeOnEscape, { capture: !this.props.allowToInterceptEscape });
   }
 


### PR DESCRIPTION
This pull request includes a small change to the `ModalPopup.jsx` file. The change ensures that the `overflow` style of the `body` element is reset when the modal is unmounted, preventing potential scrolling issues.