### PR TITLE
fix: BROS-42: LSO: Add Spacing between Labeling Interface title and Browse Templates button

### DIFF
--- a/web/apps/labelstudio/src/pages/CreateProject/Config/Config.scss
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/Config.scss
@@ -34,6 +34,7 @@ $scroll-width: 5px;
   padding: 16px 16px - $scroll-width 16px 20px;
   overflow-y: scroll;
   background-color: var(--color-neutral-background);
+  gap: var(--spacing-base);
 
   &::-webkit-scrollbar {
     width: $scroll-width;
@@ -235,7 +236,6 @@ $scroll-width: 5px;
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  margin-bottom: 16px;
 }
 
 .configure__editor {


### PR DESCRIPTION
# Reason for change
Spacing is missing between the the Labeling Interface title and Browse Templates button on the Labeling Setup step of the Create Project wizard. This PR fixes that.


# Screenshots
## Before
<img width="1174" height="335" alt="image" src="https://github.com/user-attachments/assets/f4203403-b2ae-44e8-a48f-75d7228e4195" />

## After
<img width="875" height="258" alt="image" src="https://github.com/user-attachments/assets/b7d94227-875d-4e49-9a4e-a3269fb10117" />

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
