### PR TITLE
fix: FIT-369: Temporarily turning off project_completed notifications

### DIFF
--- a/web/libs/app-common/src/pages/AccountSettings/sections/EmailPreferences.tsx
+++ b/web/libs/app-common/src/pages/AccountSettings/sections/EmailPreferences.tsx
@@ -90,6 +90,9 @@ export const EmailPreferences = () => {
       {isEnterpriseEmailNotificationsEnabled && (
         <>
           {Object.entries(emailNotificationSettings).map(([id, { value, label }]: [string, any]) => {
+            if (id === "project_completed") {
+              return null;
+            }
             const notificationToggleHandler = (
               e: React.ChangeEvent<HTMLInputElement>,
               id: string,


### PR DESCRIPTION
This email notification is not present in this release due to issues with the sending, removing it as an option for now.