### PR TITLE
fix: UTC-86: Access tokens from rotate endpoint should use TTL

### DIFF
--- a/label_studio/jwt_auth/views.py
+++ b/label_studio/jwt_auth/views.py
@@ -192,6 +192,7 @@ class LSAPITokenRotateView(TokenViewBase):
     authentication_classes = [JWTAuthentication, TokenAuthenticationPhaseout, SessionAuthentication]
     permission_classes = [IsAuthenticated]
     _serializer_class = 'jwt_auth.serializers.LSAPITokenRotateSerializer'
+    token_class = LSAPIToken
 
     @swagger_auto_schema(
         tags=['JWT'],
@@ -219,5 +220,10 @@ class LSAPITokenRotateView(TokenViewBase):
             return Response({'detail': 'Token is invalid or already blacklisted.'}, status=status.HTTP_400_BAD_REQUEST)
 
         # Create a new token for the user
-        new_token = LSAPIToken.for_user(request.user)
+        new_token = self.create_token(request.user)
         return Response({'refresh': new_token.get_full_jwt()}, status=status.HTTP_200_OK)
+
+    def create_token(self, user):
+        """Create a new token for the user. Can be overridden by child classes to use different token classes."""
+        print(f'\n{self.token_class.__dict__}\n')
+        return self.token_class.for_user(user)

--- a/label_studio/jwt_auth/views.py
+++ b/label_studio/jwt_auth/views.py
@@ -225,5 +225,4 @@ class LSAPITokenRotateView(TokenViewBase):
 
     def create_token(self, user):
         """Create a new token for the user. Can be overridden by child classes to use different token classes."""
-        print(f'\n{self.token_class.__dict__}\n')
         return self.token_class.for_user(user)


### PR DESCRIPTION
Token rotate endpoint was only available in LSO , which does not respect the org's access token settings (mainly TTL)
Overriding rotate endpoint in LSE to use LSEAPIToken which does set an expiration on the token using org's settings