### PR TITLE
Fb triag 1493/clean up empty feature flag

### DIFF
--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -23,7 +23,6 @@ STALE_FEATURE_FLAGS = {
     'fflag_fix_front_dev_3793_relative_coords_short': True,
     'ff_front_dev_2715_audio_3_280722_short': True,
     # Feb 5
-    'fflag_feat_front_optic_1351_use_new_projects_counts_api_short': True,
     'fflag_feature_all_optic_1421_cold_start_v2': False,
     'fflag_fix_back_optic_1407_optimize_tasks_api_pagination_counts': True,
     'fflag_fix_optic_1259_lse_projects_read_apis_use_replica_short': True,

--- a/label_studio/core/feature_flags/stale_feature_flags.py
+++ b/label_studio/core/feature_flags/stale_feature_flags.py
@@ -31,7 +31,6 @@ STALE_FEATURE_FLAGS = {
     'fflag_feat_optic_378_limit_projects_per_page_to_ten_short': True,
     'fflag_feat_optic_67_drag_and_drop_charts': True,
     # Feb 6
-    'fflag_feat_dia_1528_gemini_models_support_vertex_ai_support_short': True,
     'fflag_feat_all_dia_1576_prompts_easy_breezy_onboarding_short_async_presets_ks': False,
     'fflag_front_dia_1150_ddisco_sneak_preview': False,
     # Feb 25

--- a/web/libs/core/src/lib/utils/feature-flags/flags.ts
+++ b/web/libs/core/src/lib/utils/feature-flags/flags.ts
@@ -1,10 +1,5 @@
 //// LEGACY FLAGS ////
 // Consider all pre-XFN flags legacy. Should be revised and removed.
-/**
- * Aync import for task data
- * @deprecated
- */
-export const FF_LSDV_4915 = "fflag_feat_all_lsdv_4915_async_task_import_13042023_short";
 
 /**
  * Fix displaying of created_at in the review mode

--- a/web/libs/core/src/lib/utils/feature-flags/flags.ts
+++ b/web/libs/core/src/lib/utils/feature-flags/flags.ts
@@ -12,11 +12,6 @@ export const FF_LSDV_4915 = "fflag_feat_all_lsdv_4915_async_task_import_13042023
 export const FF_DEV_1480 = "ff_front_dev_1480_created_on_in_review_180122_short";
 
 /**
- * Notifications
- */
-export const FF_DEV_1658 = "ff_front_dev_1658_notification_center_170222_short";
-
-/**
  * Model version selector per model backend
  */
 export const FF_DEV_1682 = "ff_front_dev_1682_model_version_dropdown_070622_short";

--- a/web/libs/editor/LSF.init.md
+++ b/web/libs/editor/LSF.init.md
@@ -6,9 +6,8 @@ Different thoughts and investingations related to LSF init.
 
 We have 3 UI versions: old (awful), medium (outliner v1), modern (draggable panels)
 
-Flags:
+Flag:
 
-- `ff_front_1170_outliner_030222_short` — initial **FF_1170**
 - `fflag_feat_front_dev_3873_labeling_ui_improvements_short` — modern **FF_3873**
 
 Components:


### PR DESCRIPTION
I Archive a list of FF, here are the links.
Some of them has reference in the code that do not affect logic and that was consider empty flas and also removed:

List:
**ff_front_1170_outliner_030222_short**
https://github.com/search?q=org:HumanSignal+-is:archived+ff_front_1170_outliner_030222_short&type=code

**ff_front_dev_1658_notification_center_170222_short** 
https://github.com/search?q=org:HumanSignal+-is:archived+ff_front_dev_1658_notification_center_170222_short&type=code

https://github.com/search?q=org:HumanSignal+-is:archived+FF_DEV_1658&type=code  

**fflag_feat_all_lsdv_4915_async_task_import_13042023_short**
https://github.com/search?q=org:HumanSignal+-is:archived+fflag_feat_all_lsdv_4915_async_task_import_13042023_short&type=code https://github.com/search?q=org:HumanSignal+-is:archived+FF_LSDV_4915&type=code

**fflag_feat_front_lops_86_datasets_storage_edit_short**
https://github.com/search?q=org:HumanSignal+-is:archived+fflag_feat_front_lops_86_datasets_storage_edit_short&type=code

**fflag_feat_all_optic_1181_membership_performance**
https://github.com/search?q=org:HumanSignal+-is:archived+fflag_feat_all_optic_1181_membership_performance&type=code 

**fflag_feat_front_optic_1351_use_new_projects_counts_api_short**
https://github.com/search?q=org:HumanSignal+-is:archived+fflag_feat_front_optic_1351_use_new_projects_counts_api_short&type=code 
Only in stale ff


**fflag_feat_front_optic_1417_improve_project_list_cache_short**

https://github.com/search?q=org:HumanSignal+-is:archived+fflag_feat_front_optic_1417_improve_project_list_cache_short&type=code 



**fflag_feat_dia_1528_gemini_models_support_vertex_ai_support_short**

https://github.com/search?q=org:HumanSignal+-is:archived+fflag_feat_dia_1528_gemini_models_support_vertex_ai_support_short&type=code 


**fflag_feat_back_optic_1157_set_ground_truths_action**

https://github.com/search?q=org:HumanSignal+-is:archived+fflag_feat_back_optic_1157_set_ground_truths_action&type=code