### PR TITLE
fix: FIT-306: Zooming out the page breaks audio rendering of the waveform when partial rendering

### DIFF
--- a/web/libs/editor/src/lib/AudioUltra/Visual/Layer.ts
+++ b/web/libs/editor/src/lib/AudioUltra/Visual/Layer.ts
@@ -272,6 +272,10 @@ export class Layer extends Events<LayerEvents> {
   copyToBuffer() {
     this.createBufferCanvas();
 
+    // This needs to be updated to ensure it has the same pixel ratio as the canvas it is copying from/to
+    this._bufferCanvas.width = this.canvas.width;
+    this._bufferCanvas.height = this.canvas.height;
+
     // Copy the current canvas to the buffer
     this._bufferContext.imageSmoothingEnabled = false;
     this._bufferContext.clearRect(0, 0, this._bufferCanvas.width, this._bufferCanvas.height);


### PR DESCRIPTION
When we are copying and restoring from the buffer canvas, we need to ensure the size of the buffer canvas is updated to match the visual layer canvas, otherwise it ends up drawing only a partial height or width of the waveform.

This pull request includes a small but important fix in the `Layer` class to ensure proper handling of canvas pixel ratios during the `copyToBuffer` operation. 

* [`web/libs/editor/src/lib/AudioUltra/Visual/Layer.ts`](diffhunk://#diff-2dfb47cc847d29cc9902818460840d7346cbddd7015034eed373f2321eac472eR275-R278): Updated the `_bufferCanvas` dimensions to match the `canvas` dimensions, ensuring consistent pixel ratios when copying between canvases.