### PR TITLE
fix: FIT-366: CreateProject tab indicator color was low contrast and in some cases invisible

### DIFF
--- a/web/apps/labelstudio/src/pages/CreateProject/CreateProject.scss
+++ b/web/apps/labelstudio/src/pages/CreateProject/CreateProject.scss
@@ -41,7 +41,7 @@
       width: 8px;
       border-radius: 4px;
       margin-right: 6px;
-      background: var(--color-negative-background);
+      background: var(--color-negative-content);
     }
   }
 


### PR DESCRIPTION
**Before**

<img width="649" height="579" alt="Screenshot 2025-07-11 at 10 22 10 AM" src="https://github.com/user-attachments/assets/24a4ca4d-6615-4f16-a201-aaf05aaf7a34" />
<img width="649" height="579" alt="Screenshot 2025-07-11 at 10 21 34 AM" src="https://github.com/user-attachments/assets/55af51eb-704c-459c-b12c-747869b5f65b" />


**After**

<img width="649" height="579" alt="Screenshot 2025-07-11 at 10 18 05 AM" src="https://github.com/user-attachments/assets/def955d3-5dad-48da-8b23-20fdcab35703" />
<img width="649" height="579" alt="Screenshot 2025-07-11 at 10 18 42 AM" src="https://github.com/user-attachments/assets/e863222a-3b5c-41c9-a504-d4c30c62453e" />
