### PR TITLE
Fix version lookup and content-length handling

### DIFF
--- a/label_studio/__init__.py
+++ b/label_studio/__init__.py
@@ -6,7 +6,12 @@ import importlib.metadata
 package_name = 'label-studio'
 
 # Package version
-__version__ = importlib.metadata.metadata(package_name).get('version')
+try:
+    __version__ = importlib.metadata.version(package_name)
+except importlib.metadata.PackageNotFoundError:  # pragma: no cover - fallback for src installs
+    # Package isn't installed, so importlib can't find the metadata.
+    # This happens when running from a source checkout.
+    __version__ = '0.0.0'
 
 # pypi info
 __latest_version__ = None

--- a/label_studio/data_import/uploader.py
+++ b/label_studio/data_import/uploader.py
@@ -132,7 +132,11 @@ def tasks_from_url(file_upload_ids, project, user, url, could_be_tasks_list):
             url, verify=project.organization.should_verify_ssl_certs(), stream=True, headers={'Accept-Encoding': None}
         )
         file_content = response.content
-        check_tasks_max_file_size(int(response.headers['content-length']))
+        try:
+            content_length = int(response.headers.get('content-length', len(file_content)))
+        except (TypeError, ValueError):
+            content_length = len(file_content)
+        check_tasks_max_file_size(content_length)
         file_upload = create_file_upload(user, project, SimpleUploadedFile(filename, file_content))
         if file_upload.format_could_be_tasks_list:
             could_be_tasks_list = True

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,10 @@
+import importlib
+import os
+import sys
+
+# Ensure the repo root is on the path
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+def test_version_importable():
+    module = importlib.import_module('label_studio')
+    assert isinstance(module.__version__, str)


### PR DESCRIPTION
## Summary
- avoid PackageNotFoundError when importing label_studio from source
- guard against missing `Content-Length` headers when importing tasks from URL
- add a small regression test for version import

## Testing
- `pytest tests/test_version.py -q`
- `pytest label_studio/tests/data_import/test_uploader.py::TestUploader::test_user_specified_block_without_default -q` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_683fa4aa69a083219b471edf1c236cc8