### PR TITLE
fix: BROS-81: UI. Enhanced control for enabling storage proxy

### DIFF
--- a/label_studio/io_storages/azure_blob/form_layout.yml
+++ b/label_studio/io_storages/azure_blob/form_layout.yml
@@ -46,19 +46,21 @@ ImportStorage:
   - columnCount: 3
     fields: *azure_params
 
-  # 2 columns grid
-  - columnCount: 2
+  # 1 columns grid
+  - columnCount: 1
     columns:
-      - width: 345
+      - width: 600
         fields:
           - type: toggle
             name: use_blob_urls
             label: Treat every bucket object as a source file
-            description: If unchecked, treat every bucket object as a JSON-formatted task. Optional
-      - fields:
+            description: If unchecked, treat every bucket object as a JSON-formatted task
+      - width: 600
+        fields:
           - type: toggle
             name: presign
-            label: Use pre-signed URLs
+            label: "Use pre-signed URLs (On)\n Proxy through Label Studio (Off)"
+            description: "When pre-signed URLs are enabled, all data bypasses Label Studio and user browsers directly read data from storage"
             value: true
           - type: counter
             name: presign_ttl

--- a/label_studio/io_storages/gcs/form_layout.yml
+++ b/label_studio/io_storages/gcs/form_layout.yml
@@ -42,19 +42,28 @@ ImportStorage:
         validators:
           - regexp
 
-  # 2 columns grid
-  - columnCount: 2
+  # GCS credentials
+  - columnCount: 1
+    fields: *gcs_credentials
+  # Project ID
+  - columnCount: 1
+    fields: *project_id
+
+  # 1 columns grid
+  - columnCount: 1
     columns:
-      - width: 345
+      - width: 600
         fields:
           - type: toggle
             name: use_blob_urls
             label: Treat every bucket object as a source file
-            description: If unchecked, treat every bucket object as a JSON-formatted task. Optional
-      - fields:
+            description: If unchecked, treat every bucket object as a JSON-formatted task
+      - width: 600
+        fields:
           - type: toggle
             name: presign
-            label: Use pre-signed URLs
+            label: "Use pre-signed URLs (On)\n Proxy through Label Studio (Off)"
+            description: "When pre-signed URLs are enabled, all data bypasses Label Studio and user browsers directly read data from storage"
             value: true
           - type: counter
             name: presign_ttl
@@ -62,13 +71,6 @@ ImportStorage:
             min: 1
             value: 15
             dependency: presign
-
-  # GCS credentials
-  - columnCount: 1
-    fields: *gcs_credentials
-  # Project ID
-  - columnCount: 1
-    fields: *project_id
 
 ExportStorage:
   - columnCount: 3

--- a/label_studio/io_storages/localfiles/form_layout.yml
+++ b/label_studio/io_storages/localfiles/form_layout.yml
@@ -23,14 +23,14 @@ ImportStorage:
           - regexp
 
   # 2 columns grid
-  - columnCount: 2
+  - columnCount: 1
     columns:
-      - width: 371
+      - width: 600
         fields:
           - type: toggle
             name: use_blob_urls
             label: Treat every bucket object as a source file
-            description: If unchecked, treat every bucket object as a JSON-formatted task. Optional
+            description: If unchecked, treat every bucket object as a JSON-formatted task
 
 ExportStorage:
   - columnCount: 3

--- a/label_studio/io_storages/redis/form_layout.yml
+++ b/label_studio/io_storages/redis/form_layout.yml
@@ -47,7 +47,7 @@ ImportStorage:
       - type: toggle
         name: use_blob_urls
         label: Treat every bucket object as a source file
-        description: If unchecked, treat every bucket object as a JSON-formatted task. Optional
+        description: If unchecked, treat every bucket object as a JSON-formatted task
 
 ExportStorage:
   - columnCount: 2

--- a/label_studio/io_storages/s3/form_layout.yml
+++ b/label_studio/io_storages/s3/form_layout.yml
@@ -98,12 +98,13 @@ ImportStorage:
   # 2 columns grid
   - columnCount: 2
     columns:
-      - width: 345
+      - width: 400
         fields:
           - type: toggle
             name: use_blob_urls
             label: Treat every bucket object as a source file
-            description: If unchecked, treat every bucket object as a JSON-formatted task. Optional
+            description: If unchecked, treat every bucket object as a JSON-formatted task
+      - fields:
           - type: toggle
             name: recursive_scan
             label: Recursive scan
@@ -111,8 +112,10 @@ ImportStorage:
       - fields:
           - type: toggle
             name: presign
-            label: Use pre-signed URLs
+            label: "Use pre-signed URLs (On)\n Proxy through Label Studio (Off)"
+            description: "When pre-signed URLs are enabled, all data bypasses Label Studio and user browsers directly read data from storage"
             value: true
+      - fields:
           - type: counter
             name: presign_ttl
             label: Expiration minutes

--- a/web/apps/labelstudio/src/components/Form/Elements/Label/Label.scss
+++ b/web/apps/labelstudio/src/components/Form/Elements/Label/Label.scss
@@ -33,6 +33,7 @@
   &__label {
     display: flex;
     align-items: center;
+    white-space: pre-line;
   }
 
   &_size_large &__text {

--- a/web/apps/labelstudio/src/components/Form/Elements/Label/Label.scss
+++ b/web/apps/labelstudio/src/components/Form/Elements/Label/Label.scss
@@ -14,6 +14,7 @@
     color: var(--color-neutral-content-subtler);
     font-weight: 400;
     line-height: 140%;
+    white-space: pre-line;  // enable \n support in description texts
 
     a {
       color: var(--color-primary-content);
@@ -33,7 +34,7 @@
   &__label {
     display: flex;
     align-items: center;
-    white-space: pre-line;
+    white-space: pre-line;  // enable \n support in label texts
   }
 
   &_size_large &__text {

--- a/web/apps/labelstudio/src/components/Form/Form.scss
+++ b/web/apps/labelstudio/src/components/Form/Form.scss
@@ -7,10 +7,10 @@
     justify-items: stretch;
     justify-content: space-between;
     grid-template-columns: repeat(var(--column-count, 5), 1fr);
-    grid-gap: var(--row-gap, 8px) 8px;
+    grid-gap: var(--row-gap, 16px) 12px;
 
     &:not(:first-child) {
-      margin-top: 12px;
+      margin-top: 20px;
     }
 
     &__description {


### PR DESCRIPTION
This PR adds improved control for enabling storage proxies and provides more detailed descriptions to the toggles in storage settings.

|Old|New|
|---|---|
| ![img1](https://github.com/user-attachments/assets/80f7e0c5-3208-4529-9c04-44625bea9653) | ![img2](https://github.com/user-attachments/assets/46bee039-8ec9-43d2-8569-fc5aa3b00415) |
| ![image](https://github.com/user-attachments/assets/0d4ace18-af44-42ad-a43e-40f4022e2e78) |![image](https://github.com/user-attachments/assets/1c6f3c97-6a2d-46d7-90e0-b2f32213cf21) |
| ![image](https://github.com/user-attachments/assets/d72d2ab2-0f08-46d6-a6e7-de937dc08820) | ![image](https://github.com/user-attachments/assets/bffa36e7-4d51-424e-8276-5417293f0a9d) |
