### PR TITLE
fix: FIT-306: Zooming out the page breaks audio rendering of the waveform when partial rendering

### DIFF
--- a/web/libs/editor/src/lib/AudioUltra/Visual/Layer.ts
+++ b/web/libs/editor/src/lib/AudioUltra/Visual/Layer.ts
@@ -272,6 +272,10 @@ export class Layer extends Events<LayerEvents> {
   copyToBuffer() {
     this.createBufferCanvas();
 
+    // This needs to be updated to ensure it has the same pixel ratio as the canvas it is copying from/to
+    this._bufferCanvas.width = this.canvas.width;
+    this._bufferCanvas.height = this.canvas.height;
+
     // Copy the current canvas to the buffer
     this._bufferContext.imageSmoothingEnabled = false;
     this._bufferContext.clearRect(0, 0, this._bufferCanvas.width, this._bufferCanvas.height);


### PR DESCRIPTION
cherry picked 4f814c5a715bc19fc829d4b5b986bad0d127e2e0