### PR TITLE
feat: BROS-107: Visually hide Annotation ID on Annotation History empty state

### DIFF
--- a/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.scss
+++ b/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.scss
@@ -17,6 +17,10 @@
     align-items: center;
     justify-content: space-between;
 
+    &[data-hidden="true"] {
+      @apply sr-only;
+    }
+
     span {
       color: var(--color-neutral-content-subtler);
       font-weight: normal;

--- a/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.scss
+++ b/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.scss
@@ -17,10 +17,6 @@
     align-items: center;
     justify-content: space-between;
 
-    &[data-hidden="true"] {
-      @apply sr-only;
-    }
-
     span {
       color: var(--color-neutral-content-subtler);
       font-weight: normal;

--- a/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.tsx
+++ b/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.tsx
@@ -17,7 +17,7 @@ import {
 } from "@humansignal/icons";
 import { Tooltip, Userpic } from "@humansignal/ui";
 import { Space } from "../../common/Space/Space";
-import { Block, Elem } from "../../utils/bem";
+import { Block, cn, Elem } from "../../utils/bem";
 import { humanDateDiff, userDisplayName } from "../../utils/utilities";
 import { EmptyState } from "../SidePanels/Components/EmptyState";
 import "./AnnotationHistory.scss";
@@ -142,7 +142,13 @@ const AnnotationHistoryComponent: FC<any> = ({
   if (shouldShowEmptyState) {
     return (
       <Block name="annotation-history" mod={{ inline, empty: true }}>
-        {sectionHeader && <div className="lsf-annotation-history__section-head sr-only">{sectionHeader}</div>}
+        {sectionHeader && (
+          <div
+            className={`${cn("annotation-history").elem("section-head").toString()}${showEmptyState ? " sr-only" : ""}`}
+          >
+            {sectionHeader}
+          </div>
+        )}
         {renderEmptyState ? renderEmptyState() : defaultEmptyState}
       </Block>
     );

--- a/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.tsx
+++ b/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.tsx
@@ -142,11 +142,7 @@ const AnnotationHistoryComponent: FC<any> = ({
   if (shouldShowEmptyState) {
     return (
       <Block name="annotation-history" mod={{ inline, empty: true }}>
-        {sectionHeader && (
-          <Elem name="section-head" data-hidden="true">
-            {sectionHeader}
-          </Elem>
-        )}
+        {sectionHeader && <div className="lsf-annotation-history__section-head sr-only">{sectionHeader}</div>}
         {renderEmptyState ? renderEmptyState() : defaultEmptyState}
       </Block>
     );

--- a/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.tsx
+++ b/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.tsx
@@ -142,7 +142,11 @@ const AnnotationHistoryComponent: FC<any> = ({
   if (shouldShowEmptyState) {
     return (
       <Block name="annotation-history" mod={{ inline, empty: true }}>
-        {sectionHeader && <Elem name="section-head">{sectionHeader}</Elem>}
+        {sectionHeader && (
+          <Elem name="section-head" data-hidden="true">
+            {sectionHeader}
+          </Elem>
+        )}
         {renderEmptyState ? renderEmptyState() : defaultEmptyState}
       </Block>
     );


### PR DESCRIPTION
### Reason for change
In the Annotation History panel, the "Annotation ID" header was still visible even when there were no annotations to display. This change visually hides the header in the empty state to create a cleaner and more intuitive user interface, aligning with the intended design. The Annotation ID remains accessible to screen readers to maintain accessibility standards.

### Screenshots
**Before**
![image](https://github.com/user-attachments/assets/ce675b0d-d473-4666-aa95-079c44f76bd5)

**After**
![image](https://github.com/user-attachments/assets/066d2ad1-9bde-46a7-939b-f134ee227006)

### Testing
1.  Navigate the Labeling UI, and open the History panel.
2.  Ensure there are no annotation changes (create a new one), so the panel displays its empty state.
3.  **Verify** that the "Annotation ID" header is not visible.
4.  Using browser developer tools, inspect the element to **confirm** that the header is still present in the DOM.
5.  Create a new annotation.
6.  **Verify** that the "Annotation ID" and its value are now visible in the history panel.

### General notes
This change improves the overall user experience by decluttering the interface in its empty state.


<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
