### PR TITLE
fix: BROS-265: Layout of Pinned filter at Data Manager is broken (#8061)

### DIFF
--- a/web/libs/datamanager/src/components/Filters/FiltersSidebar/FilterSidebar.jsx
+++ b/web/libs/datamanager/src/components/Filters/FiltersSidebar/FilterSidebar.jsx
@@ -30,8 +30,8 @@ export const FiltersSidebar = sidebarInjector(({ viewsStore, sidebarEnabled, sid
           </Button>
           <Elem name="title">Filters</Elem>
         </Elem>
-        <Filters sidebar={true} />
       </Elem>
+      <Filters sidebar={true} />
     </Block>
   ) : null;
 });


### PR DESCRIPTION
Cherrypick for lse-release/2.27.0 with BROS-265
