### PR TITLE
fix: BROS-254: Fix schema updates in "Build docs" CI

### DIFF
--- a/.github/workflows/create-tag-docs.yml
+++ b/.github/workflows/create-tag-docs.yml
@@ -18,6 +18,7 @@ env:
   FRONTEND_MONOREPO_DIR: "web"
   FRONTEND_BUILD_COMMIT_MESSAGE: "ci: Build tag docs"
   DOCS_TARGET_DIR: "docs/source/includes/tags"
+  SCHEMA_TARGET_DIR: "web/lib/utils/schema/tags.json"
 
 jobs:
   build:
@@ -56,6 +57,7 @@ jobs:
           WORKFLOW_LINK: "Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         run: |
           git add "${{ env.DOCS_TARGET_DIR }}" || true
+          git add "${{ env.SCHEMA_TARGET_DIR }}" || true
           git status -s
           git commit -m "${COMMIT_MESSAGE}" -m "${WORKFLOW_LINK}" || true
           git push origin HEAD

--- a/.github/workflows/create-tag-docs.yml
+++ b/.github/workflows/create-tag-docs.yml
@@ -18,7 +18,7 @@ env:
   FRONTEND_MONOREPO_DIR: "web"
   FRONTEND_BUILD_COMMIT_MESSAGE: "ci: Build tag docs"
   DOCS_TARGET_DIR: "docs/source/includes/tags"
-  SCHEMA_TARGET_DIR: "web/lib/utils/schema/tags.json"
+  SCHEMA_TARGET_DIR: "web/libs/core/src/lib/utils/schema/tags.json"
 
 jobs:
   build:

--- a/web/libs/core/src/lib/utils/schema/tags.json
+++ b/web/libs/core/src/lib/utils/schema/tags.json
@@ -69,6 +69,13 @@
         "required": false,
         "default": 32
       },
+      "spectrogram": {
+        "name": "spectrogram",
+        "description": "Determines whether an audio spectrogram is automatically displayed upon loading.",
+        "type": ["true", "false"],
+        "required": false,
+        "default": false
+      },
       "splitchannels": {
         "name": "splitchannels",
         "description": "Display multiple audio channels separately, if the audio file has more than one channel. (**NOTE: Requires more memory to operate.**)",
@@ -1074,6 +1081,12 @@
         "name": "allowNested",
         "description": "Allow to use `children` field in dynamic choices to nest them. Submitted result will contain array of arrays, every item is a list of values from topmost parent choice down to selected one.",
         "type": ["true", "false"],
+        "required": false
+      },
+      "layout": {
+        "name": "layout",
+        "description": "Layout of the choices: `select` for dropdown/select box format, `inline` for horizontal single row display, `vertical` for vertically stacked display (default)",
+        "type": ["select", "inline", "vertical"],
         "required": false
       }
     }
@@ -2104,6 +2117,13 @@
         "description": "Only show smart tool for interactive pre-annotations",
         "type": ["true", "false"],
         "required": false
+      },
+      "snap": {
+        "name": "snap",
+        "description": "Snap rectangle to image pixels",
+        "type": ["pixel", "none"],
+        "required": false,
+        "default": "none"
       }
     }
   },
@@ -2175,6 +2195,13 @@
         "type": ["true", "false"],
         "required": false,
         "default": true
+      },
+      "snap": {
+        "name": "snap",
+        "description": "Snap rectangle to image pixels",
+        "type": ["pixel", "none"],
+        "required": false,
+        "default": "none"
       }
     }
   },
@@ -2570,6 +2597,13 @@
         "name": "bordered",
         "description": "Shows border",
         "type": "string",
+        "required": false,
+        "default": false
+      },
+      "open": {
+        "name": "open",
+        "description": "Sets default collapsed state",
+        "type": ["true", "false"],
         "required": false,
         "default": false
       }

--- a/web/libs/editor/src/tags/control/Rectangle.js
+++ b/web/libs/editor/src/tags/control/Rectangle.js
@@ -1,7 +1,7 @@
 import { types } from "mobx-state-tree";
 
-import Registry from "../../core/Registry";
 import ControlBase from "./Base";
+import Registry from "../../core/Registry";
 import { customTypes } from "../../core/CustomTypes";
 import { AnnotationMixin } from "../../mixins/AnnotationMixin";
 import SeparatedControlMixin from "../../mixins/SeparatedControlMixin";


### PR DESCRIPTION
`create-docs` script should update both tags documentation and autocomplete schema. It still does it, but commit step ignores new schema. This fix adds this file back to git commit step.