### PR TITLE
chore: FIT-174: Refactor DataManager Table out into reusable component

### DIFF
--- a/web/libs/datamanager/src/components/Common/Table/Table.jsx
+++ b/web/libs/datamanager/src/components/Common/Table/Table.jsx
@@ -1,15 +1,12 @@
 import { observer } from "mobx-react";
 import { createContext, forwardRef, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import AutoSizer from "react-virtualized-auto-sizer";
-import { VariableSizeList } from "react-window";
-import InfiniteLoader from "react-window-infinite-loader";
 import { useSDK } from "../../../providers/SDKProvider";
 import { isDefined } from "../../../utils/utils";
 import { Button } from "../Button/Button";
 import { Icon } from "../Icon/Icon";
 import { modal } from "../Modal/Modal";
 import { IconCode, IconGear, IconGearNewUI } from "@humansignal/icons";
-import { Tooltip } from "@humansignal/ui";
+import { AutoSizerTable, Tooltip } from "@humansignal/ui";
 import "./Table.scss";
 import { TableCheckboxCell } from "./TableCheckbox";
 import { tableCN, TableContext } from "./TableContext";
@@ -386,34 +383,19 @@ const StickyList = observer(
 
     return (
       <StickyListContext.Provider value={itemData}>
-        <AutoSizer className={tableCN.elem("auto-size")}>
-          {({ width, height }) => (
-            <InfiniteLoader
-              ref={listRef}
-              itemCount={totalCount}
-              loadMoreItems={loadMore}
-              isItemLoaded={isItemLoaded}
-              threshold={5}
-              minimumBatchSize={30}
-            >
-              {({ onItemsRendered, ref }) => (
-                <VariableSizeList
-                  className={tableCN.elem("virual").toString()}
-                  {...rest}
-                  ref={ref}
-                  width={width}
-                  height={height}
-                  itemData={itemData}
-                  itemSize={itemSize}
-                  onItemsRendered={onItemsRendered}
-                  initialScrollOffset={initialScrollOffset?.(height) ?? 0}
-                >
-                  {ItemWrapper}
-                </VariableSizeList>
-              )}
-            </InfiniteLoader>
-          )}
-        </AutoSizer>
+        <AutoSizerTable
+          ref={listRef}
+          totalCount={totalCount}
+          loadMore={loadMore}
+          isItemLoaded={isItemLoaded}
+          itemData={itemData}
+          itemSize={itemSize}
+          initialScrollOffset={initialScrollOffset}
+          className={tableCN.elem("auto-size").toString()}
+          {...rest}
+        >
+          {ItemWrapper}
+        </AutoSizerTable>
       </StickyListContext.Provider>
     );
   }),

--- a/web/libs/datamanager/src/components/Common/Table/TableHead/TableHead.scss
+++ b/web/libs/datamanager/src/components/Common/Table/TableHead/TableHead.scss
@@ -10,6 +10,7 @@
   font-size: 14px;
   border-bottom: 1px solid var(--color-neutral-border);
   color: var(--color-neutral-content);
+  position: sticky;
 
   &__extra {
     flex: 1;

--- a/web/libs/datamanager/src/components/Label/Label.scss
+++ b/web/libs/datamanager/src/components/Label/Label.scss
@@ -51,6 +51,10 @@
     height: 100%;
     display: flex;
     min-width: 200px;
+
+    .data-view-dm {
+      margin-bottom: 0;
+    }
   }
 
   &__lsf-wrapper {

--- a/web/libs/datamanager/src/components/MainView/DataView/Table.scss
+++ b/web/libs/datamanager/src/components/MainView/DataView/Table.scss
@@ -4,6 +4,7 @@
   overflow: hidden;
   flex-direction: column;
   background: var(--color-neutral-background);
+  margin-bottom: 2.5rem;
 }
 
 .no-results {

--- a/web/libs/ui/src/index.ts
+++ b/web/libs/ui/src/index.ts
@@ -19,5 +19,7 @@ export * from "./assets/icons";
 export * from "./lib/simple-card";
 export * from "./lib/space/space";
 export * from "./lib/spinner/spinner";
+export * from "./lib/popover/popover";
+export * from "./lib/auto-sizer-table/auto-sizer-table";
 
 export * from "./shadcn";

--- a/web/libs/ui/src/index.ts
+++ b/web/libs/ui/src/index.ts
@@ -19,7 +19,6 @@ export * from "./assets/icons";
 export * from "./lib/simple-card";
 export * from "./lib/space/space";
 export * from "./lib/spinner/spinner";
-export * from "./lib/popover/popover";
 export * from "./lib/auto-sizer-table/auto-sizer-table";
 
 export * from "./shadcn";

--- a/web/libs/ui/src/lib/auto-sizer-table/auto-sizer-table.tsx
+++ b/web/libs/ui/src/lib/auto-sizer-table/auto-sizer-table.tsx
@@ -1,0 +1,73 @@
+import { type FC, forwardRef, type ForwardedRef } from "react";
+import AutoSizer from "react-virtualized-auto-sizer";
+import InfiniteLoader from "react-window-infinite-loader";
+import { VariableSizeList } from "react-window";
+import clsx from "clsx";
+
+export interface AutoSizerTableProps {
+  totalCount: number;
+  loadMore: (startIndex: number, stopIndex: number) => Promise<void>;
+  isItemLoaded: (index: number) => boolean;
+  itemData: any;
+  itemSize: (index: number) => number;
+  initialScrollOffset?: (height: number) => number;
+  className?: string;
+  children: FC<any>;
+}
+
+export const AutoSizerTable = forwardRef<VariableSizeList, AutoSizerTableProps>(
+  (
+    {
+      totalCount,
+      loadMore,
+      isItemLoaded,
+      itemData,
+      itemSize,
+      initialScrollOffset,
+      className,
+      children: ItemWrapper,
+      ...rest
+    },
+    ref: ForwardedRef<VariableSizeList>,
+  ) => {
+    return (
+      <AutoSizer className={clsx(className)}>
+        {({ width, height }) => (
+          <InfiniteLoader
+            itemCount={totalCount}
+            loadMoreItems={loadMore}
+            isItemLoaded={isItemLoaded}
+            threshold={5}
+            minimumBatchSize={30}
+            ref={ref}
+          >
+            {({
+              onItemsRendered,
+              ref: infiniteLoaderRef,
+            }: { onItemsRendered: (params: { startIndex: number; stopIndex: number }) => void; ref: any }) => {
+              return (
+                <VariableSizeList
+                  ref={infiniteLoaderRef}
+                  width={width}
+                  height={height}
+                  itemCount={totalCount}
+                  itemData={itemData}
+                  itemSize={itemSize}
+                  onItemsRendered={onItemsRendered}
+                  initialScrollOffset={initialScrollOffset?.(height) ?? 0}
+                  {...rest}
+                >
+                  {ItemWrapper}
+                </VariableSizeList>
+              );
+            }}
+          </InfiniteLoader>
+        )}
+      </AutoSizer>
+    );
+  },
+);
+
+AutoSizerTable.displayName = "AutoSizerTable";
+
+export default AutoSizerTable;

--- a/web/package.json
+++ b/web/package.json
@@ -161,6 +161,8 @@
     "@types/react-dom": "18.2.14",
     "@types/react-router": "^5.1.7",
     "@types/react-router-dom": "^5.1.7",
+    "@types/react-window": "^1.8.8",
+    "@types/react-window-infinite-loader": "^1.0.9",
     "@types/sanitize-html": "^2.13.0",
     "@types/sinon": "^17.0.3",
     "@types/strman": "^2.0.0",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -6691,6 +6691,21 @@
     "@types/history" "^4.7.11"
     "@types/react" "*"
 
+"@types/react-window-infinite-loader@^1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@types/react-window-infinite-loader/-/react-window-infinite-loader-1.0.9.tgz#9b24d4e60f20397ff853c6857f7fe0645becbeb9"
+  integrity sha512-gEInTjQwURCnDOFyIEK2+fWB5gTjqwx30O62QfxA9stE5aiB6EWkGj4UMhc0axq7/FV++Gs/TGW8FtgEx0S6Tw==
+  dependencies:
+    "@types/react" "*"
+    "@types/react-window" "*"
+
+"@types/react-window@*", "@types/react-window@^1.8.8":
+  version "1.8.8"
+  resolved "https://registry.yarnpkg.com/@types/react-window/-/react-window-1.8.8.tgz#c20645414d142364fbe735818e1c1e0a145696e3"
+  integrity sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*":
   version "18.2.64"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.64.tgz#3700fbb6b2fa60a6868ec1323ae4cbd446a2197d"


### PR DESCRIPTION
this is a cherry pick of a change that went into develop on May15 - refactoring the datamanger table and adding margin at the bottom to prevent last row from clipping