### PR TITLE
docs: Update interpolate key frame SDK example in Video Object Detector

### DIFF
--- a/docs/source/templates/video_object_detector.md
+++ b/docs/source/templates/video_object_detector.md
@@ -127,6 +127,7 @@ The keyframe format inside `value.sequence` list is the following:
 | height | numeric | bounding box height in the current frame |
 | rotation | numeric | bounding box rotation angle in the current frame (clock-wise) |
 | enabled | boolean | Whether the consequent frames interpolation is toggled on / off (for example, to label occlusion) |
+| auto | boolean | True if the frame is from interpolation, not set for key frame, requires setting interpolate_key_frames to true when export |
 
 ### Example
 
@@ -240,18 +241,16 @@ project = ls.get_project(PROJECT_ID)
 # Create an export snapshot with interpolation enabled
 export_result = project.export_snapshot_create(
     title='Export with Interpolated Keyframes',
-    serialization_options={
-        'interpolate_key_frames': True
-    }
+    interpolate_key_frames=True
 )
 # Get the export ID
 export_id = export_result['id']
 # Wait for the export to complete
 while True:
-    export_status = project.get_export_status(export_id)
-    if export_status['status'] == 'completed':
+    export_status = project.export_snapshot_status(export_id)['status']
+    if export_status == 'completed':
         break
-    elif export_status['status'] == 'failed':
+    elif export_status == 'failed':
         raise Exception('Export failed')
     else:
         time.sleep(5)  # Wait for 5 seconds before checking again


### PR DESCRIPTION
Existing python example is not passing the right option

From https://github.com/HumanSignal/label-studio-sdk/blob/4ab81d23dcb3bfdfb801202b468382a3ece8e159/src/label_studio_sdk/_legacy/project.py#L2252-L2288

```py
    def export_snapshot_create(
        self,
        title: str,
        task_filter_options: dict = None,
        serialization_options_drafts: bool = True,
        serialization_options_predictions: bool = True,
        serialization_options_annotations__completed_by: bool = True,
        annotation_filter_options_usual: bool = True,
        annotation_filter_options_ground_truth: bool = True,
        annotation_filter_options_skipped: bool = True,
        interpolate_key_frames: bool = False,
    ) -> dict:
        """
```

Maybe the doc should mention this is using legacy client (with legacy API token similar to https://github.com/HumanSignal/label-studio-ml-backend/issues/749), btw: Is there support for export in the new client?
The examples are all using legacy client 

- https://github.com/HumanSignal/label-studio-sdk/blob/master/examples/export_snapshots.py
- https://github.com/HumanSignal/label-studio-sdk/blob/master/examples/export_yolo_with_images.py
