### PR TITLE
fix: default.conf to include server SNI

### DIFF
--- a/deploy/default.conf
+++ b/deploy/default.conf
@@ -164,6 +164,9 @@ http {
         proxy_set_header Cookie '';
         proxy_hide_header Content-Disposition;
         add_header Content-Disposition $upstream_http_content_disposition;
+        # Enable TLS SNI (important!)
+        proxy_ssl_server_name on;
+        proxy_ssl_name $download_host;
         # Stops the local disk from being written to (just forwards data through)
         proxy_max_temp_file_size 0;
         # Proxy the remote file through to the client


### PR DESCRIPTION
### Reason for change

This PR fixes [issue #8008](https://github.com/HumanSignal/label-studio/issues/8008), where TLS Server Name Indication (SNI) was not properly enabled when proxying requests over HTTPS. As a result, some upstream servers relying on SNI for correct routing were returning incorrect or failed responses.

### Solution

Added the following directives to the NGINX configuration to explicitly enable SNI and set the server name:

```nginx
proxy_ssl_server_name on;
proxy_ssl_name $download_host;
```