### PR TITLE
fix: BROS-265: Layout of Pinned filter at Data Manager is broken

### DIFF
--- a/web/libs/datamanager/src/components/Filters/FiltersSidebar/FilterSidebar.jsx
+++ b/web/libs/datamanager/src/components/Filters/FiltersSidebar/FilterSidebar.jsx
@@ -30,8 +30,8 @@ export const FiltersSidebar = sidebarInjector(({ viewsStore, sidebarEnabled, sid
           </Button>
           <Elem name="title">Filters</Elem>
         </Elem>
-        <Filters sidebar={true} />
       </Elem>
+      <Filters sidebar={true} />
     </Block>
   ) : null;
 });


### PR DESCRIPTION
In this pr we change the nesting of this element:
https://github.com/HumanSignal/label-studio/commit/c7d5c724b465bbcf5f0c73a49d109eb11549857b#diff-997fc98353b1f75a2d2b93ab66740b1d897bba93c90fa136ef8e53498e2b747d

Before

<img width="473" height="272" alt="Screenshot 2025-07-29 at 11 12 52 AM" src="https://github.com/user-attachments/assets/aab464bc-e8e2-4962-8b3d-e7d20836be95" />

Now
<img width="427" height="290" alt="Screenshot 2025-07-29 at 11 12 17 AM" src="https://github.com/user-attachments/assets/207a34d3-3ac5-4615-b0ad-ad5e754ef8b6" />
