### PR TITLE
fix: UTC-144: Update monospace font token to include fallback

### DIFF
--- a/web/design-tokens.json
+++ b/web/design-tokens.json
@@ -3810,13 +3810,13 @@
         },
         "mono": {
           "$type": "fontFamily",
-          "$value": "IBMPlexMono",
+          "$value": "IBM Plex Mono,monospace",
           "$description": "",
           "$variable_metadata": {
             "name": "typography/font-family/mono",
             "figmaId": "VariableID:2646:12151",
             "modes": {
-              "value": "IBMPlexMono"
+              "value": "IBM Plex Mono,monospace"
             }
           }
         }

--- a/web/libs/ui/src/tokens/tokens.scss
+++ b/web/libs/ui/src/tokens/tokens.scss
@@ -449,7 +449,7 @@
   --letter-spacing--15: -0.0094rem;
   --letter-spacing--10: -0.0063rem;
   --font-family-base: "Figtree";
-  --font-family-mono: "IBMPlexMono";
+  --font-family-mono: "IBM Plex Mono,monospace";
   --corner-radius-0: var(--spacing-0);
   --corner-radius-2: var(--spacing-50);
   --corner-radius-4: var(--spacing-100);

--- a/web/libs/ui/src/tokens/tokens.scss
+++ b/web/libs/ui/src/tokens/tokens.scss
@@ -449,7 +449,7 @@
   --letter-spacing--15: -0.0094rem;
   --letter-spacing--10: -0.0063rem;
   --font-family-base: "Figtree";
-  --font-family-mono: "IBM Plex Mono,monospace";
+  --font-family-mono: "IBM Plex Mono",monospace;
   --corner-radius-0: var(--spacing-0);
   --corner-radius-2: var(--spacing-50);
   --corner-radius-4: var(--spacing-100);

--- a/web/libs/ui/src/tokens/tokens.scss
+++ b/web/libs/ui/src/tokens/tokens.scss
@@ -449,7 +449,7 @@
   --letter-spacing--15: -0.0094rem;
   --letter-spacing--10: -0.0063rem;
   --font-family-base: "Figtree";
-  --font-family-mono: "IBM Plex Mono",monospace;
+  --font-family-mono: "IBM Plex Mono,monospace";
   --corner-radius-0: var(--spacing-0);
   --corner-radius-2: var(--spacing-50);
   --corner-radius-4: var(--spacing-100);


### PR DESCRIPTION
This pull request updates the font family definition for the monospaced font across the codebase to include a fallback option. The changes ensure better compatibility and rendering in environments where the primary font may not be available.

### Font family updates:

* [`web/design-tokens.json`](diffhunk://#diff-74f37c929d72831939c951d1bd6c6e36475ff1161f6a4e0c214e592906041e2aL3813-R3819): Updated the `mono` font family value to `"IBM Plex Mono,monospace"` to include a fallback monospace option. This change also reflects in the `modes` metadata.
* [`web/libs/ui/src/tokens/tokens.scss`](diffhunk://#diff-7972d0ac6fb81f742daba2cb1c61f92f8f9fd86c7d693d0753c7a8ed26a37559L452-R452): Modified the `--font-family-mono` CSS variable to `"IBM Plex Mono,monospace"` for consistency with the updated design tokens.