### PR TITLE
feat: UTC-99: [FE] Loading actions in the DM only when clicking on the Actions select dropdown

### DIFF
--- a/web/libs/datamanager/src/components/DataManager/Toolbar/ActionsButton.jsx
+++ b/web/libs/datamanager/src/components/DataManager/Toolbar/ActionsButton.jsx
@@ -1,5 +1,5 @@
 import { inject, observer } from "mobx-react";
-import { useCallback, useRef } from "react";
+import { useCallback, useRef, useEffect, useState } from "react";
 import { IconChevronRight, IconChevronDown, IconTrash } from "@humansignal/icons";
 import { Block, Elem } from "../../../utils/bem";
 import { FF_LOPS_E_3, isFF } from "../../../utils/feature-flags";
@@ -29,111 +29,141 @@ const buildDialogContent = (text, form, formRef) => {
   );
 };
 
+const ActionButton = ({ action, parentRef, store, formRef }) => {
+  const isDeleteAction = action.id.includes("delete");
+  const hasChildren = !!action.children?.length;
+  const submenuRef = useRef();
+
+  const onClick = useCallback(
+    (e) => {
+      e.preventDefault();
+      if (action.disabled) return;
+      action?.callback
+        ? action?.callback(store.currentView?.selected?.snapshot, action)
+        : invokeAction(action, isDeleteAction, store, formRef);
+      parentRef?.current?.close?.();
+    },
+    [store.currentView?.selected, action, isDeleteAction, parentRef, store, formRef],
+  );
+
+  const titleContainer = (
+    <Block
+      key={action.id}
+      tag={Menu.Item}
+      size="small"
+      onClick={onClick}
+      mod={{
+        hasSeperator: isDeleteAction,
+        hasSubMenu: action.children?.length > 0,
+        isSeparator: action.isSeparator,
+        isTitle: action.isTitle,
+        danger: isDeleteAction,
+        disabled: action.disabled,
+      }}
+      name="actionButton"
+    >
+      <Elem name="titleContainer" {...(action.disabled ? { title: action.disabledReason } : {})}>
+        <Elem name="title">{action.title}</Elem>
+        {hasChildren ? <Elem name="icon" tag={IconChevronRight} /> : null}
+      </Elem>
+    </Block>
+  );
+
+  if (hasChildren) {
+    return (
+      <Dropdown.Trigger
+        key={action.id}
+        align="top-right-outside"
+        toggle={false}
+        ref={submenuRef}
+        content={
+          <Block name="actionButton-submenu" tag="ul">
+            {action.children.map((childAction) => (
+              <ActionButton
+                key={childAction.id}
+                action={childAction}
+                parentRef={parentRef}
+                store={store}
+                formRef={formRef}
+              />
+            ))}
+          </Block>
+        }
+      >
+        {titleContainer}
+      </Dropdown.Trigger>
+    );
+  }
+
+  return (
+    <Menu.Item
+      size="small"
+      key={action.id}
+      danger={isDeleteAction}
+      onClick={onClick}
+      className={`actionButton${action.isSeparator ? "_isSeparator" : action.isTitle ? "_isTitle" : ""} ${
+        action.disabled ? "actionButton_disabled" : ""
+      }`}
+      icon={isDeleteAction && <IconTrash />}
+      title={action.disabled ? action.disabledReason : null}
+    >
+      {action.title}
+    </Menu.Item>
+  );
+};
+
+const invokeAction = (action, destructive, store, formRef) => {
+  if (action.dialog) {
+    const { type: dialogType, text, form, title } = action.dialog;
+    const dialog = Modal[dialogType] ?? Modal.confirm;
+
+    dialog({
+      title: title ? title : destructive ? "Destructive action" : "Confirm action",
+      body: buildDialogContent(text, form, formRef),
+      buttonLook: destructive ? "destructive" : "primary",
+      onOk() {
+        const body = formRef.current?.assembleFormData({ asJSON: true });
+
+        store.SDK.invoke("actionDialogOk", action.id, { body });
+        store.invokeAction(action.id, { body });
+      },
+      closeOnClickOutside: false,
+    });
+  } else {
+    store.invokeAction(action.id);
+  }
+};
+
 export const ActionsButton = injector(
   observer(({ store, size, hasSelected, ...rest }) => {
     const formRef = useRef();
     const selectedCount = store.currentView.selectedCount;
-    const actions = store.availableActions.filter((a) => !a.hidden).sort((a, b) => a.order - b.order);
+    const [isOpen, setIsOpen] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
 
-    const invokeAction = (action, destructive) => {
-      if (action.dialog) {
-        const { type: dialogType, text, form, title } = action.dialog;
-        const dialog = Modal[dialogType] ?? Modal.confirm;
-
-        dialog({
-          title: title ? title : destructive ? "Destructive action" : "Confirm action",
-          body: buildDialogContent(text, form, formRef),
-          buttonLook: destructive ? "destructive" : "primary",
-          onOk() {
-            const body = formRef.current?.assembleFormData({ asJSON: true });
-
-            store.SDK.invoke("actionDialogOk", action.id, { body });
-            store.invokeAction(action.id, { body });
-          },
-          closeOnClickOutside: false,
+    useEffect(() => {
+      if (isOpen) {
+        setIsLoading(true);
+        store.fetchActions().finally(() => {
+          setIsLoading(false);
         });
-      } else {
-        store.invokeAction(action.id);
       }
-    };
+    }, [isOpen]);
 
-    const ActionButton = (action, parentRef) => {
-      const isDeleteAction = action.id.includes("delete");
-      const hasChildren = !!action.children?.length;
-      const submenuRef = useRef();
-      const onClick = useCallback(
-        (e) => {
-          e.preventDefault();
-          if (action.disabled) return;
-          action?.callback
-            ? action?.callback(store.currentView?.selected?.snapshot, action)
-            : invokeAction(action, isDeleteAction);
-          parentRef?.current?.close?.();
-        },
-        [store.currentView?.selected],
-      );
-      const titleContainer = (
-        <Block
-          key={action.id}
-          tag={Menu.Item}
-          size={size}
-          onClick={onClick}
-          mod={{
-            hasSeperator: isDeleteAction,
-            hasSubMenu: action.children?.length > 0,
-            isSeparator: action.isSeparator,
-            isTitle: action.isTitle,
-            danger: isDeleteAction,
-            disabled: action.disabled,
-          }}
-          name="actionButton"
-        >
-          <Elem name="titleContainer" {...(action.disabled ? { title: action.disabledReason } : {})}>
-            <Elem name="title">{action.title}</Elem>
-            {hasChildren ? <Elem name="icon" tag={IconChevronRight} /> : null}
-          </Elem>
-        </Block>
-      );
-
-      return hasChildren ? (
-        <Dropdown.Trigger
-          key={action.id}
-          align="top-right-outside"
-          toggle={false}
-          ref={submenuRef}
-          content={
-            <Block name="actionButton-submenu" tag="ul">
-              {action.children.map(ActionButton, parentRef)}
-            </Block>
-          }
-        >
-          {titleContainer}
-        </Dropdown.Trigger>
-      ) : (
-        <Menu.Item
-          size={size}
-          key={action.id}
-          danger={isDeleteAction}
-          onClick={onClick}
-          className={`actionButton${action.isSeparator ? "_isSeparator" : action.isTitle ? "_isTitle" : ""} ${
-            action.disabled ? "actionButton_disabled" : ""
-          }`}
-          icon={isDeleteAction && <IconTrash />}
-          title={action.disabled ? action.disabledReason : null}
-        >
-          {action.title}
-        </Menu.Item>
-      );
-    };
-
-    const actionButtons = actions.map(ActionButton);
+    const actions = store.availableActions.filter((a) => !a.hidden).sort((a, b) => a.order - b.order);
+    const actionButtons = actions.map((action) => (
+      <ActionButton key={action.id} action={action} parentRef={formRef} store={store} formRef={formRef} />
+    ));
     const recordTypeLabel = isFFLOPSE3 && store.SDK.type === "DE" ? "Record" : "Task";
 
     return (
       <Dropdown.Trigger
-        content={<Menu size="compact">{actionButtons}</Menu>}
+        content={
+          <Menu size="compact">{isLoading ? <Menu.Item disabled>Loading actions...</Menu.Item> : actionButtons}</Menu>
+        }
         openUpwardForShortViewport={false}
         disabled={!hasSelected}
+        onToggle={setIsOpen}
       >
         <Button size={size} disabled={!hasSelected} {...rest}>
           {selectedCount > 0 ? `${selectedCount} ${recordTypeLabel}${selectedCount > 1 ? "s" : ""}` : "Actions"}

--- a/web/libs/datamanager/src/stores/AppStore.js
+++ b/web/libs/datamanager/src/stores/AppStore.js
@@ -567,10 +567,6 @@ export const AppStore = types
       const requests = [self.fetchProject(), self.fetchUsers()];
 
       if (!isLabelStream || (self.project?.show_annotation_history && task)) {
-        if (self.SDK.type === "dm") {
-          requests.push(self.fetchActions());
-        }
-
         if (self.SDK.settings?.onlyVirtualTabs && self.project?.show_annotation_history && !task) {
           requests.push(
             self.viewsStore.addView(


### PR DESCRIPTION
Defers the fetching of actions to when the user clicks on the Action dropdown in the DM to improve slightly the speed of the initial DM load.

Note: There is no cache implemented so every time the dropdown is open it will make a request

Improvement: Set up React Query in the DM
<img width="915" alt="Screenshot 2025-06-11 at 09 37 58" src="https://github.com/user-attachments/assets/3a9442c9-dbf9-44d8-9441-fab6db0d0ffc" />

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
