### PR TITLE
fix: FIT-255: Video settings on Labeling Interface Settings modal don't work

### DIFF
--- a/web/libs/editor/src/stores/SettingsStore.js
+++ b/web/libs/editor/src/stores/SettingsStore.js
@@ -70,6 +70,8 @@ const SettingsModel = types
     videoHopSize: types.optional(types.number, 10),
 
     isDestroying: types.optional(types.boolean, false),
+
+    videoDrawOutside: types.optional(types.boolean, false),
   })
   .views((self) => ({
     get annotation() {
@@ -235,6 +237,10 @@ const SettingsModel = types
 
     setProperty(name, value) {
       self[name] = value;
+    },
+
+    toggleProperty(name) {
+      self[name] = !self[name];
     },
   }));
 


### PR DESCRIPTION
This pull request introduces two changes to the `SettingsModel` in the `web/libs/editor/src/stores/SettingsStore.js` file. These changes add support for a new property and a utility method for toggling properties.

Enhancements to `SettingsModel`:

* Added a new optional boolean property, `videoDrawOutside`, to enable additional configuration options for video settings.
* Introduced a `toggleProperty` method to simplify toggling boolean properties dynamically within the model.