### PR TITLE
fix: FIT-362: Batching deletes in delete_tasks_without_signals to reduce memory usage

### DIFF
--- a/label_studio/core/tests/test_db_utils.py
+++ b/label_studio/core/tests/test_db_utils.py
@@ -1,0 +1,111 @@
+"""This module contains tests for database utility functions in core/utils/db.py"""
+import pytest
+from core.utils.db import batch_delete
+from django.db import transaction
+from users.models import User
+from users.tests.factories import UserFactory
+
+
+class TestBatchDelete:
+    """Test suite for the batch_delete utility function"""
+
+    @pytest.mark.django_db
+    def test_batch_delete_empty_queryset(self):
+        """Test batch deletion with an empty queryset.
+
+        This test verifies that:
+        - Function handles empty querysets gracefully
+        - Returns 0 for total deleted items
+        - No errors are raised
+        """
+        # Setup: Empty queryset
+        queryset = User.objects.filter(email='nonexistent@example.com')
+
+        # Action: Attempt to delete empty queryset
+        total_deleted = batch_delete(queryset)
+
+        # Assert: No items were deleted
+        assert total_deleted == 0
+
+    @pytest.mark.django_db
+    def test_batch_delete_single_batch(self):
+        """Test batch deletion when all items fit in a single batch.
+
+        This test verifies that:
+        - All items are deleted when count < batch_size
+        - Items are actually removed from database
+        """
+        # Setup: Create 5 users
+        [UserFactory() for _ in range(5)]
+        initial_count = User.objects.count()
+        assert initial_count == 5  # Verify setup
+        queryset = User.objects.all()
+
+        # Action: Delete with batch size larger than number of items
+        batch_delete(queryset, batch_size=10)
+
+        # Assert: All users were deleted
+        assert User.objects.count() == 0
+
+    @pytest.mark.django_db
+    def test_batch_delete_multiple_batches(self):
+        """Test batch deletion when items span multiple batches.
+
+        This test verifies that:
+        - All items are deleted when count > batch_size
+        - Items are deleted in correct batches
+        - All items are removed from database
+        """
+        # Setup: Create 25 users (will require 3 batches with batch_size=10)
+        [UserFactory() for _ in range(25)]
+        initial_count = User.objects.count()
+        assert initial_count == 25  # Verify setup
+        queryset = User.objects.all()
+
+        # Action: Delete with batch size smaller than number of items
+        batch_delete(queryset, batch_size=10)
+
+        # Assert: All users were deleted
+        assert User.objects.count() == 0
+
+    @pytest.mark.django_db
+    def test_batch_delete_with_transaction(self):
+        """Test batch deletion within a transaction.
+
+        This test verifies that:
+        - Batch deletion works correctly inside a transaction
+        - Changes are committed properly
+        - No errors occur with nested transactions
+        """
+        # Setup: Create 15 users
+        [UserFactory() for _ in range(15)]
+        initial_count = User.objects.count()
+        assert initial_count == 15  # Verify setup
+        queryset = User.objects.all()
+
+        # Action: Delete within a transaction
+        with transaction.atomic():
+            batch_delete(queryset, batch_size=10)
+
+        # Assert: All users were deleted
+        assert User.objects.count() == 0
+
+    @pytest.mark.django_db
+    def test_batch_delete_exact_batch_size(self):
+        """Test batch deletion when item count matches batch size exactly.
+
+        This test verifies that:
+        - All items are deleted when count == batch_size
+        - No extra queries are made after the last batch
+        """
+        # Setup: Create exactly 10 users
+        [UserFactory() for _ in range(10)]
+        initial_count = User.objects.count()
+        assert initial_count == 10  # Verify setup
+        queryset = User.objects.all()
+
+        # Action: Delete with batch size equal to number of items
+        batch_delete(queryset, batch_size=10)
+
+        # Assert: All users were deleted
+        assert User.objects.count() == 0

--- a/label_studio/core/utils/db.py
+++ b/label_studio/core/utils/db.py
@@ -86,21 +86,34 @@ def batch_delete(queryset, batch_size=500):
         int: Total number of deleted objects
     """
     total_deleted = 0
-    # Use iterator() to avoid loading all objects into memory at once
+
+    # Create a database cursor that yields primary keys without loading all into memory
+    # The iterator position is maintained between calls to islice
+    # Example: if queryset has 1500 records and batch_size=500:
+    # - First iteration will get records 1-500
+    # - Second iteration will get records 501-1000
+    # - Third iteration will get records 1001-1500
+    # - Fourth iteration will get empty list (no more records)
     pks_to_delete = queryset.values_list('pk', flat=True).iterator(chunk_size=batch_size)
 
     # Delete in batches
     while True:
-        # Get the next batch of primary keys
+        # Get the next batch of primary keys from where the iterator left off
+        # islice advances the iterator's position after taking batch_size items
         batch_iterator = itertools.islice(pks_to_delete, batch_size)
+
+        # Convert the slice iterator to a list we can use
+        # This only loads batch_size items into memory at a time
         batch = list(batch_iterator)
 
         # If no more items to process, we're done
+        # This happens when the iterator is exhausted
         if not batch:
             break
 
         # Delete the batch in a transaction
         with transaction.atomic():
+            # Delete all objects whose primary keys are in this batch
             deleted = queryset.model.objects.filter(pk__in=batch).delete()[0]
             total_deleted += deleted
 

--- a/label_studio/core/utils/db.py
+++ b/label_studio/core/utils/db.py
@@ -1,10 +1,10 @@
+import itertools
 import logging
 import time
 from typing import Optional, TypeVar
 
 from django.db import OperationalError, models, transaction
 from django.db.models import Model, QuerySet, Subquery
-import itertools
 
 logger = logging.getLogger(__name__)
 
@@ -88,12 +88,20 @@ def batch_delete(queryset, batch_size=500):
     total_deleted = 0
     # Use iterator() to avoid loading all objects into memory at once
     pks_to_delete = queryset.values_list('pk', flat=True).iterator(chunk_size=batch_size)
-    
+
     # Delete in batches
-    while batch := list(itertools.islice(pks_to_delete, batch_size)):
+    while True:
+        # Get the next batch of primary keys
+        batch_iterator = itertools.islice(pks_to_delete, batch_size)
+        batch = list(batch_iterator)
+
+        # If no more items to process, we're done
+        if not batch:
+            break
+
         # Delete the batch in a transaction
         with transaction.atomic():
             deleted = queryset.model.objects.filter(pk__in=batch).delete()[0]
             total_deleted += deleted
-            
+
     return total_deleted

--- a/label_studio/core/utils/db.py
+++ b/label_studio/core/utils/db.py
@@ -4,6 +4,7 @@ from typing import Optional, TypeVar
 
 from django.db import OperationalError, models, transaction
 from django.db.models import Model, QuerySet, Subquery
+import itertools
 
 logger = logging.getLogger(__name__)
 
@@ -71,3 +72,28 @@ def batch_update_with_retry(queryset, batch_size=500, max_retries=3, **update_fi
         else:
             logger.error(f'Failed to update batch after {max_retries} retries. ' f'Batch: {i}-{i+len(batch_ids)}')
             raise last_error
+
+
+def batch_delete(queryset, batch_size=500):
+    """
+    Delete objects in batches to minimize memory usage and transaction size.
+
+    Args:
+        queryset: The queryset to delete
+        batch_size: Number of objects to delete in each batch
+
+    Returns:
+        int: Total number of deleted objects
+    """
+    total_deleted = 0
+    # Use iterator() to avoid loading all objects into memory at once
+    pks_to_delete = queryset.values_list('pk', flat=True).iterator(chunk_size=batch_size)
+    
+    # Delete in batches
+    while batch := list(itertools.islice(pks_to_delete, batch_size)):
+        # Delete the batch in a transaction
+        with transaction.atomic():
+            deleted = queryset.model.objects.filter(pk__in=batch).delete()[0]
+            total_deleted += deleted
+            
+    return total_deleted

--- a/label_studio/tasks/models.py
+++ b/label_studio/tasks/models.py
@@ -23,7 +23,7 @@ from core.utils.common import (
     string_is_url,
     temporary_disconnect_list_signal,
 )
-from core.utils.db import fast_first
+from core.utils.db import fast_first, batch_delete
 from core.utils.params import get_env
 from data_import.models import FileUpload
 from data_manager.managers import PreparedTaskManager, TaskManager
@@ -535,7 +535,7 @@ class Task(TaskMixin, models.Model):
     @staticmethod
     def delete_tasks_without_signals(queryset):
         """
-        Delete Tasks queryset with switched off signals
+        Delete Tasks queryset with switched off signals in batches to minimize memory usage
         :param queryset: Tasks queryset
         """
         signals = [
@@ -543,7 +543,7 @@ class Task(TaskMixin, models.Model):
             (pre_delete, remove_data_columns, Task),
         ]
         with temporary_disconnect_list_signal(signals):
-            queryset.delete()
+            return batch_delete(queryset, batch_size=500)
 
     @staticmethod
     def delete_tasks_without_signals_from_task_ids(task_ids):

--- a/label_studio/tasks/models.py
+++ b/label_studio/tasks/models.py
@@ -23,7 +23,7 @@ from core.utils.common import (
     string_is_url,
     temporary_disconnect_list_signal,
 )
-from core.utils.db import fast_first, batch_delete
+from core.utils.db import batch_delete, fast_first
 from core.utils.params import get_env
 from data_import.models import FileUpload
 from data_manager.managers import PreparedTaskManager, TaskManager


### PR DESCRIPTION
Calling `.delete()` on a django queryset can reduce in high memory usage because each row to be deleted is loaded into an object so django can enforce `on_delete=CASCADE` constraints of other objects that have the deleted object as a ForeingKey.

This is the case for `Tasks`, it is a ForeignKey in at least 4 models in LSE and LS. We want to preserve the native django `.delete()` functionality, so to reduce memory usage, we do the delete operation in batches.