### PR TITLE
fix: UTC-36: 'Label All Tasks' doesn't change for annotators and reviewers role

### DIFF
--- a/web/libs/datamanager/src/stores/Tabs/store.js
+++ b/web/libs/datamanager/src/stores/Tabs/store.js
@@ -528,7 +528,16 @@ export const TabStore = types
         });
         tab = self.views[self.views.length - 1];
       } else {
-        tab = yield self.getViewByKey(tabKey);
+        const viewSnapshot = {
+          key: tabKey,
+          virtual: true,
+          title: tabKey,
+          selected: {
+            all: selectedItems?.all,
+            list: selectedItems?.included ?? selectedItems?.excluded ?? [],
+          },
+        };
+        tab = yield self.addVirtualView(viewSnapshot);
       }
 
       self.selected = tab;


### PR DESCRIPTION
When the DM is enabled for annotators in the project settings we are allowing the selection of tasks in the DM to narrow down the label stream when clicking on Label X Tasks however there is no task selection sent to the backend which provides the ordering of the tasks to Label hence the annotator ends up traversing all tasks and not just the selection.

This is happening because we are not sending the selection to the backend when using virtual tabs, the annotator use case.  

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
