### PR TITLE
fix: FIT-224: Hover Tooltip for Relative Timestamps Not Displaying Exact Time

### DIFF
--- a/web/libs/editor/src/components/Comments/Comment/CommentItem.tsx
+++ b/web/libs/editor/src/components/Comments/Comment/CommentItem.tsx
@@ -146,7 +146,7 @@ export const CommentItem: FC<CommentItemProps> = observer(
         return (
           <Elem name="date">
             <Tooltip alignment="top-right" title={new Date(time).toLocaleString()}>
-              <>{`${isEdited ? "updated" : ""} ${humanDateDiff(time)}`}</>
+              <span>{`${isEdited ? "updated" : ""} ${humanDateDiff(time)}`}</span>
             </Tooltip>
           </Elem>
         );

--- a/web/libs/editor/src/components/Comments/OldComment/CommentItem.tsx
+++ b/web/libs/editor/src/components/Comments/OldComment/CommentItem.tsx
@@ -74,7 +74,7 @@ export const CommentItem: FC<any> = observer(
         return (
           <Elem name="date">
             <Tooltip alignment="top-right" title={new Date(time).toLocaleString()}>
-              <>{`${isEdited ? "updated" : ""} ${humanDateDiff(time)}`}</>
+              <span>{`${isEdited ? "updated" : ""} ${humanDateDiff(time)}`}</span>
             </Tooltip>
           </Elem>
         );

--- a/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.tsx
+++ b/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.tsx
@@ -255,7 +255,7 @@ const HistoryItemComponent: FC<{
             {date && (
               <Elem name="date">
                 <Tooltip alignment="top-right" title={new Date(date).toLocaleString()}>
-                  <>{humanDateDiff(date)}</>
+                  <span>{humanDateDiff(date)}</span>
                 </Tooltip>
               </Elem>
             )}


### PR DESCRIPTION
The tooltip needs a child that can attach behavior.
I've tested the visual for history and will test for comments. Those are the only cases I spotted. None in LSE.


<img width="358" alt="Screenshot 2025-06-11 at 4 42 44 PM" src="https://github.com/user-attachments/assets/eabf78ab-f4b7-4022-b789-c3e6272b2747" />
