### PR TITLE
fix: FIT-250: SplitChannel audio with spectrogram displaying blank space on waveform (#7820)

### DIFF
--- a/web/libs/editor/src/lib/AudioUltra/Visual/Renderer/WaveformRenderer.ts
+++ b/web/libs/editor/src/lib/AudioUltra/Visual/Renderer/WaveformRenderer.ts
@@ -105,7 +105,7 @@ export class WaveformRenderer implements Renderer<WaveformRendererConfig> {
   renderWave(context: RenderContext, channelNumber: number, layer: Layer, iStart: number, iEnd: number): boolean {
     const renderId = this.config.renderId;
     const audio = this.audio;
-    const height = this.config.waveHeight / (audio?.channelCount ?? 1);
+    const height = this.config.waveHeight;
     const scrollLeftPx = context.scrollLeftPx;
     const zoom = context.zoom;
     const amp = this.config.amp ?? 1;
@@ -139,7 +139,7 @@ export class WaveformRenderer implements Renderer<WaveformRendererConfig> {
     let x = 0;
     const audio = this.audio;
     const channelCount = audio?.channelCount ?? 1;
-    const height = this.config.waveHeight / channelCount;
+    const height = this.config.waveHeight;
     const scrollLeftPx = context.scrollLeftPx;
     const dataLength = context.dataLength;
     this.lastWaveformRenderedScrollLeftPx = scrollLeftPx;

--- a/web/libs/editor/src/lib/AudioUltra/Visual/Visualizer.ts
+++ b/web/libs/editor/src/lib/AudioUltra/Visual/Visualizer.ts
@@ -154,7 +154,7 @@ export class Visualizer extends Events<VisualizerEvents> {
       backgroundLayer,
       config: {
         renderId: this.renderId,
-        waveHeight: this.waveHeight,
+        waveHeight: this.waveformHeight,
         padding: this.padding,
         reservedSpace: this.reservedSpace,
         waveColor: this.waveColor,
@@ -1092,14 +1092,13 @@ export class Visualizer extends Events<VisualizerEvents> {
     if (!spectrogramLayer?.isVisible) return 0;
 
     const channelCount = this.audio?.channelCount ?? 1;
-    const totalAvailableHeight = this.waveHeight;
 
     if (this.splitChannels) {
       // Each channel gets an equal split of the spectrogram area
-      return totalAvailableHeight / channelCount;
+      return this.waveHeight / channelCount;
     }
     // Spectrogram uses the full height when not split
-    return totalAvailableHeight;
+    return this.waveHeight;
   }
 
   setAmp(amp: number) {


### PR DESCRIPTION
Cherry picked a3fe8323e0f1e8e93fe3093b8e696eb95dcd666f