### PR TITLE
fix: FIT-429: Skeleton component is invisible

### DIFF
--- a/web/libs/ui/src/shad/components/ui/skeleton.tsx
+++ b/web/libs/ui/src/shad/components/ui/skeleton.tsx
@@ -6,7 +6,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="skeleton"
       data-testid="skeleton-loader"
       className={cn(
-        "bg-lsNeutralBorderSubtle/50 bg-no-repeat  bg-shimmer-size bg-gradient-to-r",
+        "bg-neutral-surface-active bg-no-repeat bg-shimmer-size bg-gradient-to-r",
         "from-white/5 via-white/20 to-white/5",
         "rounded-sm animate-shimmer",
         className,


### PR DESCRIPTION
This pull request updates the visual styling of the `Skeleton` component in the `web/libs/ui/src/shad/components/ui/skeleton.tsx` file to enhance consistency with the design system.

before:
<img width="126" height="53" alt="Screenshot 2025-07-23 at 10 02 06 AM" src="https://github.com/user-attachments/assets/55c4cf20-e3c2-42c3-9173-271362adc718" />


after:
<img width="138" height="50" alt="Screenshot 2025-07-23 at 10 00 27 AM" src="https://github.com/user-attachments/assets/aa05b199-c1b5-47c8-8763-5a2d2ec11a84" />
<img width="132" height="103" alt="Screenshot 2025-07-23 at 10 02 57 AM" src="https://github.com/user-attachments/assets/1e19e267-d922-4e0d-b509-4720e3122369" />




### Styling updates:
* Updated the `className` property in the `Skeleton` component to replace `"bg-lsNeutralBorderSubtle/50"` with `"bg-neutral-surface-active"`, aligning the background color with the updated design tokens.