### PR TITLE
fix: Replace surrogate characters before rendering

### DIFF
--- a/label_studio/core/templatetags/filters.py
+++ b/label_studio/core/templatetags/filters.py
@@ -52,7 +52,20 @@ def get_item(dictionary, key):
 
 @register.filter
 def json_dumps_ensure_ascii(dictionary):
-    return json.dumps(dictionary, ensure_ascii=False)
+    def clean_surrogates(obj):
+        """Recursively clean surrogate characters from strings in nested data structures"""
+        if isinstance(obj, str):
+            # Replace surrogate characters with replacement character
+            return obj.encode('utf-8', errors='replace').decode('utf-8')
+        elif isinstance(obj, dict):
+            return {k: clean_surrogates(v) for k, v in obj.items()}
+        elif isinstance(obj, list):
+            return [clean_surrogates(item) for item in obj]
+        else:
+            return obj
+
+    cleaned_dictionary = clean_surrogates(dictionary)
+    return json.dumps(cleaned_dictionary, ensure_ascii=False)
 
 
 @register.filter


### PR DESCRIPTION
This PR resolves a crash issue in base.html rendering when a git commit message includes surrogate characters, such as emojis (e.g., 🐛).
The root cause was traced to the `json_dumps_ensure_ascii` function, which does not properly handle surrogate pairs, leading to a `UnicodeEncodeError` during template rendering.

```
[2025-06-30 00:32:51,740] [django.request::log_response::253] [ERROR] Internal Server Error: /labelstudio/
Traceback (most recent call last):
  File "/label-studio/.venv/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/label-studio/.venv/lib/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/label-studio/.venv/lib/python3.12/site-packages/sentry_sdk/integrations/django/views.py", line 90, in sentry_wrapped_callback
    return callback(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/label-studio/label_studio/core/views.py", line 57, in main
    return render(request, 'home/home.html')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/label-studio/.venv/lib/python3.12/site-packages/sentry_sdk/utils.py", line 1796, in runner
    return sentry_patched_function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/label-studio/.venv/lib/python3.12/site-packages/sentry_sdk/integrations/django/templates.py", line 105, in render
    return real_render(request, template_name, context, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/label-studio/.venv/lib/python3.12/site-packages/django/shortcuts.py", line 26, in render
    return HttpResponse(content, content_type, status)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/label-studio/.venv/lib/python3.12/site-packages/django/http/response.py", line 376, in __init__
    self.content = content
    ^^^^^^^^^^^^
  File "/label-studio/.venv/lib/python3.12/site-packages/django/http/response.py", line 408, in content
    content = self.make_bytes(value)
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/label-studio/.venv/lib/python3.12/site-packages/django/http/response.py", line 317, in make_bytes
    return bytes(value.encode(self.charset))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'utf-8' codec can't encode characters in position 3038-3039: surrogates not allowed
```

So I added a preprocessing step to replace or safely handle surrogate characters before they reach the JSON encoder, ensuring that the response can be encoded in UTF-8 without failure.

While there's currently no use of emojis in commit messages, this fix can prevent potential future errors in case such characters comes up someday.
