### PR TITLE
fix: UTC-74: [FE] Error Message on Numeric Value Field

### DIFF
--- a/web/libs/editor/src/tags/control/Number.jsx
+++ b/web/libs/editor/src/tags/control/Number.jsx
@@ -89,10 +89,17 @@ const Model = types
         if (isDefined(self.step)) {
           const step = Number.parseFloat(self.step);
           const basis = isDefined(self.min) ? +self.min : 0;
-          const delta = (value - basis) % step;
 
-          if (delta !== 0) {
-            errors.push(`The two nearest valid values are ${value - delta} and ${value - delta + step}`);
+          const diff = value - basis;
+          const nearest = Math.round(diff / step) * step + basis;
+
+          // EPSILON will handle the floating-point imprecision of the binary representation (IEEE 754)
+          const EPSILON = 1e-8;
+          if (Math.abs(value - nearest) > EPSILON) {
+            const lower = Math.floor(diff / step) * step + basis;
+            const upper = lower + step;
+            const decimals = step.toString().split(".")[1]?.length || 0;
+            errors.push(`The two nearest valid values are ${lower.toFixed(decimals)} and ${upper.toFixed(decimals)}`);
           }
         }
         if (errors.length) {


### PR DESCRIPTION
Fixes the `<Number/>` tag validation by introducing a small EPSYLON (1e-8) for the comparison when we are validating the input.
This is needed to bypass the imprecision generated by javascript when handling floating-number decimals form the binary source (IEEE 754). Example:
```
0.1 + 0.2 // returns 0.30000000000000004
```

<img width="803" alt="Screenshot 2025-06-04 at 13 58 14" src="https://github.com/user-attachments/assets/bf62a60b-cc18-48b2-b032-15e31bcc92c2" />


<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
