### PR TITLE
fix: BROS-56: Fix undo hotkey for Polygon

### DIFF
--- a/web/libs/editor/src/tags/control/Polygon.js
+++ b/web/libs/editor/src/tags/control/Polygon.js
@@ -69,10 +69,10 @@ const Model = types
     return {
       initializeHotkeys() {
         hotkeys.addNamed("polygon:undo", () => {
-          if (self.annotation.isDrawing) self.annotation.undo();
+          if (self.annotation?.selected && self.annotation.isDrawing) self.annotation.undo();
         });
         hotkeys.addNamed("polygon:redo", () => {
-          if (self.annotation.isDrawing) self.annotation.redo();
+          if (self.annotation?.selected && self.annotation.isDrawing) self.annotation.redo();
         });
       },
 


### PR DESCRIPTION
Undo hotkey triggered all handlers from every annotation and from annotation store. The last one didn't even have annotation, and that trigerred an error.

This fix ensures that only the relevant handler is triggered.
