### PR TITLE
fix: FIT-220: fix tooltip bottm-left

### DIFF
--- a/web/libs/ui/src/lib/Tooltip/Tooltip.module.scss
+++ b/web/libs/ui/src/lib/Tooltip/Tooltip.module.scss
@@ -84,6 +84,16 @@
         transform: translate(-50%, -50%) rotate(45deg);
       }
     }
+    &_bottom-left {
+      margin-left: calc(calc(var(--offset-x) - (var(--pointer-size) / 2)) * -1);
+      --animation-start: 10px;
+
+      &::before {
+        top: 0;
+        left: 24px;
+        transform: translate(-50%, -50%) rotate(45deg);
+      }
+    }
 
     &_top-left {
       margin-left: calc(calc(var(--offset-x) - (var(--pointer-size) / 2)) * -1);

--- a/web/libs/ui/src/lib/Tooltip/Tooltip.module.scss
+++ b/web/libs/ui/src/lib/Tooltip/Tooltip.module.scss
@@ -84,8 +84,10 @@
         transform: translate(-50%, -50%) rotate(45deg);
       }
     }
+
     &_bottom-left {
       margin-left: calc(calc(var(--offset-x) - (var(--pointer-size) / 2)) * -1);
+
       --animation-start: 10px;
 
       &::before {

--- a/web/libs/ui/src/lib/Tooltip/Tooltip.module.scss
+++ b/web/libs/ui/src/lib/Tooltip/Tooltip.module.scss
@@ -86,7 +86,7 @@
     }
 
     &_bottom-left {
-      margin-left: calc(calc(var(--offset-x) - (var(--pointer-size) / 2)) * -1);
+      margin-left: calc(-1 * (var(--offset-x) - var(--pointer-size) / 2));
 
       --animation-start: 10px;
 
@@ -98,7 +98,7 @@
     }
 
     &_top-left {
-      margin-left: calc(calc(var(--offset-x) - (var(--pointer-size) / 2)) * -1);
+      margin-left: calc(-1 * (var(--offset-x) - var(--pointer-size) / 2));
 
       --animation-start: -10px;
 
@@ -110,7 +110,7 @@
     }
 
     &_top-right {
-      margin-left: calc(calc(var(--offset-x) - (var(--pointer-size) / 2)));
+      margin-left: calc(var(--offset-x) - (var(--pointer-size) / 2));
 
       --animation-start: -10px;
 


### PR DESCRIPTION
This pull request adds a new tooltip position style to the `Tooltip` component's SCSS file, enabling support for a `_bottom-left` tooltip alignment.
<img width="218" alt="image" src="https://github.com/user-attachments/assets/f0ea39dc-3cca-47d8-be2d-e023879c26f7" />

Styling updates for tooltip positioning:

* [`web/libs/ui/src/lib/Tooltip/Tooltip.module.scss`](diffhunk://#diff-1689043134504edaad1d5eb358066805af994052d48d6273eeefa63580a5bca6R87-R96): Added a `_bottom-left` alignment style, including adjustments for `margin-left`, `--animation-start`, and a `::before` pseudo-element for proper positioning and rotation.