### PR TITLE
fix: FIT-214: Label Editor loaded with correct data would display incorrectly if not loaded through Data Manager

### DIFF
--- a/web/libs/editor/src/stores/Annotation/Annotation.js
+++ b/web/libs/editor/src/stores/Annotation/Annotation.js
@@ -194,11 +194,29 @@ const _Annotation = types
       user = user.id;
     }
 
+    const getCreatedBy = (snapshot) => {
+      if (snapshot.type === "prediction") {
+        const modelVersion = snapshot.model_version?.trim() ?? "";
+        return modelVersion || "Admin";
+      }
+
+      return snapshot.createdBy ?? "Admin";
+    };
+
+    const getCreatedAt = (snapshot) => {
+      if (snapshot.type === "prediction") {
+        return snapshot.created_at ?? snapshot.createdDate;
+      }
+      return snapshot.draft_created_at ?? snapshot.created_at ?? snapshot.createdDate;
+    };
+
     return {
       ...sn,
       ...(isFF(FF_DEV_3391) ? { root } : {}),
       user,
       editable: sn.editable ?? sn.type === "annotation",
+      createdBy: getCreatedBy(sn),
+      createdDate: getCreatedAt(sn),
       ground_truth: sn.honeypot ?? sn.ground_truth ?? false,
       skipped: sn.skipped || sn.was_cancelled,
       acceptedState: sn.accepted_state ?? sn.acceptedState ?? null,

--- a/web/libs/editor/src/stores/Annotation/Annotation.js
+++ b/web/libs/editor/src/stores/Annotation/Annotation.js
@@ -204,9 +204,6 @@ const _Annotation = types
     };
 
     const getCreatedAt = (snapshot) => {
-      if (snapshot.type === "prediction") {
-        return snapshot.created_at ?? snapshot.createdDate;
-      }
       return snapshot.draft_created_at ?? snapshot.created_at ?? snapshot.createdDate;
     };
 


### PR DESCRIPTION
This pull request introduces utility functions to improve the handling of `createdBy` and `createdDate` fields in the `Annotation` store. These changes enhance code readability and ensure consistent data handling for different snapshot types.

### Enhancements to `Annotation` store:

* Added a `getCreatedBy` function to determine the `createdBy` value based on the snapshot type, defaulting to "Admin" if no value is available. (`web/libs/editor/src/stores/Annotation/Annotation.js`, [web/libs/editor/src/stores/Annotation/Annotation.jsR197-R219](diffhunk://#diff-c954aa71b99a7d8e33373aadf2ef578a22e2a3d2723c610bfc859806c1899b89R197-R219))
* Added a `getCreatedAt` function to standardize the logic for determining the `createdDate` field, accommodating various snapshot properties. (`web/libs/editor/src/stores/Annotation/Annotation.js`, [web/libs/editor/src/stores/Annotation/Annotation.jsR197-R219](diffhunk://#diff-c954aa71b99a7d8e33373aadf2ef578a22e2a3d2723c610bfc859806c1899b89R197-R219))
* Updated the return object to use the new `getCreatedBy` and `getCreatedAt` functions for assigning `createdBy` and `createdDate` fields. (`web/libs/editor/src/stores/Annotation/Annotation.js`, [web/libs/editor/src/stores/Annotation/Annotation.jsR197-R219](diffhunk://#diff-c954aa71b99a7d8e33373aadf2ef578a22e2a3d2723c610bfc859806c1899b89R197-R219))