### PR TITLE
fix:  FIT-138: Text on ASR Hypotheses Selection template not visible Dark mode

### DIFF
--- a/docs/source/templates/asr_hypotheses.md
+++ b/docs/source/templates/asr_hypotheses.md
@@ -29,19 +29,19 @@ When you work with automatic speech transcribers, you are provided with several 
   "data": {
     "audio": "https://htx-pub.s3.amazonaws.com/datasets/audio/f2btrop6.0.wav",
     "transcriptions": [{
-      "style": "padding-left: 5px; box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 4px; background-color: #FFFFFF",
+      "style": "padding-left: 5px;",
       "value": "potrostith points out that if school based clinics were established parental permission would be required for students to receive each service offered"
     }, {
-      "style": "padding-left: 5px; box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 4px; background-color: #F8F8F8",
+      "style": "padding-left: 5px;",
       "value": "potrostith points out that if school-based clinics were established parental permission would be required for students to receive each service offered"
     }, {
-      "style": "padding-left: 5px; box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 4px; background-color: #F5F5F5",
+      "style": "padding-left: 5px;",
       "value": "purporting points out that if school based clinics were established parental permission would be required for students to receive each service offered"
     }, {
-      "style": "padding-left: 5px; box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 4px; background-color: #F0F0F0",
+      "style": "padding-left: 5px;",
       "value": "pork roasted points out that if school based clinics were establish parental permission would be required for students to receive each service offered"
     }, {
-      "style": "padding-left: 5px; box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 4px; background-color: #E8E8E8",
+      "style": "padding-left: 5px;",
       "value": "purpose it points out that if school based clinics war establish parental permission would be required for students to receive each service offered"
     }]
   }

--- a/docs/source/templates/asr_hypotheses.md
+++ b/docs/source/templates/asr_hypotheses.md
@@ -19,21 +19,21 @@ When you work with automatic speech transcribers, you are provided with several 
 <View>
   <Audio name="audio" value="$audio"/>
   <Choices name="transcriptions" toName="audio" value="$transcriptions" selection="highlight"/>
-    <Style>
-      .lsf-choice__item {
-        padding: var(--spacing-tighter) var(--spacing-tight);
-        box-shadow: 0 2px 4px rgba(var(--color-neutral-shadow-raw) / calc(16% * var(--shadow-intensity))) ;
-        background-color: var(--color-neutral-background);
-        border-radius: var(--corner-radius-small);
-        margin: 0 var(--spacing-tighter) var(--spacing-tighter) var(--spacing-tighter);
-        line-height: 1.6rem;
-        transition: all 150ms ease-out;
-      }
-      
-      .lsf-choice__item:hover {
-        background-color: var(--color-primary-emphasis-subtle);
-      }
-    </Style>
+  <Style>
+    .lsf-choice__item {
+      padding: var(--spacing-tighter) var(--spacing-tight);
+      box-shadow: 0 2px 4px rgba(var(--color-neutral-shadow-raw) / calc(16% * var(--shadow-intensity))) ;
+      background-color: var(--color-neutral-background);
+      border-radius: var(--corner-radius-small);
+      margin: 0 var(--spacing-tighter) var(--spacing-tighter) var(--spacing-tighter);
+      line-height: 1.6rem;
+      transition: all 150ms ease-out;
+    }
+    
+    .lsf-choice__item:hover {
+      background-color: var(--color-primary-emphasis-subtle);
+    }
+  </Style>
 </View>
 ```
 

--- a/docs/source/templates/asr_hypotheses.md
+++ b/docs/source/templates/asr_hypotheses.md
@@ -19,6 +19,21 @@ When you work with automatic speech transcribers, you are provided with several 
 <View>
   <Audio name="audio" value="$audio"/>
   <Choices name="transcriptions" toName="audio" value="$transcriptions" selection="highlight"/>
+    <Style>
+      .lsf-choice__item {
+        padding: var(--spacing-tighter) var(--spacing-tight);
+        box-shadow: 0 2px 4px rgba(var(--color-neutral-shadow-raw) / calc(16% * var(--shadow-intensity))) ;
+        background-color: var(--color-neutral-background);
+        border-radius: var(--corner-radius-small);
+        margin: 0 var(--spacing-tighter) var(--spacing-tighter) var(--spacing-tighter);
+        line-height: 1.6rem;
+        transition: all 150ms ease-out;
+      }
+      
+      .lsf-choice__item:hover {
+        background-color: var(--color-primary-emphasis-subtle);
+      }
+    </Style>
 </View>
 ```
 
@@ -29,19 +44,14 @@ When you work with automatic speech transcribers, you are provided with several 
   "data": {
     "audio": "https://htx-pub.s3.amazonaws.com/datasets/audio/f2btrop6.0.wav",
     "transcriptions": [{
-      "style": "padding-left: 5px;",
       "value": "potrostith points out that if school based clinics were established parental permission would be required for students to receive each service offered"
     }, {
-      "style": "padding-left: 5px;",
       "value": "potrostith points out that if school-based clinics were established parental permission would be required for students to receive each service offered"
     }, {
-      "style": "padding-left: 5px;",
       "value": "purporting points out that if school based clinics were established parental permission would be required for students to receive each service offered"
     }, {
-      "style": "padding-left: 5px;",
       "value": "pork roasted points out that if school based clinics were establish parental permission would be required for students to receive each service offered"
     }, {
-      "style": "padding-left: 5px;",
       "value": "purpose it points out that if school based clinics war establish parental permission would be required for students to receive each service offered"
     }]
   }

--- a/label_studio/annotation_templates/ranking-and-scoring/asr-hypotheses/config.yml
+++ b/label_studio/annotation_templates/ranking-and-scoring/asr-hypotheses/config.yml
@@ -7,21 +7,21 @@ config: |
   <View>
     <Audio name="audio" value="$audio"/>
     <Choices name="transcriptions" toName="audio" value="$transcriptions" selection="highlight"/>
-      <Style>
-        .lsf-choice__item {
-          padding: var(--spacing-tighter) var(--spacing-tight);
-          box-shadow: 0 2px 4px rgba(var(--color-neutral-shadow-raw) / calc(16% * var(--shadow-intensity))) ;
-          background-color: var(--color-neutral-background);
-          border-radius: var(--corner-radius-small);
-          margin: 0 var(--spacing-tighter) var(--spacing-tighter) var(--spacing-tighter);
-          line-height: 1.6rem;
-          transition: all 150ms ease-out;
-        }
-        
-        .lsf-choice__item:hover {
-          background-color: var(--color-primary-emphasis-subtle);
-        }
-      </Style>
+    <Style>
+      .lsf-choice__item {
+        padding: var(--spacing-tighter) var(--spacing-tight);
+        box-shadow: 0 2px 4px rgba(var(--color-neutral-shadow-raw) / calc(16% * var(--shadow-intensity))) ;
+        background-color: var(--color-neutral-background);
+        border-radius: var(--corner-radius-small);
+        margin: 0 var(--spacing-tighter) var(--spacing-tighter) var(--spacing-tighter);
+        line-height: 1.6rem;
+        transition: all 150ms ease-out;
+      }
+      
+      .lsf-choice__item:hover {
+        background-color: var(--color-primary-emphasis-subtle);
+      }
+    </Style>
   </View>
   <!-- { "data": {
     "audio": "https://htx-pub.s3.amazonaws.com/datasets/audio/f2btrop6.0.wav",

--- a/label_studio/annotation_templates/ranking-and-scoring/asr-hypotheses/config.yml
+++ b/label_studio/annotation_templates/ranking-and-scoring/asr-hypotheses/config.yml
@@ -11,19 +11,19 @@ config: |
   <!-- { "data": {
     "audio": "https://htx-pub.s3.amazonaws.com/datasets/audio/f2btrop6.0.wav",
     "transcriptions": [{
-            "style": "padding-left: 5px; box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 4px; background-color: #FFFFFF",
+            "style": "padding-left: 5px;",
       "value": "potrostith points out that if school based clinics were established parental permission would be required for students to receive each service offered"
     }, {
-            "style": "padding-left: 5px; box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 4px; background-color: #F8F8F8",
+            "style": "padding-left: 5px;",
       "value": "potrostith points out that if school-based clinics were established parental permission would be required for students to receive each service offered"
     }, {
-            "style": "padding-left: 5px; box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 4px; background-color: #F5F5F5",
+            "style": "padding-left: 5px;",
       "value": "purporting points out that if school based clinics were established parental permission would be required for students to receive each service offered"
     }, {
-            "style": "padding-left: 5px; box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 4px; background-color: #F0F0F0",
+            "style": "padding-left: 5px;",
       "value": "pork roasted points out that if school based clinics were establish parental permission would be required for students to receive each service offered"
     }, {
-            "style": "padding-left: 5px; box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 4px; background-color: #E8E8E8",
+            "style": "padding-left: 5px;",
       "value": "purpose it points out that if school based clinics war establish parental permission would be required for students to receive each service offered"
     }]
   }} -->

--- a/label_studio/annotation_templates/ranking-and-scoring/asr-hypotheses/config.yml
+++ b/label_studio/annotation_templates/ranking-and-scoring/asr-hypotheses/config.yml
@@ -7,23 +7,33 @@ config: |
   <View>
     <Audio name="audio" value="$audio"/>
     <Choices name="transcriptions" toName="audio" value="$transcriptions" selection="highlight"/>
+      <Style>
+        .lsf-choice__item {
+          padding: var(--spacing-tighter) var(--spacing-tight);
+          box-shadow: 0 2px 4px rgba(var(--color-neutral-shadow-raw) / calc(16% * var(--shadow-intensity))) ;
+          background-color: var(--color-neutral-background);
+          border-radius: var(--corner-radius-small);
+          margin: 0 var(--spacing-tighter) var(--spacing-tighter) var(--spacing-tighter);
+          line-height: 1.6rem;
+          transition: all 150ms ease-out;
+        }
+        
+        .lsf-choice__item:hover {
+          background-color: var(--color-primary-emphasis-subtle);
+        }
+      </Style>
   </View>
   <!-- { "data": {
     "audio": "https://htx-pub.s3.amazonaws.com/datasets/audio/f2btrop6.0.wav",
     "transcriptions": [{
-            "style": "padding-left: 5px;",
       "value": "potrostith points out that if school based clinics were established parental permission would be required for students to receive each service offered"
     }, {
-            "style": "padding-left: 5px;",
       "value": "potrostith points out that if school-based clinics were established parental permission would be required for students to receive each service offered"
     }, {
-            "style": "padding-left: 5px;",
       "value": "purporting points out that if school based clinics were established parental permission would be required for students to receive each service offered"
     }, {
-            "style": "padding-left: 5px;",
       "value": "pork roasted points out that if school based clinics were establish parental permission would be required for students to receive each service offered"
     }, {
-            "style": "padding-left: 5px;",
       "value": "purpose it points out that if school based clinics war establish parental permission would be required for students to receive each service offered"
     }]
   }} -->


### PR DESCRIPTION
### Reason for change

The existing styling for ASR Hypotheses choices relied on individual inline styles, leading to Dark mode not being supported. This PR addresses this by centralizing the styling for `.lsf-choice__item` elements (ASR transcription choices) into a unified CSS block.

Specifically, custom CSS has been added within the `<Style>` block in `docs/source/templates/asr_hypotheses.md` and `label_studio/annotation_templates/ranking-and-scoring/asr-hypotheses/config.yml`. This new CSS defines consistent `padding`, `box-shadow`, `background-color`, `border-radius`, `margin`, `line-height`, and `transition` effects. 

A hover style has also been added for improved user interaction feedback. All previously existing per-choice inline styles have been removed, ensuring that all transcription choices now uniformly adopt the styles defined in the centralized CSS block.

This change significantly improves maintainability, consistency, and the overall visual appearance of ASR Hypotheses choices in both documentation and configuration files.

### Screenshots

Before:
<img width="816" alt="Prod_-_Label_Studio" src="https://github.com/user-attachments/assets/9571ff5a-24a1-4d88-ab09-280fb57c53af" />
<img width="788" alt="Prod_-_Label_Studio" src="https://github.com/user-attachments/assets/1d5afabb-3945-48e1-ace0-3bba92575c20" />

After:
<img width="968" alt="LSO_Local" src="https://github.com/user-attachments/assets/9b37941c-93ee-4020-88a3-a700256d7fb9" />
<img width="976" alt="LSO_Local" src="https://github.com/user-attachments/assets/c3f4154f-2229-46c4-92e5-f31847700d02" />
<img width="976" alt="image" src="https://github.com/user-attachments/assets/3bc638a2-2763-4749-a107-dc850a8cc0c7" />

### Testing

The following steps were performed to verify the fix:

1.  **Precondition:** Ensure Dark mode is turned ON.
2. Navigate to Home page.
3. Click on Create Project.
4. Navigate to Labeling Setup, then navigate to Ranking & Scoring.
5. Select the ASR Hypotheses Selection template.
6. Observe that you can read the text associated with each checkbox.
7. Close the modal, switch to Light mode, and execute steps 3-6.

### Reviewer notes

Please pay close attention to the new CSS added within the `<Style>` block in both `docs/source/templates/asr_hypotheses.md` and `label_studio/annotation_templates/ranking-and-scoring/asr-hypotheses/config.yml`. Verify that all inline styles for individual transcription choices have been successfully removed. Confirm that the new centralized styling provides a consistent and visually appealing experience for ASR hypotheses without any regressions or unexpected side effects.


### General notes

This change is a significant step towards improving the maintainability and visual consistency of our templates. By centralizing the styling, future modifications will be much simpler and less prone to inconsistencies.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
