### PR TITLE
chore: Allow yarn integration test failure screenshots to be captured in a workflow artifact

### DIFF
--- a/.github/workflows/tests-yarn-integration.yml
+++ b/.github/workflows/tests-yarn-integration.yml
@@ -77,6 +77,15 @@ jobs:
           name: cypress coverage
           path: web/libs/editor/coverage
 
+      - name: Upload test results and screenshots
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: cypress test output
+          path: |
+            dist/cypress/libs/frontend-test/src/screenshots
+            dist/cypress/libs/frontend-test/src/videos
+
       - name: Kill server
         if: always()
         continue-on-error: true


### PR DESCRIPTION
We are not capturing the failures anywhere for yarn integration tests, which makes it impossible to understand failures that occur on CI only.

This pull request adds functionality to upload test results and screenshots from Cypress tests as artifacts in the CI workflow.

* [`.github/workflows/tests-yarn-integration.yml`](diffhunk://#diff-e0bc9872a3b6113ee18cc237910ce93df2ac3574b40380c043d573ecf7f1e5edR80-R88): Added a new step named "Upload test results and screenshots" to the workflow, using `actions/upload-artifact@v4`. This step uploads Cypress test output (screenshots and videos) as artifacts, ensuring they are available for inspection after test runs.