### PR TITLE
fix: FIT-317: User can add polygon points to unfinished Polygon in Compare all annotations mode

### DIFF
--- a/web/libs/editor/src/mixins/DrawingTool.js
+++ b/web/libs/editor/src/mixins/DrawingTool.js
@@ -3,7 +3,7 @@ import { types } from "mobx-state-tree";
 import Utils from "../utils";
 import throttle from "lodash.throttle";
 import { MIN_SIZE } from "../tools/Base";
-import { FF_DEV_3793, isFF } from "../utils/feature-flags";
+import { FF_DEV_3391, FF_DEV_3793, isFF } from "../utils/feature-flags";
 import { RELATIVE_STAGE_HEIGHT, RELATIVE_STAGE_WIDTH } from "../components/ImageView/Image";
 
 const DrawingTool = types
@@ -75,6 +75,9 @@ const DrawingTool = types
        * @return {boolean} Returns true if the interaction is allowed, otherwise false.
        */
       isAllowedInteraction(ev) {
+        if (isFF(FF_DEV_3391) && !self.annotation.editable) {
+          return false;
+        }
         if (self.group !== "segmentation") return true;
         if (ev.offsetX > self.obj.canvasSize.width) return false;
         if (ev.offsetY > self.obj.canvasSize.height) return false;


### PR DESCRIPTION
This pull request modifies the `DrawingTool` mixin in the `web/libs/editor/src/mixins/DrawingTool.js` file to check feature flag (`FF_DEV_3391`) and update the behavior of the `isAllowedInteraction` method based on this flag.

issue occurs with FF `fflag_fix_front_dev_3391_interactive_view_all` switched on

https://github.com/user-attachments/assets/63358a50-de0f-46a1-86fd-2e2610a6529f

after fix - Compare all view will act as read only

Feature flag integration:

* [`web/libs/editor/src/mixins/DrawingTool.js`](diffhunk://#diff-581af9608126169103db082f692e1927228458ebcd229fe0fb4b56980876a603L6-R6): Added `FF_DEV_3391` to the feature flags import list to enable conditional logic for the new feature.

Behavior update:

* [`web/libs/editor/src/mixins/DrawingTool.js`](diffhunk://#diff-581af9608126169103db082f692e1927228458ebcd229fe0fb4b56980876a603R78-R80): Updated the `isAllowedInteraction` method to return `false` if the `FF_DEV_3391` flag is enabled and the annotation is not editable, ensuring stricter control over interactions when the flag is active.