### PR TITLE
fix: BROS-272: Fix missing autocomplete in Create Project editor

### DIFF
--- a/web/libs/ui/src/lib/code-editor/code-editor.module.scss
+++ b/web/libs/ui/src/lib/code-editor/code-editor.module.scss
@@ -29,10 +29,10 @@
       padding: 0 var(--spacing-tight);
     }
 
-    :global(.CodeMirror-hints) {
-      z-index: 3000;
-    }
-
+    /**
+     * @todo .CodeMirror-hints and all descendants are outside of editor in a modal,
+     * so we need to move them to the top level of this file
+     */
     :global(.CodeMirror-hint-tag) {
       white-space: normal;
       line-height: 1.4em;
@@ -111,6 +111,7 @@
   background-color: var(--color-neutral-background);
   border: 1px solid var(--color-neutral-border);
   box-shadow: 0 2px 4px rgba(var(--color-neutral-shadow-raw) / calc( 30% * var(--shadow-intensity))), 0 4px 16px rgba(var(--color-neutral-shadow-raw) / calc( 15% * var(--shadow-intensity)));
+  z-index: 3000;
 }
 
 :global(.CodeMirror-hints .CodeMirror-hint) {


### PR DESCRIPTION
`z-index` of CodeMirror's "hint" was too small. We already tried to fix it, but selector was in a wrong place. This PR moves it to the global level without any nesting.
