### PR TITLE
fix: FIT-171: LSO: sidebar has lower z-index than datamanager status bar

### DIFF
--- a/web/apps/labelstudio/src/pages/DataManager/DataManager.scss
+++ b/web/apps/labelstudio/src/pages/DataManager/DataManager.scss
@@ -1,5 +1,7 @@
 .datamanager {
   height: calc(100vh - var(--header-height));
+  position: relative;
+  z-index: 1;
 
   #label-studio-dm [class*="Annotations_annotation_selected"] {
     background: var(--color-primary-surface-content);


### PR DESCRIPTION
This pull request includes a small change to the `DataManager.scss` file. The change adds `position: relative;` and `z-index: 1;` to the `.datamanager` class to improve layout stacking behavior.

before:
<img width="484" alt="Screenshot 2025-05-28 at 10 43 17 AM" src="https://github.com/user-attachments/assets/2c5db6fc-98fd-4832-a081-f06d3dd6584a" />

after:
<img width="330" alt="image" src="https://github.com/user-attachments/assets/2d6e1d6c-9b72-4992-990d-88416f9cff0e" />
