### PR TITLE
docs: Add clarification to PDF tag page

### DIFF
--- a/docs/source/tags/pdf.md
+++ b/docs/source/tags/pdf.md
@@ -14,7 +14,7 @@ Use with the following data types: PDF.
 
 ### Supported control tags
 
-The `<Pdf>` is intended for document-level classification tasks and does not support applying annotations to the actual content of the PDF. 
+The `<Pdf>` tag is intended for document-level classification tasks and does not support applying annotations to the actual content of the PDF. 
 
 For example, if you want to apply labels for OCR tasks, you will need to convert the PDF into images first. For more information, see [Multi-Page Document Annotation](/templates/multi-page-document-annotation). 
 

--- a/docs/source/tags/pdf.md
+++ b/docs/source/tags/pdf.md
@@ -29,7 +29,7 @@ You can use the following control tags:
 - [TextArea](textarea)
 
 !!! error Enterprise
-    You can also use the PDF tag with [Prompts](https://docs.humansignal.com/guide/prompts_overview) to perform auto-labeling work such as PDF summarization and classification. 
+    You can also use the PDF tag with [Prompts](https://docs.humansignal.com/guide/prompts_overview) to perform auto-labeling work such as PDF summarization, classification, information extraction, and document intelligence. 
 
 ### Example
 

--- a/docs/source/tags/pdf.md
+++ b/docs/source/tags/pdf.md
@@ -2,22 +2,34 @@
 title: PDF
 type: tags
 order: 302
-meta_title: PDF Tag for loading PDF documents
-meta_description: Label Studio PDF Tag for loading PDF documents for machine learning and data science projects.
+meta_title: PDF tag for loading PDF documents
+meta_description: Label Studio PDF tag for loading PDF documents for machine learning and data science projects.
 ---
 
-The `Pdf` tag displays a PDF document for labeling. Use for performing document-level annotations, transcription, and summarization.
+The `Pdf` tag displays a PDF document in the labeling interface. Use this tag to perform document-level annotations, transcription, and summarization.
 
 Use with the following data types: PDF.
 
 {% insertmd includes/tags/pdf.md %}
 
-### Supported Control tags
-Document-level annotations are supported with Pdf tag, for example:
+### Supported control tags
 
-- Document classification with [Choices](/tags/choices.html)
-- Document rating with [Rating](/tags/rating.html)
-- Transcription and summarization with [TextArea](/tags/textarea.html)
+The `<Pdf>` is intended for document-level classification tasks and does not support applying annotations to the actual content of the PDF. 
+
+For example, if you want to apply labels for OCR tasks, you will need to convert the PDF into images first. For more information, see [Multi-Page Document Annotation](/templates/multi-page-document-annotation). 
+
+You can use the following control tags:
+
+- [Choices](choices)
+- [DateTime](datetime)
+- [Number](number)
+- [Pairwise](pairwise)
+- [Rating](rating)
+- [Taxonomy](taxonomy)
+- [TextArea](textarea)
+
+!!! error Enterprise
+    You can also use the PDF tag with [Prompts](https://docs.humansignal.com/guide/prompts_overview) to perform auto-labeling work such as PDF summarization and classification. 
 
 ### Example
 


### PR DESCRIPTION
Clarifying which types of tags can be used with the PDF tag. 