### PR TITLE
fix: UTC-98: [FE] Page is NOT refreshed automatically when new 'Personal Access Token' is created

### DIFF
--- a/web/libs/app-common/src/pages/AccountSettings/sections/PersonalJWTToken.tsx
+++ b/web/libs/app-common/src/pages/AccountSettings/sections/PersonalJWTToken.tsx
@@ -100,6 +100,7 @@ export function PersonalJWTToken() {
   const tokens = useAtomValue(tokensListAtom);
   const revokeToken = useAtomValue(revokeTokenAtom);
   const createToken = useAtomValue(refreshTokenAtom);
+  const queryClient = useAtomValue(queryClientAtom);
 
   const tokensListClassName = clsx({
     [styles.tokensList]: tokens.data && tokens.data.length,
@@ -135,7 +136,10 @@ export function PersonalJWTToken() {
       style: { width: 680 },
       body: CreateTokenForm,
       closeOnClickOutside: false,
-      onHidden: () => setDialogOpened(false),
+      onHidden: () => {
+        setDialogOpened(false);
+        queryClient.invalidateQueries({ queryKey: ACCESS_TOKENS_QUERY_KEY });
+      },
     });
   }
 


### PR DESCRIPTION
Added cache invalidation to the access-token creation to force the reload of newly created access tokens

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
