### PR TITLE
fix: BROS-65: Persistent storage use `attachment` instead of `inline` and can't load PDF. Simple fix

### DIFF
--- a/label_studio/data_import/api.py
+++ b/label_studio/data_import/api.py
@@ -744,5 +744,5 @@ class DownloadStorageData(APIView):
         redirect = '/file_download/' + protocol + '/' + url.replace(protocol + '://', '')
 
         response['X-Accel-Redirect'] = redirect
-        response['Content-Disposition'] = 'attachment; filename="{}"'.format(filepath)
+        response['Content-Disposition'] = 'inline; filename="{}"'.format(filepath)
         return response


### PR DESCRIPTION
Persistent storage uses `attachment` instead of `inline` as the content disposition. Because of this, users experience a problem: instead of displaying the PDF within the labeling interface, the browser starts downloading the file as an attachment.