### PR TITLE
fix: BROS-125: Allow bitmask eraser to erase single pixels

### DIFF
--- a/web/libs/editor/src/components/ImageView/ImageView.jsx
+++ b/web/libs/editor/src/components/ImageView/ImageView.jsx
@@ -1335,14 +1335,37 @@ const CursorLayer = observer(({ item, tool }) => {
   }, [item.stageRef]);
 
   const size = useMemo(() => {
-    return (item.imageIsSmallerThanStage ? tool.strokeWidth : tool.strokeWidth / item.stageToImageRatio) + 2;
+    return item.imageIsSmallerThanStage ? tool.strokeWidth : tool.strokeWidth / item.stageToImageRatio;
   }, [tool.strokeWidth, item.imageIsSmallerThanStage, item.stageToImageRatio]);
 
   return visible ? (
-    <Layer>
-      <Circle x={x} y={y} radius={size} stroke="black" strokeWidth={3} strokeScaleEnabled={false} />
-      <Circle x={x} y={y} radius={size} stroke="white" strokeWidth={1} strokeScaleEnabled={false} />
-    </Layer>
+    tool.strokeWidth <= 2 ? (
+      <Layer listening={false}>
+        <Rect
+          x={x - size / 2}
+          y={y - size / 2}
+          width={size}
+          height={size}
+          stroke="black"
+          strokeWidth={3}
+          strokeScaleEnabled={false}
+        />
+        <Rect
+          x={x - size / 2}
+          y={y - size / 2}
+          width={size}
+          height={size}
+          stroke="white"
+          strokeWidth={1}
+          strokeScaleEnabled={false}
+        />
+      </Layer>
+    ) : (
+      <Layer listening={false}>
+        <Circle x={x} y={y} radius={size} stroke="black" strokeWidth={3} strokeScaleEnabled={false} />
+        <Circle x={x} y={y} radius={size} stroke="white" strokeWidth={1} strokeScaleEnabled={false} />
+      </Layer>
+    )
   ) : null;
 });
 

--- a/web/libs/editor/src/components/ImageView/ImageView.jsx
+++ b/web/libs/editor/src/components/ImageView/ImageView.jsx
@@ -1247,7 +1247,6 @@ const EntireStage = observer(
           item.setStageRef(ref);
         }}
         className={[styles["image-element"], ...imagePositionClassnames].join(" ")}
-        style={{ cursor: "none" }}
         width={size.width}
         height={size.height}
         scaleX={item.zoomScale}

--- a/web/libs/editor/src/components/ImageView/ImageView.jsx
+++ b/web/libs/editor/src/components/ImageView/ImageView.jsx
@@ -1339,33 +1339,35 @@ const CursorLayer = observer(({ item, tool }) => {
   }, [tool.strokeWidth, item.imageIsSmallerThanStage, item.stageToImageRatio]);
 
   return visible ? (
-    tool.strokeWidth <= 2 ? (
-      <Layer listening={false}>
-        <Rect
-          x={x - size / 2}
-          y={y - size / 2}
-          width={size}
-          height={size}
-          stroke="black"
-          strokeWidth={3}
-          strokeScaleEnabled={false}
-        />
-        <Rect
-          x={x - size / 2}
-          y={y - size / 2}
-          width={size}
-          height={size}
-          stroke="white"
-          strokeWidth={1}
-          strokeScaleEnabled={false}
-        />
-      </Layer>
-    ) : (
-      <Layer listening={false}>
-        <Circle x={x} y={y} radius={size} stroke="black" strokeWidth={3} strokeScaleEnabled={false} />
-        <Circle x={x} y={y} radius={size} stroke="white" strokeWidth={1} strokeScaleEnabled={false} />
-      </Layer>
-    )
+    <Layer listening={false}>
+      {tool.strokeWidth <= 2 ? (
+        <>
+          <Rect
+            x={x - size / 2}
+            y={y - size / 2}
+            width={size}
+            height={size}
+            stroke="black"
+            strokeWidth={3}
+            strokeScaleEnabled={false}
+          />
+          <Rect
+            x={x - size / 2}
+            y={y - size / 2}
+            width={size}
+            height={size}
+            stroke="white"
+            strokeWidth={1}
+            strokeScaleEnabled={false}
+          />
+        </>
+      ) : (
+        <>
+          <Circle x={x} y={y} radius={size} stroke="black" strokeWidth={3} strokeScaleEnabled={false} />
+          <Circle x={x} y={y} radius={size} stroke="white" strokeWidth={1} strokeScaleEnabled={false} />
+        </>
+      )}
+    </Layer>
   ) : null;
 });
 

--- a/web/libs/editor/src/components/ImageView/ImageView.jsx
+++ b/web/libs/editor/src/components/ImageView/ImageView.jsx
@@ -464,7 +464,7 @@ const PixelGridLayer = observer(({ item }) => {
   const { stageWidth, stageHeight } = item;
   const imageSmallerThanStage = naturalWidth < stageWidth || naturalHeight < stageHeight;
 
-  const step = 1 / (item.imageIsSmallerThanStage ? 1 : item.stageToImageRatio); // image pixel
+  const step = item.stageZoom; // image pixel
 
   const { verticalPoints, horizontalPoints } = useMemo(() => {
     const vPts = [];
@@ -1288,14 +1288,14 @@ const ImageLayer = observer(({ item }) => {
 
   const { width, height } = useMemo(() => {
     return {
-      width: Math.min(imageEntity.naturalWidth, item.stageWidth),
-      height: Math.min(imageEntity.naturalHeight, item.stageHeight),
+      width: imageEntity.naturalWidth,
+      height: imageEntity.naturalHeight,
     };
   }, [imageEntity.naturalWidth, imageEntity.naturalHeight, item.stageWidth, item.stageHeight]);
 
   return image ? (
     <>
-      <Layer imageSmoothingEnabled={item.smoothing}>
+      <Layer imageSmoothingEnabled={item.smoothing} scale={{ x: item.stageZoom, y: item.stageZoom }}>
         <KonvaImage image={image} width={width} height={height} listening={false} />
       </Layer>
     </>
@@ -1334,8 +1334,8 @@ const CursorLayer = observer(({ item, tool }) => {
   }, [item.stageRef]);
 
   const size = useMemo(() => {
-    return item.imageIsSmallerThanStage ? tool.strokeWidth : tool.strokeWidth / item.stageToImageRatio;
-  }, [tool.strokeWidth, item.imageIsSmallerThanStage, item.stageToImageRatio]);
+    return tool.strokeWidth * item.stageZoom;
+  }, [tool.strokeWidth, item.stageZoom]);
 
   return visible ? (
     <Layer listening={false}>

--- a/web/libs/editor/src/tags/object/Image/Image.js
+++ b/web/libs/editor/src/tags/object/Image/Image.js
@@ -284,16 +284,6 @@ const Model = types
       }[self.rotation];
     },
 
-    get stageToImageRatio() {
-      const ent = self.currentImageEntity;
-      return Math.min(ent.naturalWidth / self.stageWidth, ent.naturalHeight / self.stageHeight);
-    },
-
-    get imageIsSmallerThanStage() {
-      const ent = self.currentImageEntity;
-      return ent.naturalWidth < self.stageWidth || ent.naturalHeight < self.stageHeight;
-    },
-
     get stageScale() {
       return self.zoomScale;
     },

--- a/web/libs/editor/src/tools/BitmaskErase.jsx
+++ b/web/libs/editor/src/tools/BitmaskErase.jsx
@@ -108,7 +108,7 @@ const _Tool = types
       },
 
       addPoint(x, y) {
-        brush.addPoint(Math.floor(x), Math.floor(y), self.strokeWidth, { erase: true });
+        brush.addPoint(x, y, self.strokeWidth, { erase: true });
       },
 
       setStroke(val) {


### PR DESCRIPTION
This is a fix for bitmask eraser tool that unlocks per-pixel erase. Previously it would jump between two closest points. Now it's precisely targeting each pixel when the brush is set to 1px.

It also improves cursor visuals slightly when working with 1-2px brushes.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
