### PR TITLE
fix: PLT-796: Prevent deadlocks with batch updates

### DIFF
--- a/label_studio/core/utils/db.py
+++ b/label_studio/core/utils/db.py
@@ -1,7 +1,8 @@
 import logging
+import time
 from typing import Optional, TypeVar
 
-from django.db import models
+from django.db import OperationalError, models, transaction
 from django.db.models import Model, QuerySet, Subquery
 
 logger = logging.getLogger(__name__)
@@ -30,3 +31,43 @@ def fast_first_or_create(model, **model_params) -> Optional[ModelType]:
     if instance := fast_first(model.objects.filter(**model_params)):
         return instance
     return model.objects.create(**model_params)
+
+
+def batch_update_with_retry(queryset, batch_size=500, max_retries=3, **update_fields):
+    """
+    Update objects in batches with retry logic to handle deadlocks.
+
+    Args:
+        queryset: QuerySet of objects to update
+        batch_size: Number of objects to update in each batch
+        max_retries: Maximum number of retry attempts for each batch
+        **update_fields: Fields to update (e.g., overlap=1)
+    """
+    object_ids = list(queryset.values_list('id', flat=True))
+    total_objects = len(object_ids)
+
+    for i in range(0, total_objects, batch_size):
+        batch_ids = object_ids[i : i + batch_size]
+        retry_count = 0
+        last_error = None
+
+        while retry_count < max_retries:
+            try:
+                with transaction.atomic():
+                    queryset.model.objects.filter(id__in=batch_ids).update(**update_fields)
+                break
+            except OperationalError as e:
+                last_error = e
+                if 'deadlock detected' in str(e):
+                    retry_count += 1
+                    wait_time = 0.1 * (2**retry_count)  # Exponential backoff
+                    logger.warning(
+                        f'Deadlock detected, retry {retry_count}/{max_retries} '
+                        f'for batch {i}-{i+len(batch_ids)}. Waiting {wait_time}s...'
+                    )
+                    time.sleep(wait_time)
+                else:
+                    raise
+        else:
+            logger.error(f'Failed to update batch after {max_retries} retries. ' f'Batch: {i}-{i+len(batch_ids)}')
+            raise last_error

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -2,6 +2,7 @@
 """
 import json
 import logging
+import time
 from typing import Any, Mapping, Optional
 
 from annoying.fields import AutoOneToOneField
@@ -28,7 +29,7 @@ from core.utils.common import (
 from core.utils.db import fast_first
 from django.conf import settings
 from django.core.validators import MaxLengthValidator, MinLengthValidator
-from django.db import models, transaction
+from django.db import OperationalError, models, transaction
 from django.db.models import Avg, BooleanField, Case, Count, JSONField, Max, Q, Sum, Value, When
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
@@ -451,6 +452,47 @@ class Project(ProjectMixin, models.Model):
         elif tasks_number_changed and self.overlap_cohort_percentage < 100 and self.maximum_annotations > 1:
             self._rearrange_overlap_cohort()
 
+    def _batch_update_with_retry(self, queryset, batch_size=500, max_retries=3, **update_fields):
+        """
+        Update tasks in batches with retry logic to handle deadlocks.
+
+        Args:
+            queryset: QuerySet of tasks to update
+            batch_size: Number of tasks to update in each batch
+            max_retries: Maximum number of retry attempts for each batch
+            **update_fields: Fields to update (e.g., overlap=1)
+        """
+        task_ids = list(queryset.values_list('id', flat=True))
+        total_tasks = len(task_ids)
+
+        for i in range(0, total_tasks, batch_size):
+            batch_ids = task_ids[i : i + batch_size]
+            retry_count = 0
+
+            while retry_count < max_retries:
+                try:
+                    with transaction.atomic():
+                        Task.objects.filter(id__in=batch_ids).update(**update_fields)
+                    break
+                except OperationalError as e:
+                    if 'deadlock detected' in str(e):
+                        retry_count += 1
+                        if retry_count >= max_retries:
+                            logger.error(
+                                f'Failed to update batch after {max_retries} retries. '
+                                f'Project: {self.id}, Batch: {i}-{i+len(batch_ids)}, Error: {e}'
+                            )
+                            raise
+                        else:
+                            wait_time = 0.1 * (2**retry_count)  # Exponential backoff
+                            logger.warning(
+                                f'Deadlock detected, retry {retry_count}/{max_retries} '
+                                f'for batch {i}-{i+len(batch_ids)}. Waiting {wait_time}s...'
+                            )
+                            time.sleep(wait_time)
+                    else:
+                        raise
+
     def _rearrange_overlap_cohort(self):
         """
         Rearrange overlap depending on annotation count in tasks
@@ -473,7 +515,9 @@ class Project(ProjectMixin, models.Model):
         if left_must_tasks > 0:
             # if there are unfinished tasks update tasks with count(annotations) >= overlap
             ids = list(tasks_with_max_annotations.values_list('id', flat=True))
-            all_project_tasks.filter(id__in=ids).update(overlap=max_annotations, is_labeled=True)
+            self._batch_update_with_retry(
+                all_project_tasks.filter(id__in=ids), overlap=max_annotations, is_labeled=True
+            )
             # order other tasks by count(annotations)
             tasks_with_min_annotations = (
                 tasks_with_min_annotations.annotate(anno=Count('annotations')).order_by('-anno').distinct()
@@ -481,16 +525,16 @@ class Project(ProjectMixin, models.Model):
             # assign overlap depending on annotation count
             # assign max_annotations and update is_labeled
             ids = list(tasks_with_min_annotations[:left_must_tasks].values_list('id', flat=True))
-            all_project_tasks.filter(id__in=ids).update(overlap=max_annotations)
+            self._batch_update_with_retry(all_project_tasks.filter(id__in=ids), overlap=max_annotations)
             # assign 1 to left
             ids = list(tasks_with_min_annotations[left_must_tasks:].values_list('id', flat=True))
             min_tasks_to_update = all_project_tasks.filter(id__in=ids)
-            min_tasks_to_update.update(overlap=1)
+            self._batch_update_with_retry(min_tasks_to_update, overlap=1)
         else:
             ids = list(tasks_with_max_annotations.values_list('id', flat=True))
-            all_project_tasks.filter(id__in=ids).update(overlap=max_annotations)
+            self._batch_update_with_retry(all_project_tasks.filter(id__in=ids), overlap=max_annotations)
             ids = list(tasks_with_min_annotations.values_list('id', flat=True))
-            all_project_tasks.filter(id__in=ids).update(overlap=1)
+            self._batch_update_with_retry(all_project_tasks.filter(id__in=ids), overlap=1)
         # update is labeled after tasks rearrange overlap
         bulk_update_stats_project_tasks(all_project_tasks, project=self)
 

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -2,7 +2,6 @@
 """
 import json
 import logging
-import time
 from typing import Any, Mapping, Optional
 
 from annoying.fields import AutoOneToOneField
@@ -26,10 +25,10 @@ from core.utils.common import (
     load_func,
     merge_labels_counters,
 )
-from core.utils.db import fast_first
+from core.utils.db import batch_update_with_retry, fast_first
 from django.conf import settings
 from django.core.validators import MaxLengthValidator, MinLengthValidator
-from django.db import OperationalError, models, transaction
+from django.db import models, transaction
 from django.db.models import Avg, BooleanField, Case, Count, JSONField, Max, Q, Sum, Value, When
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
@@ -453,45 +452,7 @@ class Project(ProjectMixin, models.Model):
             self._rearrange_overlap_cohort()
 
     def _batch_update_with_retry(self, queryset, batch_size=500, max_retries=3, **update_fields):
-        """
-        Update tasks in batches with retry logic to handle deadlocks.
-
-        Args:
-            queryset: QuerySet of tasks to update
-            batch_size: Number of tasks to update in each batch
-            max_retries: Maximum number of retry attempts for each batch
-            **update_fields: Fields to update (e.g., overlap=1)
-        """
-        task_ids = list(queryset.values_list('id', flat=True))
-        total_tasks = len(task_ids)
-
-        for i in range(0, total_tasks, batch_size):
-            batch_ids = task_ids[i : i + batch_size]
-            retry_count = 0
-
-            while retry_count < max_retries:
-                try:
-                    with transaction.atomic():
-                        Task.objects.filter(id__in=batch_ids).update(**update_fields)
-                    break
-                except OperationalError as e:
-                    if 'deadlock detected' in str(e):
-                        retry_count += 1
-                        if retry_count >= max_retries:
-                            logger.error(
-                                f'Failed to update batch after {max_retries} retries. '
-                                f'Project: {self.id}, Batch: {i}-{i+len(batch_ids)}, Error: {e}'
-                            )
-                            raise
-                        else:
-                            wait_time = 0.1 * (2**retry_count)  # Exponential backoff
-                            logger.warning(
-                                f'Deadlock detected, retry {retry_count}/{max_retries} '
-                                f'for batch {i}-{i+len(batch_ids)}. Waiting {wait_time}s...'
-                            )
-                            time.sleep(wait_time)
-                    else:
-                        raise
+        batch_update_with_retry(queryset, batch_size, max_retries, **update_fields)
 
     def _rearrange_overlap_cohort(self):
         """

--- a/label_studio/tests/test_batch_update_deadlock.py
+++ b/label_studio/tests/test_batch_update_deadlock.py
@@ -1,0 +1,67 @@
+from unittest.mock import patch
+
+import pytest
+from django.db import OperationalError
+from projects.tests.factories import ProjectFactory
+from tasks.models import Task
+from tasks.tests.factories import TaskFactory
+
+
+@pytest.mark.django_db
+class TestBatchUpdateWithRetry:
+    def test_batch_update_success_without_deadlock(self):
+        project = ProjectFactory(overlap_cohort_percentage=50, maximum_annotations=3)
+
+        tasks = TaskFactory.create_batch(10, project=project)
+        task_ids = [task.id for task in tasks]
+
+        tasks_qs = Task.objects.filter(id__in=task_ids)
+        project._batch_update_with_retry(tasks_qs, batch_size=3, overlap=2)
+
+        updated_tasks = Task.objects.filter(id__in=task_ids, overlap=2)
+        assert updated_tasks.count() == 10
+
+    def test_batch_update_with_deadlock_retry(self):
+        project = ProjectFactory(overlap_cohort_percentage=50, maximum_annotations=3)
+
+        tasks = TaskFactory.create_batch(5, project=project)
+        task_ids = [task.id for task in tasks]
+
+        tasks_qs = Task.objects.filter(id__in=task_ids)
+
+        call_count = 0
+
+        original_batch_update = project._batch_update_with_retry
+
+        def mock_batch_update(queryset, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # Simulate deadlock on first call
+                with patch('django.db.transaction.atomic') as mock_atomic:
+                    mock_atomic.side_effect = OperationalError('deadlock detected')
+                    try:
+                        original_batch_update(queryset, *args, **kwargs)
+                    except OperationalError:
+                        pass
+            return original_batch_update(queryset, *args, **kwargs)
+
+        with patch.object(project, '_batch_update_with_retry', side_effect=mock_batch_update):
+            project._batch_update_with_retry(tasks_qs, batch_size=5, overlap=2)
+
+        assert call_count >= 1
+
+        updated_tasks = Task.objects.filter(id__in=task_ids, overlap=2)
+        assert updated_tasks.count() == 5
+
+    def test_batch_update_with_multiple_batches(self):
+        project = ProjectFactory(overlap_cohort_percentage=50, maximum_annotations=3)
+
+        tasks = TaskFactory.create_batch(15, project=project)
+        task_ids = [task.id for task in tasks]
+
+        tasks_qs = Task.objects.filter(id__in=task_ids)
+        project._batch_update_with_retry(tasks_qs, batch_size=5, overlap=3, is_labeled=True)
+
+        updated_tasks = Task.objects.filter(id__in=task_ids, overlap=3, is_labeled=True)
+        assert updated_tasks.count() == 15

--- a/label_studio/tests/test_batch_update_deadlock.py
+++ b/label_studio/tests/test_batch_update_deadlock.py
@@ -65,3 +65,23 @@ class TestBatchUpdateWithRetry:
 
         updated_tasks = Task.objects.filter(id__in=task_ids, overlap=3, is_labeled=True)
         assert updated_tasks.count() == 15
+
+    def test_batch_update_exceeds_max_retries(self):
+        project = ProjectFactory(overlap_cohort_percentage=50, maximum_annotations=3)
+
+        tasks = TaskFactory.create_batch(5, project=project)
+        task_ids = [task.id for task in tasks]
+
+        tasks_qs = Task.objects.filter(id__in=task_ids)
+
+        def mock_batch_update_always_deadlock(queryset, *args, **kwargs):
+            # Always simulate deadlock to test max retries exceeded
+            with patch('django.db.transaction.atomic') as mock_atomic:
+                mock_atomic.side_effect = OperationalError('deadlock detected')
+                from core.utils.db import batch_update_with_retry
+
+                batch_update_with_retry(queryset, max_retries=2, **kwargs)
+
+        with patch.object(project, '_batch_update_with_retry', side_effect=mock_batch_update_always_deadlock):
+            with pytest.raises(OperationalError, match='deadlock detected'):
+                project._batch_update_with_retry(tasks_qs, batch_size=5, overlap=2)


### PR DESCRIPTION
 When multiple users are simultaneously working on projects with a large number of tasks, PostgreSQL deadlocks were occurring during massive tasks update operations. These deadlocks happen when the _rearrange_overlap_cohort() method tries to update thousands of task records in a single database
   transaction while other users are also modifying tasks in the same project.


  - Split large UPDATE operations into batches (500 records)
  - Added retry logic with exponential backoff (up to 3 attempts)
  - Updated _rearrange_overlap_cohort() to use batch updates


<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
