### PR TITLE
fix: BROS-185: Timeseries initialization and playhead click behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ docker-compose.override.yml
 .netlify
 
 CLAUDE.local.md
+web/libs/editor/tests/coverage
+.cache

--- a/web/libs/editor/src/tags/object/__tests__/TimeSeries.test.js
+++ b/web/libs/editor/src/tags/object/__tests__/TimeSeries.test.js
@@ -1,0 +1,305 @@
+// Set up performance.now mock before any imports
+import * as d3 from "d3";
+import { types } from "mobx-state-tree";
+import { mockFF } from "../../../../__mocks__/global";
+import { FF_TIMESERIES_SYNC } from "../../../utils/feature-flags";
+import { TimeSeriesModel } from "../TimeSeries";
+
+const ff = mockFF();
+
+// Mock environment
+const mockEnv = {
+  events: { addNamed: jest.fn(), removeNamed: jest.fn() },
+  syncManager: { syncSend: jest.fn() },
+};
+
+// Mock store setup following the pattern from Paragraphs tests
+const MockStore = types
+  .model({
+    timeseries: TimeSeriesModel,
+  })
+  .volatile(() => ({
+    task: { dataObj: {} },
+    annotationStore: {
+      initialized: true,
+      selected: {},
+      root: {},
+      names: [],
+      addErrors: jest.fn(),
+    },
+  }));
+
+// Set up feature flags
+ff.setup();
+ff.set(FF_TIMESERIES_SYNC, true);
+
+describe("TimeSeries brush range calculation", () => {
+  // creating models can be a long one, so all tests will share one model
+  const model = TimeSeriesModel.create(
+    {
+      name: "timeseries",
+      value: "$timeseries",
+      sync: "video1",
+      timeformat: "",
+      defaultwidth: "100%",
+      timecolumn: "time",
+      children: [],
+    },
+    mockEnv,
+  );
+  const store = MockStore.create({ timeseries: model }, mockEnv);
+
+  // Set up test data with proper structure
+  const times = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  store.task.dataObj = {
+    timeseries: {
+      time: times,
+      value: times.map((t) => t * 2),
+    },
+  };
+  model.updateValue(store);
+
+  it("returns full range if times.length < MIN_POINTS_ON_SCREEN", () => {
+    const result = model.calculateInitialBrushRange(times);
+    expect(result).toEqual([0, 9]);
+  });
+
+  it("returns expanded range if initial range is too small", () => {
+    const times = Array.from({ length: 20 }, (_, i) => i);
+    store.task.dataObj = {
+      timeseries: {
+        time: times,
+        value: times.map((t) => t * 2),
+      },
+    };
+    model.updateValue(store);
+
+    // defaultOverviewWidth = [0, 0.05] would only select 1-2 points
+    const result = model.calculateInitialBrushRange(times, [0, 0.05]);
+    // Should expand to at least 10 points
+    expect(result[1] - result[0] + 1).toBeGreaterThanOrEqual(10);
+  });
+
+  it("returns range based on defaultOverviewWidth", () => {
+    const times = Array.from({ length: 20 }, (_, i) => i);
+    store.task.dataObj = {
+      timeseries: {
+        time: times,
+        value: times.map((t) => t * 2),
+      },
+    };
+    model.updateValue(store);
+
+    // With defaultOverviewWidth = [0, 0.5], for 20 points:
+    // startIndex = Math.round((20 - 1) * 0) = 0
+    // endIndex = Math.round((20 - 1) * 0.5) = 9
+    const result = model.calculateInitialBrushRange(times, [0, 0.5]);
+    expect(result).toEqual([0, 9]); // Not 10, because endIndex is calculated as 9
+  });
+});
+
+describe("TimeSeries time parsing", () => {
+  const model = TimeSeriesModel.create(
+    {
+      name: "timeseries",
+      timeformat: "%Y-%m-%d %H:%M:%S.%L",
+      value: "$timeseries",
+      sync: "video1",
+      defaultwidth: "100%",
+      timecolumn: "time",
+      children: [],
+    },
+    mockEnv,
+  );
+  const store = MockStore.create({ timeseries: model }, mockEnv);
+
+  it("parses millisecond timestamps into unix timestamps", () => {
+    const value = "2024-07-15 12:34:56.123";
+    const parsed = model.parseTime(value);
+    const expected = d3.utcParse("%Y-%m-%d %H:%M:%S.%L")(value).getTime();
+    expect(parsed).toBe(expected);
+  });
+
+  it("parses microseconds as milliseconds", () => {
+    const modelWithMicros = TimeSeriesModel.create(
+      {
+        name: "timeseries",
+        timeformat: "%Y-%m-%d %H:%M:%S.%f",
+        value: "$timeseries",
+        sync: "video1",
+        defaultwidth: "100%",
+        timecolumn: "time",
+        children: [],
+      },
+      mockEnv,
+    );
+    const storeWithMicros = MockStore.create({ timeseries: modelWithMicros }, mockEnv);
+
+    const value = "2024-07-15 12:34:56.123456";
+    const parsed = modelWithMicros.parseTime(value);
+    // Should parse as if it were "2024-07-15 12:34:56.123"
+    const expected = d3.utcParse("%Y-%m-%d %H:%M:%S.%L")("2024-07-15 12:34:56.123").getTime();
+    expect(parsed).toBe(expected);
+  });
+
+  it("returns numeric values as-is when no timeformat is specified", () => {
+    const modelNoFormat = TimeSeriesModel.create(
+      {
+        name: "timeseries",
+        timeformat: "",
+        value: "$timeseries",
+        sync: "video1",
+        defaultwidth: "100%",
+        timecolumn: "time",
+        children: [],
+      },
+      mockEnv,
+    );
+    const storeNoFormat = MockStore.create({ timeseries: modelNoFormat }, mockEnv);
+
+    const time = 1234.56;
+    expect(modelNoFormat.parseTime(time)).toBe(time);
+  });
+});
+
+describe("TimeSeries playback", () => {
+  const model = TimeSeriesModel.create(
+    {
+      name: "timeseries",
+      value: "$timeseries",
+      sync: "video1",
+      timeformat: "",
+      defaultwidth: "100%",
+      timecolumn: "time", // This is important for keyColumn
+      children: [],
+    },
+    mockEnv,
+  );
+  const store = MockStore.create({ timeseries: model }, mockEnv);
+
+  // Store original window functions
+  const originalRequestAnimationFrame = global.requestAnimationFrame;
+  const originalCancelAnimationFrame = global.cancelAnimationFrame;
+  const originalPerformanceNow = performance.now;
+
+  beforeAll(() => {
+    // Ensure performance.now mock is in place
+    jest.spyOn(performance, "now").mockImplementation(() => 1000);
+  });
+
+  beforeEach(() => {
+    // Reset all mocks
+    jest.clearAllMocks();
+
+    // Set up other mocks
+    global.requestAnimationFrame = jest.fn().mockReturnValue(1); // Return a frame ID
+    global.cancelAnimationFrame = jest.fn();
+
+    // Set up test data with proper structure
+    const times = [0, 20, 40, 60, 80, 100];
+    const data = {
+      time: times, // Must match timecolumn
+      value: times.map((t) => t * 2),
+    };
+
+    // Initialize the model with the data
+    model.setData(data); // This also sets valueLoaded to true
+    model.setColumnNames(["time", "value"]);
+
+    // Set up required view properties
+    model.updateCanvasWidth(1000);
+
+    // Verify data is properly set up
+    expect(model.dataObj).toBeTruthy();
+    expect(model.dataObj.time).toEqual(times);
+    expect(model.keysRange).toEqual([0, 100]);
+
+    // Set up view range
+    model.updateTR([0, 100]); // Set initial time range
+    expect(model.brushRange).toEqual([0, 100]);
+    expect(model.canvasWidth).toBe(1000);
+
+    // Register sync handlers
+    model.registerSyncHandlers();
+  });
+
+  afterEach(() => {
+    // Restore original functions
+    global.requestAnimationFrame = originalRequestAnimationFrame;
+    global.cancelAnimationFrame = originalCancelAnimationFrame;
+  });
+
+  afterAll(() => {
+    // Restore all mocks
+    jest.restoreAllMocks();
+    performance.now = originalPerformanceNow;
+  });
+
+  it("should start playback", () => {
+    // Initial state
+    expect(model.isPlaying).toBe(false);
+    expect(model.playStartTime).toBeNull();
+    expect(model.playStartPosition).toBeNull();
+    expect(model.playbackSpeed).toBe(1);
+
+    // Verify mock is working
+    expect(performance.now()).toBe(1000);
+
+    // Start playback
+    const data = { time: 50, speed: 2 };
+    model._handlePlay(data);
+
+    // Verify playback state
+    expect(model.isPlaying).toBe(true);
+    expect(model.playStartPosition).toBe(50);
+    expect(model.playStartTime).toBe(1000); // From our mock
+    expect(model.playbackSpeed).toBe(2);
+    expect(global.requestAnimationFrame).toHaveBeenCalledWith(model.playbackLoop);
+  });
+
+  it("should pause playback", () => {
+    // Start playback first
+    model._handlePlay({ time: 50, speed: 2 });
+    expect(model.isPlaying).toBe(true);
+    expect(model.animationFrameId).toBe(1); // Check for specific frame ID
+
+    // Pause playback
+    model._handlePause({ time: 60 });
+
+    // Verify paused state
+    expect(model.isPlaying).toBe(false);
+    expect(model.playStartTime).toBeNull();
+    expect(model.playStartPosition).toBeNull();
+    expect(global.cancelAnimationFrame).toHaveBeenCalledWith(1); // Check frame ID was passed
+    expect(model.animationFrameId).toBeNull();
+  });
+
+  it("should update view during playback loop", () => {
+    // Set initial time to 0
+    jest.spyOn(performance, "now").mockImplementation(() => 0);
+
+    // Start playback at position 50
+    const data = { time: 50, speed: 2 };
+    model._handlePlay(data);
+
+    // Verify initial playback state
+    expect(model.isPlaying).toBe(true);
+    expect(model.playStartPosition).toBe(50);
+    expect(model.playStartTime).toBe(0); // Initial time
+    expect(model.playbackSpeed).toBe(2);
+
+    // Mock performance.now() to return a time 1 second later
+    jest.spyOn(performance, "now").mockImplementation(() => 1000);
+
+    // Run playback loop
+    model.playbackLoop();
+
+    // With 1 second elapsed and speed=2, we should have moved 2 seconds forward
+    // from position 50, so we should be at position 52
+    expect(model.cursorTime).toBe(52);
+    expect(model.isPlaying).toBe(true);
+    expect(global.requestAnimationFrame).toHaveBeenCalledWith(model.playbackLoop);
+  });
+});
+
+ff.reset();

--- a/web/libs/editor/tests/e2e/tests/timeseries.test.js
+++ b/web/libs/editor/tests/e2e/tests/timeseries.test.js
@@ -89,6 +89,19 @@ const scenarios = {
       I.seeElement(locate(".lsf-errors"));
     },
   },
+
+  "Works with microseconds in time column and %f timeFormat": {
+    timeformat: "%Y-%m-%d %H:%M:%S.%f",
+    timeseries: {
+      time: ["2024-07-15 12:34:56.123456", "2024-07-15 12:34:57.654321", "2024-07-15 12:34:58.000123"],
+      one: [1, 2, 3],
+      two: [4, 5, 6],
+    },
+    assert(I) {
+      I.waitForVisible(".htx-timeseries", 5);
+      I.dontSeeElement(locate(".lsf-errors"));
+    },
+  },
 };
 
 function generateData(stepsNumber) {


### PR DESCRIPTION
## Reason for Change

**Problem:**  
The TimeSeries component previously did not correctly handle time values with 6 decimal microseconds (`%f`), which could cause parsing errors or incorrect rendering when such data was provided.

**Solution:**  
A patch was applied to convert `%f` (microseconds) to `%L` (milliseconds) and truncate the time string accordingly. This PR adds an E2E test to ensure that time series data with microseconds is parsed and displayed correctly in the UI, preventing regressions for this edge case.

---

## Screenshots

The following screenshot shows the TimeSeries UI successfully loading time data with 6-decimal microseconds and no errors present, confirming the test and patch work as intended:

![TimeSeries microseconds E2E test passing](https://github.com/user-attachments/assets/0cb0145e-ad62-4734-a3c4-d82af8ea0ed0)

---

## Rollout Strategy

- No feature flag or environment variable is required.
- The test will run as part of the standard E2E suite.

---

## Testing

- Added a new scenario to `timeseries.test.js` that provides time values with 6 decimal microseconds and `timeFormat="%Y-%m-%d %H:%M:%S.%f"`.
- The test asserts that the timeseries UI loads and no error is shown.
- Verified locally by running the E2E suite and confirming the test passes (see screenshot above).

---

## Risks

- No known risks. This change only adds a test and does not affect production code paths.
- The test ensures that future changes do not break microsecond time parsing.

---

## Reviewer Notes

- The new test is located in `web/libs/editor/tests/e2e/tests/timeseries.test.js` under the scenario `"Works with microseconds in time column and %f timeFormat"`.
- Please review the test data and assertions to ensure they accurately reflect the intended edge case.

---

## General Notes

- This test covers a regression vector for time parsing in the TimeSeries component.
- No changes to user-facing features or performance.
- No additional dependencies introduced.

