### PR TITLE
fix: UTC-156: Fetching task object after trying authentication

### DIFF
--- a/label_studio/tasks/api.py
+++ b/label_studio/tasks/api.py
@@ -260,8 +260,8 @@ class TaskAPI(generics.RetrieveUpdateDestroyAPIView):
     )
 
     def initial(self, request, *args, **kwargs):
+        super().initial(request, *args, **kwargs)
         self.task = self.get_object()
-        return super().initial(request, *args, **kwargs)
 
     @staticmethod
     def prefetch(queryset):


### PR DESCRIPTION
<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->

`super().initial(...)` tries to authenticate the request or fails. We were calling `self.get_object()` before that and failing in some because we assumed a logged in user downstream.
