### PR TITLE
fix: Correctly determine holdsState in onlyTime mode to prevent result removal

### DIFF
--- a/web/libs/editor/src/tags/control/DateTime.jsx
+++ b/web/libs/editor/src/tags/control/DateTime.jsx
@@ -76,7 +76,7 @@ const Model = types
     },
 
     get holdsState() {
-      if (self.onlyTime && !isDefined(self.time)) return false;
+      if (self.onlyTime) return isDefined(self.time);
       return isDefined(self.month) || isDefined(self.year);
     },
 


### PR DESCRIPTION
### 🧠 Problem Summary 


In `only="time"` mode, the original logic of the `holdsState()` method was:

```js
if (self.onlyTime && !isDefined(self.time)) return false;
return isDefined(self.month) || isDefined(self.year);
```


During the **first time selecting a time**:
- `self.time` is assigned;
- `updateResult()` triggers `createPerObjectResult()`, successfully creating the result.

However, during the **second time modifying the time**:
- `self.time` is assigned;
- `updateResult()` triggers `self.result.area.setValue(self);`
- It enters setValue(tag)；
- The `tag.holdsState` is evaluated to determine whether to keep the result；
- Since `!isDefined(self.time)` is `false`, it falls through to `return isDefined(self.month) || isDefined(self.year)`；
- In `only="time"` mode, `month` and `year` are always `undefined`, so `holdsState` returns `false`；
- As a result, setValue(tag) calls `removeResult(result)`, **removing the result**, causing the bug where the input disappears after being set.

Changing the value again after that is just repeating this process.This behavior leads to an incorrect state evaluation that breaks expected functionality.

###### The involved files include: DateTime.jsx, ClassificationBase.js, AreaMixin.js

---

### Description:

In `only="time"` mode, the previous logic of `holdsState()` caused a regression where time updates would be discarded unexpectedly. The original condition:

```js
if (self.onlyTime && !isDefined(self.time)) return false;
return isDefined(self.month) || isDefined(self.year);
```


would fall through to checking `month` and `year`, which are always undefined in `only="time"` mode, leading to an incorrect `false` return value. This resulted in the result being removed during subsequent time changes.

This change simplifies and corrects the logic:

```js
if (self.onlyTime) return isDefined(self.time);
return isDefined(self.month) || isDefined(self.year);
```


Now, in `only="time"` mode, the state is solely determined by whether `self.time` is defined — aligning with the intended behavior and preventing unintended result removal.

---
### 🔍Problem Solved:
- fix #7628 

#### before:
![before](https://github.com/user-attachments/assets/0d324098-98e4-44f6-a9e6-ce9d3f4e42b5)

#### after:
![after](https://github.com/user-attachments/assets/ffae3e5c-5ad9-4e13-a27d-d77b43524c88)

---

### 📁 Changed Files

**Path:** `libs/editor/src/tags/control/DateTime.jsx`

#### Code Changes:

```diff
 get holdsState() {
-  if (self.onlyTime && !isDefined(self.time)) return false;
-  return isDefined(self.month) || isDefined(self.year);
+  if (self.onlyTime) return isDefined(self.time);
+  return isDefined(self.month) || isDefined(self.year);
 },
```


---

### ✅ Testing Recommendation:

- Test time input on odd/even updates.
- Ensure results persist in `only="time"` mode.
- Validate behavior in other modes.
- Verify mixed-mode behavior.
