### PR TITLE
fix: BROS-59: Remove accidential 0 above Audio

### DIFF
--- a/web/libs/editor/src/tags/object/AudioUltra/view.tsx
+++ b/web/libs/editor/src/tags/object/AudioUltra/view.tsx
@@ -242,7 +242,9 @@ const AudioUltraWithSettings: FC<AudioUltraProps> = ({ item }) => {
   return (
     <TimelineContextProvider value={contextValue}>
       <AudioUltraView item={item}>
-        {item.errors?.map((error: any, i: any) => <ErrorMessage key={`err-${i}`} error={error} />)}
+        {item.errors?.map((error: any, i: number) => (
+          <ErrorMessage key={`err-${i}`} error={error} />
+        ))}
       </AudioUltraView>
     </TimelineContextProvider>
   );

--- a/web/libs/editor/src/tags/object/AudioUltra/view.tsx
+++ b/web/libs/editor/src/tags/object/AudioUltra/view.tsx
@@ -242,8 +242,7 @@ const AudioUltraWithSettings: FC<AudioUltraProps> = ({ item }) => {
   return (
     <TimelineContextProvider value={contextValue}>
       <AudioUltraView item={item}>
-        {item.errors.length &&
-          item.errors?.map((error: any, i: any) => <ErrorMessage key={`err-${i}`} error={error} />)}
+        {item.errors?.map((error: any, i: any) => <ErrorMessage key={`err-${i}`} error={error} />)}
       </AudioUltraView>
     </TimelineContextProvider>
   );


### PR DESCRIPTION
Just a wrong condition inside render.

<img width="308" alt="Screenshot 2025-05-28 at 11 24 40" src="https://github.com/user-attachments/assets/2ca59828-9d8b-4a18-afe3-4f1e85451ae5" />
