### PR TITLE
fix: FIT-255: Video settings on Labeling Interface Settings modal don't work

### DIFF
--- a/web/libs/editor/src/stores/SettingsStore.js
+++ b/web/libs/editor/src/stores/SettingsStore.js
@@ -70,6 +70,8 @@ const SettingsModel = types
     videoHopSize: types.optional(types.number, 10),
 
     isDestroying: types.optional(types.boolean, false),
+
+    videoDrawOutside: types.optional(types.boolean, false),
   })
   .views((self) => ({
     get annotation() {
@@ -235,6 +237,10 @@ const SettingsModel = types
 
     setProperty(name, value) {
       self[name] = value;
+    },
+
+    toggleProperty(name) {
+      self[name] = !self[name];
     },
   }));
 


### PR DESCRIPTION
This pull request introduces two changes to the `SettingsModel` in `web/libs/editor/src/stores/SettingsStore.js`. These changes enhance the model's functionality by adding a new property and a method for toggling boolean properties.
before:
<img width="657" alt="image" src="https://github.com/user-attachments/assets/667eb5fb-6668-45c5-9cee-8fbf47c6f733" />

after:
<img width="1234" alt="image" src="https://github.com/user-attachments/assets/a1f9a13e-2586-4eb2-bfd5-febe6769a69d" />

Enhancements to `SettingsModel`:

* Added a new optional boolean property, `videoDrawOutside`, to the `SettingsModel`. This property can be used to control whether video elements are drawn outside a specific boundary.
* Introduced a new method, `toggleProperty(name)`, which allows toggling the value of a boolean property dynamically. This simplifies the process of flipping boolean states in the model.