### PR TITLE
fix: FIT-221: fix Toggle behavior when parent driven

### DIFF
--- a/web/libs/ui/src/lib/toggle/toggle.tsx
+++ b/web/libs/ui/src/lib/toggle/toggle.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useMemo, useState } from "react";
+import { forwardRef, useCallback, useEffect, useMemo, useState } from "react";
 import clsx from "clsx";
 import { Label } from "@humansignal/ui";
 import styles from "./toggle.module.scss";
@@ -40,6 +40,16 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
       setIsChecked(initialChecked);
     }, [initialChecked]);
 
+    const onChangeHandler = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (typeof checked === undefined) {
+          setIsChecked(e.target.checked);
+        }
+        onChange?.(e);
+      },
+      [onChange, checked],
+    );
+
     const formField = (
       <div
         className={clsx(
@@ -59,10 +69,7 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
           className={clsx(styles.toggle__input)}
           type="checkbox"
           checked={isChecked}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            setIsChecked(e.target.checked);
-            onChange?.(e);
-          }}
+          onChange={onChangeHandler}
         />
         <span className={clsx(styles.toggle__indicator)} />
       </div>

--- a/web/libs/ui/src/lib/toggle/toggle.tsx
+++ b/web/libs/ui/src/lib/toggle/toggle.tsx
@@ -42,7 +42,7 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
 
     const onChangeHandler = useCallback(
       (e: React.ChangeEvent<HTMLInputElement>) => {
-        if (typeof checked === undefined) {
+        if (typeof checked === "undefined") {
           setIsChecked(e.target.checked);
         }
         onChange?.(e);


### PR DESCRIPTION
This pull request updates the `Toggle` component in `web/libs/ui/src/lib/toggle/toggle.tsx` to improve performance and maintainability by introducing the `useCallback` hook for the `onChange` handler. The most important changes are summarized below:

Ultimatly this allows us to undo a toggle from the parent if needed

### Performance Improvement:

* **Introduced `useCallback` for `onChange` handler**: Added a memoized `onChangeHandler` function using `useCallback` to optimize re-renders and ensure consistent function references.

### Code Simplification:

* **Replaced inline `onChange` logic with `onChangeHandler`**: Updated the `onChange` prop of the input element to use the new `onChangeHandler` function, replacing the previous inline logic.

### Dependency Updates:

* **Updated imports to include `useCallback`**: Added `useCallback` to the list of imported hooks from React.