### PR TITLE
fix: FIT-407: buttonVariant font size cleanup

### DIFF
--- a/web/libs/ui/src/lib/button/button.tsx
+++ b/web/libs/ui/src/lib/button/button.tsx
@@ -69,7 +69,7 @@ export function buttonVariant(
   const buttonStyles = [styles.base, variants[variant], looks[look], sizes[size], alignment[align]];
   return cn(
     "inline-flex items-center rounded-smaller border text-shadow-button box-border border transition-all",
-    "text-label-medium font-medium text-[color:--text-color] bg-[color:--background-color] bg-[image:--background-image] border-[color:--border-color] shadow-[shadow:--emboss-shadow] text-center",
+    "font-medium text-[color:--text-color] bg-[color:--background-color] bg-[image:--background-image] border-[color:--border-color] shadow-[shadow:--emboss-shadow] text-center",
     "hover:text-[color:--text-color] hover:bg-[color:--background-color-hover] hover:border-[color:--border-color-hover]",
     "active:bg-[color:--background-color-active] active:border-[color:--border-color]",
     "[&_svg]:h-full [&_svg]:inline-block [&_svg]:aspect-square",


### PR DESCRIPTION
This pull request includes a minor update to the `buttonVariant` function in `web/libs/ui/src/lib/button/button.tsx`. The change removes the `text-label-medium` class from the button styles to simplify the applied text styles.

before:
<img width="622" height="588" alt="Screenshot 2025-07-18 at 2 32 41 PM" src="https://github.com/user-attachments/assets/738ad556-5afd-4283-baf6-f7ddc58b3c13" />


after:
<img width="638" height="597" alt="Screenshot 2025-07-18 at 2 30 55 PM" src="https://github.com/user-attachments/assets/d6ef302e-5fac-44ff-a2b7-287eb4c663ab" />



* [`web/libs/ui/src/lib/button/button.tsx`](diffhunk://#diff-259a95d990638123fd08358c173b4a3fb80fa24ec5971af905c9a551db1f665cL72-R72): Removed the `text-label-medium` class from the button's style definitions in the `buttonVariant` function. This simplifies the text styling by relying on other existing classes.