### PR TITLE
fix: FIT-429: Skeleton component is invisible (#8034)

### DIFF
--- a/web/libs/ui/src/shad/components/ui/skeleton.tsx
+++ b/web/libs/ui/src/shad/components/ui/skeleton.tsx
@@ -6,7 +6,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="skeleton"
       data-testid="skeleton-loader"
       className={cn(
-        "bg-lsNeutralBorderSubtle/50 bg-no-repeat  bg-shimmer-size bg-gradient-to-r",
+        "bg-neutral-surface-active bg-no-repeat bg-shimmer-size bg-gradient-to-r",
         "from-white/5 via-white/20 to-white/5",
         "rounded-sm animate-shimmer",
         className,


### PR DESCRIPTION
This pull request updates the `Skeleton` component in the `web/libs/ui` library to use a new color token for its background, aligning it with the updated design system.

### Design system alignment:

* [`web/libs/ui/src/shad/components/ui/skeleton.tsx`](diffhunk://#diff-4ea1a5828903310691c866d31ea077469715b1d44d8e9c5552b7523da6791bedL9-R9): Replaced the `bg-lsNeutralBorderSubtle/50` background color token with `bg-neutral-surface-active` to reflect the latest design guidelines.