### PR TITLE
fix: FIT-312: Firefox cross browser issue with RichText

### DIFF
--- a/web/libs/editor/src/tags/object/RichText/domManager.ts
+++ b/web/libs/editor/src/tags/object/RichText/domManager.ts
@@ -741,6 +741,7 @@ export default class DomManager {
     const range: Range = new Range();
     const lastRanges = [];
 
+    if (!selection) return "";
     // save previous selection
     for (let idx = 0; idx < selection.rangeCount; idx++) {
       lastRanges.push(selection.getRangeAt(idx));


### PR DESCRIPTION
This pull request includes a small change to the `DomManager` class in `web/libs/editor/src/tags/object/RichText/domManager.ts`. The change adds a check to return an empty string if `selection` is falsy, ensuring the code handles cases where `selection` is undefined or null.

before:
![image (38)](https://github.com/user-attachments/assets/7eff1570-7b1a-4d41-b23a-979e4edb434d)

after:
<img width="736" alt="image" src="https://github.com/user-attachments/assets/fca3afe8-18f8-444f-a50b-5d2d1f9a025d" />

