### PR TITLE
fix: FIT-212: Editor side-column interface now used to toggle showing the side tab panels

### DIFF
--- a/web/libs/editor/src/components/App/App.jsx
+++ b/web/libs/editor/src/components/App/App.jsx
@@ -279,7 +279,7 @@ class App extends Component {
               }}
             >
               {newUIEnabled ? (
-                isBulkMode ? (
+                isBulkMode || !store.hasInterface("side-column") ? (
                   <>
                     {mainContent}
                     {store.hasInterface("topbar") && <BottomBar store={store} />}
@@ -296,7 +296,7 @@ class App extends Component {
                     {store.hasInterface("topbar") && <BottomBar store={store} />}
                   </SideTabsPanels>
                 )
-              ) : isBulkMode ? (
+              ) : isBulkMode || !store.hasInterface("side-column") ? (
                 mainContent
               ) : (
                 <SidePanels


### PR DESCRIPTION
This pull request modifies the rendering logic in the `App` component within the `web/libs/editor/src/components/App/App.jsx` file to account for cases where the "side-column" interface is not available. The changes ensure that the UI adapts appropriately based on the presence or absence of this interface.

Key changes:

### UI Rendering Logic Updates:
* Adjusted the condition for rendering the main content and `BottomBar` to include scenarios where the "side-column" interface is unavailable. (`[web/libs/editor/src/components/App/App.jsxL282-R282](diffhunk://#diff-bbac6a55022c600df09f9730a5cd6d74d4e3bb0de5c18142b50f6f0b2a47c84eL282-R282)`)
* Updated the fallback rendering logic for `mainContent` to handle cases where the "side-column" interface is not present, ensuring consistent behavior in both bulk mode and non-bulk mode. (`[web/libs/editor/src/components/App/App.jsxL299-R299](diffhunk://#diff-bbac6a55022c600df09f9730a5cd6d74d4e3bb0de5c18142b50f6f0b2a47c84eL299-R299)`)