### PR TITLE
fix: FIT-263: Audio region start and end editor inputs not updating on change

### DIFF
--- a/web/libs/editor/src/components/SidePanels/DetailsPanel/RegionEditor.tsx
+++ b/web/libs/editor/src/components/SidePanels/DetailsPanel/RegionEditor.tsx
@@ -19,6 +19,7 @@ import { FF_DEV_2715, isFF } from "../../../utils/feature-flags";
 import { TimeDurationControl } from "../../TimeDurationControl/TimeDurationControl";
 import { TimelineRegionEditor } from "./TimelineRegionEditor";
 import "./RegionEditor.scss";
+import type { MSTRegion } from "../../../stores/types";
 
 interface RegionEditorProps {
   region: MSTRegion;
@@ -83,7 +84,7 @@ const RegionProperties = ({ region }: RegionEditorProps) => {
   );
 };
 
-const AudioRegionProperties = ({ region }: { region: any }) => {
+const AudioRegionProperties = observer(({ region }: { region: any }) => {
   const changeStartTimeHandler = (value: number) => {
     region.setProperty("start", value);
   };
@@ -107,7 +108,7 @@ const AudioRegionProperties = ({ region }: { region: any }) => {
       />
     </Elem>
   );
-};
+});
 
 interface RegionPropertyProps {
   property: string;


### PR DESCRIPTION
[Kapture 2025-06-24 at 09.57.17.webm](https://github.com/user-attachments/assets/db7e481a-e8e9-43bb-9dd0-b9b3438baf45)

This pull request introduces updates to the `RegionEditor.tsx` file to enhance type safety and improve state management. The changes include adding a type import for `MSTRegion` and wrapping a component with MobX's `observer` to enable reactive rendering.

### Type safety improvements:
* Added the `MSTRegion` type import to ensure the `region` prop in `RegionEditorProps` is strongly typed. (`[web/libs/editor/src/components/SidePanels/DetailsPanel/RegionEditor.tsxR22](diffhunk://#diff-f8ab8d5429cab03058f9ed3cca07385bf31d8044c7798adaeca6667366769468R22)`)

### State management improvements:
* Wrapped the `AudioRegionProperties` component with MobX's `observer` to make it reactive to state changes. (`[[1]](diffhunk://#diff-f8ab8d5429cab03058f9ed3cca07385bf31d8044c7798adaeca6667366769468L86-R87)`, `[[2]](diffhunk://#diff-f8ab8d5429cab03058f9ed3cca07385bf31d8044c7798adaeca6667366769468L110-R111)`)