### PR TITLE
fix: BROS-269: Ensure page refresh is not required when changing hotkeys

### DIFF
--- a/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
+++ b/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
@@ -7,408 +7,365 @@ import { useAPI } from "apps/labelstudio/src/providers/ApiProvider";
 import { Hotkey as EditorHotkey } from "libs/editor/src/core/Hotkey";
 import { useCallback, useEffect, useState } from "react";
 import {
-	type ApiResponse,
-	type ExportData,
-	getTypedDefaultHotkeys,
-	type Hotkey,
-	type HotkeySettings,
-	type ImportData,
-	type SaveResult,
+  type ApiResponse,
+  type ExportData,
+  getTypedDefaultHotkeys,
+  type Hotkey,
+  type HotkeySettings,
+  type ImportData,
+  type SaveResult,
 } from "../sections/Hotkeys/utils";
 
 // Type the imported defaults and convert numeric ids to strings
 const typedDefaultHotkeys: Hotkey[] = getTypedDefaultHotkeys();
 
 export const useHotkeys = () => {
-	const toast = useToast();
-	const [hotkeys, setHotkeys] = useState<Hotkey[]>([]);
-	const [hotkeySettings, setHotkeySettings] = useState<HotkeySettings>({});
-	const [isLoading, setIsLoading] = useState<boolean>(false);
-	const api = useAPI();
+  const toast = useToast();
+  const [hotkeys, setHotkeys] = useState<Hotkey[]>([]);
+  const [hotkeySettings, setHotkeySettings] = useState<HotkeySettings>({});
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const api = useAPI();
 
-	// Update hotkeys with custom settings
-	const updateHotkeysWithCustomSettings = useCallback(
-		(
-			defaultHotkeys: Hotkey[],
-			customHotkeys: Record<
-				string,
-				{ key: string; active: boolean; description?: string }
-			>,
-		): Hotkey[] => {
-			return defaultHotkeys.map((hotkey: Hotkey) => {
-				// Create the lookup key format used in the API response (section:element)
-				const lookupKey = `${hotkey.section}:${hotkey.element}`;
+  // Update hotkeys with custom settings
+  const updateHotkeysWithCustomSettings = useCallback(
+    (
+      defaultHotkeys: Hotkey[],
+      customHotkeys: Record<string, { key: string; active: boolean; description?: string }>,
+    ): Hotkey[] => {
+      return defaultHotkeys.map((hotkey: Hotkey) => {
+        // Create the lookup key format used in the API response (section:element)
+        const lookupKey = `${hotkey.section}:${hotkey.element}`;
 
-				// Check if there's a custom setting for this hotkey
-				if (customHotkeys[lookupKey]) {
-					const customSetting = customHotkeys[lookupKey];
-					// Create a new object with the default properties and override with custom ones
-					return {
-						...hotkey,
-						key: customSetting.key,
-						active: customSetting.active,
-						// Preserve the original label, only update description if provided
-						...(customSetting.description && {
-							description: customSetting.description,
-						}),
-					};
-				}
+        // Check if there's a custom setting for this hotkey
+        if (customHotkeys[lookupKey]) {
+          const customSetting = customHotkeys[lookupKey];
+          // Create a new object with the default properties and override with custom ones
+          return {
+            ...hotkey,
+            key: customSetting.key,
+            active: customSetting.active,
+            // Preserve the original label, only update description if provided
+            ...(customSetting.description && {
+              description: customSetting.description,
+            }),
+          };
+        }
 
-				// If no custom setting exists, return the default hotkey unchanged
-				return hotkey;
-			});
-		},
-		[],
-	);
+        // If no custom setting exists, return the default hotkey unchanged
+        return hotkey;
+      });
+    },
+    [],
+  );
 
-	// Simple hotkey reload - just update global state and call setKeymap
-	const reloadHotkeysInRuntime = useCallback(
-		(
-			customHotkeys: Record<
-				string,
-				{ key: string; active: boolean; description?: string }
-			>,
-		) => {
-			// Update APP_SETTINGS.user.customHotkeys (for Help modal and fallback)
-			if (window.APP_SETTINGS?.user) {
-				window.APP_SETTINGS.user.customHotkeys = customHotkeys;
-			}
+  // Simple hotkey reload - just update global state and call setKeymap
+  const reloadHotkeysInRuntime = useCallback(
+    (customHotkeys: Record<string, { key: string; active: boolean; description?: string }>) => {
+      // Update APP_SETTINGS.user.customHotkeys (for Help modal and fallback)
+      if (window.APP_SETTINGS?.user) {
+        window.APP_SETTINGS.user.customHotkeys = customHotkeys;
+      }
 
-			// Transform custom hotkeys to editor format (same logic as base.html)
-			const editorCustomHotkeys: Record<string, any> = {};
-			const prefixRegex =
-				/^(annotation|timeseries|audio|regions|video|image_gallery|tools):(.*)/;
+      // Transform custom hotkeys to editor format (same logic as base.html)
+      const editorCustomHotkeys: Record<string, any> = {};
+      const prefixRegex = /^(annotation|timeseries|audio|regions|video|image_gallery|tools):(.*)/;
 
-			for (const key in customHotkeys) {
-				const match = key.match(prefixRegex);
-				if (match) {
-					const [, , shortKey] = match;
-					const value = customHotkeys[key];
+      for (const key in customHotkeys) {
+        const match = key.match(prefixRegex);
+        if (match) {
+          const [, , shortKey] = match;
+          const value = customHotkeys[key];
 
-					if (value && value.active === false) {
-						editorCustomHotkeys[shortKey] = { ...value, key: null };
-					} else {
-						editorCustomHotkeys[shortKey] = value;
-					}
-				}
-			}
+          if (value && value.active === false) {
+            editorCustomHotkeys[shortKey] = { ...value, key: null };
+          } else {
+            editorCustomHotkeys[shortKey] = value;
+          }
+        }
+      }
 
-			// Get current keymap and merge with custom hotkeys
-			const currentKeymap = EditorHotkey.keymap
-				? { ...EditorHotkey.keymap }
-				: {};
-			const mergedKeymap = Object.assign(
-				{},
-				currentKeymap,
-				editorCustomHotkeys,
-			);
+      // Get current keymap and merge with custom hotkeys
+      const currentKeymap = EditorHotkey.keymap ? { ...EditorHotkey.keymap } : {};
+      const mergedKeymap = Object.assign({}, currentKeymap, editorCustomHotkeys);
 
-			// Update APP_SETTINGS.editor_keymap (for DataManager/Explorer)
-			if (window.APP_SETTINGS) {
-				window.APP_SETTINGS.editor_keymap = mergedKeymap;
-			}
+      // Update APP_SETTINGS.editor_keymap (for DataManager/Explorer)
+      if (window.APP_SETTINGS) {
+        window.APP_SETTINGS.editor_keymap = mergedKeymap;
+      }
 
-			// Call Hotkey.setKeymap() - the main propagation path
-			try {
-				EditorHotkey.setKeymap(mergedKeymap as any);
-			} catch (error) {
-				console.warn("Failed to update hotkeys:", error);
-			}
-		},
-		[],
-	);
+      // Call Hotkey.setKeymap() - the main propagation path
+      try {
+        EditorHotkey.setKeymap(mergedKeymap as any);
+      } catch (error) {
+        console.warn("Failed to update hotkeys:", error);
+      }
+    },
+    [],
+  );
 
-	// Load hotkeys from API
-	const loadHotkeysFromAPI = useCallback(async () => {
-		try {
-			setIsLoading(true);
+  // Load hotkeys from API
+  const loadHotkeysFromAPI = useCallback(async () => {
+    try {
+      setIsLoading(true);
 
-			// Use proper API endpoint name from the config
-			const response = await api.callApi("hotkeys" as any);
+      // Use proper API endpoint name from the config
+      const response = await api.callApi("hotkeys" as any);
 
-			if (response && (response as ApiResponse).custom_hotkeys) {
-				// Use API data
-				const apiResponse = response as ApiResponse;
-				const updatedHotkeys = updateHotkeysWithCustomSettings(
-					typedDefaultHotkeys,
-					apiResponse.custom_hotkeys || {},
-				);
-				setHotkeys(updatedHotkeys);
-				// Store current settings from API response
-				setHotkeySettings(apiResponse.hotkey_settings || {});
-			} else {
-				// Fallback to window.APP_SETTINGS
-				const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
-				const updatedHotkeys = updateHotkeysWithCustomSettings(
-					typedDefaultHotkeys,
-					customHotkeys,
-				);
-				setHotkeys(updatedHotkeys);
-				// No settings available in fallback
-				setHotkeySettings({});
-			}
-		} catch (error) {
-			console.error("Error loading hotkeys from API:", error);
+      if (response && (response as ApiResponse).custom_hotkeys) {
+        // Use API data
+        const apiResponse = response as ApiResponse;
+        const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, apiResponse.custom_hotkeys || {});
+        setHotkeys(updatedHotkeys);
+        // Store current settings from API response
+        setHotkeySettings(apiResponse.hotkey_settings || {});
+      } else {
+        // Fallback to window.APP_SETTINGS
+        const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
+        const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, customHotkeys);
+        setHotkeys(updatedHotkeys);
+        // No settings available in fallback
+        setHotkeySettings({});
+      }
+    } catch (error) {
+      console.error("Error loading hotkeys from API:", error);
 
-			// Fallback to window.APP_SETTINGS on error
-			const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
-			const updatedHotkeys = updateHotkeysWithCustomSettings(
-				typedDefaultHotkeys,
-				customHotkeys,
-			);
-			setHotkeys(updatedHotkeys);
-			// No settings available in fallback
-			setHotkeySettings({});
+      // Fallback to window.APP_SETTINGS on error
+      const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
+      const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, customHotkeys);
+      setHotkeys(updatedHotkeys);
+      // No settings available in fallback
+      setHotkeySettings({});
 
-			// Show non-blocking error notification
-			if (toast) {
-				toast.show({
-					message:
-						"Could not load custom hotkeys from server, using cached settings",
-					type: ToastType.error,
-				});
-			}
-		} finally {
-			setIsLoading(false);
-		}
-	}, [api, toast, updateHotkeysWithCustomSettings]);
+      // Show non-blocking error notification
+      if (toast) {
+        toast.show({
+          message: "Could not load custom hotkeys from server, using cached settings",
+          type: ToastType.error,
+        });
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [api, toast, updateHotkeysWithCustomSettings]);
 
-	// Save hotkeys to API function (handles both save and reset operations)
-	const saveHotkeysToAPI = useCallback(
-		async (
-			currentHotkeys: Hotkey[],
-			currentSettings: HotkeySettings,
-		): Promise<SaveResult> => {
-			// Convert current hotkeys to API format - INCLUDE description to maintain API compatibility
-			const customHotkeys: Record<
-				string,
-				{ key: string; active: boolean; description?: string }
-			> = {};
+  // Save hotkeys to API function (handles both save and reset operations)
+  const saveHotkeysToAPI = useCallback(
+    async (currentHotkeys: Hotkey[], currentSettings: HotkeySettings): Promise<SaveResult> => {
+      // Convert current hotkeys to API format - INCLUDE description to maintain API compatibility
+      const customHotkeys: Record<string, { key: string; active: boolean; description?: string }> = {};
 
-			// Process all current hotkeys (if empty, this results in reset)
-			currentHotkeys.forEach((hotkey: Hotkey) => {
-				const keyId = `${hotkey.section}:${hotkey.element}`;
-				customHotkeys[keyId] = {
-					key: hotkey.key,
-					active: hotkey.active,
-					...(hotkey.description && { description: hotkey.description }),
-				};
-			});
+      // Process all current hotkeys (if empty, this results in reset)
+      currentHotkeys.forEach((hotkey: Hotkey) => {
+        const keyId = `${hotkey.section}:${hotkey.element}`;
+        customHotkeys[keyId] = {
+          key: hotkey.key,
+          active: hotkey.active,
+          ...(hotkey.description && { description: hotkey.description }),
+        };
+      });
 
-			const requestBody = {
-				custom_hotkeys: customHotkeys,
-				hotkey_settings: currentSettings,
-			};
+      const requestBody = {
+        custom_hotkeys: customHotkeys,
+        hotkey_settings: currentSettings,
+      };
 
-			try {
-				// Use proper API endpoint name from the config
-				const response = await api.callApi("updateHotkeys" as any, {
-					body: requestBody,
-				});
+      try {
+        // Use proper API endpoint name from the config
+        const response = await api.callApi("updateHotkeys" as any, {
+          body: requestBody,
+        });
 
-				// Check for API-level errors
-				if (response?.error) {
-					return {
-						ok: false,
-						error: response.error,
-						data: response,
-					};
-				}
+        // Check for API-level errors
+        if (response?.error) {
+          return {
+            ok: false,
+            error: response.error,
+            data: response,
+          };
+        }
 
-				// Apply hotkeys immediately without page refresh
-				reloadHotkeysInRuntime(customHotkeys);
+        // Apply hotkeys immediately without page refresh
+        reloadHotkeysInRuntime(customHotkeys);
 
-				return {
-					ok: true,
-					error: undefined,
-					data: response,
-				};
-			} catch (error: unknown) {
-				const isReset = currentHotkeys.length === 0;
-				const operation = isReset ? "resetting" : "saving";
-				console.error(`Error ${operation} hotkeys:`, error);
+        return {
+          ok: true,
+          error: undefined,
+          data: response,
+        };
+      } catch (error: unknown) {
+        const isReset = currentHotkeys.length === 0;
+        const operation = isReset ? "resetting" : "saving";
+        console.error(`Error ${operation} hotkeys:`, error);
 
-				// Provide more specific error messages
-				let errorMessage = `Failed to ${isReset ? "reset" : "save"} hotkeys`;
-				if (error && typeof error === "object" && "response" in error) {
-					const err = error as any;
-					// Server responded with error status
-					if (err.response?.status === 400) {
-						errorMessage =
-							err.response.data?.error ||
-							`Invalid ${isReset ? "reset request" : "hotkeys configuration"}`;
-					} else if (err.response?.status === 401) {
-						errorMessage = "Authentication required";
-					} else if (err.response?.status >= 500) {
-						errorMessage = "Server error - please try again later";
-					}
-				} else if (error && typeof error === "object" && "request" in error) {
-					// Network error
-					errorMessage = "Network error - please check your connection";
-				}
+        // Provide more specific error messages
+        let errorMessage = `Failed to ${isReset ? "reset" : "save"} hotkeys`;
+        if (error && typeof error === "object" && "response" in error) {
+          const err = error as any;
+          // Server responded with error status
+          if (err.response?.status === 400) {
+            errorMessage = err.response.data?.error || `Invalid ${isReset ? "reset request" : "hotkeys configuration"}`;
+          } else if (err.response?.status === 401) {
+            errorMessage = "Authentication required";
+          } else if (err.response?.status >= 500) {
+            errorMessage = "Server error - please try again later";
+          }
+        } else if (error && typeof error === "object" && "request" in error) {
+          // Network error
+          errorMessage = "Network error - please check your connection";
+        }
 
-				return {
-					ok: false,
-					error: errorMessage,
-				};
-			}
-		},
-		[api],
-	);
+        return {
+          ok: false,
+          error: errorMessage,
+        };
+      }
+    },
+    [api],
+  );
 
-	// Handle resetting all hotkeys to defaults
-	const handleResetToDefaults = useCallback(() => {
-		confirm({
-			title: "Reset Hotkeys to Defaults?",
-			body: "Are you sure you want to reset all hotkeys and settings to their default values? This action cannot be undone.",
-			okText: "Reset to Defaults",
-			buttonLook: "negative",
-			style: { width: 500 },
-			onOk: async () => {
-				setIsLoading(true);
+  // Handle resetting all hotkeys to defaults
+  const handleResetToDefaults = useCallback(() => {
+    confirm({
+      title: "Reset Hotkeys to Defaults?",
+      body: "Are you sure you want to reset all hotkeys and settings to their default values? This action cannot be undone.",
+      okText: "Reset to Defaults",
+      buttonLook: "negative",
+      style: { width: 500 },
+      onOk: async () => {
+        setIsLoading(true);
 
-				try {
-					// Reset hotkeys to defaults in the backend API (sets custom_hotkeys to {})
-					const result = await saveHotkeysToAPI([], {});
+        try {
+          // Reset hotkeys to defaults in the backend API (sets custom_hotkeys to {})
+          const result = await saveHotkeysToAPI([], {});
 
-					if (result.ok) {
-						if (toast) {
-							toast.show({
-								message:
-									"All hotkeys and settings have been reset to defaults and saved",
-								type: ToastType.info,
-							});
-						}
-						// Update local state to reflect the reset
-						setHotkeys([...typedDefaultHotkeys]);
-					} else {
-						if (toast) {
-							toast.show({
-								message: `Failed to save reset hotkeys: ${result.error || "Unknown error"}`,
-								type: ToastType.error,
-							});
-						}
-					}
-				} catch (error: unknown) {
-					if (toast) {
-						const errorMessage =
-							error instanceof Error ? error.message : "Unknown error";
-						toast.show({
-							message: `Error resetting hotkeys: ${errorMessage}`,
-							type: ToastType.error,
-						});
-					}
-				} finally {
-					setIsLoading(false);
-				}
-			},
-		});
-	}, [saveHotkeysToAPI, toast]);
+          if (result.ok) {
+            if (toast) {
+              toast.show({
+                message: "All hotkeys and settings have been reset to defaults and saved",
+                type: ToastType.info,
+              });
+            }
+            // Update local state to reflect the reset
+            setHotkeys([...typedDefaultHotkeys]);
+          } else {
+            if (toast) {
+              toast.show({
+                message: `Failed to save reset hotkeys: ${result.error || "Unknown error"}`,
+                type: ToastType.error,
+              });
+            }
+          }
+        } catch (error: unknown) {
+          if (toast) {
+            const errorMessage = error instanceof Error ? error.message : "Unknown error";
+            toast.show({
+              message: `Error resetting hotkeys: ${errorMessage}`,
+              type: ToastType.error,
+            });
+          }
+        } finally {
+          setIsLoading(false);
+        }
+      },
+    });
+  }, [saveHotkeysToAPI, toast]);
 
-	// Handle exporting hotkeys
-	const handleExportHotkeys = useCallback(() => {
-		// Create export data including current settings
-		const exportData: ExportData = {
-			hotkeys: hotkeys,
-			settings: hotkeySettings,
-			exportedAt: new Date().toISOString(),
-			version: "1.0",
-		};
+  // Handle exporting hotkeys
+  const handleExportHotkeys = useCallback(() => {
+    // Create export data including current settings
+    const exportData: ExportData = {
+      hotkeys: hotkeys,
+      settings: hotkeySettings,
+      exportedAt: new Date().toISOString(),
+      version: "1.0",
+    };
 
-		// Create a JSON string of the export data
-		const exportJson = JSON.stringify(exportData, null, 2);
+    // Create a JSON string of the export data
+    const exportJson = JSON.stringify(exportData, null, 2);
 
-		// Create a blob with the JSON
-		const blob = new Blob([exportJson], { type: "application/json" });
-		const url = URL.createObjectURL(blob);
+    // Create a blob with the JSON
+    const blob = new Blob([exportJson], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
 
-		// Create a temporary link and click it to download the file
-		const link = document.createElement("a");
-		link.href = url;
-		link.download = "hotkeys-export.json";
-		document.body.appendChild(link);
-		link.click();
+    // Create a temporary link and click it to download the file
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "hotkeys-export.json";
+    document.body.appendChild(link);
+    link.click();
 
-		// Clean up
-		document.body.removeChild(link);
-		URL.revokeObjectURL(url);
+    // Clean up
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
 
-		if (toast) {
-			toast.show({
-				message: "Hotkeys exported successfully",
-				type: ToastType.info,
-			});
-		}
-	}, [hotkeys, hotkeySettings, toast]);
+    if (toast) {
+      toast.show({
+        message: "Hotkeys exported successfully",
+        type: ToastType.info,
+      });
+    }
+  }, [hotkeys, hotkeySettings, toast]);
 
-	// Handle importing hotkeys
-	const handleImportHotkeys = useCallback(
-		async (importedData: ImportData | Hotkey[]) => {
-			try {
-				setIsLoading(true);
+  // Handle importing hotkeys
+  const handleImportHotkeys = useCallback(
+    async (importedData: ImportData | Hotkey[]) => {
+      try {
+        setIsLoading(true);
 
-				// Handle both old format (just hotkeys array) and new format (with settings)
-				const importedHotkeys = Array.isArray(importedData)
-					? importedData
-					: importedData.hotkeys || [];
-				const importedSettings: HotkeySettings = Array.isArray(importedData)
-					? {}
-					: importedData.settings || {};
+        // Handle both old format (just hotkeys array) and new format (with settings)
+        const importedHotkeys = Array.isArray(importedData) ? importedData : importedData.hotkeys || [];
+        const importedSettings: HotkeySettings = Array.isArray(importedData) ? {} : importedData.settings || {};
 
-				// Save all imported data to API
-				const result = await saveHotkeysToAPI(
-					importedHotkeys,
-					importedSettings,
-				);
+        // Save all imported data to API
+        const result = await saveHotkeysToAPI(importedHotkeys, importedSettings);
 
-				if (!result.ok) {
-					throw new Error(result.error || "Failed to save imported hotkeys");
-				}
+        if (!result.ok) {
+          throw new Error(result.error || "Failed to save imported hotkeys");
+        }
 
-				// Update local state
-				setHotkeys(importedHotkeys);
+        // Update local state
+        setHotkeys(importedHotkeys);
 
-				if (toast) {
-					toast.show({
-						message: "Hotkeys imported successfully",
-						type: ToastType.info,
-					});
-				}
+        if (toast) {
+          toast.show({
+            message: "Hotkeys imported successfully",
+            type: ToastType.info,
+          });
+        }
 
-				// Reload from API to ensure consistency
-				await loadHotkeysFromAPI();
-			} catch (error: unknown) {
-				if (toast) {
-					const errorMessage =
-						error instanceof Error ? error.message : "Unknown error";
-					toast.show({
-						message: `Error importing hotkeys: ${errorMessage}`,
-						type: ToastType.error,
-					});
-				}
-			} finally {
-				setIsLoading(false);
-			}
-		},
-		[saveHotkeysToAPI, loadHotkeysFromAPI, toast],
-	);
+        // Reload from API to ensure consistency
+        await loadHotkeysFromAPI();
+      } catch (error: unknown) {
+        if (toast) {
+          const errorMessage = error instanceof Error ? error.message : "Unknown error";
+          toast.show({
+            message: `Error importing hotkeys: ${errorMessage}`,
+            type: ToastType.error,
+          });
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [saveHotkeysToAPI, loadHotkeysFromAPI, toast],
+  );
 
-	// Load hotkeys on hook mount
-	useEffect(() => {
-		loadHotkeysFromAPI();
-	}, [loadHotkeysFromAPI]);
+  // Load hotkeys on hook mount
+  useEffect(() => {
+    loadHotkeysFromAPI();
+  }, [loadHotkeysFromAPI]);
 
-	return {
-		hotkeys,
-		setHotkeys,
-		hotkeySettings,
-		setHotkeySettings,
-		isLoading,
-		setIsLoading,
-		loadHotkeysFromAPI,
-		saveHotkeysToAPI,
-		handleResetToDefaults,
-		handleExportHotkeys,
-		handleImportHotkeys,
-	};
+  return {
+    hotkeys,
+    setHotkeys,
+    hotkeySettings,
+    setHotkeySettings,
+    isLoading,
+    setIsLoading,
+    loadHotkeysFromAPI,
+    saveHotkeysToAPI,
+    handleResetToDefaults,
+    handleExportHotkeys,
+    handleImportHotkeys,
+  };
 };

--- a/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
+++ b/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
@@ -63,7 +63,7 @@ export const useHotkeys = () => {
         window.APP_SETTINGS.user.customHotkeys = customHotkeys;
       }
 
-      const EditorHotkey = Htx.Hotkey;
+      const EditorHotkey = window.Htx?.Hotkey;
 
       if (!EditorHotkey) {
         return;

--- a/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
+++ b/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
@@ -4,520 +4,456 @@ import { confirm } from "apps/labelstudio/src/components/Modal/Modal";
 import { useAPI } from "apps/labelstudio/src/providers/ApiProvider";
 import { useCallback, useEffect, useState } from "react";
 import {
-	type ApiResponse,
-	type ExportData,
-	getTypedDefaultHotkeys,
-	type Hotkey,
-	type HotkeySettings,
-	type ImportData,
-	type SaveResult,
+  type ApiResponse,
+  type ExportData,
+  getTypedDefaultHotkeys,
+  type Hotkey,
+  type HotkeySettings,
+  type ImportData,
+  type SaveResult,
 } from "../sections/Hotkeys/utils";
 
 // Type the imported defaults and convert numeric ids to strings
 const typedDefaultHotkeys: Hotkey[] = getTypedDefaultHotkeys();
 
 export const useHotkeys = () => {
-	const toast = useToast();
-	const [hotkeys, setHotkeys] = useState<Hotkey[]>([]);
-	const [hotkeySettings, setHotkeySettings] = useState<HotkeySettings>({});
-	const [isLoading, setIsLoading] = useState<boolean>(false);
-	const api = useAPI();
+  const toast = useToast();
+  const [hotkeys, setHotkeys] = useState<Hotkey[]>([]);
+  const [hotkeySettings, setHotkeySettings] = useState<HotkeySettings>({});
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const api = useAPI();
 
-	// Update hotkeys with custom settings
-	const updateHotkeysWithCustomSettings = useCallback(
-		(
-			defaultHotkeys: Hotkey[],
-			customHotkeys: Record<
-				string,
-				{ key: string; active: boolean; description?: string }
-			>,
-		): Hotkey[] => {
-			return defaultHotkeys.map((hotkey: Hotkey) => {
-				// Create the lookup key format used in the API response (section:element)
-				const lookupKey = `${hotkey.section}:${hotkey.element}`;
+  // Update hotkeys with custom settings
+  const updateHotkeysWithCustomSettings = useCallback(
+    (
+      defaultHotkeys: Hotkey[],
+      customHotkeys: Record<string, { key: string; active: boolean; description?: string }>,
+    ): Hotkey[] => {
+      return defaultHotkeys.map((hotkey: Hotkey) => {
+        // Create the lookup key format used in the API response (section:element)
+        const lookupKey = `${hotkey.section}:${hotkey.element}`;
 
-				// Check if there's a custom setting for this hotkey
-				if (customHotkeys[lookupKey]) {
-					const customSetting = customHotkeys[lookupKey];
-					// Create a new object with the default properties and override with custom ones
-					return {
-						...hotkey,
-						key: customSetting.key,
-						active: customSetting.active,
-						// Preserve the original label, only update description if provided
-						...(customSetting.description && {
-							description: customSetting.description,
-						}),
-					};
-				}
+        // Check if there's a custom setting for this hotkey
+        if (customHotkeys[lookupKey]) {
+          const customSetting = customHotkeys[lookupKey];
+          // Create a new object with the default properties and override with custom ones
+          return {
+            ...hotkey,
+            key: customSetting.key,
+            active: customSetting.active,
+            // Preserve the original label, only update description if provided
+            ...(customSetting.description && {
+              description: customSetting.description,
+            }),
+          };
+        }
 
-				// If no custom setting exists, return the default hotkey unchanged
-				return hotkey;
-			});
-		},
-		[],
-	);
+        // If no custom setting exists, return the default hotkey unchanged
+        return hotkey;
+      });
+    },
+    [],
+  );
 
-	// Runtime hotkey reload function - applies hotkeys without page refresh
-	const reloadHotkeysInRuntime = useCallback(
-		async (
-			customHotkeys: Record<
-				string,
-				{ key: string; active: boolean; description?: string }
-			>,
-		) => {
-			try {
-				// Step 1: Process custom hotkeys the same way the server does in base.html
-				const editorCustomHotkeys: Record<string, any> = {};
-				const prefixRegex =
-					/^(annotation|timeseries|audio|regions|video|image_gallery|tools):(.*)/;
+  // Runtime hotkey reload function - applies hotkeys without page refresh
+  const reloadHotkeysInRuntime = useCallback(
+    async (customHotkeys: Record<string, { key: string; active: boolean; description?: string }>) => {
+      try {
+        // Step 1: Process custom hotkeys the same way the server does in base.html
+        const editorCustomHotkeys: Record<string, any> = {};
+        const prefixRegex = /^(annotation|timeseries|audio|regions|video|image_gallery|tools):(.*)/;
 
-				for (const key in customHotkeys) {
-					const match = key.match(prefixRegex);
-					if (match) {
-						const [, prefix, shortKey] = match;
-						const value = customHotkeys[key];
+        for (const key in customHotkeys) {
+          const match = key.match(prefixRegex);
+          if (match) {
+            const [, prefix, shortKey] = match;
+            const value = customHotkeys[key];
 
-						// The shortKey might have double prefixes like "annotation:submit"
-						// We need to construct the correct editor keymap key format
-						const editorKey = shortKey.includes(":")
-							? shortKey
-							: `${prefix}:${shortKey}`;
+            // The shortKey might have double prefixes like "annotation:submit"
+            // We need to construct the correct editor keymap key format
+            const editorKey = shortKey.includes(":") ? shortKey : `${prefix}:${shortKey}`;
 
-						// Check if value has active property set to false
-						if (value && value.active === false) {
-							// Create a copy of the value with key set to null
-							const modifiedValue = { ...value, key: null };
-							editorCustomHotkeys[editorKey] = modifiedValue;
-						} else {
-							// Use the original value
-							editorCustomHotkeys[editorKey] = value;
-						}
-					}
-				}
+            // Check if value has active property set to false
+            if (value && value.active === false) {
+              // Create a copy of the value with key set to null
+              const modifiedValue = { ...value, key: null };
+              editorCustomHotkeys[editorKey] = modifiedValue;
+            } else {
+              // Use the original value
+              editorCustomHotkeys[editorKey] = value;
+            }
+          }
+        }
 
-				// Step 2: Get default editor keymap and merge with custom hotkeys
-				// Use the original defaults, which are now properly exposed globally
-				const defaultEditorKeymap = window.DEFAULT_HOTKEYS || {};
+        // Step 2: Get default editor keymap and merge with custom hotkeys
+        // Use the original defaults, which are now properly exposed globally
+        const defaultEditorKeymap = window.DEFAULT_HOTKEYS || {};
 
-				const mergedEditorKeymap = Object.assign(
-					{},
-					defaultEditorKeymap,
-					editorCustomHotkeys,
-				);
+        const mergedEditorKeymap = Object.assign({}, defaultEditorKeymap, editorCustomHotkeys);
 
-				// Step 3: Update window.APP_SETTINGS with new hotkeys
-				if (window.APP_SETTINGS) {
-					window.APP_SETTINGS.editor_keymap = mergedEditorKeymap;
-					window.APP_SETTINGS.user = window.APP_SETTINGS.user || {};
-					window.APP_SETTINGS.user.customHotkeys = customHotkeys;
-				}
+        // Step 3: Update window.APP_SETTINGS with new hotkeys
+        if (window.APP_SETTINGS) {
+          window.APP_SETTINGS.editor_keymap = mergedEditorKeymap;
+          window.APP_SETTINGS.user = window.APP_SETTINGS.user || {};
+          window.APP_SETTINGS.user.customHotkeys = customHotkeys;
+        }
 
-				// Step 4: Re-apply keymap to editor instances if available
-				// Check if Hotkey class is available globally (it should be)
-				if (typeof window !== "undefined") {
-					// Try to access the Hotkey class through various possible global references
-					const HotkeyClass =
-						(window as any).Hotkey ||
-						(window as any).LSF?.Hotkey ||
-						(window as any).LabelStudio?.Hotkey;
+        // Step 4: Re-apply keymap to editor instances if available
+        // Check if Hotkey class is available globally (it should be)
+        if (typeof window !== "undefined") {
+          // Try to access the Hotkey class through various possible global references
+          const HotkeyClass =
+            (window as any).Hotkey || (window as any).LSF?.Hotkey || (window as any).LabelStudio?.Hotkey;
 
-					if (HotkeyClass && typeof HotkeyClass.setKeymap === "function") {
-						HotkeyClass.setKeymap(mergedEditorKeymap);
-					}
-				}
+          if (HotkeyClass && typeof HotkeyClass.setKeymap === "function") {
+            HotkeyClass.setKeymap(mergedEditorKeymap);
+          }
+        }
 
-				// Step 5: Trigger re-initialization of hotkeys in editor instances
-				// This is the most complex part as we need to access LabelStudio instances
-				if (typeof window !== "undefined") {
-					// Try to access LabelStudio instances through various possible global references
-					const instances =
-						(window as any).LabelStudio?.instances ||
-						(window as any).LSF?.instances ||
-						[];
+        // Step 5: Trigger re-initialization of hotkeys in editor instances
+        // This is the most complex part as we need to access LabelStudio instances
+        if (typeof window !== "undefined") {
+          // Try to access LabelStudio instances through various possible global references
+          const instances = (window as any).LabelStudio?.instances || (window as any).LSF?.instances || [];
 
-					// Iterate through instances and trigger hotkey re-initialization
-					if (Array.isArray(instances)) {
-						instances.forEach((instance: any) => {
-							try {
-								// Check if the instance has the store and annotation with setupHotKeys method
-								if (
-									instance?.store?.annotation?.setupHotKeys &&
-									typeof instance.store.annotation.setupHotKeys === "function"
-								) {
-									instance.store.annotation.setupHotKeys();
-								} else if (
-									instance?.annotation?.setupHotKeys &&
-									typeof instance.annotation.setupHotKeys === "function"
-								) {
-									instance.annotation.setupHotKeys();
-								}
-							} catch (error) {
-								// Only log editor instance refresh failures in debug mode
-								if (
-									typeof window !== "undefined" &&
-									window.APP_SETTINGS?.debug
-								) {
-									console.warn(
-										"Failed to refresh hotkeys for editor instance:",
-										error,
-									);
-								}
-							}
-						});
-					} else if (instances && typeof instances.forEach === "function") {
-						// Handle Set or other iterable
-						instances.forEach((instance: any) => {
-							try {
-								if (
-									instance?.store?.annotation?.setupHotKeys &&
-									typeof instance.store.annotation.setupHotKeys === "function"
-								) {
-									instance.store.annotation.setupHotKeys();
-								} else if (
-									instance?.annotation?.setupHotKeys &&
-									typeof instance.annotation.setupHotKeys === "function"
-								) {
-									instance.annotation.setupHotKeys();
-								}
-							} catch (error) {
-								// Only log editor instance refresh failures in debug mode
-								if (
-									typeof window !== "undefined" &&
-									window.APP_SETTINGS?.debug
-								) {
-									console.warn(
-										"Failed to refresh hotkeys for editor instance:",
-										error,
-									);
-								}
-							}
-						});
-					}
-				}
+          // Iterate through instances and trigger hotkey re-initialization
+          if (Array.isArray(instances)) {
+            instances.forEach((instance: any) => {
+              try {
+                // Check if the instance has the store and annotation with setupHotKeys method
+                if (
+                  instance?.store?.annotation?.setupHotKeys &&
+                  typeof instance.store.annotation.setupHotKeys === "function"
+                ) {
+                  instance.store.annotation.setupHotKeys();
+                } else if (
+                  instance?.annotation?.setupHotKeys &&
+                  typeof instance.annotation.setupHotKeys === "function"
+                ) {
+                  instance.annotation.setupHotKeys();
+                }
+              } catch (error) {
+                // Only log editor instance refresh failures in debug mode
+                if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+                  console.warn("Failed to refresh hotkeys for editor instance:", error);
+                }
+              }
+            });
+          } else if (instances && typeof instances.forEach === "function") {
+            // Handle Set or other iterable
+            instances.forEach((instance: any) => {
+              try {
+                if (
+                  instance?.store?.annotation?.setupHotKeys &&
+                  typeof instance.store.annotation.setupHotKeys === "function"
+                ) {
+                  instance.store.annotation.setupHotKeys();
+                } else if (
+                  instance?.annotation?.setupHotKeys &&
+                  typeof instance.annotation.setupHotKeys === "function"
+                ) {
+                  instance.annotation.setupHotKeys();
+                }
+              } catch (error) {
+                // Only log editor instance refresh failures in debug mode
+                if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+                  console.warn("Failed to refresh hotkeys for editor instance:", error);
+                }
+              }
+            });
+          }
+        }
 
-				// Only log in debug mode
-				if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-					console.log("Hotkeys successfully reloaded at runtime");
-				}
-				return true;
-			} catch (error) {
-				// Only log in debug mode
-				if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-					console.error("Failed to reload hotkeys at runtime:", error);
-				}
-				return false;
-			}
-		},
-		[],
-	);
+        // Only log in debug mode
+        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+          console.log("Hotkeys successfully reloaded at runtime");
+        }
+        return true;
+      } catch (error) {
+        // Only log in debug mode
+        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+          console.error("Failed to reload hotkeys at runtime:", error);
+        }
+        return false;
+      }
+    },
+    [],
+  );
 
-	// Load hotkeys from API
-	const loadHotkeysFromAPI = useCallback(async () => {
-		try {
-			setIsLoading(true);
+  // Load hotkeys from API
+  const loadHotkeysFromAPI = useCallback(async () => {
+    try {
+      setIsLoading(true);
 
-			// Use proper API endpoint name from the config
-			const response = await api.callApi("hotkeys" as any);
+      // Use proper API endpoint name from the config
+      const response = await api.callApi("hotkeys" as any);
 
-			if (response && (response as ApiResponse).custom_hotkeys) {
-				// Use API data
-				const apiResponse = response as ApiResponse;
-				const updatedHotkeys = updateHotkeysWithCustomSettings(
-					typedDefaultHotkeys,
-					apiResponse.custom_hotkeys!,
-				);
-				setHotkeys(updatedHotkeys);
-				// Store current settings from API response
-				setHotkeySettings(apiResponse.hotkey_settings || {});
-			} else {
-				// Fallback to window.APP_SETTINGS
-				const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
-				const updatedHotkeys = updateHotkeysWithCustomSettings(
-					typedDefaultHotkeys,
-					customHotkeys,
-				);
-				setHotkeys(updatedHotkeys);
-				// No settings available in fallback
-				setHotkeySettings({});
-			}
-		} catch (error) {
-			console.error("Error loading hotkeys from API:", error);
+      if (response && (response as ApiResponse).custom_hotkeys) {
+        // Use API data
+        const apiResponse = response as ApiResponse;
+        const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, apiResponse.custom_hotkeys!);
+        setHotkeys(updatedHotkeys);
+        // Store current settings from API response
+        setHotkeySettings(apiResponse.hotkey_settings || {});
+      } else {
+        // Fallback to window.APP_SETTINGS
+        const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
+        const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, customHotkeys);
+        setHotkeys(updatedHotkeys);
+        // No settings available in fallback
+        setHotkeySettings({});
+      }
+    } catch (error) {
+      console.error("Error loading hotkeys from API:", error);
 
-			// Fallback to window.APP_SETTINGS on error
-			const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
-			const updatedHotkeys = updateHotkeysWithCustomSettings(
-				typedDefaultHotkeys,
-				customHotkeys,
-			);
-			setHotkeys(updatedHotkeys);
-			// No settings available in fallback
-			setHotkeySettings({});
+      // Fallback to window.APP_SETTINGS on error
+      const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
+      const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, customHotkeys);
+      setHotkeys(updatedHotkeys);
+      // No settings available in fallback
+      setHotkeySettings({});
 
-			// Show non-blocking error notification
-			if (toast) {
-				toast.show({
-					message:
-						"Could not load custom hotkeys from server, using cached settings",
-					type: ToastType.error,
-				});
-			}
-		} finally {
-			setIsLoading(false);
-		}
-	}, [api, toast, updateHotkeysWithCustomSettings]);
+      // Show non-blocking error notification
+      if (toast) {
+        toast.show({
+          message: "Could not load custom hotkeys from server, using cached settings",
+          type: ToastType.error,
+        });
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [api, toast, updateHotkeysWithCustomSettings]);
 
-	// Save hotkeys to API function (handles both save and reset operations)
-	const saveHotkeysToAPI = useCallback(
-		async (
-			currentHotkeys: Hotkey[],
-			currentSettings: HotkeySettings,
-		): Promise<SaveResult> => {
-			// Convert current hotkeys to API format - INCLUDE description to maintain API compatibility
-			const customHotkeys: Record<
-				string,
-				{ key: string; active: boolean; description?: string }
-			> = {};
+  // Save hotkeys to API function (handles both save and reset operations)
+  const saveHotkeysToAPI = useCallback(
+    async (currentHotkeys: Hotkey[], currentSettings: HotkeySettings): Promise<SaveResult> => {
+      // Convert current hotkeys to API format - INCLUDE description to maintain API compatibility
+      const customHotkeys: Record<string, { key: string; active: boolean; description?: string }> = {};
 
-			// Process all current hotkeys (if empty, this results in reset)
-			currentHotkeys.forEach((hotkey: Hotkey) => {
-				const keyId = `${hotkey.section}:${hotkey.element}`;
-				customHotkeys[keyId] = {
-					key: hotkey.key,
-					active: hotkey.active,
-					...(hotkey.description && { description: hotkey.description }),
-				};
-			});
+      // Process all current hotkeys (if empty, this results in reset)
+      currentHotkeys.forEach((hotkey: Hotkey) => {
+        const keyId = `${hotkey.section}:${hotkey.element}`;
+        customHotkeys[keyId] = {
+          key: hotkey.key,
+          active: hotkey.active,
+          ...(hotkey.description && { description: hotkey.description }),
+        };
+      });
 
-			const requestBody = {
-				custom_hotkeys: customHotkeys,
-				hotkey_settings: currentSettings,
-			};
+      const requestBody = {
+        custom_hotkeys: customHotkeys,
+        hotkey_settings: currentSettings,
+      };
 
-			try {
-				// Use proper API endpoint name from the config
-				const response = await api.callApi("updateHotkeys" as any, {
-					body: requestBody,
-				});
+      try {
+        // Use proper API endpoint name from the config
+        const response = await api.callApi("updateHotkeys" as any, {
+          body: requestBody,
+        });
 
-				// Check for API-level errors
-				if (response?.error) {
-					return {
-						ok: false,
-						error: response.error,
-						data: response,
-					};
-				}
+        // Check for API-level errors
+        if (response?.error) {
+          return {
+            ok: false,
+            error: response.error,
+            data: response,
+          };
+        }
 
-				// After successful save, reload hotkeys at runtime to apply changes immediately
-				const reloadSuccess = await reloadHotkeysInRuntime(customHotkeys);
+        // After successful save, reload hotkeys at runtime to apply changes immediately
+        const reloadSuccess = await reloadHotkeysInRuntime(customHotkeys);
 
-				// Only log runtime reload status in debug mode
-				if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-					if (reloadSuccess) {
-						console.log(
-							"Hotkeys successfully applied at runtime - no page refresh needed",
-						);
-					} else {
-						console.warn(
-							"Runtime hotkey reload failed - page refresh may be required",
-						);
-					}
-				}
+        // Only log runtime reload status in debug mode
+        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+          if (reloadSuccess) {
+            console.log("Hotkeys successfully applied at runtime - no page refresh needed");
+          } else {
+            console.warn("Runtime hotkey reload failed - page refresh may be required");
+          }
+        }
 
-				return {
-					ok: true,
-					error: undefined,
-					data: response,
-					runtimeReloadSuccess: reloadSuccess,
-				};
-			} catch (error: unknown) {
-				const isReset = currentHotkeys.length === 0;
-				const operation = isReset ? "resetting" : "saving";
-				console.error(`Error ${operation} hotkeys:`, error);
+        return {
+          ok: true,
+          error: undefined,
+          data: response,
+          runtimeReloadSuccess: reloadSuccess,
+        };
+      } catch (error: unknown) {
+        const isReset = currentHotkeys.length === 0;
+        const operation = isReset ? "resetting" : "saving";
+        console.error(`Error ${operation} hotkeys:`, error);
 
-				// Provide more specific error messages
-				let errorMessage = `Failed to ${isReset ? "reset" : "save"} hotkeys`;
-				if (error && typeof error === "object" && "response" in error) {
-					const err = error as any;
-					// Server responded with error status
-					if (err.response?.status === 400) {
-						errorMessage =
-							err.response.data?.error ||
-							`Invalid ${isReset ? "reset request" : "hotkeys configuration"}`;
-					} else if (err.response?.status === 401) {
-						errorMessage = "Authentication required";
-					} else if (err.response?.status >= 500) {
-						errorMessage = "Server error - please try again later";
-					}
-				} else if (error && typeof error === "object" && "request" in error) {
-					// Network error
-					errorMessage = "Network error - please check your connection";
-				}
+        // Provide more specific error messages
+        let errorMessage = `Failed to ${isReset ? "reset" : "save"} hotkeys`;
+        if (error && typeof error === "object" && "response" in error) {
+          const err = error as any;
+          // Server responded with error status
+          if (err.response?.status === 400) {
+            errorMessage = err.response.data?.error || `Invalid ${isReset ? "reset request" : "hotkeys configuration"}`;
+          } else if (err.response?.status === 401) {
+            errorMessage = "Authentication required";
+          } else if (err.response?.status >= 500) {
+            errorMessage = "Server error - please try again later";
+          }
+        } else if (error && typeof error === "object" && "request" in error) {
+          // Network error
+          errorMessage = "Network error - please check your connection";
+        }
 
-				return {
-					ok: false,
-					error: errorMessage,
-				};
-			}
-		},
-		[api],
-	);
+        return {
+          ok: false,
+          error: errorMessage,
+        };
+      }
+    },
+    [api],
+  );
 
-	// Handle resetting all hotkeys to defaults
-	const handleResetToDefaults = useCallback(() => {
-		confirm({
-			title: "Reset Hotkeys to Defaults?",
-			body: "Are you sure you want to reset all hotkeys and settings to their default values? This action cannot be undone.",
-			okText: "Reset to Defaults",
-			buttonLook: "negative",
-			style: { width: 500 },
-			onOk: async () => {
-				setIsLoading(true);
+  // Handle resetting all hotkeys to defaults
+  const handleResetToDefaults = useCallback(() => {
+    confirm({
+      title: "Reset Hotkeys to Defaults?",
+      body: "Are you sure you want to reset all hotkeys and settings to their default values? This action cannot be undone.",
+      okText: "Reset to Defaults",
+      buttonLook: "negative",
+      style: { width: 500 },
+      onOk: async () => {
+        setIsLoading(true);
 
-				try {
-					// Reset hotkeys to defaults in the backend API (sets custom_hotkeys to {})
-					const result = await saveHotkeysToAPI([], {});
+        try {
+          // Reset hotkeys to defaults in the backend API (sets custom_hotkeys to {})
+          const result = await saveHotkeysToAPI([], {});
 
-					if (result.ok) {
-						if (toast) {
-							toast.show({
-								message:
-									"All hotkeys and settings have been reset to defaults and saved",
-								type: ToastType.info,
-							});
-						}
-						// Update local state to reflect the reset
-						setHotkeys([...typedDefaultHotkeys]);
-					} else {
-						if (toast) {
-							toast.show({
-								message: `Failed to save reset hotkeys: ${result.error || "Unknown error"}`,
-								type: ToastType.error,
-							});
-						}
-					}
-				} catch (error: unknown) {
-					if (toast) {
-						const errorMessage =
-							error instanceof Error ? error.message : "Unknown error";
-						toast.show({
-							message: `Error resetting hotkeys: ${errorMessage}`,
-							type: ToastType.error,
-						});
-					}
-				} finally {
-					setIsLoading(false);
-				}
-			},
-		});
-	}, [saveHotkeysToAPI, toast]);
+          if (result.ok) {
+            if (toast) {
+              toast.show({
+                message: "All hotkeys and settings have been reset to defaults and saved",
+                type: ToastType.info,
+              });
+            }
+            // Update local state to reflect the reset
+            setHotkeys([...typedDefaultHotkeys]);
+          } else {
+            if (toast) {
+              toast.show({
+                message: `Failed to save reset hotkeys: ${result.error || "Unknown error"}`,
+                type: ToastType.error,
+              });
+            }
+          }
+        } catch (error: unknown) {
+          if (toast) {
+            const errorMessage = error instanceof Error ? error.message : "Unknown error";
+            toast.show({
+              message: `Error resetting hotkeys: ${errorMessage}`,
+              type: ToastType.error,
+            });
+          }
+        } finally {
+          setIsLoading(false);
+        }
+      },
+    });
+  }, [saveHotkeysToAPI, toast]);
 
-	// Handle exporting hotkeys
-	const handleExportHotkeys = useCallback(() => {
-		// Create export data including current settings
-		const exportData: ExportData = {
-			hotkeys: hotkeys,
-			settings: hotkeySettings,
-			exportedAt: new Date().toISOString(),
-			version: "1.0",
-		};
+  // Handle exporting hotkeys
+  const handleExportHotkeys = useCallback(() => {
+    // Create export data including current settings
+    const exportData: ExportData = {
+      hotkeys: hotkeys,
+      settings: hotkeySettings,
+      exportedAt: new Date().toISOString(),
+      version: "1.0",
+    };
 
-		// Create a JSON string of the export data
-		const exportJson = JSON.stringify(exportData, null, 2);
+    // Create a JSON string of the export data
+    const exportJson = JSON.stringify(exportData, null, 2);
 
-		// Create a blob with the JSON
-		const blob = new Blob([exportJson], { type: "application/json" });
-		const url = URL.createObjectURL(blob);
+    // Create a blob with the JSON
+    const blob = new Blob([exportJson], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
 
-		// Create a temporary link and click it to download the file
-		const link = document.createElement("a");
-		link.href = url;
-		link.download = "hotkeys-export.json";
-		document.body.appendChild(link);
-		link.click();
+    // Create a temporary link and click it to download the file
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "hotkeys-export.json";
+    document.body.appendChild(link);
+    link.click();
 
-		// Clean up
-		document.body.removeChild(link);
-		URL.revokeObjectURL(url);
+    // Clean up
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
 
-		if (toast) {
-			toast.show({
-				message: "Hotkeys exported successfully",
-				type: ToastType.info,
-			});
-		}
-	}, [hotkeys, hotkeySettings, toast]);
+    if (toast) {
+      toast.show({
+        message: "Hotkeys exported successfully",
+        type: ToastType.info,
+      });
+    }
+  }, [hotkeys, hotkeySettings, toast]);
 
-	// Handle importing hotkeys
-	const handleImportHotkeys = useCallback(
-		async (importedData: ImportData | Hotkey[]) => {
-			try {
-				setIsLoading(true);
+  // Handle importing hotkeys
+  const handleImportHotkeys = useCallback(
+    async (importedData: ImportData | Hotkey[]) => {
+      try {
+        setIsLoading(true);
 
-				// Handle both old format (just hotkeys array) and new format (with settings)
-				const importedHotkeys = Array.isArray(importedData)
-					? importedData
-					: importedData.hotkeys || [];
-				const importedSettings: HotkeySettings = Array.isArray(importedData)
-					? {}
-					: importedData.settings || {};
+        // Handle both old format (just hotkeys array) and new format (with settings)
+        const importedHotkeys = Array.isArray(importedData) ? importedData : importedData.hotkeys || [];
+        const importedSettings: HotkeySettings = Array.isArray(importedData) ? {} : importedData.settings || {};
 
-				// Save all imported data to API
-				const result = await saveHotkeysToAPI(
-					importedHotkeys,
-					importedSettings,
-				);
+        // Save all imported data to API
+        const result = await saveHotkeysToAPI(importedHotkeys, importedSettings);
 
-				if (!result.ok) {
-					throw new Error(result.error || "Failed to save imported hotkeys");
-				}
+        if (!result.ok) {
+          throw new Error(result.error || "Failed to save imported hotkeys");
+        }
 
-				// Update local state
-				setHotkeys(importedHotkeys);
+        // Update local state
+        setHotkeys(importedHotkeys);
 
-				if (toast) {
-					toast.show({
-						message: "Hotkeys imported successfully",
-						type: ToastType.info,
-					});
-				}
+        if (toast) {
+          toast.show({
+            message: "Hotkeys imported successfully",
+            type: ToastType.info,
+          });
+        }
 
-				// Reload from API to ensure consistency
-				await loadHotkeysFromAPI();
-			} catch (error: unknown) {
-				if (toast) {
-					const errorMessage =
-						error instanceof Error ? error.message : "Unknown error";
-					toast.show({
-						message: `Error importing hotkeys: ${errorMessage}`,
-						type: ToastType.error,
-					});
-				}
-			} finally {
-				setIsLoading(false);
-			}
-		},
-		[saveHotkeysToAPI, loadHotkeysFromAPI, toast],
-	);
+        // Reload from API to ensure consistency
+        await loadHotkeysFromAPI();
+      } catch (error: unknown) {
+        if (toast) {
+          const errorMessage = error instanceof Error ? error.message : "Unknown error";
+          toast.show({
+            message: `Error importing hotkeys: ${errorMessage}`,
+            type: ToastType.error,
+          });
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [saveHotkeysToAPI, loadHotkeysFromAPI, toast],
+  );
 
-	// Load hotkeys on hook mount
-	useEffect(() => {
-		loadHotkeysFromAPI();
-	}, [loadHotkeysFromAPI]);
+  // Load hotkeys on hook mount
+  useEffect(() => {
+    loadHotkeysFromAPI();
+  }, [loadHotkeysFromAPI]);
 
-	return {
-		hotkeys,
-		setHotkeys,
-		hotkeySettings,
-		setHotkeySettings,
-		isLoading,
-		setIsLoading,
-		loadHotkeysFromAPI,
-		saveHotkeysToAPI,
-		reloadHotkeysInRuntime,
-		handleResetToDefaults,
-		handleExportHotkeys,
-		handleImportHotkeys,
-	};
+  return {
+    hotkeys,
+    setHotkeys,
+    hotkeySettings,
+    setHotkeySettings,
+    isLoading,
+    setIsLoading,
+    loadHotkeysFromAPI,
+    saveHotkeysToAPI,
+    reloadHotkeysInRuntime,
+    handleResetToDefaults,
+    handleExportHotkeys,
+    handleImportHotkeys,
+  };
 };

--- a/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
+++ b/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
@@ -4,535 +4,466 @@ import { confirm } from "apps/labelstudio/src/components/Modal/Modal";
 import { useAPI } from "apps/labelstudio/src/providers/ApiProvider";
 import { useCallback, useEffect, useState } from "react";
 import {
-	type ApiResponse,
-	type ExportData,
-	getTypedDefaultHotkeys,
-	type Hotkey,
-	type HotkeySettings,
-	type ImportData,
-	type SaveResult,
+  type ApiResponse,
+  type ExportData,
+  getTypedDefaultHotkeys,
+  type Hotkey,
+  type HotkeySettings,
+  type ImportData,
+  type SaveResult,
 } from "../sections/Hotkeys/utils";
 
 // Type definitions for better type safety
 type EditorInstance = {
-	store?: {
-		annotation?: {
-			setupHotKeys?: () => void;
-		};
-	};
-	annotation?: {
-		setupHotKeys?: () => void;
-	};
+  store?: {
+    annotation?: {
+      setupHotKeys?: () => void;
+    };
+  };
+  annotation?: {
+    setupHotKeys?: () => void;
+  };
 };
 
 // Type the imported defaults and convert numeric ids to strings
 const typedDefaultHotkeys: Hotkey[] = getTypedDefaultHotkeys();
 
 export const useHotkeys = () => {
-	const toast = useToast();
-	const [hotkeys, setHotkeys] = useState<Hotkey[]>([]);
-	const [hotkeySettings, setHotkeySettings] = useState<HotkeySettings>({});
-	const [isLoading, setIsLoading] = useState<boolean>(false);
-	const api = useAPI();
+  const toast = useToast();
+  const [hotkeys, setHotkeys] = useState<Hotkey[]>([]);
+  const [hotkeySettings, setHotkeySettings] = useState<HotkeySettings>({});
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const api = useAPI();
 
-	// Update hotkeys with custom settings
-	const updateHotkeysWithCustomSettings = useCallback(
-		(
-			defaultHotkeys: Hotkey[],
-			customHotkeys: Record<
-				string,
-				{ key: string; active: boolean; description?: string }
-			>,
-		): Hotkey[] => {
-			return defaultHotkeys.map((hotkey: Hotkey) => {
-				// Create the lookup key format used in the API response (section:element)
-				const lookupKey = `${hotkey.section}:${hotkey.element}`;
+  // Update hotkeys with custom settings
+  const updateHotkeysWithCustomSettings = useCallback(
+    (
+      defaultHotkeys: Hotkey[],
+      customHotkeys: Record<string, { key: string; active: boolean; description?: string }>,
+    ): Hotkey[] => {
+      return defaultHotkeys.map((hotkey: Hotkey) => {
+        // Create the lookup key format used in the API response (section:element)
+        const lookupKey = `${hotkey.section}:${hotkey.element}`;
 
-				// Check if there's a custom setting for this hotkey
-				if (customHotkeys[lookupKey]) {
-					const customSetting = customHotkeys[lookupKey];
-					// Create a new object with the default properties and override with custom ones
-					return {
-						...hotkey,
-						key: customSetting.key,
-						active: customSetting.active,
-						// Preserve the original label, only update description if provided
-						...(customSetting.description && {
-							description: customSetting.description,
-						}),
-					};
-				}
+        // Check if there's a custom setting for this hotkey
+        if (customHotkeys[lookupKey]) {
+          const customSetting = customHotkeys[lookupKey];
+          // Create a new object with the default properties and override with custom ones
+          return {
+            ...hotkey,
+            key: customSetting.key,
+            active: customSetting.active,
+            // Preserve the original label, only update description if provided
+            ...(customSetting.description && {
+              description: customSetting.description,
+            }),
+          };
+        }
 
-				// If no custom setting exists, return the default hotkey unchanged
-				return hotkey;
-			});
-		},
-		[],
-	);
+        // If no custom setting exists, return the default hotkey unchanged
+        return hotkey;
+      });
+    },
+    [],
+  );
 
-	// Runtime hotkey reload function - applies hotkeys without page refresh
-	const reloadHotkeysInRuntime = useCallback(
-		async (
-			customHotkeys: Record<
-				string,
-				{ key: string; active: boolean; description?: string }
-			>,
-		) => {
-			try {
-				// Step 1: Process custom hotkeys the same way the server does in base.html
-				const editorCustomHotkeys: Record<
-					string,
-					{ key: string | null; active: boolean; description?: string }
-				> = {};
-				const prefixRegex =
-					/^(annotation|timeseries|audio|regions|video|image_gallery|tools):(.*)/;
+  // Runtime hotkey reload function - applies hotkeys without page refresh
+  const reloadHotkeysInRuntime = useCallback(
+    async (customHotkeys: Record<string, { key: string; active: boolean; description?: string }>) => {
+      try {
+        // Step 1: Process custom hotkeys the same way the server does in base.html
+        const editorCustomHotkeys: Record<string, { key: string | null; active: boolean; description?: string }> = {};
+        const prefixRegex = /^(annotation|timeseries|audio|regions|video|image_gallery|tools):(.*)/;
 
-				for (const key in customHotkeys) {
-					const match = key.match(prefixRegex);
-					if (match) {
-						const [, prefix, shortKey] = match;
-						const value = customHotkeys[key];
+        for (const key in customHotkeys) {
+          const match = key.match(prefixRegex);
+          if (match) {
+            const [, prefix, shortKey] = match;
+            const value = customHotkeys[key];
 
-						// The shortKey might have double prefixes like "annotation:submit"
-						// We need to construct the correct editor keymap key format
-						const editorKey = shortKey.includes(":")
-							? shortKey
-							: `${prefix}:${shortKey}`;
+            // The shortKey might have double prefixes like "annotation:submit"
+            // We need to construct the correct editor keymap key format
+            const editorKey = shortKey.includes(":") ? shortKey : `${prefix}:${shortKey}`;
 
-						// Check if value has active property set to false
-						if (value && value.active === false) {
-							// Create a copy of the value with key set to null
-							const modifiedValue = { ...value, key: null };
-							editorCustomHotkeys[editorKey] = modifiedValue;
-						} else {
-							// Use the original value
-							editorCustomHotkeys[editorKey] = value;
-						}
-					}
-				}
+            // Check if value has active property set to false
+            if (value && value.active === false) {
+              // Create a copy of the value with key set to null
+              const modifiedValue = { ...value, key: null };
+              editorCustomHotkeys[editorKey] = modifiedValue;
+            } else {
+              // Use the original value
+              editorCustomHotkeys[editorKey] = value;
+            }
+          }
+        }
 
-				// Step 2: Get default editor keymap and merge with custom hotkeys
-				// Use the original defaults, which are now properly exposed globally
-				const defaultEditorKeymap = window.DEFAULT_HOTKEYS || {};
+        // Step 2: Get default editor keymap and merge with custom hotkeys
+        // Use the original defaults, which are now properly exposed globally
+        const defaultEditorKeymap = window.DEFAULT_HOTKEYS || {};
 
-				const mergedEditorKeymap = Object.assign(
-					{},
-					defaultEditorKeymap,
-					editorCustomHotkeys,
-				);
+        const mergedEditorKeymap = Object.assign({}, defaultEditorKeymap, editorCustomHotkeys);
 
-				// Step 3: Update window.APP_SETTINGS with new hotkeys
-				if (window.APP_SETTINGS) {
-					window.APP_SETTINGS.editor_keymap = mergedEditorKeymap;
-					window.APP_SETTINGS.user = window.APP_SETTINGS.user || {};
-					window.APP_SETTINGS.user.customHotkeys = customHotkeys;
-				}
+        // Step 3: Update window.APP_SETTINGS with new hotkeys
+        if (window.APP_SETTINGS) {
+          window.APP_SETTINGS.editor_keymap = mergedEditorKeymap;
+          window.APP_SETTINGS.user = window.APP_SETTINGS.user || {};
+          window.APP_SETTINGS.user.customHotkeys = customHotkeys;
+        }
 
-				// Step 4: Re-apply keymap to editor instances if available
-				// Check if Hotkey class is available globally
-				if (typeof window !== "undefined") {
-					// Try to access the Hotkey class through various possible global references
-					const HotkeyClass =
-						(window as any).Hotkey || (window as any).LSF?.Hotkey;
+        // Step 4: Re-apply keymap to editor instances if available
+        // Check if Hotkey class is available globally
+        if (typeof window !== "undefined") {
+          // Try to access the Hotkey class through various possible global references
+          const HotkeyClass = (window as any).Hotkey || (window as any).LSF?.Hotkey;
 
-					if (HotkeyClass && typeof HotkeyClass.setKeymap === "function") {
-						HotkeyClass.setKeymap(mergedEditorKeymap);
-					}
-				}
+          if (HotkeyClass && typeof HotkeyClass.setKeymap === "function") {
+            HotkeyClass.setKeymap(mergedEditorKeymap);
+          }
+        }
 
-				// Step 5: Trigger re-initialization of hotkeys in editor instances
-				// This is the most complex part as we need to access LabelStudio instances
-				if (typeof window !== "undefined") {
-					// Try to access LabelStudio instances through various possible global references
-					const instances =
-						(window as any).LabelStudio?.instances ||
-						(window as any).LSF?.instances ||
-						[];
+        // Step 5: Trigger re-initialization of hotkeys in editor instances
+        // This is the most complex part as we need to access LabelStudio instances
+        if (typeof window !== "undefined") {
+          // Try to access LabelStudio instances through various possible global references
+          const instances = (window as any).LabelStudio?.instances || (window as any).LSF?.instances || [];
 
-					// Iterate through instances and trigger hotkey re-initialization
-					if (Array.isArray(instances)) {
-						instances.forEach((instance: EditorInstance) => {
-							try {
-								// Check if the instance has the store and annotation with setupHotKeys method
-								if (
-									instance?.store?.annotation?.setupHotKeys &&
-									typeof instance.store.annotation.setupHotKeys === "function"
-								) {
-									instance.store.annotation.setupHotKeys();
-								} else if (
-									instance?.annotation?.setupHotKeys &&
-									typeof instance.annotation.setupHotKeys === "function"
-								) {
-									instance.annotation.setupHotKeys();
-								}
-							} catch (error) {
-								// Only log editor instance refresh failures in debug mode
-								if (
-									typeof window !== "undefined" &&
-									window.APP_SETTINGS?.debug
-								) {
-									console.warn(
-										"Failed to refresh hotkeys for editor instance:",
-										error,
-									);
-								}
-							}
-						});
-					} else if (
-						instances &&
-						typeof (instances as any).forEach === "function"
-					) {
-						// Handle Set or other iterable
-						(instances as any).forEach((instance: EditorInstance) => {
-							try {
-								if (
-									instance?.store?.annotation?.setupHotKeys &&
-									typeof instance.store.annotation.setupHotKeys === "function"
-								) {
-									instance.store.annotation.setupHotKeys();
-								} else if (
-									instance?.annotation?.setupHotKeys &&
-									typeof instance.annotation.setupHotKeys === "function"
-								) {
-									instance.annotation.setupHotKeys();
-								}
-							} catch (error) {
-								// Only log editor instance refresh failures in debug mode
-								if (
-									typeof window !== "undefined" &&
-									window.APP_SETTINGS?.debug
-								) {
-									console.warn(
-										"Failed to refresh hotkeys for editor instance:",
-										error,
-									);
-								}
-							}
-						});
-					}
-				}
+          // Iterate through instances and trigger hotkey re-initialization
+          if (Array.isArray(instances)) {
+            instances.forEach((instance: EditorInstance) => {
+              try {
+                // Check if the instance has the store and annotation with setupHotKeys method
+                if (
+                  instance?.store?.annotation?.setupHotKeys &&
+                  typeof instance.store.annotation.setupHotKeys === "function"
+                ) {
+                  instance.store.annotation.setupHotKeys();
+                } else if (
+                  instance?.annotation?.setupHotKeys &&
+                  typeof instance.annotation.setupHotKeys === "function"
+                ) {
+                  instance.annotation.setupHotKeys();
+                }
+              } catch (error) {
+                // Only log editor instance refresh failures in debug mode
+                if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+                  console.warn("Failed to refresh hotkeys for editor instance:", error);
+                }
+              }
+            });
+          } else if (instances && typeof (instances as any).forEach === "function") {
+            // Handle Set or other iterable
+            (instances as any).forEach((instance: EditorInstance) => {
+              try {
+                if (
+                  instance?.store?.annotation?.setupHotKeys &&
+                  typeof instance.store.annotation.setupHotKeys === "function"
+                ) {
+                  instance.store.annotation.setupHotKeys();
+                } else if (
+                  instance?.annotation?.setupHotKeys &&
+                  typeof instance.annotation.setupHotKeys === "function"
+                ) {
+                  instance.annotation.setupHotKeys();
+                }
+              } catch (error) {
+                // Only log editor instance refresh failures in debug mode
+                if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+                  console.warn("Failed to refresh hotkeys for editor instance:", error);
+                }
+              }
+            });
+          }
+        }
 
-				// Only log in debug mode
-				if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-					console.log("Hotkeys successfully reloaded at runtime");
-				}
-				return true;
-			} catch (error) {
-				// Only log in debug mode
-				if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-					console.error("Failed to reload hotkeys at runtime:", error);
-				}
-				return false;
-			}
-		},
-		[],
-	);
+        // Only log in debug mode
+        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+          console.log("Hotkeys successfully reloaded at runtime");
+        }
+        return true;
+      } catch (error) {
+        // Only log in debug mode
+        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+          console.error("Failed to reload hotkeys at runtime:", error);
+        }
+        return false;
+      }
+    },
+    [],
+  );
 
-	// Load hotkeys from API
-	const loadHotkeysFromAPI = useCallback(async () => {
-		try {
-			setIsLoading(true);
+  // Load hotkeys from API
+  const loadHotkeysFromAPI = useCallback(async () => {
+    try {
+      setIsLoading(true);
 
-			// Use proper API endpoint name from the config
-			const response = await api.callApi("hotkeys" as any);
+      // Use proper API endpoint name from the config
+      const response = await api.callApi("hotkeys" as any);
 
-			if (response && (response as ApiResponse).custom_hotkeys) {
-				// Use API data
-				const apiResponse = response as ApiResponse;
-				const updatedHotkeys = updateHotkeysWithCustomSettings(
-					typedDefaultHotkeys,
-					apiResponse.custom_hotkeys!,
-				);
-				setHotkeys(updatedHotkeys);
-				// Store current settings from API response
-				setHotkeySettings(apiResponse.hotkey_settings || {});
-			} else {
-				// Fallback to window.APP_SETTINGS
-				const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
-				const updatedHotkeys = updateHotkeysWithCustomSettings(
-					typedDefaultHotkeys,
-					customHotkeys,
-				);
-				setHotkeys(updatedHotkeys);
-				// No settings available in fallback
-				setHotkeySettings({});
-			}
-		} catch (error) {
-			console.error("Error loading hotkeys from API:", error);
+      if (response && (response as ApiResponse).custom_hotkeys) {
+        // Use API data
+        const apiResponse = response as ApiResponse;
+        const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, apiResponse.custom_hotkeys!);
+        setHotkeys(updatedHotkeys);
+        // Store current settings from API response
+        setHotkeySettings(apiResponse.hotkey_settings || {});
+      } else {
+        // Fallback to window.APP_SETTINGS
+        const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
+        const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, customHotkeys);
+        setHotkeys(updatedHotkeys);
+        // No settings available in fallback
+        setHotkeySettings({});
+      }
+    } catch (error) {
+      console.error("Error loading hotkeys from API:", error);
 
-			// Fallback to window.APP_SETTINGS on error
-			const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
-			const updatedHotkeys = updateHotkeysWithCustomSettings(
-				typedDefaultHotkeys,
-				customHotkeys,
-			);
-			setHotkeys(updatedHotkeys);
-			// No settings available in fallback
-			setHotkeySettings({});
+      // Fallback to window.APP_SETTINGS on error
+      const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
+      const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, customHotkeys);
+      setHotkeys(updatedHotkeys);
+      // No settings available in fallback
+      setHotkeySettings({});
 
-			// Show non-blocking error notification
-			if (toast) {
-				toast.show({
-					message:
-						"Could not load custom hotkeys from server, using cached settings",
-					type: ToastType.error,
-				});
-			}
-		} finally {
-			setIsLoading(false);
-		}
-	}, [api, toast, updateHotkeysWithCustomSettings]);
+      // Show non-blocking error notification
+      if (toast) {
+        toast.show({
+          message: "Could not load custom hotkeys from server, using cached settings",
+          type: ToastType.error,
+        });
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [api, toast, updateHotkeysWithCustomSettings]);
 
-	// Save hotkeys to API function (handles both save and reset operations)
-	const saveHotkeysToAPI = useCallback(
-		async (
-			currentHotkeys: Hotkey[],
-			currentSettings: HotkeySettings,
-		): Promise<SaveResult> => {
-			// Convert current hotkeys to API format - INCLUDE description to maintain API compatibility
-			const customHotkeys: Record<
-				string,
-				{ key: string; active: boolean; description?: string }
-			> = {};
+  // Save hotkeys to API function (handles both save and reset operations)
+  const saveHotkeysToAPI = useCallback(
+    async (currentHotkeys: Hotkey[], currentSettings: HotkeySettings): Promise<SaveResult> => {
+      // Convert current hotkeys to API format - INCLUDE description to maintain API compatibility
+      const customHotkeys: Record<string, { key: string; active: boolean; description?: string }> = {};
 
-			// Process all current hotkeys (if empty, this results in reset)
-			currentHotkeys.forEach((hotkey: Hotkey) => {
-				const keyId = `${hotkey.section}:${hotkey.element}`;
-				customHotkeys[keyId] = {
-					key: hotkey.key,
-					active: hotkey.active,
-					...(hotkey.description && { description: hotkey.description }),
-				};
-			});
+      // Process all current hotkeys (if empty, this results in reset)
+      currentHotkeys.forEach((hotkey: Hotkey) => {
+        const keyId = `${hotkey.section}:${hotkey.element}`;
+        customHotkeys[keyId] = {
+          key: hotkey.key,
+          active: hotkey.active,
+          ...(hotkey.description && { description: hotkey.description }),
+        };
+      });
 
-			const requestBody = {
-				custom_hotkeys: customHotkeys,
-				hotkey_settings: currentSettings,
-			};
+      const requestBody = {
+        custom_hotkeys: customHotkeys,
+        hotkey_settings: currentSettings,
+      };
 
-			try {
-				// Use proper API endpoint name from the config
-				const response = await api.callApi("updateHotkeys" as any, {
-					body: requestBody,
-				});
+      try {
+        // Use proper API endpoint name from the config
+        const response = await api.callApi("updateHotkeys" as any, {
+          body: requestBody,
+        });
 
-				// Check for API-level errors
-				if (response?.error) {
-					return {
-						ok: false,
-						error: response.error,
-						data: response,
-					};
-				}
+        // Check for API-level errors
+        if (response?.error) {
+          return {
+            ok: false,
+            error: response.error,
+            data: response,
+          };
+        }
 
-				// After successful save, reload hotkeys at runtime to apply changes immediately
-				const reloadSuccess = await reloadHotkeysInRuntime(customHotkeys);
+        // After successful save, reload hotkeys at runtime to apply changes immediately
+        const reloadSuccess = await reloadHotkeysInRuntime(customHotkeys);
 
-				// Only log runtime reload status in debug mode
-				if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-					if (reloadSuccess) {
-						console.log(
-							"Hotkeys successfully applied at runtime - no page refresh needed",
-						);
-					} else {
-						console.warn(
-							"Runtime hotkey reload failed - page refresh may be required",
-						);
-					}
-				}
+        // Only log runtime reload status in debug mode
+        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+          if (reloadSuccess) {
+            console.log("Hotkeys successfully applied at runtime - no page refresh needed");
+          } else {
+            console.warn("Runtime hotkey reload failed - page refresh may be required");
+          }
+        }
 
-				return {
-					ok: true,
-					error: undefined,
-					data: response,
-					runtimeReloadSuccess: reloadSuccess,
-				};
-			} catch (error: unknown) {
-				const isReset = currentHotkeys.length === 0;
-				const operation = isReset ? "resetting" : "saving";
-				console.error(`Error ${operation} hotkeys:`, error);
+        return {
+          ok: true,
+          error: undefined,
+          data: response,
+          runtimeReloadSuccess: reloadSuccess,
+        };
+      } catch (error: unknown) {
+        const isReset = currentHotkeys.length === 0;
+        const operation = isReset ? "resetting" : "saving";
+        console.error(`Error ${operation} hotkeys:`, error);
 
-				// Provide more specific error messages
-				let errorMessage = `Failed to ${isReset ? "reset" : "save"} hotkeys`;
-				if (error && typeof error === "object" && "response" in error) {
-					const err = error as any;
-					// Server responded with error status
-					if (err.response?.status === 400) {
-						errorMessage =
-							err.response.data?.error ||
-							`Invalid ${isReset ? "reset request" : "hotkeys configuration"}`;
-					} else if (err.response?.status === 401) {
-						errorMessage = "Authentication required";
-					} else if (err.response?.status >= 500) {
-						errorMessage = "Server error - please try again later";
-					}
-				} else if (error && typeof error === "object" && "request" in error) {
-					// Network error
-					errorMessage = "Network error - please check your connection";
-				}
+        // Provide more specific error messages
+        let errorMessage = `Failed to ${isReset ? "reset" : "save"} hotkeys`;
+        if (error && typeof error === "object" && "response" in error) {
+          const err = error as any;
+          // Server responded with error status
+          if (err.response?.status === 400) {
+            errorMessage = err.response.data?.error || `Invalid ${isReset ? "reset request" : "hotkeys configuration"}`;
+          } else if (err.response?.status === 401) {
+            errorMessage = "Authentication required";
+          } else if (err.response?.status >= 500) {
+            errorMessage = "Server error - please try again later";
+          }
+        } else if (error && typeof error === "object" && "request" in error) {
+          // Network error
+          errorMessage = "Network error - please check your connection";
+        }
 
-				return {
-					ok: false,
-					error: errorMessage,
-				};
-			}
-		},
-		[api],
-	);
+        return {
+          ok: false,
+          error: errorMessage,
+        };
+      }
+    },
+    [api],
+  );
 
-	// Handle resetting all hotkeys to defaults
-	const handleResetToDefaults = useCallback(() => {
-		confirm({
-			title: "Reset Hotkeys to Defaults?",
-			body: "Are you sure you want to reset all hotkeys and settings to their default values? This action cannot be undone.",
-			okText: "Reset to Defaults",
-			buttonLook: "negative",
-			style: { width: 500 },
-			onOk: async () => {
-				setIsLoading(true);
+  // Handle resetting all hotkeys to defaults
+  const handleResetToDefaults = useCallback(() => {
+    confirm({
+      title: "Reset Hotkeys to Defaults?",
+      body: "Are you sure you want to reset all hotkeys and settings to their default values? This action cannot be undone.",
+      okText: "Reset to Defaults",
+      buttonLook: "negative",
+      style: { width: 500 },
+      onOk: async () => {
+        setIsLoading(true);
 
-				try {
-					// Reset hotkeys to defaults in the backend API (sets custom_hotkeys to {})
-					const result = await saveHotkeysToAPI([], {});
+        try {
+          // Reset hotkeys to defaults in the backend API (sets custom_hotkeys to {})
+          const result = await saveHotkeysToAPI([], {});
 
-					if (result.ok) {
-						if (toast) {
-							toast.show({
-								message:
-									"All hotkeys and settings have been reset to defaults and saved",
-								type: ToastType.info,
-							});
-						}
-						// Update local state to reflect the reset
-						setHotkeys([...typedDefaultHotkeys]);
-					} else {
-						if (toast) {
-							toast.show({
-								message: `Failed to save reset hotkeys: ${result.error || "Unknown error"}`,
-								type: ToastType.error,
-							});
-						}
-					}
-				} catch (error: unknown) {
-					if (toast) {
-						const errorMessage =
-							error instanceof Error ? error.message : "Unknown error";
-						toast.show({
-							message: `Error resetting hotkeys: ${errorMessage}`,
-							type: ToastType.error,
-						});
-					}
-				} finally {
-					setIsLoading(false);
-				}
-			},
-		});
-	}, [saveHotkeysToAPI, toast]);
+          if (result.ok) {
+            if (toast) {
+              toast.show({
+                message: "All hotkeys and settings have been reset to defaults and saved",
+                type: ToastType.info,
+              });
+            }
+            // Update local state to reflect the reset
+            setHotkeys([...typedDefaultHotkeys]);
+          } else {
+            if (toast) {
+              toast.show({
+                message: `Failed to save reset hotkeys: ${result.error || "Unknown error"}`,
+                type: ToastType.error,
+              });
+            }
+          }
+        } catch (error: unknown) {
+          if (toast) {
+            const errorMessage = error instanceof Error ? error.message : "Unknown error";
+            toast.show({
+              message: `Error resetting hotkeys: ${errorMessage}`,
+              type: ToastType.error,
+            });
+          }
+        } finally {
+          setIsLoading(false);
+        }
+      },
+    });
+  }, [saveHotkeysToAPI, toast]);
 
-	// Handle exporting hotkeys
-	const handleExportHotkeys = useCallback(() => {
-		// Create export data including current settings
-		const exportData: ExportData = {
-			hotkeys: hotkeys,
-			settings: hotkeySettings,
-			exportedAt: new Date().toISOString(),
-			version: "1.0",
-		};
+  // Handle exporting hotkeys
+  const handleExportHotkeys = useCallback(() => {
+    // Create export data including current settings
+    const exportData: ExportData = {
+      hotkeys: hotkeys,
+      settings: hotkeySettings,
+      exportedAt: new Date().toISOString(),
+      version: "1.0",
+    };
 
-		// Create a JSON string of the export data
-		const exportJson = JSON.stringify(exportData, null, 2);
+    // Create a JSON string of the export data
+    const exportJson = JSON.stringify(exportData, null, 2);
 
-		// Create a blob with the JSON
-		const blob = new Blob([exportJson], { type: "application/json" });
-		const url = URL.createObjectURL(blob);
+    // Create a blob with the JSON
+    const blob = new Blob([exportJson], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
 
-		// Create a temporary link and click it to download the file
-		const link = document.createElement("a");
-		link.href = url;
-		link.download = "hotkeys-export.json";
-		document.body.appendChild(link);
-		link.click();
+    // Create a temporary link and click it to download the file
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "hotkeys-export.json";
+    document.body.appendChild(link);
+    link.click();
 
-		// Clean up
-		document.body.removeChild(link);
-		URL.revokeObjectURL(url);
+    // Clean up
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
 
-		if (toast) {
-			toast.show({
-				message: "Hotkeys exported successfully",
-				type: ToastType.info,
-			});
-		}
-	}, [hotkeys, hotkeySettings, toast]);
+    if (toast) {
+      toast.show({
+        message: "Hotkeys exported successfully",
+        type: ToastType.info,
+      });
+    }
+  }, [hotkeys, hotkeySettings, toast]);
 
-	// Handle importing hotkeys
-	const handleImportHotkeys = useCallback(
-		async (importedData: ImportData | Hotkey[]) => {
-			try {
-				setIsLoading(true);
+  // Handle importing hotkeys
+  const handleImportHotkeys = useCallback(
+    async (importedData: ImportData | Hotkey[]) => {
+      try {
+        setIsLoading(true);
 
-				// Handle both old format (just hotkeys array) and new format (with settings)
-				const importedHotkeys = Array.isArray(importedData)
-					? importedData
-					: importedData.hotkeys || [];
-				const importedSettings: HotkeySettings = Array.isArray(importedData)
-					? {}
-					: importedData.settings || {};
+        // Handle both old format (just hotkeys array) and new format (with settings)
+        const importedHotkeys = Array.isArray(importedData) ? importedData : importedData.hotkeys || [];
+        const importedSettings: HotkeySettings = Array.isArray(importedData) ? {} : importedData.settings || {};
 
-				// Save all imported data to API
-				const result = await saveHotkeysToAPI(
-					importedHotkeys,
-					importedSettings,
-				);
+        // Save all imported data to API
+        const result = await saveHotkeysToAPI(importedHotkeys, importedSettings);
 
-				if (!result.ok) {
-					throw new Error(result.error || "Failed to save imported hotkeys");
-				}
+        if (!result.ok) {
+          throw new Error(result.error || "Failed to save imported hotkeys");
+        }
 
-				// Update local state
-				setHotkeys(importedHotkeys);
+        // Update local state
+        setHotkeys(importedHotkeys);
 
-				if (toast) {
-					toast.show({
-						message: "Hotkeys imported successfully",
-						type: ToastType.info,
-					});
-				}
+        if (toast) {
+          toast.show({
+            message: "Hotkeys imported successfully",
+            type: ToastType.info,
+          });
+        }
 
-				// Reload from API to ensure consistency
-				await loadHotkeysFromAPI();
-			} catch (error: unknown) {
-				if (toast) {
-					const errorMessage =
-						error instanceof Error ? error.message : "Unknown error";
-					toast.show({
-						message: `Error importing hotkeys: ${errorMessage}`,
-						type: ToastType.error,
-					});
-				}
-			} finally {
-				setIsLoading(false);
-			}
-		},
-		[saveHotkeysToAPI, loadHotkeysFromAPI, toast],
-	);
+        // Reload from API to ensure consistency
+        await loadHotkeysFromAPI();
+      } catch (error: unknown) {
+        if (toast) {
+          const errorMessage = error instanceof Error ? error.message : "Unknown error";
+          toast.show({
+            message: `Error importing hotkeys: ${errorMessage}`,
+            type: ToastType.error,
+          });
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [saveHotkeysToAPI, loadHotkeysFromAPI, toast],
+  );
 
-	// Load hotkeys on hook mount
-	useEffect(() => {
-		loadHotkeysFromAPI();
-	}, [loadHotkeysFromAPI]);
+  // Load hotkeys on hook mount
+  useEffect(() => {
+    loadHotkeysFromAPI();
+  }, [loadHotkeysFromAPI]);
 
-	return {
-		hotkeys,
-		setHotkeys,
-		hotkeySettings,
-		setHotkeySettings,
-		isLoading,
-		setIsLoading,
-		loadHotkeysFromAPI,
-		saveHotkeysToAPI,
-		handleResetToDefaults,
-		handleExportHotkeys,
-		handleImportHotkeys,
-	};
+  return {
+    hotkeys,
+    setHotkeys,
+    hotkeySettings,
+    setHotkeySettings,
+    isLoading,
+    setIsLoading,
+    loadHotkeysFromAPI,
+    saveHotkeysToAPI,
+    handleResetToDefaults,
+    handleExportHotkeys,
+    handleImportHotkeys,
+  };
 };

--- a/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
+++ b/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
@@ -2,468 +2,413 @@ import { ToastType, useToast } from "@humansignal/ui";
 // @ts-ignore
 import { confirm } from "apps/labelstudio/src/components/Modal/Modal";
 import { useAPI } from "apps/labelstudio/src/providers/ApiProvider";
+// Import Hotkey from editor for updating keymap
+// @ts-ignore
+import { Hotkey as EditorHotkey } from "libs/editor/src/core/Hotkey";
 import { useCallback, useEffect, useState } from "react";
 import {
-  type ApiResponse,
-  type ExportData,
-  getTypedDefaultHotkeys,
-  type Hotkey,
-  type HotkeySettings,
-  type ImportData,
-  type SaveResult,
+	type ApiResponse,
+	type ExportData,
+	getTypedDefaultHotkeys,
+	type Hotkey,
+	type HotkeySettings,
+	type ImportData,
+	type SaveResult,
 } from "../sections/Hotkeys/utils";
-
-// Type definitions for better type safety
-type EditorInstance = {
-  store?: {
-    annotation?: {
-      setupHotKeys?: () => void;
-    };
-  };
-  annotation?: {
-    setupHotKeys?: () => void;
-  };
-};
 
 // Type the imported defaults and convert numeric ids to strings
 const typedDefaultHotkeys: Hotkey[] = getTypedDefaultHotkeys();
 
 export const useHotkeys = () => {
-  const toast = useToast();
-  const [hotkeys, setHotkeys] = useState<Hotkey[]>([]);
-  const [hotkeySettings, setHotkeySettings] = useState<HotkeySettings>({});
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const api = useAPI();
+	const toast = useToast();
+	const [hotkeys, setHotkeys] = useState<Hotkey[]>([]);
+	const [hotkeySettings, setHotkeySettings] = useState<HotkeySettings>({});
+	const [isLoading, setIsLoading] = useState<boolean>(false);
+	const api = useAPI();
 
-  // Update hotkeys with custom settings
-  const updateHotkeysWithCustomSettings = useCallback(
-    (
-      defaultHotkeys: Hotkey[],
-      customHotkeys: Record<string, { key: string; active: boolean; description?: string }>,
-    ): Hotkey[] => {
-      return defaultHotkeys.map((hotkey: Hotkey) => {
-        // Create the lookup key format used in the API response (section:element)
-        const lookupKey = `${hotkey.section}:${hotkey.element}`;
+	// Update hotkeys with custom settings
+	const updateHotkeysWithCustomSettings = useCallback(
+		(
+			defaultHotkeys: Hotkey[],
+			customHotkeys: Record<
+				string,
+				{ key: string; active: boolean; description?: string }
+			>,
+		): Hotkey[] => {
+			return defaultHotkeys.map((hotkey: Hotkey) => {
+				// Create the lookup key format used in the API response (section:element)
+				const lookupKey = `${hotkey.section}:${hotkey.element}`;
 
-        // Check if there's a custom setting for this hotkey
-        if (customHotkeys[lookupKey]) {
-          const customSetting = customHotkeys[lookupKey];
-          // Create a new object with the default properties and override with custom ones
-          return {
-            ...hotkey,
-            key: customSetting.key,
-            active: customSetting.active,
-            // Preserve the original label, only update description if provided
-            ...(customSetting.description && {
-              description: customSetting.description,
-            }),
-          };
-        }
+				// Check if there's a custom setting for this hotkey
+				if (customHotkeys[lookupKey]) {
+					const customSetting = customHotkeys[lookupKey];
+					// Create a new object with the default properties and override with custom ones
+					return {
+						...hotkey,
+						key: customSetting.key,
+						active: customSetting.active,
+						// Preserve the original label, only update description if provided
+						...(customSetting.description && {
+							description: customSetting.description,
+						}),
+					};
+				}
 
-        // If no custom setting exists, return the default hotkey unchanged
-        return hotkey;
-      });
-    },
-    [],
-  );
+				// If no custom setting exists, return the default hotkey unchanged
+				return hotkey;
+			});
+		},
+		[],
+	);
 
-  // Runtime hotkey reload function - applies hotkeys without page refresh
-  const reloadHotkeysInRuntime = useCallback(
-    async (customHotkeys: Record<string, { key: string; active: boolean; description?: string }>) => {
-      try {
-        // Step 1: Process custom hotkeys the same way the server does in base.html
-        const editorCustomHotkeys: Record<string, { key: string | null; active: boolean; description?: string }> = {};
-        const prefixRegex = /^(annotation|timeseries|audio|regions|video|image_gallery|tools|data_manager):(.*)/;
+	// Simple hotkey reload - just update global state and call setKeymap
+	const reloadHotkeysInRuntime = useCallback(
+		(
+			customHotkeys: Record<
+				string,
+				{ key: string; active: boolean; description?: string }
+			>,
+		) => {
+			// Update APP_SETTINGS.user.customHotkeys (for Help modal and fallback)
+			if (window.APP_SETTINGS?.user) {
+				window.APP_SETTINGS.user.customHotkeys = customHotkeys;
+			}
 
-        for (const key in customHotkeys) {
-          const match = key.match(prefixRegex);
-          if (match) {
-            const [, prefix, shortKey] = match;
-            const value = customHotkeys[key];
+			// Transform custom hotkeys to editor format (same logic as base.html)
+			const editorCustomHotkeys: Record<string, any> = {};
+			const prefixRegex =
+				/^(annotation|timeseries|audio|regions|video|image_gallery|tools):(.*)/;
 
-            // The shortKey might have double prefixes like "annotation:submit"
-            // We need to construct the correct editor keymap key format
-            const editorKey = shortKey.includes(":") ? shortKey : `${prefix}:${shortKey}`;
+			for (const key in customHotkeys) {
+				const match = key.match(prefixRegex);
+				if (match) {
+					const [, , shortKey] = match;
+					const value = customHotkeys[key];
 
-            // Check if value has active property set to false
-            if (value && value.active === false) {
-              // Create a copy of the value with key set to null
-              const modifiedValue = { ...value, key: null };
-              editorCustomHotkeys[editorKey] = modifiedValue;
-            } else {
-              // Use the original value
-              editorCustomHotkeys[editorKey] = value;
-            }
-          }
-        }
+					if (value && value.active === false) {
+						editorCustomHotkeys[shortKey] = { ...value, key: null };
+					} else {
+						editorCustomHotkeys[shortKey] = value;
+					}
+				}
+			}
 
-        // Step 2: Get default editor keymap and merge with custom hotkeys
-        // Use the original defaults, which are now properly exposed globally
-        const defaultEditorKeymap = window.DEFAULT_HOTKEYS || {};
+			// Get current keymap and merge with custom hotkeys
+			const currentKeymap = EditorHotkey.keymap
+				? { ...EditorHotkey.keymap }
+				: {};
+			const mergedKeymap = Object.assign(
+				{},
+				currentKeymap,
+				editorCustomHotkeys,
+			);
 
-        const mergedEditorKeymap = Object.assign({}, defaultEditorKeymap, editorCustomHotkeys);
+			// Update APP_SETTINGS.editor_keymap (for DataManager/Explorer)
+			if (window.APP_SETTINGS) {
+				window.APP_SETTINGS.editor_keymap = mergedKeymap;
+			}
 
-        // Step 3: Update window.APP_SETTINGS with new hotkeys
-        if (window.APP_SETTINGS) {
-          window.APP_SETTINGS.editor_keymap = mergedEditorKeymap;
-          window.APP_SETTINGS.user = window.APP_SETTINGS.user || {};
-          window.APP_SETTINGS.user.customHotkeys = customHotkeys;
-        }
+			// Call Hotkey.setKeymap() - the main propagation path
+			try {
+				EditorHotkey.setKeymap(mergedKeymap as any);
+			} catch (error) {
+				console.warn("Failed to update hotkeys:", error);
+			}
+		},
+		[],
+	);
 
-        // Step 4: Re-apply keymap to editor instances if available
-        // Check if Hotkey class is available globally
-        if (typeof window !== "undefined") {
-          // Try to access the Hotkey class through various possible global references
-          const HotkeyClass = (window as any).Hotkey || (window as any).LSF?.Hotkey;
+	// Load hotkeys from API
+	const loadHotkeysFromAPI = useCallback(async () => {
+		try {
+			setIsLoading(true);
 
-          if (HotkeyClass && typeof HotkeyClass.setKeymap === "function") {
-            HotkeyClass.setKeymap(mergedEditorKeymap);
-          }
-        }
+			// Use proper API endpoint name from the config
+			const response = await api.callApi("hotkeys" as any);
 
-        // Step 5: Trigger re-initialization of hotkeys in editor instances
-        // This is the most complex part as we need to access LabelStudio instances
-        if (typeof window !== "undefined") {
-          // Try to access LabelStudio instances through various possible global references
-          const instances = (window as any).LabelStudio?.instances || (window as any).LSF?.instances || [];
+			if (response && (response as ApiResponse).custom_hotkeys) {
+				// Use API data
+				const apiResponse = response as ApiResponse;
+				const updatedHotkeys = updateHotkeysWithCustomSettings(
+					typedDefaultHotkeys,
+					apiResponse.custom_hotkeys || {},
+				);
+				setHotkeys(updatedHotkeys);
+				// Store current settings from API response
+				setHotkeySettings(apiResponse.hotkey_settings || {});
+			} else {
+				// Fallback to window.APP_SETTINGS
+				const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
+				const updatedHotkeys = updateHotkeysWithCustomSettings(
+					typedDefaultHotkeys,
+					customHotkeys,
+				);
+				setHotkeys(updatedHotkeys);
+				// No settings available in fallback
+				setHotkeySettings({});
+			}
+		} catch (error) {
+			console.error("Error loading hotkeys from API:", error);
 
-          // Iterate through instances and trigger hotkey re-initialization
-          if (Array.isArray(instances)) {
-            instances.forEach((instance: EditorInstance) => {
-              try {
-                // Check if the instance has the store and annotation with setupHotKeys method
-                if (
-                  instance?.store?.annotation?.setupHotKeys &&
-                  typeof instance.store.annotation.setupHotKeys === "function"
-                ) {
-                  instance.store.annotation.setupHotKeys();
-                } else if (
-                  instance?.annotation?.setupHotKeys &&
-                  typeof instance.annotation.setupHotKeys === "function"
-                ) {
-                  instance.annotation.setupHotKeys();
-                }
-              } catch (error) {
-                // Only log editor instance refresh failures in debug mode
-                if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-                  console.warn("Failed to refresh hotkeys for editor instance:", error);
-                }
-              }
-            });
-          } else if (instances && typeof (instances as any).forEach === "function") {
-            // Handle Set or other iterable
-            (instances as any).forEach((instance: EditorInstance) => {
-              try {
-                if (
-                  instance?.store?.annotation?.setupHotKeys &&
-                  typeof instance.store.annotation.setupHotKeys === "function"
-                ) {
-                  instance.store.annotation.setupHotKeys();
-                } else if (
-                  instance?.annotation?.setupHotKeys &&
-                  typeof instance.annotation.setupHotKeys === "function"
-                ) {
-                  instance.annotation.setupHotKeys();
-                }
-              } catch (error) {
-                // Only log editor instance refresh failures in debug mode
-                if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-                  console.warn("Failed to refresh hotkeys for editor instance:", error);
-                }
-              }
-            });
-          }
-        }
+			// Fallback to window.APP_SETTINGS on error
+			const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
+			const updatedHotkeys = updateHotkeysWithCustomSettings(
+				typedDefaultHotkeys,
+				customHotkeys,
+			);
+			setHotkeys(updatedHotkeys);
+			// No settings available in fallback
+			setHotkeySettings({});
 
-        // Only log in debug mode
-        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-          console.log("Hotkeys successfully reloaded at runtime");
-        }
-        return true;
-      } catch (error) {
-        // Only log in debug mode
-        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-          console.error("Failed to reload hotkeys at runtime:", error);
-        }
-        return false;
-      }
-    },
-    [],
-  );
+			// Show non-blocking error notification
+			if (toast) {
+				toast.show({
+					message:
+						"Could not load custom hotkeys from server, using cached settings",
+					type: ToastType.error,
+				});
+			}
+		} finally {
+			setIsLoading(false);
+		}
+	}, [api, toast, updateHotkeysWithCustomSettings]);
 
-  // Load hotkeys from API
-  const loadHotkeysFromAPI = useCallback(async () => {
-    try {
-      setIsLoading(true);
+	// Save hotkeys to API function (handles both save and reset operations)
+	const saveHotkeysToAPI = useCallback(
+		async (
+			currentHotkeys: Hotkey[],
+			currentSettings: HotkeySettings,
+		): Promise<SaveResult> => {
+			// Convert current hotkeys to API format - INCLUDE description to maintain API compatibility
+			const customHotkeys: Record<
+				string,
+				{ key: string; active: boolean; description?: string }
+			> = {};
 
-      // Use proper API endpoint name from the config
-      const response = await api.callApi("hotkeys" as any);
+			// Process all current hotkeys (if empty, this results in reset)
+			currentHotkeys.forEach((hotkey: Hotkey) => {
+				const keyId = `${hotkey.section}:${hotkey.element}`;
+				customHotkeys[keyId] = {
+					key: hotkey.key,
+					active: hotkey.active,
+					...(hotkey.description && { description: hotkey.description }),
+				};
+			});
 
-      if (response && (response as ApiResponse).custom_hotkeys) {
-        // Use API data
-        const apiResponse = response as ApiResponse;
-        const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, apiResponse.custom_hotkeys!);
-        setHotkeys(updatedHotkeys);
-        // Store current settings from API response
-        setHotkeySettings(apiResponse.hotkey_settings || {});
-      } else {
-        // Fallback to window.APP_SETTINGS
-        const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
-        const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, customHotkeys);
-        setHotkeys(updatedHotkeys);
-        // No settings available in fallback
-        setHotkeySettings({});
-      }
-    } catch (error) {
-      console.error("Error loading hotkeys from API:", error);
+			const requestBody = {
+				custom_hotkeys: customHotkeys,
+				hotkey_settings: currentSettings,
+			};
 
-      // Fallback to window.APP_SETTINGS on error
-      const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
-      const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, customHotkeys);
-      setHotkeys(updatedHotkeys);
-      // No settings available in fallback
-      setHotkeySettings({});
+			try {
+				// Use proper API endpoint name from the config
+				const response = await api.callApi("updateHotkeys" as any, {
+					body: requestBody,
+				});
 
-      // Show non-blocking error notification
-      if (toast) {
-        toast.show({
-          message: "Could not load custom hotkeys from server, using cached settings",
-          type: ToastType.error,
-        });
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  }, [api, toast, updateHotkeysWithCustomSettings]);
+				// Check for API-level errors
+				if (response?.error) {
+					return {
+						ok: false,
+						error: response.error,
+						data: response,
+					};
+				}
 
-  // Save hotkeys to API function (handles both save and reset operations)
-  const saveHotkeysToAPI = useCallback(
-    async (currentHotkeys: Hotkey[], currentSettings: HotkeySettings): Promise<SaveResult> => {
-      // Convert current hotkeys to API format - INCLUDE description to maintain API compatibility
-      const customHotkeys: Record<string, { key: string; active: boolean; description?: string }> = {};
+				// Apply hotkeys immediately without page refresh
+				reloadHotkeysInRuntime(customHotkeys);
 
-      // Process all current hotkeys (if empty, this results in reset)
-      currentHotkeys.forEach((hotkey: Hotkey) => {
-        const keyId = `${hotkey.section}:${hotkey.element}`;
-        customHotkeys[keyId] = {
-          key: hotkey.key,
-          active: hotkey.active,
-          ...(hotkey.description && { description: hotkey.description }),
-        };
-      });
+				return {
+					ok: true,
+					error: undefined,
+					data: response,
+				};
+			} catch (error: unknown) {
+				const isReset = currentHotkeys.length === 0;
+				const operation = isReset ? "resetting" : "saving";
+				console.error(`Error ${operation} hotkeys:`, error);
 
-      const requestBody = {
-        custom_hotkeys: customHotkeys,
-        hotkey_settings: currentSettings,
-      };
+				// Provide more specific error messages
+				let errorMessage = `Failed to ${isReset ? "reset" : "save"} hotkeys`;
+				if (error && typeof error === "object" && "response" in error) {
+					const err = error as any;
+					// Server responded with error status
+					if (err.response?.status === 400) {
+						errorMessage =
+							err.response.data?.error ||
+							`Invalid ${isReset ? "reset request" : "hotkeys configuration"}`;
+					} else if (err.response?.status === 401) {
+						errorMessage = "Authentication required";
+					} else if (err.response?.status >= 500) {
+						errorMessage = "Server error - please try again later";
+					}
+				} else if (error && typeof error === "object" && "request" in error) {
+					// Network error
+					errorMessage = "Network error - please check your connection";
+				}
 
-      try {
-        // Use proper API endpoint name from the config
-        const response = await api.callApi("updateHotkeys" as any, {
-          body: requestBody,
-        });
+				return {
+					ok: false,
+					error: errorMessage,
+				};
+			}
+		},
+		[api],
+	);
 
-        // Check for API-level errors
-        if (response?.error) {
-          return {
-            ok: false,
-            error: response.error,
-            data: response,
-          };
-        }
+	// Handle resetting all hotkeys to defaults
+	const handleResetToDefaults = useCallback(() => {
+		confirm({
+			title: "Reset Hotkeys to Defaults?",
+			body: "Are you sure you want to reset all hotkeys and settings to their default values? This action cannot be undone.",
+			okText: "Reset to Defaults",
+			buttonLook: "negative",
+			style: { width: 500 },
+			onOk: async () => {
+				setIsLoading(true);
 
-        // After successful save, reload hotkeys at runtime to apply changes immediately
-        const reloadSuccess = await reloadHotkeysInRuntime(customHotkeys);
+				try {
+					// Reset hotkeys to defaults in the backend API (sets custom_hotkeys to {})
+					const result = await saveHotkeysToAPI([], {});
 
-        // Only log runtime reload status in debug mode
-        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-          if (reloadSuccess) {
-            console.log("Hotkeys successfully applied at runtime - no page refresh needed");
-          } else {
-            console.warn("Runtime hotkey reload failed - page refresh may be required");
-          }
-        }
+					if (result.ok) {
+						if (toast) {
+							toast.show({
+								message:
+									"All hotkeys and settings have been reset to defaults and saved",
+								type: ToastType.info,
+							});
+						}
+						// Update local state to reflect the reset
+						setHotkeys([...typedDefaultHotkeys]);
+					} else {
+						if (toast) {
+							toast.show({
+								message: `Failed to save reset hotkeys: ${result.error || "Unknown error"}`,
+								type: ToastType.error,
+							});
+						}
+					}
+				} catch (error: unknown) {
+					if (toast) {
+						const errorMessage =
+							error instanceof Error ? error.message : "Unknown error";
+						toast.show({
+							message: `Error resetting hotkeys: ${errorMessage}`,
+							type: ToastType.error,
+						});
+					}
+				} finally {
+					setIsLoading(false);
+				}
+			},
+		});
+	}, [saveHotkeysToAPI, toast]);
 
-        return {
-          ok: true,
-          error: undefined,
-          data: response,
-          runtimeReloadSuccess: reloadSuccess,
-        };
-      } catch (error: unknown) {
-        const isReset = currentHotkeys.length === 0;
-        const operation = isReset ? "resetting" : "saving";
-        console.error(`Error ${operation} hotkeys:`, error);
+	// Handle exporting hotkeys
+	const handleExportHotkeys = useCallback(() => {
+		// Create export data including current settings
+		const exportData: ExportData = {
+			hotkeys: hotkeys,
+			settings: hotkeySettings,
+			exportedAt: new Date().toISOString(),
+			version: "1.0",
+		};
 
-        // Provide more specific error messages
-        let errorMessage = `Failed to ${isReset ? "reset" : "save"} hotkeys`;
-        if (error && typeof error === "object" && "response" in error) {
-          const err = error as any;
-          // Server responded with error status
-          if (err.response?.status === 400) {
-            errorMessage = err.response.data?.error || `Invalid ${isReset ? "reset request" : "hotkeys configuration"}`;
-          } else if (err.response?.status === 401) {
-            errorMessage = "Authentication required";
-          } else if (err.response?.status >= 500) {
-            errorMessage = "Server error - please try again later";
-          }
-        } else if (error && typeof error === "object" && "request" in error) {
-          // Network error
-          errorMessage = "Network error - please check your connection";
-        }
+		// Create a JSON string of the export data
+		const exportJson = JSON.stringify(exportData, null, 2);
 
-        return {
-          ok: false,
-          error: errorMessage,
-        };
-      }
-    },
-    [api],
-  );
+		// Create a blob with the JSON
+		const blob = new Blob([exportJson], { type: "application/json" });
+		const url = URL.createObjectURL(blob);
 
-  // Handle resetting all hotkeys to defaults
-  const handleResetToDefaults = useCallback(() => {
-    confirm({
-      title: "Reset Hotkeys to Defaults?",
-      body: "Are you sure you want to reset all hotkeys and settings to their default values? This action cannot be undone.",
-      okText: "Reset to Defaults",
-      buttonLook: "negative",
-      style: { width: 500 },
-      onOk: async () => {
-        setIsLoading(true);
+		// Create a temporary link and click it to download the file
+		const link = document.createElement("a");
+		link.href = url;
+		link.download = "hotkeys-export.json";
+		document.body.appendChild(link);
+		link.click();
 
-        try {
-          // Reset hotkeys to defaults in the backend API (sets custom_hotkeys to {})
-          const result = await saveHotkeysToAPI([], {});
+		// Clean up
+		document.body.removeChild(link);
+		URL.revokeObjectURL(url);
 
-          if (result.ok) {
-            if (toast) {
-              toast.show({
-                message: "All hotkeys and settings have been reset to defaults and saved",
-                type: ToastType.info,
-              });
-            }
-            // Update local state to reflect the reset
-            setHotkeys([...typedDefaultHotkeys]);
-          } else {
-            if (toast) {
-              toast.show({
-                message: `Failed to save reset hotkeys: ${result.error || "Unknown error"}`,
-                type: ToastType.error,
-              });
-            }
-          }
-        } catch (error: unknown) {
-          if (toast) {
-            const errorMessage = error instanceof Error ? error.message : "Unknown error";
-            toast.show({
-              message: `Error resetting hotkeys: ${errorMessage}`,
-              type: ToastType.error,
-            });
-          }
-        } finally {
-          setIsLoading(false);
-        }
-      },
-    });
-  }, [saveHotkeysToAPI, toast]);
+		if (toast) {
+			toast.show({
+				message: "Hotkeys exported successfully",
+				type: ToastType.info,
+			});
+		}
+	}, [hotkeys, hotkeySettings, toast]);
 
-  // Handle exporting hotkeys
-  const handleExportHotkeys = useCallback(() => {
-    // Create export data including current settings
-    const exportData: ExportData = {
-      hotkeys: hotkeys,
-      settings: hotkeySettings,
-      exportedAt: new Date().toISOString(),
-      version: "1.0",
-    };
+	// Handle importing hotkeys
+	const handleImportHotkeys = useCallback(
+		async (importedData: ImportData | Hotkey[]) => {
+			try {
+				setIsLoading(true);
 
-    // Create a JSON string of the export data
-    const exportJson = JSON.stringify(exportData, null, 2);
+				// Handle both old format (just hotkeys array) and new format (with settings)
+				const importedHotkeys = Array.isArray(importedData)
+					? importedData
+					: importedData.hotkeys || [];
+				const importedSettings: HotkeySettings = Array.isArray(importedData)
+					? {}
+					: importedData.settings || {};
 
-    // Create a blob with the JSON
-    const blob = new Blob([exportJson], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
+				// Save all imported data to API
+				const result = await saveHotkeysToAPI(
+					importedHotkeys,
+					importedSettings,
+				);
 
-    // Create a temporary link and click it to download the file
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = "hotkeys-export.json";
-    document.body.appendChild(link);
-    link.click();
+				if (!result.ok) {
+					throw new Error(result.error || "Failed to save imported hotkeys");
+				}
 
-    // Clean up
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
+				// Update local state
+				setHotkeys(importedHotkeys);
 
-    if (toast) {
-      toast.show({
-        message: "Hotkeys exported successfully",
-        type: ToastType.info,
-      });
-    }
-  }, [hotkeys, hotkeySettings, toast]);
+				if (toast) {
+					toast.show({
+						message: "Hotkeys imported successfully",
+						type: ToastType.info,
+					});
+				}
 
-  // Handle importing hotkeys
-  const handleImportHotkeys = useCallback(
-    async (importedData: ImportData | Hotkey[]) => {
-      try {
-        setIsLoading(true);
+				// Reload from API to ensure consistency
+				await loadHotkeysFromAPI();
+			} catch (error: unknown) {
+				if (toast) {
+					const errorMessage =
+						error instanceof Error ? error.message : "Unknown error";
+					toast.show({
+						message: `Error importing hotkeys: ${errorMessage}`,
+						type: ToastType.error,
+					});
+				}
+			} finally {
+				setIsLoading(false);
+			}
+		},
+		[saveHotkeysToAPI, loadHotkeysFromAPI, toast],
+	);
 
-        // Handle both old format (just hotkeys array) and new format (with settings)
-        const importedHotkeys = Array.isArray(importedData) ? importedData : importedData.hotkeys || [];
-        const importedSettings: HotkeySettings = Array.isArray(importedData) ? {} : importedData.settings || {};
+	// Load hotkeys on hook mount
+	useEffect(() => {
+		loadHotkeysFromAPI();
+	}, [loadHotkeysFromAPI]);
 
-        // Save all imported data to API
-        const result = await saveHotkeysToAPI(importedHotkeys, importedSettings);
-
-        if (!result.ok) {
-          throw new Error(result.error || "Failed to save imported hotkeys");
-        }
-
-        // Update local state
-        setHotkeys(importedHotkeys);
-
-        if (toast) {
-          toast.show({
-            message: "Hotkeys imported successfully",
-            type: ToastType.info,
-          });
-        }
-
-        // Reload from API to ensure consistency
-        await loadHotkeysFromAPI();
-      } catch (error: unknown) {
-        if (toast) {
-          const errorMessage = error instanceof Error ? error.message : "Unknown error";
-          toast.show({
-            message: `Error importing hotkeys: ${errorMessage}`,
-            type: ToastType.error,
-          });
-        }
-      } finally {
-        setIsLoading(false);
-      }
-    },
-    [saveHotkeysToAPI, loadHotkeysFromAPI, toast],
-  );
-
-  // Load hotkeys on hook mount
-  useEffect(() => {
-    loadHotkeysFromAPI();
-  }, [loadHotkeysFromAPI]);
-
-  return {
-    hotkeys,
-    setHotkeys,
-    hotkeySettings,
-    setHotkeySettings,
-    isLoading,
-    setIsLoading,
-    loadHotkeysFromAPI,
-    saveHotkeysToAPI,
-    handleResetToDefaults,
-    handleExportHotkeys,
-    handleImportHotkeys,
-  };
+	return {
+		hotkeys,
+		setHotkeys,
+		hotkeySettings,
+		setHotkeySettings,
+		isLoading,
+		setIsLoading,
+		loadHotkeysFromAPI,
+		saveHotkeysToAPI,
+		handleResetToDefaults,
+		handleExportHotkeys,
+		handleImportHotkeys,
+	};
 };

--- a/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
+++ b/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
@@ -1,16 +1,16 @@
-import { useCallback, useEffect, useState } from "react";
 import { ToastType, useToast } from "@humansignal/ui";
-import { useAPI } from "apps/labelstudio/src/providers/ApiProvider";
 // @ts-ignore
 import { confirm } from "apps/labelstudio/src/components/Modal/Modal";
+import { useAPI } from "apps/labelstudio/src/providers/ApiProvider";
+import { useCallback, useEffect, useState } from "react";
 import {
+  type ApiResponse,
+  type ExportData,
   getTypedDefaultHotkeys,
   type Hotkey,
   type HotkeySettings,
-  type ExportData,
   type ImportData,
   type SaveResult,
-  type ApiResponse,
 } from "../sections/Hotkeys/utils";
 
 // Type the imported defaults and convert numeric ids to strings
@@ -51,6 +51,113 @@ export const useHotkeys = () => {
         // If no custom setting exists, return the default hotkey unchanged
         return hotkey;
       });
+    },
+    [],
+  );
+
+  // Runtime hotkey reload function - applies hotkeys without page refresh
+  const reloadHotkeysInRuntime = useCallback(
+    async (customHotkeys: Record<string, { key: string; active: boolean; description?: string }>) => {
+      try {
+        // Step 1: Process custom hotkeys the same way the server does in base.html
+        const editorCustomHotkeys: Record<string, any> = {};
+        const prefixRegex = /^(annotation|timeseries|audio|regions|video|image_gallery|tools):(.*)/;
+
+        for (const key in customHotkeys) {
+          const match = key.match(prefixRegex);
+          if (match) {
+            const [, prefix, shortKey] = match;
+            const value = customHotkeys[key];
+
+            // Check if value has active property set to false
+            if (value && value.active === false) {
+              // Create a copy of the value with key set to null
+              const modifiedValue = { ...value, key: null };
+              editorCustomHotkeys[shortKey] = modifiedValue;
+            } else {
+              // Use the original value
+              editorCustomHotkeys[shortKey] = value;
+            }
+          }
+        }
+
+        // Step 2: Get default editor keymap and merge with custom hotkeys
+        const defaultEditorKeymap = window.DEFAULT_HOTKEYS || {};
+        const mergedEditorKeymap = Object.assign({}, defaultEditorKeymap, editorCustomHotkeys);
+
+        // Step 3: Update window.APP_SETTINGS with new hotkeys
+        if (window.APP_SETTINGS) {
+          window.APP_SETTINGS.editor_keymap = mergedEditorKeymap;
+          window.APP_SETTINGS.user = window.APP_SETTINGS.user || {};
+          window.APP_SETTINGS.user.customHotkeys = customHotkeys;
+        }
+
+        // Step 4: Re-apply keymap to editor instances if available
+        // Check if Hotkey class is available globally (it should be)
+        if (typeof window !== "undefined") {
+          // Try to access the Hotkey class through various possible global references
+          const HotkeyClass =
+            (window as any).Hotkey || (window as any).LSF?.Hotkey || (window as any).LabelStudio?.Hotkey;
+
+          if (HotkeyClass && typeof HotkeyClass.setKeymap === "function") {
+            HotkeyClass.setKeymap(mergedEditorKeymap);
+          }
+        }
+
+        // Step 5: Trigger re-initialization of hotkeys in editor instances
+        // This is the most complex part as we need to access LabelStudio instances
+        if (typeof window !== "undefined") {
+          // Try to access LabelStudio instances through various possible global references
+          const instances = (window as any).LabelStudio?.instances || (window as any).LSF?.instances || [];
+
+          // Iterate through instances and trigger hotkey re-initialization
+          if (Array.isArray(instances)) {
+            instances.forEach((instance: any) => {
+              try {
+                // Check if the instance has the store and annotation with setupHotKeys method
+                if (
+                  instance?.store?.annotation?.setupHotKeys &&
+                  typeof instance.store.annotation.setupHotKeys === "function"
+                ) {
+                  instance.store.annotation.setupHotKeys();
+                } else if (
+                  instance?.annotation?.setupHotKeys &&
+                  typeof instance.annotation.setupHotKeys === "function"
+                ) {
+                  instance.annotation.setupHotKeys();
+                }
+              } catch (error) {
+                console.warn("Failed to refresh hotkeys for editor instance:", error);
+              }
+            });
+          } else if (instances && typeof instances.forEach === "function") {
+            // Handle Set or other iterable
+            instances.forEach((instance: any) => {
+              try {
+                if (
+                  instance?.store?.annotation?.setupHotKeys &&
+                  typeof instance.store.annotation.setupHotKeys === "function"
+                ) {
+                  instance.store.annotation.setupHotKeys();
+                } else if (
+                  instance?.annotation?.setupHotKeys &&
+                  typeof instance.annotation.setupHotKeys === "function"
+                ) {
+                  instance.annotation.setupHotKeys();
+                }
+              } catch (error) {
+                console.warn("Failed to refresh hotkeys for editor instance:", error);
+              }
+            });
+          }
+        }
+
+        console.log("Hotkeys successfully reloaded at runtime");
+        return true;
+      } catch (error) {
+        console.error("Failed to reload hotkeys at runtime:", error);
+        return false;
+      }
     },
     [],
   );
@@ -136,10 +243,20 @@ export const useHotkeys = () => {
           };
         }
 
+        // After successful save, reload hotkeys at runtime to apply changes immediately
+        const reloadSuccess = await reloadHotkeysInRuntime(customHotkeys);
+
+        if (reloadSuccess) {
+          console.log("Hotkeys successfully applied at runtime - no page refresh needed");
+        } else {
+          console.warn("Runtime hotkey reload failed - page refresh may be required");
+        }
+
         return {
           ok: true,
           error: undefined,
           data: response,
+          runtimeReloadSuccess: reloadSuccess,
         };
       } catch (error: unknown) {
         const isReset = currentHotkeys.length === 0;
@@ -248,7 +365,10 @@ export const useHotkeys = () => {
     URL.revokeObjectURL(url);
 
     if (toast) {
-      toast.show({ message: "Hotkeys exported successfully", type: ToastType.info });
+      toast.show({
+        message: "Hotkeys exported successfully",
+        type: ToastType.info,
+      });
     }
   }, [hotkeys, hotkeySettings, toast]);
 
@@ -273,7 +393,10 @@ export const useHotkeys = () => {
         setHotkeys(importedHotkeys);
 
         if (toast) {
-          toast.show({ message: "Hotkeys imported successfully", type: ToastType.info });
+          toast.show({
+            message: "Hotkeys imported successfully",
+            type: ToastType.info,
+          });
         }
 
         // Reload from API to ensure consistency
@@ -281,7 +404,10 @@ export const useHotkeys = () => {
       } catch (error: unknown) {
         if (toast) {
           const errorMessage = error instanceof Error ? error.message : "Unknown error";
-          toast.show({ message: `Error importing hotkeys: ${errorMessage}`, type: ToastType.error });
+          toast.show({
+            message: `Error importing hotkeys: ${errorMessage}`,
+            type: ToastType.error,
+          });
         }
       } finally {
         setIsLoading(false);
@@ -304,6 +430,7 @@ export const useHotkeys = () => {
     setIsLoading,
     loadHotkeysFromAPI,
     saveHotkeysToAPI,
+    reloadHotkeysInRuntime,
     handleResetToDefaults,
     handleExportHotkeys,
     handleImportHotkeys,

--- a/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
+++ b/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
@@ -2,9 +2,6 @@ import { ToastType, useToast } from "@humansignal/ui";
 // @ts-ignore
 import { confirm } from "apps/labelstudio/src/components/Modal/Modal";
 import { useAPI } from "apps/labelstudio/src/providers/ApiProvider";
-// Import Hotkey from editor for updating keymap
-// @ts-ignore
-import { Hotkey as EditorHotkey } from "libs/editor/src/core/Hotkey";
 import { useCallback, useEffect, useState } from "react";
 import {
   type ApiResponse,
@@ -64,6 +61,12 @@ export const useHotkeys = () => {
       // Update APP_SETTINGS.user.customHotkeys (for Help modal and fallback)
       if (window.APP_SETTINGS?.user) {
         window.APP_SETTINGS.user.customHotkeys = customHotkeys;
+      }
+
+      const EditorHotkey = Htx.Hotkey;
+
+      if (!EditorHotkey) {
+        return;
       }
 
       // Transform custom hotkeys to editor format (same logic as base.html)

--- a/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
+++ b/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
@@ -4,466 +4,535 @@ import { confirm } from "apps/labelstudio/src/components/Modal/Modal";
 import { useAPI } from "apps/labelstudio/src/providers/ApiProvider";
 import { useCallback, useEffect, useState } from "react";
 import {
-  type ApiResponse,
-  type ExportData,
-  getTypedDefaultHotkeys,
-  type Hotkey,
-  type HotkeySettings,
-  type ImportData,
-  type SaveResult,
+	type ApiResponse,
+	type ExportData,
+	getTypedDefaultHotkeys,
+	type Hotkey,
+	type HotkeySettings,
+	type ImportData,
+	type SaveResult,
 } from "../sections/Hotkeys/utils";
 
 // Type definitions for better type safety
 type EditorInstance = {
-  store?: {
-    annotation?: {
-      setupHotKeys?: () => void;
-    };
-  };
-  annotation?: {
-    setupHotKeys?: () => void;
-  };
+	store?: {
+		annotation?: {
+			setupHotKeys?: () => void;
+		};
+	};
+	annotation?: {
+		setupHotKeys?: () => void;
+	};
 };
 
 // Type the imported defaults and convert numeric ids to strings
 const typedDefaultHotkeys: Hotkey[] = getTypedDefaultHotkeys();
 
 export const useHotkeys = () => {
-  const toast = useToast();
-  const [hotkeys, setHotkeys] = useState<Hotkey[]>([]);
-  const [hotkeySettings, setHotkeySettings] = useState<HotkeySettings>({});
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const api = useAPI();
+	const toast = useToast();
+	const [hotkeys, setHotkeys] = useState<Hotkey[]>([]);
+	const [hotkeySettings, setHotkeySettings] = useState<HotkeySettings>({});
+	const [isLoading, setIsLoading] = useState<boolean>(false);
+	const api = useAPI();
 
-  // Update hotkeys with custom settings
-  const updateHotkeysWithCustomSettings = useCallback(
-    (
-      defaultHotkeys: Hotkey[],
-      customHotkeys: Record<string, { key: string; active: boolean; description?: string }>,
-    ): Hotkey[] => {
-      return defaultHotkeys.map((hotkey: Hotkey) => {
-        // Create the lookup key format used in the API response (section:element)
-        const lookupKey = `${hotkey.section}:${hotkey.element}`;
+	// Update hotkeys with custom settings
+	const updateHotkeysWithCustomSettings = useCallback(
+		(
+			defaultHotkeys: Hotkey[],
+			customHotkeys: Record<
+				string,
+				{ key: string; active: boolean; description?: string }
+			>,
+		): Hotkey[] => {
+			return defaultHotkeys.map((hotkey: Hotkey) => {
+				// Create the lookup key format used in the API response (section:element)
+				const lookupKey = `${hotkey.section}:${hotkey.element}`;
 
-        // Check if there's a custom setting for this hotkey
-        if (customHotkeys[lookupKey]) {
-          const customSetting = customHotkeys[lookupKey];
-          // Create a new object with the default properties and override with custom ones
-          return {
-            ...hotkey,
-            key: customSetting.key,
-            active: customSetting.active,
-            // Preserve the original label, only update description if provided
-            ...(customSetting.description && {
-              description: customSetting.description,
-            }),
-          };
-        }
+				// Check if there's a custom setting for this hotkey
+				if (customHotkeys[lookupKey]) {
+					const customSetting = customHotkeys[lookupKey];
+					// Create a new object with the default properties and override with custom ones
+					return {
+						...hotkey,
+						key: customSetting.key,
+						active: customSetting.active,
+						// Preserve the original label, only update description if provided
+						...(customSetting.description && {
+							description: customSetting.description,
+						}),
+					};
+				}
 
-        // If no custom setting exists, return the default hotkey unchanged
-        return hotkey;
-      });
-    },
-    [],
-  );
+				// If no custom setting exists, return the default hotkey unchanged
+				return hotkey;
+			});
+		},
+		[],
+	);
 
-  // Runtime hotkey reload function - applies hotkeys without page refresh
-  const reloadHotkeysInRuntime = useCallback(
-    async (customHotkeys: Record<string, { key: string; active: boolean; description?: string }>) => {
-      try {
-        // Step 1: Process custom hotkeys the same way the server does in base.html
-        const editorCustomHotkeys: Record<string, { key: string | null; active: boolean; description?: string }> = {};
-        const prefixRegex = /^(annotation|timeseries|audio|regions|video|image_gallery|tools):(.*)/;
+	// Runtime hotkey reload function - applies hotkeys without page refresh
+	const reloadHotkeysInRuntime = useCallback(
+		async (
+			customHotkeys: Record<
+				string,
+				{ key: string; active: boolean; description?: string }
+			>,
+		) => {
+			try {
+				// Step 1: Process custom hotkeys the same way the server does in base.html
+				const editorCustomHotkeys: Record<
+					string,
+					{ key: string | null; active: boolean; description?: string }
+				> = {};
+				const prefixRegex =
+					/^(annotation|timeseries|audio|regions|video|image_gallery|tools|data_manager):(.*)/;
 
-        for (const key in customHotkeys) {
-          const match = key.match(prefixRegex);
-          if (match) {
-            const [, prefix, shortKey] = match;
-            const value = customHotkeys[key];
+				for (const key in customHotkeys) {
+					const match = key.match(prefixRegex);
+					if (match) {
+						const [, prefix, shortKey] = match;
+						const value = customHotkeys[key];
 
-            // The shortKey might have double prefixes like "annotation:submit"
-            // We need to construct the correct editor keymap key format
-            const editorKey = shortKey.includes(":") ? shortKey : `${prefix}:${shortKey}`;
+						// The shortKey might have double prefixes like "annotation:submit"
+						// We need to construct the correct editor keymap key format
+						const editorKey = shortKey.includes(":")
+							? shortKey
+							: `${prefix}:${shortKey}`;
 
-            // Check if value has active property set to false
-            if (value && value.active === false) {
-              // Create a copy of the value with key set to null
-              const modifiedValue = { ...value, key: null };
-              editorCustomHotkeys[editorKey] = modifiedValue;
-            } else {
-              // Use the original value
-              editorCustomHotkeys[editorKey] = value;
-            }
-          }
-        }
+						// Check if value has active property set to false
+						if (value && value.active === false) {
+							// Create a copy of the value with key set to null
+							const modifiedValue = { ...value, key: null };
+							editorCustomHotkeys[editorKey] = modifiedValue;
+						} else {
+							// Use the original value
+							editorCustomHotkeys[editorKey] = value;
+						}
+					}
+				}
 
-        // Step 2: Get default editor keymap and merge with custom hotkeys
-        // Use the original defaults, which are now properly exposed globally
-        const defaultEditorKeymap = window.DEFAULT_HOTKEYS || {};
+				// Step 2: Get default editor keymap and merge with custom hotkeys
+				// Use the original defaults, which are now properly exposed globally
+				const defaultEditorKeymap = window.DEFAULT_HOTKEYS || {};
 
-        const mergedEditorKeymap = Object.assign({}, defaultEditorKeymap, editorCustomHotkeys);
+				const mergedEditorKeymap = Object.assign(
+					{},
+					defaultEditorKeymap,
+					editorCustomHotkeys,
+				);
 
-        // Step 3: Update window.APP_SETTINGS with new hotkeys
-        if (window.APP_SETTINGS) {
-          window.APP_SETTINGS.editor_keymap = mergedEditorKeymap;
-          window.APP_SETTINGS.user = window.APP_SETTINGS.user || {};
-          window.APP_SETTINGS.user.customHotkeys = customHotkeys;
-        }
+				// Step 3: Update window.APP_SETTINGS with new hotkeys
+				if (window.APP_SETTINGS) {
+					window.APP_SETTINGS.editor_keymap = mergedEditorKeymap;
+					window.APP_SETTINGS.user = window.APP_SETTINGS.user || {};
+					window.APP_SETTINGS.user.customHotkeys = customHotkeys;
+				}
 
-        // Step 4: Re-apply keymap to editor instances if available
-        // Check if Hotkey class is available globally
-        if (typeof window !== "undefined") {
-          // Try to access the Hotkey class through various possible global references
-          const HotkeyClass = (window as any).Hotkey || (window as any).LSF?.Hotkey;
+				// Step 4: Re-apply keymap to editor instances if available
+				// Check if Hotkey class is available globally
+				if (typeof window !== "undefined") {
+					// Try to access the Hotkey class through various possible global references
+					const HotkeyClass =
+						(window as any).Hotkey || (window as any).LSF?.Hotkey;
 
-          if (HotkeyClass && typeof HotkeyClass.setKeymap === "function") {
-            HotkeyClass.setKeymap(mergedEditorKeymap);
-          }
-        }
+					if (HotkeyClass && typeof HotkeyClass.setKeymap === "function") {
+						HotkeyClass.setKeymap(mergedEditorKeymap);
+					}
+				}
 
-        // Step 5: Trigger re-initialization of hotkeys in editor instances
-        // This is the most complex part as we need to access LabelStudio instances
-        if (typeof window !== "undefined") {
-          // Try to access LabelStudio instances through various possible global references
-          const instances = (window as any).LabelStudio?.instances || (window as any).LSF?.instances || [];
+				// Step 5: Trigger re-initialization of hotkeys in editor instances
+				// This is the most complex part as we need to access LabelStudio instances
+				if (typeof window !== "undefined") {
+					// Try to access LabelStudio instances through various possible global references
+					const instances =
+						(window as any).LabelStudio?.instances ||
+						(window as any).LSF?.instances ||
+						[];
 
-          // Iterate through instances and trigger hotkey re-initialization
-          if (Array.isArray(instances)) {
-            instances.forEach((instance: EditorInstance) => {
-              try {
-                // Check if the instance has the store and annotation with setupHotKeys method
-                if (
-                  instance?.store?.annotation?.setupHotKeys &&
-                  typeof instance.store.annotation.setupHotKeys === "function"
-                ) {
-                  instance.store.annotation.setupHotKeys();
-                } else if (
-                  instance?.annotation?.setupHotKeys &&
-                  typeof instance.annotation.setupHotKeys === "function"
-                ) {
-                  instance.annotation.setupHotKeys();
-                }
-              } catch (error) {
-                // Only log editor instance refresh failures in debug mode
-                if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-                  console.warn("Failed to refresh hotkeys for editor instance:", error);
-                }
-              }
-            });
-          } else if (instances && typeof (instances as any).forEach === "function") {
-            // Handle Set or other iterable
-            (instances as any).forEach((instance: EditorInstance) => {
-              try {
-                if (
-                  instance?.store?.annotation?.setupHotKeys &&
-                  typeof instance.store.annotation.setupHotKeys === "function"
-                ) {
-                  instance.store.annotation.setupHotKeys();
-                } else if (
-                  instance?.annotation?.setupHotKeys &&
-                  typeof instance.annotation.setupHotKeys === "function"
-                ) {
-                  instance.annotation.setupHotKeys();
-                }
-              } catch (error) {
-                // Only log editor instance refresh failures in debug mode
-                if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-                  console.warn("Failed to refresh hotkeys for editor instance:", error);
-                }
-              }
-            });
-          }
-        }
+					// Iterate through instances and trigger hotkey re-initialization
+					if (Array.isArray(instances)) {
+						instances.forEach((instance: EditorInstance) => {
+							try {
+								// Check if the instance has the store and annotation with setupHotKeys method
+								if (
+									instance?.store?.annotation?.setupHotKeys &&
+									typeof instance.store.annotation.setupHotKeys === "function"
+								) {
+									instance.store.annotation.setupHotKeys();
+								} else if (
+									instance?.annotation?.setupHotKeys &&
+									typeof instance.annotation.setupHotKeys === "function"
+								) {
+									instance.annotation.setupHotKeys();
+								}
+							} catch (error) {
+								// Only log editor instance refresh failures in debug mode
+								if (
+									typeof window !== "undefined" &&
+									window.APP_SETTINGS?.debug
+								) {
+									console.warn(
+										"Failed to refresh hotkeys for editor instance:",
+										error,
+									);
+								}
+							}
+						});
+					} else if (
+						instances &&
+						typeof (instances as any).forEach === "function"
+					) {
+						// Handle Set or other iterable
+						(instances as any).forEach((instance: EditorInstance) => {
+							try {
+								if (
+									instance?.store?.annotation?.setupHotKeys &&
+									typeof instance.store.annotation.setupHotKeys === "function"
+								) {
+									instance.store.annotation.setupHotKeys();
+								} else if (
+									instance?.annotation?.setupHotKeys &&
+									typeof instance.annotation.setupHotKeys === "function"
+								) {
+									instance.annotation.setupHotKeys();
+								}
+							} catch (error) {
+								// Only log editor instance refresh failures in debug mode
+								if (
+									typeof window !== "undefined" &&
+									window.APP_SETTINGS?.debug
+								) {
+									console.warn(
+										"Failed to refresh hotkeys for editor instance:",
+										error,
+									);
+								}
+							}
+						});
+					}
+				}
 
-        // Only log in debug mode
-        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-          console.log("Hotkeys successfully reloaded at runtime");
-        }
-        return true;
-      } catch (error) {
-        // Only log in debug mode
-        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-          console.error("Failed to reload hotkeys at runtime:", error);
-        }
-        return false;
-      }
-    },
-    [],
-  );
+				// Only log in debug mode
+				if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+					console.log("Hotkeys successfully reloaded at runtime");
+				}
+				return true;
+			} catch (error) {
+				// Only log in debug mode
+				if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+					console.error("Failed to reload hotkeys at runtime:", error);
+				}
+				return false;
+			}
+		},
+		[],
+	);
 
-  // Load hotkeys from API
-  const loadHotkeysFromAPI = useCallback(async () => {
-    try {
-      setIsLoading(true);
+	// Load hotkeys from API
+	const loadHotkeysFromAPI = useCallback(async () => {
+		try {
+			setIsLoading(true);
 
-      // Use proper API endpoint name from the config
-      const response = await api.callApi("hotkeys" as any);
+			// Use proper API endpoint name from the config
+			const response = await api.callApi("hotkeys" as any);
 
-      if (response && (response as ApiResponse).custom_hotkeys) {
-        // Use API data
-        const apiResponse = response as ApiResponse;
-        const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, apiResponse.custom_hotkeys!);
-        setHotkeys(updatedHotkeys);
-        // Store current settings from API response
-        setHotkeySettings(apiResponse.hotkey_settings || {});
-      } else {
-        // Fallback to window.APP_SETTINGS
-        const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
-        const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, customHotkeys);
-        setHotkeys(updatedHotkeys);
-        // No settings available in fallback
-        setHotkeySettings({});
-      }
-    } catch (error) {
-      console.error("Error loading hotkeys from API:", error);
+			if (response && (response as ApiResponse).custom_hotkeys) {
+				// Use API data
+				const apiResponse = response as ApiResponse;
+				const updatedHotkeys = updateHotkeysWithCustomSettings(
+					typedDefaultHotkeys,
+					apiResponse.custom_hotkeys!,
+				);
+				setHotkeys(updatedHotkeys);
+				// Store current settings from API response
+				setHotkeySettings(apiResponse.hotkey_settings || {});
+			} else {
+				// Fallback to window.APP_SETTINGS
+				const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
+				const updatedHotkeys = updateHotkeysWithCustomSettings(
+					typedDefaultHotkeys,
+					customHotkeys,
+				);
+				setHotkeys(updatedHotkeys);
+				// No settings available in fallback
+				setHotkeySettings({});
+			}
+		} catch (error) {
+			console.error("Error loading hotkeys from API:", error);
 
-      // Fallback to window.APP_SETTINGS on error
-      const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
-      const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, customHotkeys);
-      setHotkeys(updatedHotkeys);
-      // No settings available in fallback
-      setHotkeySettings({});
+			// Fallback to window.APP_SETTINGS on error
+			const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
+			const updatedHotkeys = updateHotkeysWithCustomSettings(
+				typedDefaultHotkeys,
+				customHotkeys,
+			);
+			setHotkeys(updatedHotkeys);
+			// No settings available in fallback
+			setHotkeySettings({});
 
-      // Show non-blocking error notification
-      if (toast) {
-        toast.show({
-          message: "Could not load custom hotkeys from server, using cached settings",
-          type: ToastType.error,
-        });
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  }, [api, toast, updateHotkeysWithCustomSettings]);
+			// Show non-blocking error notification
+			if (toast) {
+				toast.show({
+					message:
+						"Could not load custom hotkeys from server, using cached settings",
+					type: ToastType.error,
+				});
+			}
+		} finally {
+			setIsLoading(false);
+		}
+	}, [api, toast, updateHotkeysWithCustomSettings]);
 
-  // Save hotkeys to API function (handles both save and reset operations)
-  const saveHotkeysToAPI = useCallback(
-    async (currentHotkeys: Hotkey[], currentSettings: HotkeySettings): Promise<SaveResult> => {
-      // Convert current hotkeys to API format - INCLUDE description to maintain API compatibility
-      const customHotkeys: Record<string, { key: string; active: boolean; description?: string }> = {};
+	// Save hotkeys to API function (handles both save and reset operations)
+	const saveHotkeysToAPI = useCallback(
+		async (
+			currentHotkeys: Hotkey[],
+			currentSettings: HotkeySettings,
+		): Promise<SaveResult> => {
+			// Convert current hotkeys to API format - INCLUDE description to maintain API compatibility
+			const customHotkeys: Record<
+				string,
+				{ key: string; active: boolean; description?: string }
+			> = {};
 
-      // Process all current hotkeys (if empty, this results in reset)
-      currentHotkeys.forEach((hotkey: Hotkey) => {
-        const keyId = `${hotkey.section}:${hotkey.element}`;
-        customHotkeys[keyId] = {
-          key: hotkey.key,
-          active: hotkey.active,
-          ...(hotkey.description && { description: hotkey.description }),
-        };
-      });
+			// Process all current hotkeys (if empty, this results in reset)
+			currentHotkeys.forEach((hotkey: Hotkey) => {
+				const keyId = `${hotkey.section}:${hotkey.element}`;
+				customHotkeys[keyId] = {
+					key: hotkey.key,
+					active: hotkey.active,
+					...(hotkey.description && { description: hotkey.description }),
+				};
+			});
 
-      const requestBody = {
-        custom_hotkeys: customHotkeys,
-        hotkey_settings: currentSettings,
-      };
+			const requestBody = {
+				custom_hotkeys: customHotkeys,
+				hotkey_settings: currentSettings,
+			};
 
-      try {
-        // Use proper API endpoint name from the config
-        const response = await api.callApi("updateHotkeys" as any, {
-          body: requestBody,
-        });
+			try {
+				// Use proper API endpoint name from the config
+				const response = await api.callApi("updateHotkeys" as any, {
+					body: requestBody,
+				});
 
-        // Check for API-level errors
-        if (response?.error) {
-          return {
-            ok: false,
-            error: response.error,
-            data: response,
-          };
-        }
+				// Check for API-level errors
+				if (response?.error) {
+					return {
+						ok: false,
+						error: response.error,
+						data: response,
+					};
+				}
 
-        // After successful save, reload hotkeys at runtime to apply changes immediately
-        const reloadSuccess = await reloadHotkeysInRuntime(customHotkeys);
+				// After successful save, reload hotkeys at runtime to apply changes immediately
+				const reloadSuccess = await reloadHotkeysInRuntime(customHotkeys);
 
-        // Only log runtime reload status in debug mode
-        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-          if (reloadSuccess) {
-            console.log("Hotkeys successfully applied at runtime - no page refresh needed");
-          } else {
-            console.warn("Runtime hotkey reload failed - page refresh may be required");
-          }
-        }
+				// Only log runtime reload status in debug mode
+				if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+					if (reloadSuccess) {
+						console.log(
+							"Hotkeys successfully applied at runtime - no page refresh needed",
+						);
+					} else {
+						console.warn(
+							"Runtime hotkey reload failed - page refresh may be required",
+						);
+					}
+				}
 
-        return {
-          ok: true,
-          error: undefined,
-          data: response,
-          runtimeReloadSuccess: reloadSuccess,
-        };
-      } catch (error: unknown) {
-        const isReset = currentHotkeys.length === 0;
-        const operation = isReset ? "resetting" : "saving";
-        console.error(`Error ${operation} hotkeys:`, error);
+				return {
+					ok: true,
+					error: undefined,
+					data: response,
+					runtimeReloadSuccess: reloadSuccess,
+				};
+			} catch (error: unknown) {
+				const isReset = currentHotkeys.length === 0;
+				const operation = isReset ? "resetting" : "saving";
+				console.error(`Error ${operation} hotkeys:`, error);
 
-        // Provide more specific error messages
-        let errorMessage = `Failed to ${isReset ? "reset" : "save"} hotkeys`;
-        if (error && typeof error === "object" && "response" in error) {
-          const err = error as any;
-          // Server responded with error status
-          if (err.response?.status === 400) {
-            errorMessage = err.response.data?.error || `Invalid ${isReset ? "reset request" : "hotkeys configuration"}`;
-          } else if (err.response?.status === 401) {
-            errorMessage = "Authentication required";
-          } else if (err.response?.status >= 500) {
-            errorMessage = "Server error - please try again later";
-          }
-        } else if (error && typeof error === "object" && "request" in error) {
-          // Network error
-          errorMessage = "Network error - please check your connection";
-        }
+				// Provide more specific error messages
+				let errorMessage = `Failed to ${isReset ? "reset" : "save"} hotkeys`;
+				if (error && typeof error === "object" && "response" in error) {
+					const err = error as any;
+					// Server responded with error status
+					if (err.response?.status === 400) {
+						errorMessage =
+							err.response.data?.error ||
+							`Invalid ${isReset ? "reset request" : "hotkeys configuration"}`;
+					} else if (err.response?.status === 401) {
+						errorMessage = "Authentication required";
+					} else if (err.response?.status >= 500) {
+						errorMessage = "Server error - please try again later";
+					}
+				} else if (error && typeof error === "object" && "request" in error) {
+					// Network error
+					errorMessage = "Network error - please check your connection";
+				}
 
-        return {
-          ok: false,
-          error: errorMessage,
-        };
-      }
-    },
-    [api],
-  );
+				return {
+					ok: false,
+					error: errorMessage,
+				};
+			}
+		},
+		[api],
+	);
 
-  // Handle resetting all hotkeys to defaults
-  const handleResetToDefaults = useCallback(() => {
-    confirm({
-      title: "Reset Hotkeys to Defaults?",
-      body: "Are you sure you want to reset all hotkeys and settings to their default values? This action cannot be undone.",
-      okText: "Reset to Defaults",
-      buttonLook: "negative",
-      style: { width: 500 },
-      onOk: async () => {
-        setIsLoading(true);
+	// Handle resetting all hotkeys to defaults
+	const handleResetToDefaults = useCallback(() => {
+		confirm({
+			title: "Reset Hotkeys to Defaults?",
+			body: "Are you sure you want to reset all hotkeys and settings to their default values? This action cannot be undone.",
+			okText: "Reset to Defaults",
+			buttonLook: "negative",
+			style: { width: 500 },
+			onOk: async () => {
+				setIsLoading(true);
 
-        try {
-          // Reset hotkeys to defaults in the backend API (sets custom_hotkeys to {})
-          const result = await saveHotkeysToAPI([], {});
+				try {
+					// Reset hotkeys to defaults in the backend API (sets custom_hotkeys to {})
+					const result = await saveHotkeysToAPI([], {});
 
-          if (result.ok) {
-            if (toast) {
-              toast.show({
-                message: "All hotkeys and settings have been reset to defaults and saved",
-                type: ToastType.info,
-              });
-            }
-            // Update local state to reflect the reset
-            setHotkeys([...typedDefaultHotkeys]);
-          } else {
-            if (toast) {
-              toast.show({
-                message: `Failed to save reset hotkeys: ${result.error || "Unknown error"}`,
-                type: ToastType.error,
-              });
-            }
-          }
-        } catch (error: unknown) {
-          if (toast) {
-            const errorMessage = error instanceof Error ? error.message : "Unknown error";
-            toast.show({
-              message: `Error resetting hotkeys: ${errorMessage}`,
-              type: ToastType.error,
-            });
-          }
-        } finally {
-          setIsLoading(false);
-        }
-      },
-    });
-  }, [saveHotkeysToAPI, toast]);
+					if (result.ok) {
+						if (toast) {
+							toast.show({
+								message:
+									"All hotkeys and settings have been reset to defaults and saved",
+								type: ToastType.info,
+							});
+						}
+						// Update local state to reflect the reset
+						setHotkeys([...typedDefaultHotkeys]);
+					} else {
+						if (toast) {
+							toast.show({
+								message: `Failed to save reset hotkeys: ${result.error || "Unknown error"}`,
+								type: ToastType.error,
+							});
+						}
+					}
+				} catch (error: unknown) {
+					if (toast) {
+						const errorMessage =
+							error instanceof Error ? error.message : "Unknown error";
+						toast.show({
+							message: `Error resetting hotkeys: ${errorMessage}`,
+							type: ToastType.error,
+						});
+					}
+				} finally {
+					setIsLoading(false);
+				}
+			},
+		});
+	}, [saveHotkeysToAPI, toast]);
 
-  // Handle exporting hotkeys
-  const handleExportHotkeys = useCallback(() => {
-    // Create export data including current settings
-    const exportData: ExportData = {
-      hotkeys: hotkeys,
-      settings: hotkeySettings,
-      exportedAt: new Date().toISOString(),
-      version: "1.0",
-    };
+	// Handle exporting hotkeys
+	const handleExportHotkeys = useCallback(() => {
+		// Create export data including current settings
+		const exportData: ExportData = {
+			hotkeys: hotkeys,
+			settings: hotkeySettings,
+			exportedAt: new Date().toISOString(),
+			version: "1.0",
+		};
 
-    // Create a JSON string of the export data
-    const exportJson = JSON.stringify(exportData, null, 2);
+		// Create a JSON string of the export data
+		const exportJson = JSON.stringify(exportData, null, 2);
 
-    // Create a blob with the JSON
-    const blob = new Blob([exportJson], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
+		// Create a blob with the JSON
+		const blob = new Blob([exportJson], { type: "application/json" });
+		const url = URL.createObjectURL(blob);
 
-    // Create a temporary link and click it to download the file
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = "hotkeys-export.json";
-    document.body.appendChild(link);
-    link.click();
+		// Create a temporary link and click it to download the file
+		const link = document.createElement("a");
+		link.href = url;
+		link.download = "hotkeys-export.json";
+		document.body.appendChild(link);
+		link.click();
 
-    // Clean up
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
+		// Clean up
+		document.body.removeChild(link);
+		URL.revokeObjectURL(url);
 
-    if (toast) {
-      toast.show({
-        message: "Hotkeys exported successfully",
-        type: ToastType.info,
-      });
-    }
-  }, [hotkeys, hotkeySettings, toast]);
+		if (toast) {
+			toast.show({
+				message: "Hotkeys exported successfully",
+				type: ToastType.info,
+			});
+		}
+	}, [hotkeys, hotkeySettings, toast]);
 
-  // Handle importing hotkeys
-  const handleImportHotkeys = useCallback(
-    async (importedData: ImportData | Hotkey[]) => {
-      try {
-        setIsLoading(true);
+	// Handle importing hotkeys
+	const handleImportHotkeys = useCallback(
+		async (importedData: ImportData | Hotkey[]) => {
+			try {
+				setIsLoading(true);
 
-        // Handle both old format (just hotkeys array) and new format (with settings)
-        const importedHotkeys = Array.isArray(importedData) ? importedData : importedData.hotkeys || [];
-        const importedSettings: HotkeySettings = Array.isArray(importedData) ? {} : importedData.settings || {};
+				// Handle both old format (just hotkeys array) and new format (with settings)
+				const importedHotkeys = Array.isArray(importedData)
+					? importedData
+					: importedData.hotkeys || [];
+				const importedSettings: HotkeySettings = Array.isArray(importedData)
+					? {}
+					: importedData.settings || {};
 
-        // Save all imported data to API
-        const result = await saveHotkeysToAPI(importedHotkeys, importedSettings);
+				// Save all imported data to API
+				const result = await saveHotkeysToAPI(
+					importedHotkeys,
+					importedSettings,
+				);
 
-        if (!result.ok) {
-          throw new Error(result.error || "Failed to save imported hotkeys");
-        }
+				if (!result.ok) {
+					throw new Error(result.error || "Failed to save imported hotkeys");
+				}
 
-        // Update local state
-        setHotkeys(importedHotkeys);
+				// Update local state
+				setHotkeys(importedHotkeys);
 
-        if (toast) {
-          toast.show({
-            message: "Hotkeys imported successfully",
-            type: ToastType.info,
-          });
-        }
+				if (toast) {
+					toast.show({
+						message: "Hotkeys imported successfully",
+						type: ToastType.info,
+					});
+				}
 
-        // Reload from API to ensure consistency
-        await loadHotkeysFromAPI();
-      } catch (error: unknown) {
-        if (toast) {
-          const errorMessage = error instanceof Error ? error.message : "Unknown error";
-          toast.show({
-            message: `Error importing hotkeys: ${errorMessage}`,
-            type: ToastType.error,
-          });
-        }
-      } finally {
-        setIsLoading(false);
-      }
-    },
-    [saveHotkeysToAPI, loadHotkeysFromAPI, toast],
-  );
+				// Reload from API to ensure consistency
+				await loadHotkeysFromAPI();
+			} catch (error: unknown) {
+				if (toast) {
+					const errorMessage =
+						error instanceof Error ? error.message : "Unknown error";
+					toast.show({
+						message: `Error importing hotkeys: ${errorMessage}`,
+						type: ToastType.error,
+					});
+				}
+			} finally {
+				setIsLoading(false);
+			}
+		},
+		[saveHotkeysToAPI, loadHotkeysFromAPI, toast],
+	);
 
-  // Load hotkeys on hook mount
-  useEffect(() => {
-    loadHotkeysFromAPI();
-  }, [loadHotkeysFromAPI]);
+	// Load hotkeys on hook mount
+	useEffect(() => {
+		loadHotkeysFromAPI();
+	}, [loadHotkeysFromAPI]);
 
-  return {
-    hotkeys,
-    setHotkeys,
-    hotkeySettings,
-    setHotkeySettings,
-    isLoading,
-    setIsLoading,
-    loadHotkeysFromAPI,
-    saveHotkeysToAPI,
-    handleResetToDefaults,
-    handleExportHotkeys,
-    handleImportHotkeys,
-  };
+	return {
+		hotkeys,
+		setHotkeys,
+		hotkeySettings,
+		setHotkeySettings,
+		isLoading,
+		setIsLoading,
+		loadHotkeysFromAPI,
+		saveHotkeysToAPI,
+		handleResetToDefaults,
+		handleExportHotkeys,
+		handleImportHotkeys,
+	};
 };

--- a/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
+++ b/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
@@ -65,10 +65,6 @@ export const useHotkeys = () => {
 
       const EditorHotkey = window.Htx?.Hotkey;
 
-      if (!EditorHotkey) {
-        return;
-      }
-
       // Transform custom hotkeys to editor format (same logic as base.html)
       const editorCustomHotkeys: Record<string, any> = {};
       const prefixRegex = /^(annotation|timeseries|audio|regions|video|image_gallery|tools):(.*)/;
@@ -88,7 +84,7 @@ export const useHotkeys = () => {
       }
 
       // Get current keymap and merge with custom hotkeys
-      const currentKeymap = EditorHotkey.keymap ? { ...EditorHotkey.keymap } : {};
+      const currentKeymap = EditorHotkey?.keymap ? { ...EditorHotkey.keymap } : {};
       const mergedKeymap = Object.assign({}, currentKeymap, editorCustomHotkeys);
 
       // Update APP_SETTINGS.editor_keymap (for DataManager/Explorer)
@@ -98,7 +94,7 @@ export const useHotkeys = () => {
 
       // Call Hotkey.setKeymap() - the main propagation path
       try {
-        EditorHotkey.setKeymap(mergedKeymap as any);
+        EditorHotkey?.setKeymap(mergedKeymap as any);
       } catch (error) {
         console.warn("Failed to update hotkeys:", error);
       }

--- a/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
+++ b/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
@@ -4,456 +4,535 @@ import { confirm } from "apps/labelstudio/src/components/Modal/Modal";
 import { useAPI } from "apps/labelstudio/src/providers/ApiProvider";
 import { useCallback, useEffect, useState } from "react";
 import {
-  type ApiResponse,
-  type ExportData,
-  getTypedDefaultHotkeys,
-  type Hotkey,
-  type HotkeySettings,
-  type ImportData,
-  type SaveResult,
+	type ApiResponse,
+	type ExportData,
+	getTypedDefaultHotkeys,
+	type Hotkey,
+	type HotkeySettings,
+	type ImportData,
+	type SaveResult,
 } from "../sections/Hotkeys/utils";
+
+// Type definitions for better type safety
+type EditorInstance = {
+	store?: {
+		annotation?: {
+			setupHotKeys?: () => void;
+		};
+	};
+	annotation?: {
+		setupHotKeys?: () => void;
+	};
+};
 
 // Type the imported defaults and convert numeric ids to strings
 const typedDefaultHotkeys: Hotkey[] = getTypedDefaultHotkeys();
 
 export const useHotkeys = () => {
-  const toast = useToast();
-  const [hotkeys, setHotkeys] = useState<Hotkey[]>([]);
-  const [hotkeySettings, setHotkeySettings] = useState<HotkeySettings>({});
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const api = useAPI();
+	const toast = useToast();
+	const [hotkeys, setHotkeys] = useState<Hotkey[]>([]);
+	const [hotkeySettings, setHotkeySettings] = useState<HotkeySettings>({});
+	const [isLoading, setIsLoading] = useState<boolean>(false);
+	const api = useAPI();
 
-  // Update hotkeys with custom settings
-  const updateHotkeysWithCustomSettings = useCallback(
-    (
-      defaultHotkeys: Hotkey[],
-      customHotkeys: Record<string, { key: string; active: boolean; description?: string }>,
-    ): Hotkey[] => {
-      return defaultHotkeys.map((hotkey: Hotkey) => {
-        // Create the lookup key format used in the API response (section:element)
-        const lookupKey = `${hotkey.section}:${hotkey.element}`;
+	// Update hotkeys with custom settings
+	const updateHotkeysWithCustomSettings = useCallback(
+		(
+			defaultHotkeys: Hotkey[],
+			customHotkeys: Record<
+				string,
+				{ key: string; active: boolean; description?: string }
+			>,
+		): Hotkey[] => {
+			return defaultHotkeys.map((hotkey: Hotkey) => {
+				// Create the lookup key format used in the API response (section:element)
+				const lookupKey = `${hotkey.section}:${hotkey.element}`;
 
-        // Check if there's a custom setting for this hotkey
-        if (customHotkeys[lookupKey]) {
-          const customSetting = customHotkeys[lookupKey];
-          // Create a new object with the default properties and override with custom ones
-          return {
-            ...hotkey,
-            key: customSetting.key,
-            active: customSetting.active,
-            // Preserve the original label, only update description if provided
-            ...(customSetting.description && {
-              description: customSetting.description,
-            }),
-          };
-        }
+				// Check if there's a custom setting for this hotkey
+				if (customHotkeys[lookupKey]) {
+					const customSetting = customHotkeys[lookupKey];
+					// Create a new object with the default properties and override with custom ones
+					return {
+						...hotkey,
+						key: customSetting.key,
+						active: customSetting.active,
+						// Preserve the original label, only update description if provided
+						...(customSetting.description && {
+							description: customSetting.description,
+						}),
+					};
+				}
 
-        // If no custom setting exists, return the default hotkey unchanged
-        return hotkey;
-      });
-    },
-    [],
-  );
+				// If no custom setting exists, return the default hotkey unchanged
+				return hotkey;
+			});
+		},
+		[],
+	);
 
-  // Runtime hotkey reload function - applies hotkeys without page refresh
-  const reloadHotkeysInRuntime = useCallback(
-    async (customHotkeys: Record<string, { key: string; active: boolean; description?: string }>) => {
-      try {
-        // Step 1: Process custom hotkeys the same way the server does in base.html
-        const editorCustomHotkeys: Record<string, any> = {};
-        const prefixRegex = /^(annotation|timeseries|audio|regions|video|image_gallery|tools):(.*)/;
+	// Runtime hotkey reload function - applies hotkeys without page refresh
+	const reloadHotkeysInRuntime = useCallback(
+		async (
+			customHotkeys: Record<
+				string,
+				{ key: string; active: boolean; description?: string }
+			>,
+		) => {
+			try {
+				// Step 1: Process custom hotkeys the same way the server does in base.html
+				const editorCustomHotkeys: Record<
+					string,
+					{ key: string | null; active: boolean; description?: string }
+				> = {};
+				const prefixRegex =
+					/^(annotation|timeseries|audio|regions|video|image_gallery|tools):(.*)/;
 
-        for (const key in customHotkeys) {
-          const match = key.match(prefixRegex);
-          if (match) {
-            const [, prefix, shortKey] = match;
-            const value = customHotkeys[key];
+				for (const key in customHotkeys) {
+					const match = key.match(prefixRegex);
+					if (match) {
+						const [, prefix, shortKey] = match;
+						const value = customHotkeys[key];
 
-            // The shortKey might have double prefixes like "annotation:submit"
-            // We need to construct the correct editor keymap key format
-            const editorKey = shortKey.includes(":") ? shortKey : `${prefix}:${shortKey}`;
+						// The shortKey might have double prefixes like "annotation:submit"
+						// We need to construct the correct editor keymap key format
+						const editorKey = shortKey.includes(":")
+							? shortKey
+							: `${prefix}:${shortKey}`;
 
-            // Check if value has active property set to false
-            if (value && value.active === false) {
-              // Create a copy of the value with key set to null
-              const modifiedValue = { ...value, key: null };
-              editorCustomHotkeys[editorKey] = modifiedValue;
-            } else {
-              // Use the original value
-              editorCustomHotkeys[editorKey] = value;
-            }
-          }
-        }
+						// Check if value has active property set to false
+						if (value && value.active === false) {
+							// Create a copy of the value with key set to null
+							const modifiedValue = { ...value, key: null };
+							editorCustomHotkeys[editorKey] = modifiedValue;
+						} else {
+							// Use the original value
+							editorCustomHotkeys[editorKey] = value;
+						}
+					}
+				}
 
-        // Step 2: Get default editor keymap and merge with custom hotkeys
-        // Use the original defaults, which are now properly exposed globally
-        const defaultEditorKeymap = window.DEFAULT_HOTKEYS || {};
+				// Step 2: Get default editor keymap and merge with custom hotkeys
+				// Use the original defaults, which are now properly exposed globally
+				const defaultEditorKeymap = window.DEFAULT_HOTKEYS || {};
 
-        const mergedEditorKeymap = Object.assign({}, defaultEditorKeymap, editorCustomHotkeys);
+				const mergedEditorKeymap = Object.assign(
+					{},
+					defaultEditorKeymap,
+					editorCustomHotkeys,
+				);
 
-        // Step 3: Update window.APP_SETTINGS with new hotkeys
-        if (window.APP_SETTINGS) {
-          window.APP_SETTINGS.editor_keymap = mergedEditorKeymap;
-          window.APP_SETTINGS.user = window.APP_SETTINGS.user || {};
-          window.APP_SETTINGS.user.customHotkeys = customHotkeys;
-        }
+				// Step 3: Update window.APP_SETTINGS with new hotkeys
+				if (window.APP_SETTINGS) {
+					window.APP_SETTINGS.editor_keymap = mergedEditorKeymap;
+					window.APP_SETTINGS.user = window.APP_SETTINGS.user || {};
+					window.APP_SETTINGS.user.customHotkeys = customHotkeys;
+				}
 
-        // Step 4: Re-apply keymap to editor instances if available
-        // Check if Hotkey class is available globally (it should be)
-        if (typeof window !== "undefined") {
-          // Try to access the Hotkey class through various possible global references
-          const HotkeyClass =
-            (window as any).Hotkey || (window as any).LSF?.Hotkey || (window as any).LabelStudio?.Hotkey;
+				// Step 4: Re-apply keymap to editor instances if available
+				// Check if Hotkey class is available globally
+				if (typeof window !== "undefined") {
+					// Try to access the Hotkey class through various possible global references
+					const HotkeyClass =
+						(window as any).Hotkey || (window as any).LSF?.Hotkey;
 
-          if (HotkeyClass && typeof HotkeyClass.setKeymap === "function") {
-            HotkeyClass.setKeymap(mergedEditorKeymap);
-          }
-        }
+					if (HotkeyClass && typeof HotkeyClass.setKeymap === "function") {
+						HotkeyClass.setKeymap(mergedEditorKeymap);
+					}
+				}
 
-        // Step 5: Trigger re-initialization of hotkeys in editor instances
-        // This is the most complex part as we need to access LabelStudio instances
-        if (typeof window !== "undefined") {
-          // Try to access LabelStudio instances through various possible global references
-          const instances = (window as any).LabelStudio?.instances || (window as any).LSF?.instances || [];
+				// Step 5: Trigger re-initialization of hotkeys in editor instances
+				// This is the most complex part as we need to access LabelStudio instances
+				if (typeof window !== "undefined") {
+					// Try to access LabelStudio instances through various possible global references
+					const instances =
+						(window as any).LabelStudio?.instances ||
+						(window as any).LSF?.instances ||
+						[];
 
-          // Iterate through instances and trigger hotkey re-initialization
-          if (Array.isArray(instances)) {
-            instances.forEach((instance: any) => {
-              try {
-                // Check if the instance has the store and annotation with setupHotKeys method
-                if (
-                  instance?.store?.annotation?.setupHotKeys &&
-                  typeof instance.store.annotation.setupHotKeys === "function"
-                ) {
-                  instance.store.annotation.setupHotKeys();
-                } else if (
-                  instance?.annotation?.setupHotKeys &&
-                  typeof instance.annotation.setupHotKeys === "function"
-                ) {
-                  instance.annotation.setupHotKeys();
-                }
-              } catch (error) {
-                // Only log editor instance refresh failures in debug mode
-                if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-                  console.warn("Failed to refresh hotkeys for editor instance:", error);
-                }
-              }
-            });
-          } else if (instances && typeof instances.forEach === "function") {
-            // Handle Set or other iterable
-            instances.forEach((instance: any) => {
-              try {
-                if (
-                  instance?.store?.annotation?.setupHotKeys &&
-                  typeof instance.store.annotation.setupHotKeys === "function"
-                ) {
-                  instance.store.annotation.setupHotKeys();
-                } else if (
-                  instance?.annotation?.setupHotKeys &&
-                  typeof instance.annotation.setupHotKeys === "function"
-                ) {
-                  instance.annotation.setupHotKeys();
-                }
-              } catch (error) {
-                // Only log editor instance refresh failures in debug mode
-                if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-                  console.warn("Failed to refresh hotkeys for editor instance:", error);
-                }
-              }
-            });
-          }
-        }
+					// Iterate through instances and trigger hotkey re-initialization
+					if (Array.isArray(instances)) {
+						instances.forEach((instance: EditorInstance) => {
+							try {
+								// Check if the instance has the store and annotation with setupHotKeys method
+								if (
+									instance?.store?.annotation?.setupHotKeys &&
+									typeof instance.store.annotation.setupHotKeys === "function"
+								) {
+									instance.store.annotation.setupHotKeys();
+								} else if (
+									instance?.annotation?.setupHotKeys &&
+									typeof instance.annotation.setupHotKeys === "function"
+								) {
+									instance.annotation.setupHotKeys();
+								}
+							} catch (error) {
+								// Only log editor instance refresh failures in debug mode
+								if (
+									typeof window !== "undefined" &&
+									window.APP_SETTINGS?.debug
+								) {
+									console.warn(
+										"Failed to refresh hotkeys for editor instance:",
+										error,
+									);
+								}
+							}
+						});
+					} else if (
+						instances &&
+						typeof (instances as any).forEach === "function"
+					) {
+						// Handle Set or other iterable
+						(instances as any).forEach((instance: EditorInstance) => {
+							try {
+								if (
+									instance?.store?.annotation?.setupHotKeys &&
+									typeof instance.store.annotation.setupHotKeys === "function"
+								) {
+									instance.store.annotation.setupHotKeys();
+								} else if (
+									instance?.annotation?.setupHotKeys &&
+									typeof instance.annotation.setupHotKeys === "function"
+								) {
+									instance.annotation.setupHotKeys();
+								}
+							} catch (error) {
+								// Only log editor instance refresh failures in debug mode
+								if (
+									typeof window !== "undefined" &&
+									window.APP_SETTINGS?.debug
+								) {
+									console.warn(
+										"Failed to refresh hotkeys for editor instance:",
+										error,
+									);
+								}
+							}
+						});
+					}
+				}
 
-        // Only log in debug mode
-        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-          console.log("Hotkeys successfully reloaded at runtime");
-        }
-        return true;
-      } catch (error) {
-        // Only log in debug mode
-        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-          console.error("Failed to reload hotkeys at runtime:", error);
-        }
-        return false;
-      }
-    },
-    [],
-  );
+				// Only log in debug mode
+				if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+					console.log("Hotkeys successfully reloaded at runtime");
+				}
+				return true;
+			} catch (error) {
+				// Only log in debug mode
+				if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+					console.error("Failed to reload hotkeys at runtime:", error);
+				}
+				return false;
+			}
+		},
+		[],
+	);
 
-  // Load hotkeys from API
-  const loadHotkeysFromAPI = useCallback(async () => {
-    try {
-      setIsLoading(true);
+	// Load hotkeys from API
+	const loadHotkeysFromAPI = useCallback(async () => {
+		try {
+			setIsLoading(true);
 
-      // Use proper API endpoint name from the config
-      const response = await api.callApi("hotkeys" as any);
+			// Use proper API endpoint name from the config
+			const response = await api.callApi("hotkeys" as any);
 
-      if (response && (response as ApiResponse).custom_hotkeys) {
-        // Use API data
-        const apiResponse = response as ApiResponse;
-        const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, apiResponse.custom_hotkeys!);
-        setHotkeys(updatedHotkeys);
-        // Store current settings from API response
-        setHotkeySettings(apiResponse.hotkey_settings || {});
-      } else {
-        // Fallback to window.APP_SETTINGS
-        const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
-        const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, customHotkeys);
-        setHotkeys(updatedHotkeys);
-        // No settings available in fallback
-        setHotkeySettings({});
-      }
-    } catch (error) {
-      console.error("Error loading hotkeys from API:", error);
+			if (response && (response as ApiResponse).custom_hotkeys) {
+				// Use API data
+				const apiResponse = response as ApiResponse;
+				const updatedHotkeys = updateHotkeysWithCustomSettings(
+					typedDefaultHotkeys,
+					apiResponse.custom_hotkeys!,
+				);
+				setHotkeys(updatedHotkeys);
+				// Store current settings from API response
+				setHotkeySettings(apiResponse.hotkey_settings || {});
+			} else {
+				// Fallback to window.APP_SETTINGS
+				const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
+				const updatedHotkeys = updateHotkeysWithCustomSettings(
+					typedDefaultHotkeys,
+					customHotkeys,
+				);
+				setHotkeys(updatedHotkeys);
+				// No settings available in fallback
+				setHotkeySettings({});
+			}
+		} catch (error) {
+			console.error("Error loading hotkeys from API:", error);
 
-      // Fallback to window.APP_SETTINGS on error
-      const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
-      const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, customHotkeys);
-      setHotkeys(updatedHotkeys);
-      // No settings available in fallback
-      setHotkeySettings({});
+			// Fallback to window.APP_SETTINGS on error
+			const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
+			const updatedHotkeys = updateHotkeysWithCustomSettings(
+				typedDefaultHotkeys,
+				customHotkeys,
+			);
+			setHotkeys(updatedHotkeys);
+			// No settings available in fallback
+			setHotkeySettings({});
 
-      // Show non-blocking error notification
-      if (toast) {
-        toast.show({
-          message: "Could not load custom hotkeys from server, using cached settings",
-          type: ToastType.error,
-        });
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  }, [api, toast, updateHotkeysWithCustomSettings]);
+			// Show non-blocking error notification
+			if (toast) {
+				toast.show({
+					message:
+						"Could not load custom hotkeys from server, using cached settings",
+					type: ToastType.error,
+				});
+			}
+		} finally {
+			setIsLoading(false);
+		}
+	}, [api, toast, updateHotkeysWithCustomSettings]);
 
-  // Save hotkeys to API function (handles both save and reset operations)
-  const saveHotkeysToAPI = useCallback(
-    async (currentHotkeys: Hotkey[], currentSettings: HotkeySettings): Promise<SaveResult> => {
-      // Convert current hotkeys to API format - INCLUDE description to maintain API compatibility
-      const customHotkeys: Record<string, { key: string; active: boolean; description?: string }> = {};
+	// Save hotkeys to API function (handles both save and reset operations)
+	const saveHotkeysToAPI = useCallback(
+		async (
+			currentHotkeys: Hotkey[],
+			currentSettings: HotkeySettings,
+		): Promise<SaveResult> => {
+			// Convert current hotkeys to API format - INCLUDE description to maintain API compatibility
+			const customHotkeys: Record<
+				string,
+				{ key: string; active: boolean; description?: string }
+			> = {};
 
-      // Process all current hotkeys (if empty, this results in reset)
-      currentHotkeys.forEach((hotkey: Hotkey) => {
-        const keyId = `${hotkey.section}:${hotkey.element}`;
-        customHotkeys[keyId] = {
-          key: hotkey.key,
-          active: hotkey.active,
-          ...(hotkey.description && { description: hotkey.description }),
-        };
-      });
+			// Process all current hotkeys (if empty, this results in reset)
+			currentHotkeys.forEach((hotkey: Hotkey) => {
+				const keyId = `${hotkey.section}:${hotkey.element}`;
+				customHotkeys[keyId] = {
+					key: hotkey.key,
+					active: hotkey.active,
+					...(hotkey.description && { description: hotkey.description }),
+				};
+			});
 
-      const requestBody = {
-        custom_hotkeys: customHotkeys,
-        hotkey_settings: currentSettings,
-      };
+			const requestBody = {
+				custom_hotkeys: customHotkeys,
+				hotkey_settings: currentSettings,
+			};
 
-      try {
-        // Use proper API endpoint name from the config
-        const response = await api.callApi("updateHotkeys" as any, {
-          body: requestBody,
-        });
+			try {
+				// Use proper API endpoint name from the config
+				const response = await api.callApi("updateHotkeys" as any, {
+					body: requestBody,
+				});
 
-        // Check for API-level errors
-        if (response?.error) {
-          return {
-            ok: false,
-            error: response.error,
-            data: response,
-          };
-        }
+				// Check for API-level errors
+				if (response?.error) {
+					return {
+						ok: false,
+						error: response.error,
+						data: response,
+					};
+				}
 
-        // After successful save, reload hotkeys at runtime to apply changes immediately
-        const reloadSuccess = await reloadHotkeysInRuntime(customHotkeys);
+				// After successful save, reload hotkeys at runtime to apply changes immediately
+				const reloadSuccess = await reloadHotkeysInRuntime(customHotkeys);
 
-        // Only log runtime reload status in debug mode
-        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-          if (reloadSuccess) {
-            console.log("Hotkeys successfully applied at runtime - no page refresh needed");
-          } else {
-            console.warn("Runtime hotkey reload failed - page refresh may be required");
-          }
-        }
+				// Only log runtime reload status in debug mode
+				if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+					if (reloadSuccess) {
+						console.log(
+							"Hotkeys successfully applied at runtime - no page refresh needed",
+						);
+					} else {
+						console.warn(
+							"Runtime hotkey reload failed - page refresh may be required",
+						);
+					}
+				}
 
-        return {
-          ok: true,
-          error: undefined,
-          data: response,
-          runtimeReloadSuccess: reloadSuccess,
-        };
-      } catch (error: unknown) {
-        const isReset = currentHotkeys.length === 0;
-        const operation = isReset ? "resetting" : "saving";
-        console.error(`Error ${operation} hotkeys:`, error);
+				return {
+					ok: true,
+					error: undefined,
+					data: response,
+					runtimeReloadSuccess: reloadSuccess,
+				};
+			} catch (error: unknown) {
+				const isReset = currentHotkeys.length === 0;
+				const operation = isReset ? "resetting" : "saving";
+				console.error(`Error ${operation} hotkeys:`, error);
 
-        // Provide more specific error messages
-        let errorMessage = `Failed to ${isReset ? "reset" : "save"} hotkeys`;
-        if (error && typeof error === "object" && "response" in error) {
-          const err = error as any;
-          // Server responded with error status
-          if (err.response?.status === 400) {
-            errorMessage = err.response.data?.error || `Invalid ${isReset ? "reset request" : "hotkeys configuration"}`;
-          } else if (err.response?.status === 401) {
-            errorMessage = "Authentication required";
-          } else if (err.response?.status >= 500) {
-            errorMessage = "Server error - please try again later";
-          }
-        } else if (error && typeof error === "object" && "request" in error) {
-          // Network error
-          errorMessage = "Network error - please check your connection";
-        }
+				// Provide more specific error messages
+				let errorMessage = `Failed to ${isReset ? "reset" : "save"} hotkeys`;
+				if (error && typeof error === "object" && "response" in error) {
+					const err = error as any;
+					// Server responded with error status
+					if (err.response?.status === 400) {
+						errorMessage =
+							err.response.data?.error ||
+							`Invalid ${isReset ? "reset request" : "hotkeys configuration"}`;
+					} else if (err.response?.status === 401) {
+						errorMessage = "Authentication required";
+					} else if (err.response?.status >= 500) {
+						errorMessage = "Server error - please try again later";
+					}
+				} else if (error && typeof error === "object" && "request" in error) {
+					// Network error
+					errorMessage = "Network error - please check your connection";
+				}
 
-        return {
-          ok: false,
-          error: errorMessage,
-        };
-      }
-    },
-    [api],
-  );
+				return {
+					ok: false,
+					error: errorMessage,
+				};
+			}
+		},
+		[api],
+	);
 
-  // Handle resetting all hotkeys to defaults
-  const handleResetToDefaults = useCallback(() => {
-    confirm({
-      title: "Reset Hotkeys to Defaults?",
-      body: "Are you sure you want to reset all hotkeys and settings to their default values? This action cannot be undone.",
-      okText: "Reset to Defaults",
-      buttonLook: "negative",
-      style: { width: 500 },
-      onOk: async () => {
-        setIsLoading(true);
+	// Handle resetting all hotkeys to defaults
+	const handleResetToDefaults = useCallback(() => {
+		confirm({
+			title: "Reset Hotkeys to Defaults?",
+			body: "Are you sure you want to reset all hotkeys and settings to their default values? This action cannot be undone.",
+			okText: "Reset to Defaults",
+			buttonLook: "negative",
+			style: { width: 500 },
+			onOk: async () => {
+				setIsLoading(true);
 
-        try {
-          // Reset hotkeys to defaults in the backend API (sets custom_hotkeys to {})
-          const result = await saveHotkeysToAPI([], {});
+				try {
+					// Reset hotkeys to defaults in the backend API (sets custom_hotkeys to {})
+					const result = await saveHotkeysToAPI([], {});
 
-          if (result.ok) {
-            if (toast) {
-              toast.show({
-                message: "All hotkeys and settings have been reset to defaults and saved",
-                type: ToastType.info,
-              });
-            }
-            // Update local state to reflect the reset
-            setHotkeys([...typedDefaultHotkeys]);
-          } else {
-            if (toast) {
-              toast.show({
-                message: `Failed to save reset hotkeys: ${result.error || "Unknown error"}`,
-                type: ToastType.error,
-              });
-            }
-          }
-        } catch (error: unknown) {
-          if (toast) {
-            const errorMessage = error instanceof Error ? error.message : "Unknown error";
-            toast.show({
-              message: `Error resetting hotkeys: ${errorMessage}`,
-              type: ToastType.error,
-            });
-          }
-        } finally {
-          setIsLoading(false);
-        }
-      },
-    });
-  }, [saveHotkeysToAPI, toast]);
+					if (result.ok) {
+						if (toast) {
+							toast.show({
+								message:
+									"All hotkeys and settings have been reset to defaults and saved",
+								type: ToastType.info,
+							});
+						}
+						// Update local state to reflect the reset
+						setHotkeys([...typedDefaultHotkeys]);
+					} else {
+						if (toast) {
+							toast.show({
+								message: `Failed to save reset hotkeys: ${result.error || "Unknown error"}`,
+								type: ToastType.error,
+							});
+						}
+					}
+				} catch (error: unknown) {
+					if (toast) {
+						const errorMessage =
+							error instanceof Error ? error.message : "Unknown error";
+						toast.show({
+							message: `Error resetting hotkeys: ${errorMessage}`,
+							type: ToastType.error,
+						});
+					}
+				} finally {
+					setIsLoading(false);
+				}
+			},
+		});
+	}, [saveHotkeysToAPI, toast]);
 
-  // Handle exporting hotkeys
-  const handleExportHotkeys = useCallback(() => {
-    // Create export data including current settings
-    const exportData: ExportData = {
-      hotkeys: hotkeys,
-      settings: hotkeySettings,
-      exportedAt: new Date().toISOString(),
-      version: "1.0",
-    };
+	// Handle exporting hotkeys
+	const handleExportHotkeys = useCallback(() => {
+		// Create export data including current settings
+		const exportData: ExportData = {
+			hotkeys: hotkeys,
+			settings: hotkeySettings,
+			exportedAt: new Date().toISOString(),
+			version: "1.0",
+		};
 
-    // Create a JSON string of the export data
-    const exportJson = JSON.stringify(exportData, null, 2);
+		// Create a JSON string of the export data
+		const exportJson = JSON.stringify(exportData, null, 2);
 
-    // Create a blob with the JSON
-    const blob = new Blob([exportJson], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
+		// Create a blob with the JSON
+		const blob = new Blob([exportJson], { type: "application/json" });
+		const url = URL.createObjectURL(blob);
 
-    // Create a temporary link and click it to download the file
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = "hotkeys-export.json";
-    document.body.appendChild(link);
-    link.click();
+		// Create a temporary link and click it to download the file
+		const link = document.createElement("a");
+		link.href = url;
+		link.download = "hotkeys-export.json";
+		document.body.appendChild(link);
+		link.click();
 
-    // Clean up
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
+		// Clean up
+		document.body.removeChild(link);
+		URL.revokeObjectURL(url);
 
-    if (toast) {
-      toast.show({
-        message: "Hotkeys exported successfully",
-        type: ToastType.info,
-      });
-    }
-  }, [hotkeys, hotkeySettings, toast]);
+		if (toast) {
+			toast.show({
+				message: "Hotkeys exported successfully",
+				type: ToastType.info,
+			});
+		}
+	}, [hotkeys, hotkeySettings, toast]);
 
-  // Handle importing hotkeys
-  const handleImportHotkeys = useCallback(
-    async (importedData: ImportData | Hotkey[]) => {
-      try {
-        setIsLoading(true);
+	// Handle importing hotkeys
+	const handleImportHotkeys = useCallback(
+		async (importedData: ImportData | Hotkey[]) => {
+			try {
+				setIsLoading(true);
 
-        // Handle both old format (just hotkeys array) and new format (with settings)
-        const importedHotkeys = Array.isArray(importedData) ? importedData : importedData.hotkeys || [];
-        const importedSettings: HotkeySettings = Array.isArray(importedData) ? {} : importedData.settings || {};
+				// Handle both old format (just hotkeys array) and new format (with settings)
+				const importedHotkeys = Array.isArray(importedData)
+					? importedData
+					: importedData.hotkeys || [];
+				const importedSettings: HotkeySettings = Array.isArray(importedData)
+					? {}
+					: importedData.settings || {};
 
-        // Save all imported data to API
-        const result = await saveHotkeysToAPI(importedHotkeys, importedSettings);
+				// Save all imported data to API
+				const result = await saveHotkeysToAPI(
+					importedHotkeys,
+					importedSettings,
+				);
 
-        if (!result.ok) {
-          throw new Error(result.error || "Failed to save imported hotkeys");
-        }
+				if (!result.ok) {
+					throw new Error(result.error || "Failed to save imported hotkeys");
+				}
 
-        // Update local state
-        setHotkeys(importedHotkeys);
+				// Update local state
+				setHotkeys(importedHotkeys);
 
-        if (toast) {
-          toast.show({
-            message: "Hotkeys imported successfully",
-            type: ToastType.info,
-          });
-        }
+				if (toast) {
+					toast.show({
+						message: "Hotkeys imported successfully",
+						type: ToastType.info,
+					});
+				}
 
-        // Reload from API to ensure consistency
-        await loadHotkeysFromAPI();
-      } catch (error: unknown) {
-        if (toast) {
-          const errorMessage = error instanceof Error ? error.message : "Unknown error";
-          toast.show({
-            message: `Error importing hotkeys: ${errorMessage}`,
-            type: ToastType.error,
-          });
-        }
-      } finally {
-        setIsLoading(false);
-      }
-    },
-    [saveHotkeysToAPI, loadHotkeysFromAPI, toast],
-  );
+				// Reload from API to ensure consistency
+				await loadHotkeysFromAPI();
+			} catch (error: unknown) {
+				if (toast) {
+					const errorMessage =
+						error instanceof Error ? error.message : "Unknown error";
+					toast.show({
+						message: `Error importing hotkeys: ${errorMessage}`,
+						type: ToastType.error,
+					});
+				}
+			} finally {
+				setIsLoading(false);
+			}
+		},
+		[saveHotkeysToAPI, loadHotkeysFromAPI, toast],
+	);
 
-  // Load hotkeys on hook mount
-  useEffect(() => {
-    loadHotkeysFromAPI();
-  }, [loadHotkeysFromAPI]);
+	// Load hotkeys on hook mount
+	useEffect(() => {
+		loadHotkeysFromAPI();
+	}, [loadHotkeysFromAPI]);
 
-  return {
-    hotkeys,
-    setHotkeys,
-    hotkeySettings,
-    setHotkeySettings,
-    isLoading,
-    setIsLoading,
-    loadHotkeysFromAPI,
-    saveHotkeysToAPI,
-    reloadHotkeysInRuntime,
-    handleResetToDefaults,
-    handleExportHotkeys,
-    handleImportHotkeys,
-  };
+	return {
+		hotkeys,
+		setHotkeys,
+		hotkeySettings,
+		setHotkeySettings,
+		isLoading,
+		setIsLoading,
+		loadHotkeysFromAPI,
+		saveHotkeysToAPI,
+		handleResetToDefaults,
+		handleExportHotkeys,
+		handleImportHotkeys,
+	};
 };

--- a/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
+++ b/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
@@ -4,450 +4,520 @@ import { confirm } from "apps/labelstudio/src/components/Modal/Modal";
 import { useAPI } from "apps/labelstudio/src/providers/ApiProvider";
 import { useCallback, useEffect, useState } from "react";
 import {
-  type ApiResponse,
-  type ExportData,
-  getTypedDefaultHotkeys,
-  type Hotkey,
-  type HotkeySettings,
-  type ImportData,
-  type SaveResult,
+	type ApiResponse,
+	type ExportData,
+	getTypedDefaultHotkeys,
+	type Hotkey,
+	type HotkeySettings,
+	type ImportData,
+	type SaveResult,
 } from "../sections/Hotkeys/utils";
 
 // Type the imported defaults and convert numeric ids to strings
 const typedDefaultHotkeys: Hotkey[] = getTypedDefaultHotkeys();
 
 export const useHotkeys = () => {
-  const toast = useToast();
-  const [hotkeys, setHotkeys] = useState<Hotkey[]>([]);
-  const [hotkeySettings, setHotkeySettings] = useState<HotkeySettings>({});
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const api = useAPI();
+	const toast = useToast();
+	const [hotkeys, setHotkeys] = useState<Hotkey[]>([]);
+	const [hotkeySettings, setHotkeySettings] = useState<HotkeySettings>({});
+	const [isLoading, setIsLoading] = useState<boolean>(false);
+	const api = useAPI();
 
-  // Update hotkeys with custom settings
-  const updateHotkeysWithCustomSettings = useCallback(
-    (
-      defaultHotkeys: Hotkey[],
-      customHotkeys: Record<string, { key: string; active: boolean; description?: string }>,
-    ): Hotkey[] => {
-      return defaultHotkeys.map((hotkey: Hotkey) => {
-        // Create the lookup key format used in the API response (section:element)
-        const lookupKey = `${hotkey.section}:${hotkey.element}`;
+	// Update hotkeys with custom settings
+	const updateHotkeysWithCustomSettings = useCallback(
+		(
+			defaultHotkeys: Hotkey[],
+			customHotkeys: Record<
+				string,
+				{ key: string; active: boolean; description?: string }
+			>,
+		): Hotkey[] => {
+			return defaultHotkeys.map((hotkey: Hotkey) => {
+				// Create the lookup key format used in the API response (section:element)
+				const lookupKey = `${hotkey.section}:${hotkey.element}`;
 
-        // Check if there's a custom setting for this hotkey
-        if (customHotkeys[lookupKey]) {
-          const customSetting = customHotkeys[lookupKey];
-          // Create a new object with the default properties and override with custom ones
-          return {
-            ...hotkey,
-            key: customSetting.key,
-            active: customSetting.active,
-            // Preserve the original label, only update description if provided
-            ...(customSetting.description && {
-              description: customSetting.description,
-            }),
-          };
-        }
+				// Check if there's a custom setting for this hotkey
+				if (customHotkeys[lookupKey]) {
+					const customSetting = customHotkeys[lookupKey];
+					// Create a new object with the default properties and override with custom ones
+					return {
+						...hotkey,
+						key: customSetting.key,
+						active: customSetting.active,
+						// Preserve the original label, only update description if provided
+						...(customSetting.description && {
+							description: customSetting.description,
+						}),
+					};
+				}
 
-        // If no custom setting exists, return the default hotkey unchanged
-        return hotkey;
-      });
-    },
-    [],
-  );
+				// If no custom setting exists, return the default hotkey unchanged
+				return hotkey;
+			});
+		},
+		[],
+	);
 
-  // Runtime hotkey reload function - applies hotkeys without page refresh
-  const reloadHotkeysInRuntime = useCallback(
-    async (customHotkeys: Record<string, { key: string; active: boolean; description?: string }>) => {
-      try {
-        // Step 1: Process custom hotkeys the same way the server does in base.html
-        const editorCustomHotkeys: Record<string, any> = {};
-        const prefixRegex = /^(annotation|timeseries|audio|regions|video|image_gallery|tools):(.*)/;
+	// Runtime hotkey reload function - applies hotkeys without page refresh
+	const reloadHotkeysInRuntime = useCallback(
+		async (
+			customHotkeys: Record<
+				string,
+				{ key: string; active: boolean; description?: string }
+			>,
+		) => {
+			try {
+				// Step 1: Process custom hotkeys the same way the server does in base.html
+				const editorCustomHotkeys: Record<string, any> = {};
+				const prefixRegex =
+					/^(annotation|timeseries|audio|regions|video|image_gallery|tools):(.*)/;
 
-        for (const key in customHotkeys) {
-          const match = key.match(prefixRegex);
-          if (match) {
-            const [, prefix, shortKey] = match;
-            const value = customHotkeys[key];
+				for (const key in customHotkeys) {
+					const match = key.match(prefixRegex);
+					if (match) {
+						const [, prefix, shortKey] = match;
+						const value = customHotkeys[key];
 
-            // Check if value has active property set to false
-            if (value && value.active === false) {
-              // Create a copy of the value with key set to null
-              const modifiedValue = { ...value, key: null };
-              editorCustomHotkeys[shortKey] = modifiedValue;
-            } else {
-              // Use the original value
-              editorCustomHotkeys[shortKey] = value;
-            }
-          }
-        }
+						// The shortKey might have double prefixes like "annotation:submit"
+						// We need to construct the correct editor keymap key format
+						const editorKey = shortKey.includes(":")
+							? shortKey
+							: `${prefix}:${shortKey}`;
 
-        // Step 2: Get default editor keymap and merge with custom hotkeys
-        const defaultEditorKeymap = window.DEFAULT_HOTKEYS || {};
-        const mergedEditorKeymap = Object.assign({}, defaultEditorKeymap, editorCustomHotkeys);
+						// Check if value has active property set to false
+						if (value && value.active === false) {
+							// Create a copy of the value with key set to null
+							const modifiedValue = { ...value, key: null };
+							editorCustomHotkeys[editorKey] = modifiedValue;
+						} else {
+							// Use the original value
+							editorCustomHotkeys[editorKey] = value;
+						}
+					}
+				}
 
-        // Step 3: Update window.APP_SETTINGS with new hotkeys
-        if (window.APP_SETTINGS) {
-          window.APP_SETTINGS.editor_keymap = mergedEditorKeymap;
-          window.APP_SETTINGS.user = window.APP_SETTINGS.user || {};
-          window.APP_SETTINGS.user.customHotkeys = customHotkeys;
-        }
+				// Step 2: Get default editor keymap and merge with custom hotkeys
+				// Use the original defaults, which are now properly exposed globally
+				const defaultEditorKeymap = window.DEFAULT_HOTKEYS || {};
 
-        // Step 4: Re-apply keymap to editor instances if available
-        // Check if Hotkey class is available globally (it should be)
-        if (typeof window !== "undefined") {
-          // Try to access the Hotkey class through various possible global references
-          const HotkeyClass =
-            (window as any).Hotkey || (window as any).LSF?.Hotkey || (window as any).LabelStudio?.Hotkey;
+				const mergedEditorKeymap = Object.assign(
+					{},
+					defaultEditorKeymap,
+					editorCustomHotkeys,
+				);
 
-          if (HotkeyClass && typeof HotkeyClass.setKeymap === "function") {
-            HotkeyClass.setKeymap(mergedEditorKeymap);
-          }
-        }
+				// Step 3: Update window.APP_SETTINGS with new hotkeys
+				if (window.APP_SETTINGS) {
+					window.APP_SETTINGS.editor_keymap = mergedEditorKeymap;
+					window.APP_SETTINGS.user = window.APP_SETTINGS.user || {};
+					window.APP_SETTINGS.user.customHotkeys = customHotkeys;
+				}
 
-        // Step 5: Trigger re-initialization of hotkeys in editor instances
-        // This is the most complex part as we need to access LabelStudio instances
-        if (typeof window !== "undefined") {
-          // Try to access LabelStudio instances through various possible global references
-          const instances = (window as any).LabelStudio?.instances || (window as any).LSF?.instances || [];
+				// Step 4: Re-apply keymap to editor instances if available
+				// Check if Hotkey class is available globally (it should be)
+				if (typeof window !== "undefined") {
+					// Try to access the Hotkey class through various possible global references
+					const HotkeyClass =
+						(window as any).Hotkey ||
+						(window as any).LSF?.Hotkey ||
+						(window as any).LabelStudio?.Hotkey;
 
-          // Iterate through instances and trigger hotkey re-initialization
-          if (Array.isArray(instances)) {
-            instances.forEach((instance: any) => {
-              try {
-                // Check if the instance has the store and annotation with setupHotKeys method
-                if (
-                  instance?.store?.annotation?.setupHotKeys &&
-                  typeof instance.store.annotation.setupHotKeys === "function"
-                ) {
-                  instance.store.annotation.setupHotKeys();
-                } else if (
-                  instance?.annotation?.setupHotKeys &&
-                  typeof instance.annotation.setupHotKeys === "function"
-                ) {
-                  instance.annotation.setupHotKeys();
-                }
-              } catch (error) {
-                // Only log editor instance refresh failures in debug mode
-                if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-                  console.warn("Failed to refresh hotkeys for editor instance:", error);
-                }
-              }
-            });
-          } else if (instances && typeof instances.forEach === "function") {
-            // Handle Set or other iterable
-            instances.forEach((instance: any) => {
-              try {
-                if (
-                  instance?.store?.annotation?.setupHotKeys &&
-                  typeof instance.store.annotation.setupHotKeys === "function"
-                ) {
-                  instance.store.annotation.setupHotKeys();
-                } else if (
-                  instance?.annotation?.setupHotKeys &&
-                  typeof instance.annotation.setupHotKeys === "function"
-                ) {
-                  instance.annotation.setupHotKeys();
-                }
-              } catch (error) {
-                // Only log editor instance refresh failures in debug mode
-                if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-                  console.warn("Failed to refresh hotkeys for editor instance:", error);
-                }
-              }
-            });
-          }
-        }
+					if (HotkeyClass && typeof HotkeyClass.setKeymap === "function") {
+						HotkeyClass.setKeymap(mergedEditorKeymap);
+					}
+				}
 
-        // Only log in debug mode
-        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-          console.log("Hotkeys successfully reloaded at runtime");
-        }
-        return true;
-      } catch (error) {
-        // Only log in debug mode
-        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-          console.error("Failed to reload hotkeys at runtime:", error);
-        }
-        return false;
-      }
-    },
-    [],
-  );
+				// Step 5: Trigger re-initialization of hotkeys in editor instances
+				// This is the most complex part as we need to access LabelStudio instances
+				if (typeof window !== "undefined") {
+					// Try to access LabelStudio instances through various possible global references
+					const instances =
+						(window as any).LabelStudio?.instances ||
+						(window as any).LSF?.instances ||
+						[];
 
-  // Load hotkeys from API
-  const loadHotkeysFromAPI = useCallback(async () => {
-    try {
-      setIsLoading(true);
+					// Iterate through instances and trigger hotkey re-initialization
+					if (Array.isArray(instances)) {
+						instances.forEach((instance: any) => {
+							try {
+								// Check if the instance has the store and annotation with setupHotKeys method
+								if (
+									instance?.store?.annotation?.setupHotKeys &&
+									typeof instance.store.annotation.setupHotKeys === "function"
+								) {
+									instance.store.annotation.setupHotKeys();
+								} else if (
+									instance?.annotation?.setupHotKeys &&
+									typeof instance.annotation.setupHotKeys === "function"
+								) {
+									instance.annotation.setupHotKeys();
+								}
+							} catch (error) {
+								// Only log editor instance refresh failures in debug mode
+								if (
+									typeof window !== "undefined" &&
+									window.APP_SETTINGS?.debug
+								) {
+									console.warn(
+										"Failed to refresh hotkeys for editor instance:",
+										error,
+									);
+								}
+							}
+						});
+					} else if (instances && typeof instances.forEach === "function") {
+						// Handle Set or other iterable
+						instances.forEach((instance: any) => {
+							try {
+								if (
+									instance?.store?.annotation?.setupHotKeys &&
+									typeof instance.store.annotation.setupHotKeys === "function"
+								) {
+									instance.store.annotation.setupHotKeys();
+								} else if (
+									instance?.annotation?.setupHotKeys &&
+									typeof instance.annotation.setupHotKeys === "function"
+								) {
+									instance.annotation.setupHotKeys();
+								}
+							} catch (error) {
+								// Only log editor instance refresh failures in debug mode
+								if (
+									typeof window !== "undefined" &&
+									window.APP_SETTINGS?.debug
+								) {
+									console.warn(
+										"Failed to refresh hotkeys for editor instance:",
+										error,
+									);
+								}
+							}
+						});
+					}
+				}
 
-      // Use proper API endpoint name from the config
-      const response = await api.callApi("hotkeys" as any);
+				// Only log in debug mode
+				if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+					console.log("Hotkeys successfully reloaded at runtime");
+				}
+				return true;
+			} catch (error) {
+				// Only log in debug mode
+				if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+					console.error("Failed to reload hotkeys at runtime:", error);
+				}
+				return false;
+			}
+		},
+		[],
+	);
 
-      if (response && (response as ApiResponse).custom_hotkeys) {
-        // Use API data
-        const apiResponse = response as ApiResponse;
-        const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, apiResponse.custom_hotkeys!);
-        setHotkeys(updatedHotkeys);
-        // Store current settings from API response
-        setHotkeySettings(apiResponse.hotkey_settings || {});
-      } else {
-        // Fallback to window.APP_SETTINGS
-        const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
-        const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, customHotkeys);
-        setHotkeys(updatedHotkeys);
-        // No settings available in fallback
-        setHotkeySettings({});
-      }
-    } catch (error) {
-      console.error("Error loading hotkeys from API:", error);
+	// Load hotkeys from API
+	const loadHotkeysFromAPI = useCallback(async () => {
+		try {
+			setIsLoading(true);
 
-      // Fallback to window.APP_SETTINGS on error
-      const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
-      const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, customHotkeys);
-      setHotkeys(updatedHotkeys);
-      // No settings available in fallback
-      setHotkeySettings({});
+			// Use proper API endpoint name from the config
+			const response = await api.callApi("hotkeys" as any);
 
-      // Show non-blocking error notification
-      if (toast) {
-        toast.show({
-          message: "Could not load custom hotkeys from server, using cached settings",
-          type: ToastType.error,
-        });
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  }, [api, toast, updateHotkeysWithCustomSettings]);
+			if (response && (response as ApiResponse).custom_hotkeys) {
+				// Use API data
+				const apiResponse = response as ApiResponse;
+				const updatedHotkeys = updateHotkeysWithCustomSettings(
+					typedDefaultHotkeys,
+					apiResponse.custom_hotkeys!,
+				);
+				setHotkeys(updatedHotkeys);
+				// Store current settings from API response
+				setHotkeySettings(apiResponse.hotkey_settings || {});
+			} else {
+				// Fallback to window.APP_SETTINGS
+				const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
+				const updatedHotkeys = updateHotkeysWithCustomSettings(
+					typedDefaultHotkeys,
+					customHotkeys,
+				);
+				setHotkeys(updatedHotkeys);
+				// No settings available in fallback
+				setHotkeySettings({});
+			}
+		} catch (error) {
+			console.error("Error loading hotkeys from API:", error);
 
-  // Save hotkeys to API function (handles both save and reset operations)
-  const saveHotkeysToAPI = useCallback(
-    async (currentHotkeys: Hotkey[], currentSettings: HotkeySettings): Promise<SaveResult> => {
-      // Convert current hotkeys to API format - INCLUDE description to maintain API compatibility
-      const customHotkeys: Record<string, { key: string; active: boolean; description?: string }> = {};
+			// Fallback to window.APP_SETTINGS on error
+			const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
+			const updatedHotkeys = updateHotkeysWithCustomSettings(
+				typedDefaultHotkeys,
+				customHotkeys,
+			);
+			setHotkeys(updatedHotkeys);
+			// No settings available in fallback
+			setHotkeySettings({});
 
-      // Process all current hotkeys (if empty, this results in reset)
-      currentHotkeys.forEach((hotkey: Hotkey) => {
-        const keyId = `${hotkey.section}:${hotkey.element}`;
-        customHotkeys[keyId] = {
-          key: hotkey.key,
-          active: hotkey.active,
-          ...(hotkey.description && { description: hotkey.description }),
-        };
-      });
+			// Show non-blocking error notification
+			if (toast) {
+				toast.show({
+					message:
+						"Could not load custom hotkeys from server, using cached settings",
+					type: ToastType.error,
+				});
+			}
+		} finally {
+			setIsLoading(false);
+		}
+	}, [api, toast, updateHotkeysWithCustomSettings]);
 
-      const requestBody = {
-        custom_hotkeys: customHotkeys,
-        hotkey_settings: currentSettings,
-      };
+	// Save hotkeys to API function (handles both save and reset operations)
+	const saveHotkeysToAPI = useCallback(
+		async (
+			currentHotkeys: Hotkey[],
+			currentSettings: HotkeySettings,
+		): Promise<SaveResult> => {
+			// Convert current hotkeys to API format - INCLUDE description to maintain API compatibility
+			const customHotkeys: Record<
+				string,
+				{ key: string; active: boolean; description?: string }
+			> = {};
 
-      try {
-        // Use proper API endpoint name from the config
-        const response = await api.callApi("updateHotkeys" as any, {
-          body: requestBody,
-        });
+			// Process all current hotkeys (if empty, this results in reset)
+			currentHotkeys.forEach((hotkey: Hotkey) => {
+				const keyId = `${hotkey.section}:${hotkey.element}`;
+				customHotkeys[keyId] = {
+					key: hotkey.key,
+					active: hotkey.active,
+					...(hotkey.description && { description: hotkey.description }),
+				};
+			});
 
-        // Check for API-level errors
-        if (response?.error) {
-          return {
-            ok: false,
-            error: response.error,
-            data: response,
-          };
-        }
+			const requestBody = {
+				custom_hotkeys: customHotkeys,
+				hotkey_settings: currentSettings,
+			};
 
-        // After successful save, reload hotkeys at runtime to apply changes immediately
-        const reloadSuccess = await reloadHotkeysInRuntime(customHotkeys);
+			try {
+				// Use proper API endpoint name from the config
+				const response = await api.callApi("updateHotkeys" as any, {
+					body: requestBody,
+				});
 
-        // Only log runtime reload status in debug mode
-        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-          if (reloadSuccess) {
-            console.log("Hotkeys successfully applied at runtime - no page refresh needed");
-          } else {
-            console.warn("Runtime hotkey reload failed - page refresh may be required");
-          }
-        }
+				// Check for API-level errors
+				if (response?.error) {
+					return {
+						ok: false,
+						error: response.error,
+						data: response,
+					};
+				}
 
-        return {
-          ok: true,
-          error: undefined,
-          data: response,
-          runtimeReloadSuccess: reloadSuccess,
-        };
-      } catch (error: unknown) {
-        const isReset = currentHotkeys.length === 0;
-        const operation = isReset ? "resetting" : "saving";
-        console.error(`Error ${operation} hotkeys:`, error);
+				// After successful save, reload hotkeys at runtime to apply changes immediately
+				const reloadSuccess = await reloadHotkeysInRuntime(customHotkeys);
 
-        // Provide more specific error messages
-        let errorMessage = `Failed to ${isReset ? "reset" : "save"} hotkeys`;
-        if (error && typeof error === "object" && "response" in error) {
-          const err = error as any;
-          // Server responded with error status
-          if (err.response?.status === 400) {
-            errorMessage = err.response.data?.error || `Invalid ${isReset ? "reset request" : "hotkeys configuration"}`;
-          } else if (err.response?.status === 401) {
-            errorMessage = "Authentication required";
-          } else if (err.response?.status >= 500) {
-            errorMessage = "Server error - please try again later";
-          }
-        } else if (error && typeof error === "object" && "request" in error) {
-          // Network error
-          errorMessage = "Network error - please check your connection";
-        }
+				// Only log runtime reload status in debug mode
+				if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+					if (reloadSuccess) {
+						console.log(
+							"Hotkeys successfully applied at runtime - no page refresh needed",
+						);
+					} else {
+						console.warn(
+							"Runtime hotkey reload failed - page refresh may be required",
+						);
+					}
+				}
 
-        return {
-          ok: false,
-          error: errorMessage,
-        };
-      }
-    },
-    [api],
-  );
+				return {
+					ok: true,
+					error: undefined,
+					data: response,
+					runtimeReloadSuccess: reloadSuccess,
+				};
+			} catch (error: unknown) {
+				const isReset = currentHotkeys.length === 0;
+				const operation = isReset ? "resetting" : "saving";
+				console.error(`Error ${operation} hotkeys:`, error);
 
-  // Handle resetting all hotkeys to defaults
-  const handleResetToDefaults = useCallback(() => {
-    confirm({
-      title: "Reset Hotkeys to Defaults?",
-      body: "Are you sure you want to reset all hotkeys and settings to their default values? This action cannot be undone.",
-      okText: "Reset to Defaults",
-      buttonLook: "negative",
-      style: { width: 500 },
-      onOk: async () => {
-        setIsLoading(true);
+				// Provide more specific error messages
+				let errorMessage = `Failed to ${isReset ? "reset" : "save"} hotkeys`;
+				if (error && typeof error === "object" && "response" in error) {
+					const err = error as any;
+					// Server responded with error status
+					if (err.response?.status === 400) {
+						errorMessage =
+							err.response.data?.error ||
+							`Invalid ${isReset ? "reset request" : "hotkeys configuration"}`;
+					} else if (err.response?.status === 401) {
+						errorMessage = "Authentication required";
+					} else if (err.response?.status >= 500) {
+						errorMessage = "Server error - please try again later";
+					}
+				} else if (error && typeof error === "object" && "request" in error) {
+					// Network error
+					errorMessage = "Network error - please check your connection";
+				}
 
-        try {
-          // Reset hotkeys to defaults in the backend API (sets custom_hotkeys to {})
-          const result = await saveHotkeysToAPI([], {});
+				return {
+					ok: false,
+					error: errorMessage,
+				};
+			}
+		},
+		[api],
+	);
 
-          if (result.ok) {
-            if (toast) {
-              toast.show({
-                message: "All hotkeys and settings have been reset to defaults and saved",
-                type: ToastType.info,
-              });
-            }
-            // Update local state to reflect the reset
-            setHotkeys([...typedDefaultHotkeys]);
-          } else {
-            if (toast) {
-              toast.show({
-                message: `Failed to save reset hotkeys: ${result.error || "Unknown error"}`,
-                type: ToastType.error,
-              });
-            }
-          }
-        } catch (error: unknown) {
-          if (toast) {
-            const errorMessage = error instanceof Error ? error.message : "Unknown error";
-            toast.show({
-              message: `Error resetting hotkeys: ${errorMessage}`,
-              type: ToastType.error,
-            });
-          }
-        } finally {
-          setIsLoading(false);
-        }
-      },
-    });
-  }, [saveHotkeysToAPI, toast]);
+	// Handle resetting all hotkeys to defaults
+	const handleResetToDefaults = useCallback(() => {
+		confirm({
+			title: "Reset Hotkeys to Defaults?",
+			body: "Are you sure you want to reset all hotkeys and settings to their default values? This action cannot be undone.",
+			okText: "Reset to Defaults",
+			buttonLook: "negative",
+			style: { width: 500 },
+			onOk: async () => {
+				setIsLoading(true);
 
-  // Handle exporting hotkeys
-  const handleExportHotkeys = useCallback(() => {
-    // Create export data including current settings
-    const exportData: ExportData = {
-      hotkeys: hotkeys,
-      settings: hotkeySettings,
-      exportedAt: new Date().toISOString(),
-      version: "1.0",
-    };
+				try {
+					// Reset hotkeys to defaults in the backend API (sets custom_hotkeys to {})
+					const result = await saveHotkeysToAPI([], {});
 
-    // Create a JSON string of the export data
-    const exportJson = JSON.stringify(exportData, null, 2);
+					if (result.ok) {
+						if (toast) {
+							toast.show({
+								message:
+									"All hotkeys and settings have been reset to defaults and saved",
+								type: ToastType.info,
+							});
+						}
+						// Update local state to reflect the reset
+						setHotkeys([...typedDefaultHotkeys]);
+					} else {
+						if (toast) {
+							toast.show({
+								message: `Failed to save reset hotkeys: ${result.error || "Unknown error"}`,
+								type: ToastType.error,
+							});
+						}
+					}
+				} catch (error: unknown) {
+					if (toast) {
+						const errorMessage =
+							error instanceof Error ? error.message : "Unknown error";
+						toast.show({
+							message: `Error resetting hotkeys: ${errorMessage}`,
+							type: ToastType.error,
+						});
+					}
+				} finally {
+					setIsLoading(false);
+				}
+			},
+		});
+	}, [saveHotkeysToAPI, toast]);
 
-    // Create a blob with the JSON
-    const blob = new Blob([exportJson], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
+	// Handle exporting hotkeys
+	const handleExportHotkeys = useCallback(() => {
+		// Create export data including current settings
+		const exportData: ExportData = {
+			hotkeys: hotkeys,
+			settings: hotkeySettings,
+			exportedAt: new Date().toISOString(),
+			version: "1.0",
+		};
 
-    // Create a temporary link and click it to download the file
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = "hotkeys-export.json";
-    document.body.appendChild(link);
-    link.click();
+		// Create a JSON string of the export data
+		const exportJson = JSON.stringify(exportData, null, 2);
 
-    // Clean up
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
+		// Create a blob with the JSON
+		const blob = new Blob([exportJson], { type: "application/json" });
+		const url = URL.createObjectURL(blob);
 
-    if (toast) {
-      toast.show({
-        message: "Hotkeys exported successfully",
-        type: ToastType.info,
-      });
-    }
-  }, [hotkeys, hotkeySettings, toast]);
+		// Create a temporary link and click it to download the file
+		const link = document.createElement("a");
+		link.href = url;
+		link.download = "hotkeys-export.json";
+		document.body.appendChild(link);
+		link.click();
 
-  // Handle importing hotkeys
-  const handleImportHotkeys = useCallback(
-    async (importedData: ImportData | Hotkey[]) => {
-      try {
-        setIsLoading(true);
+		// Clean up
+		document.body.removeChild(link);
+		URL.revokeObjectURL(url);
 
-        // Handle both old format (just hotkeys array) and new format (with settings)
-        const importedHotkeys = Array.isArray(importedData) ? importedData : importedData.hotkeys || [];
-        const importedSettings: HotkeySettings = Array.isArray(importedData) ? {} : importedData.settings || {};
+		if (toast) {
+			toast.show({
+				message: "Hotkeys exported successfully",
+				type: ToastType.info,
+			});
+		}
+	}, [hotkeys, hotkeySettings, toast]);
 
-        // Save all imported data to API
-        const result = await saveHotkeysToAPI(importedHotkeys, importedSettings);
+	// Handle importing hotkeys
+	const handleImportHotkeys = useCallback(
+		async (importedData: ImportData | Hotkey[]) => {
+			try {
+				setIsLoading(true);
 
-        if (!result.ok) {
-          throw new Error(result.error || "Failed to save imported hotkeys");
-        }
+				// Handle both old format (just hotkeys array) and new format (with settings)
+				const importedHotkeys = Array.isArray(importedData)
+					? importedData
+					: importedData.hotkeys || [];
+				const importedSettings: HotkeySettings = Array.isArray(importedData)
+					? {}
+					: importedData.settings || {};
 
-        // Update local state
-        setHotkeys(importedHotkeys);
+				// Save all imported data to API
+				const result = await saveHotkeysToAPI(
+					importedHotkeys,
+					importedSettings,
+				);
 
-        if (toast) {
-          toast.show({
-            message: "Hotkeys imported successfully",
-            type: ToastType.info,
-          });
-        }
+				if (!result.ok) {
+					throw new Error(result.error || "Failed to save imported hotkeys");
+				}
 
-        // Reload from API to ensure consistency
-        await loadHotkeysFromAPI();
-      } catch (error: unknown) {
-        if (toast) {
-          const errorMessage = error instanceof Error ? error.message : "Unknown error";
-          toast.show({
-            message: `Error importing hotkeys: ${errorMessage}`,
-            type: ToastType.error,
-          });
-        }
-      } finally {
-        setIsLoading(false);
-      }
-    },
-    [saveHotkeysToAPI, loadHotkeysFromAPI, toast],
-  );
+				// Update local state
+				setHotkeys(importedHotkeys);
 
-  // Load hotkeys on hook mount
-  useEffect(() => {
-    loadHotkeysFromAPI();
-  }, [loadHotkeysFromAPI]);
+				if (toast) {
+					toast.show({
+						message: "Hotkeys imported successfully",
+						type: ToastType.info,
+					});
+				}
 
-  return {
-    hotkeys,
-    setHotkeys,
-    hotkeySettings,
-    setHotkeySettings,
-    isLoading,
-    setIsLoading,
-    loadHotkeysFromAPI,
-    saveHotkeysToAPI,
-    reloadHotkeysInRuntime,
-    handleResetToDefaults,
-    handleExportHotkeys,
-    handleImportHotkeys,
-  };
+				// Reload from API to ensure consistency
+				await loadHotkeysFromAPI();
+			} catch (error: unknown) {
+				if (toast) {
+					const errorMessage =
+						error instanceof Error ? error.message : "Unknown error";
+					toast.show({
+						message: `Error importing hotkeys: ${errorMessage}`,
+						type: ToastType.error,
+					});
+				}
+			} finally {
+				setIsLoading(false);
+			}
+		},
+		[saveHotkeysToAPI, loadHotkeysFromAPI, toast],
+	);
+
+	// Load hotkeys on hook mount
+	useEffect(() => {
+		loadHotkeysFromAPI();
+	}, [loadHotkeysFromAPI]);
+
+	return {
+		hotkeys,
+		setHotkeys,
+		hotkeySettings,
+		setHotkeySettings,
+		isLoading,
+		setIsLoading,
+		loadHotkeysFromAPI,
+		saveHotkeysToAPI,
+		reloadHotkeysInRuntime,
+		handleResetToDefaults,
+		handleExportHotkeys,
+		handleImportHotkeys,
+	};
 };

--- a/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
+++ b/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
@@ -127,7 +127,10 @@ export const useHotkeys = () => {
                   instance.annotation.setupHotKeys();
                 }
               } catch (error) {
-                console.warn("Failed to refresh hotkeys for editor instance:", error);
+                // Only log editor instance refresh failures in debug mode
+                if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+                  console.warn("Failed to refresh hotkeys for editor instance:", error);
+                }
               }
             });
           } else if (instances && typeof instances.forEach === "function") {
@@ -146,16 +149,25 @@ export const useHotkeys = () => {
                   instance.annotation.setupHotKeys();
                 }
               } catch (error) {
-                console.warn("Failed to refresh hotkeys for editor instance:", error);
+                // Only log editor instance refresh failures in debug mode
+                if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+                  console.warn("Failed to refresh hotkeys for editor instance:", error);
+                }
               }
             });
           }
         }
 
-        console.log("Hotkeys successfully reloaded at runtime");
+        // Only log in debug mode
+        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+          console.log("Hotkeys successfully reloaded at runtime");
+        }
         return true;
       } catch (error) {
-        console.error("Failed to reload hotkeys at runtime:", error);
+        // Only log in debug mode
+        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+          console.error("Failed to reload hotkeys at runtime:", error);
+        }
         return false;
       }
     },
@@ -246,10 +258,13 @@ export const useHotkeys = () => {
         // After successful save, reload hotkeys at runtime to apply changes immediately
         const reloadSuccess = await reloadHotkeysInRuntime(customHotkeys);
 
-        if (reloadSuccess) {
-          console.log("Hotkeys successfully applied at runtime - no page refresh needed");
-        } else {
-          console.warn("Runtime hotkey reload failed - page refresh may be required");
+        // Only log runtime reload status in debug mode
+        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+          if (reloadSuccess) {
+            console.log("Hotkeys successfully applied at runtime - no page refresh needed");
+          } else {
+            console.warn("Runtime hotkey reload failed - page refresh may be required");
+          }
         }
 
         return {

--- a/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
+++ b/web/libs/app-common/src/pages/AccountSettings/hooks/useHotkeys.ts
@@ -4,535 +4,466 @@ import { confirm } from "apps/labelstudio/src/components/Modal/Modal";
 import { useAPI } from "apps/labelstudio/src/providers/ApiProvider";
 import { useCallback, useEffect, useState } from "react";
 import {
-	type ApiResponse,
-	type ExportData,
-	getTypedDefaultHotkeys,
-	type Hotkey,
-	type HotkeySettings,
-	type ImportData,
-	type SaveResult,
+  type ApiResponse,
+  type ExportData,
+  getTypedDefaultHotkeys,
+  type Hotkey,
+  type HotkeySettings,
+  type ImportData,
+  type SaveResult,
 } from "../sections/Hotkeys/utils";
 
 // Type definitions for better type safety
 type EditorInstance = {
-	store?: {
-		annotation?: {
-			setupHotKeys?: () => void;
-		};
-	};
-	annotation?: {
-		setupHotKeys?: () => void;
-	};
+  store?: {
+    annotation?: {
+      setupHotKeys?: () => void;
+    };
+  };
+  annotation?: {
+    setupHotKeys?: () => void;
+  };
 };
 
 // Type the imported defaults and convert numeric ids to strings
 const typedDefaultHotkeys: Hotkey[] = getTypedDefaultHotkeys();
 
 export const useHotkeys = () => {
-	const toast = useToast();
-	const [hotkeys, setHotkeys] = useState<Hotkey[]>([]);
-	const [hotkeySettings, setHotkeySettings] = useState<HotkeySettings>({});
-	const [isLoading, setIsLoading] = useState<boolean>(false);
-	const api = useAPI();
+  const toast = useToast();
+  const [hotkeys, setHotkeys] = useState<Hotkey[]>([]);
+  const [hotkeySettings, setHotkeySettings] = useState<HotkeySettings>({});
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const api = useAPI();
 
-	// Update hotkeys with custom settings
-	const updateHotkeysWithCustomSettings = useCallback(
-		(
-			defaultHotkeys: Hotkey[],
-			customHotkeys: Record<
-				string,
-				{ key: string; active: boolean; description?: string }
-			>,
-		): Hotkey[] => {
-			return defaultHotkeys.map((hotkey: Hotkey) => {
-				// Create the lookup key format used in the API response (section:element)
-				const lookupKey = `${hotkey.section}:${hotkey.element}`;
+  // Update hotkeys with custom settings
+  const updateHotkeysWithCustomSettings = useCallback(
+    (
+      defaultHotkeys: Hotkey[],
+      customHotkeys: Record<string, { key: string; active: boolean; description?: string }>,
+    ): Hotkey[] => {
+      return defaultHotkeys.map((hotkey: Hotkey) => {
+        // Create the lookup key format used in the API response (section:element)
+        const lookupKey = `${hotkey.section}:${hotkey.element}`;
 
-				// Check if there's a custom setting for this hotkey
-				if (customHotkeys[lookupKey]) {
-					const customSetting = customHotkeys[lookupKey];
-					// Create a new object with the default properties and override with custom ones
-					return {
-						...hotkey,
-						key: customSetting.key,
-						active: customSetting.active,
-						// Preserve the original label, only update description if provided
-						...(customSetting.description && {
-							description: customSetting.description,
-						}),
-					};
-				}
+        // Check if there's a custom setting for this hotkey
+        if (customHotkeys[lookupKey]) {
+          const customSetting = customHotkeys[lookupKey];
+          // Create a new object with the default properties and override with custom ones
+          return {
+            ...hotkey,
+            key: customSetting.key,
+            active: customSetting.active,
+            // Preserve the original label, only update description if provided
+            ...(customSetting.description && {
+              description: customSetting.description,
+            }),
+          };
+        }
 
-				// If no custom setting exists, return the default hotkey unchanged
-				return hotkey;
-			});
-		},
-		[],
-	);
+        // If no custom setting exists, return the default hotkey unchanged
+        return hotkey;
+      });
+    },
+    [],
+  );
 
-	// Runtime hotkey reload function - applies hotkeys without page refresh
-	const reloadHotkeysInRuntime = useCallback(
-		async (
-			customHotkeys: Record<
-				string,
-				{ key: string; active: boolean; description?: string }
-			>,
-		) => {
-			try {
-				// Step 1: Process custom hotkeys the same way the server does in base.html
-				const editorCustomHotkeys: Record<
-					string,
-					{ key: string | null; active: boolean; description?: string }
-				> = {};
-				const prefixRegex =
-					/^(annotation|timeseries|audio|regions|video|image_gallery|tools|data_manager):(.*)/;
+  // Runtime hotkey reload function - applies hotkeys without page refresh
+  const reloadHotkeysInRuntime = useCallback(
+    async (customHotkeys: Record<string, { key: string; active: boolean; description?: string }>) => {
+      try {
+        // Step 1: Process custom hotkeys the same way the server does in base.html
+        const editorCustomHotkeys: Record<string, { key: string | null; active: boolean; description?: string }> = {};
+        const prefixRegex = /^(annotation|timeseries|audio|regions|video|image_gallery|tools|data_manager):(.*)/;
 
-				for (const key in customHotkeys) {
-					const match = key.match(prefixRegex);
-					if (match) {
-						const [, prefix, shortKey] = match;
-						const value = customHotkeys[key];
+        for (const key in customHotkeys) {
+          const match = key.match(prefixRegex);
+          if (match) {
+            const [, prefix, shortKey] = match;
+            const value = customHotkeys[key];
 
-						// The shortKey might have double prefixes like "annotation:submit"
-						// We need to construct the correct editor keymap key format
-						const editorKey = shortKey.includes(":")
-							? shortKey
-							: `${prefix}:${shortKey}`;
+            // The shortKey might have double prefixes like "annotation:submit"
+            // We need to construct the correct editor keymap key format
+            const editorKey = shortKey.includes(":") ? shortKey : `${prefix}:${shortKey}`;
 
-						// Check if value has active property set to false
-						if (value && value.active === false) {
-							// Create a copy of the value with key set to null
-							const modifiedValue = { ...value, key: null };
-							editorCustomHotkeys[editorKey] = modifiedValue;
-						} else {
-							// Use the original value
-							editorCustomHotkeys[editorKey] = value;
-						}
-					}
-				}
+            // Check if value has active property set to false
+            if (value && value.active === false) {
+              // Create a copy of the value with key set to null
+              const modifiedValue = { ...value, key: null };
+              editorCustomHotkeys[editorKey] = modifiedValue;
+            } else {
+              // Use the original value
+              editorCustomHotkeys[editorKey] = value;
+            }
+          }
+        }
 
-				// Step 2: Get default editor keymap and merge with custom hotkeys
-				// Use the original defaults, which are now properly exposed globally
-				const defaultEditorKeymap = window.DEFAULT_HOTKEYS || {};
+        // Step 2: Get default editor keymap and merge with custom hotkeys
+        // Use the original defaults, which are now properly exposed globally
+        const defaultEditorKeymap = window.DEFAULT_HOTKEYS || {};
 
-				const mergedEditorKeymap = Object.assign(
-					{},
-					defaultEditorKeymap,
-					editorCustomHotkeys,
-				);
+        const mergedEditorKeymap = Object.assign({}, defaultEditorKeymap, editorCustomHotkeys);
 
-				// Step 3: Update window.APP_SETTINGS with new hotkeys
-				if (window.APP_SETTINGS) {
-					window.APP_SETTINGS.editor_keymap = mergedEditorKeymap;
-					window.APP_SETTINGS.user = window.APP_SETTINGS.user || {};
-					window.APP_SETTINGS.user.customHotkeys = customHotkeys;
-				}
+        // Step 3: Update window.APP_SETTINGS with new hotkeys
+        if (window.APP_SETTINGS) {
+          window.APP_SETTINGS.editor_keymap = mergedEditorKeymap;
+          window.APP_SETTINGS.user = window.APP_SETTINGS.user || {};
+          window.APP_SETTINGS.user.customHotkeys = customHotkeys;
+        }
 
-				// Step 4: Re-apply keymap to editor instances if available
-				// Check if Hotkey class is available globally
-				if (typeof window !== "undefined") {
-					// Try to access the Hotkey class through various possible global references
-					const HotkeyClass =
-						(window as any).Hotkey || (window as any).LSF?.Hotkey;
+        // Step 4: Re-apply keymap to editor instances if available
+        // Check if Hotkey class is available globally
+        if (typeof window !== "undefined") {
+          // Try to access the Hotkey class through various possible global references
+          const HotkeyClass = (window as any).Hotkey || (window as any).LSF?.Hotkey;
 
-					if (HotkeyClass && typeof HotkeyClass.setKeymap === "function") {
-						HotkeyClass.setKeymap(mergedEditorKeymap);
-					}
-				}
+          if (HotkeyClass && typeof HotkeyClass.setKeymap === "function") {
+            HotkeyClass.setKeymap(mergedEditorKeymap);
+          }
+        }
 
-				// Step 5: Trigger re-initialization of hotkeys in editor instances
-				// This is the most complex part as we need to access LabelStudio instances
-				if (typeof window !== "undefined") {
-					// Try to access LabelStudio instances through various possible global references
-					const instances =
-						(window as any).LabelStudio?.instances ||
-						(window as any).LSF?.instances ||
-						[];
+        // Step 5: Trigger re-initialization of hotkeys in editor instances
+        // This is the most complex part as we need to access LabelStudio instances
+        if (typeof window !== "undefined") {
+          // Try to access LabelStudio instances through various possible global references
+          const instances = (window as any).LabelStudio?.instances || (window as any).LSF?.instances || [];
 
-					// Iterate through instances and trigger hotkey re-initialization
-					if (Array.isArray(instances)) {
-						instances.forEach((instance: EditorInstance) => {
-							try {
-								// Check if the instance has the store and annotation with setupHotKeys method
-								if (
-									instance?.store?.annotation?.setupHotKeys &&
-									typeof instance.store.annotation.setupHotKeys === "function"
-								) {
-									instance.store.annotation.setupHotKeys();
-								} else if (
-									instance?.annotation?.setupHotKeys &&
-									typeof instance.annotation.setupHotKeys === "function"
-								) {
-									instance.annotation.setupHotKeys();
-								}
-							} catch (error) {
-								// Only log editor instance refresh failures in debug mode
-								if (
-									typeof window !== "undefined" &&
-									window.APP_SETTINGS?.debug
-								) {
-									console.warn(
-										"Failed to refresh hotkeys for editor instance:",
-										error,
-									);
-								}
-							}
-						});
-					} else if (
-						instances &&
-						typeof (instances as any).forEach === "function"
-					) {
-						// Handle Set or other iterable
-						(instances as any).forEach((instance: EditorInstance) => {
-							try {
-								if (
-									instance?.store?.annotation?.setupHotKeys &&
-									typeof instance.store.annotation.setupHotKeys === "function"
-								) {
-									instance.store.annotation.setupHotKeys();
-								} else if (
-									instance?.annotation?.setupHotKeys &&
-									typeof instance.annotation.setupHotKeys === "function"
-								) {
-									instance.annotation.setupHotKeys();
-								}
-							} catch (error) {
-								// Only log editor instance refresh failures in debug mode
-								if (
-									typeof window !== "undefined" &&
-									window.APP_SETTINGS?.debug
-								) {
-									console.warn(
-										"Failed to refresh hotkeys for editor instance:",
-										error,
-									);
-								}
-							}
-						});
-					}
-				}
+          // Iterate through instances and trigger hotkey re-initialization
+          if (Array.isArray(instances)) {
+            instances.forEach((instance: EditorInstance) => {
+              try {
+                // Check if the instance has the store and annotation with setupHotKeys method
+                if (
+                  instance?.store?.annotation?.setupHotKeys &&
+                  typeof instance.store.annotation.setupHotKeys === "function"
+                ) {
+                  instance.store.annotation.setupHotKeys();
+                } else if (
+                  instance?.annotation?.setupHotKeys &&
+                  typeof instance.annotation.setupHotKeys === "function"
+                ) {
+                  instance.annotation.setupHotKeys();
+                }
+              } catch (error) {
+                // Only log editor instance refresh failures in debug mode
+                if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+                  console.warn("Failed to refresh hotkeys for editor instance:", error);
+                }
+              }
+            });
+          } else if (instances && typeof (instances as any).forEach === "function") {
+            // Handle Set or other iterable
+            (instances as any).forEach((instance: EditorInstance) => {
+              try {
+                if (
+                  instance?.store?.annotation?.setupHotKeys &&
+                  typeof instance.store.annotation.setupHotKeys === "function"
+                ) {
+                  instance.store.annotation.setupHotKeys();
+                } else if (
+                  instance?.annotation?.setupHotKeys &&
+                  typeof instance.annotation.setupHotKeys === "function"
+                ) {
+                  instance.annotation.setupHotKeys();
+                }
+              } catch (error) {
+                // Only log editor instance refresh failures in debug mode
+                if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+                  console.warn("Failed to refresh hotkeys for editor instance:", error);
+                }
+              }
+            });
+          }
+        }
 
-				// Only log in debug mode
-				if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-					console.log("Hotkeys successfully reloaded at runtime");
-				}
-				return true;
-			} catch (error) {
-				// Only log in debug mode
-				if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-					console.error("Failed to reload hotkeys at runtime:", error);
-				}
-				return false;
-			}
-		},
-		[],
-	);
+        // Only log in debug mode
+        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+          console.log("Hotkeys successfully reloaded at runtime");
+        }
+        return true;
+      } catch (error) {
+        // Only log in debug mode
+        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+          console.error("Failed to reload hotkeys at runtime:", error);
+        }
+        return false;
+      }
+    },
+    [],
+  );
 
-	// Load hotkeys from API
-	const loadHotkeysFromAPI = useCallback(async () => {
-		try {
-			setIsLoading(true);
+  // Load hotkeys from API
+  const loadHotkeysFromAPI = useCallback(async () => {
+    try {
+      setIsLoading(true);
 
-			// Use proper API endpoint name from the config
-			const response = await api.callApi("hotkeys" as any);
+      // Use proper API endpoint name from the config
+      const response = await api.callApi("hotkeys" as any);
 
-			if (response && (response as ApiResponse).custom_hotkeys) {
-				// Use API data
-				const apiResponse = response as ApiResponse;
-				const updatedHotkeys = updateHotkeysWithCustomSettings(
-					typedDefaultHotkeys,
-					apiResponse.custom_hotkeys!,
-				);
-				setHotkeys(updatedHotkeys);
-				// Store current settings from API response
-				setHotkeySettings(apiResponse.hotkey_settings || {});
-			} else {
-				// Fallback to window.APP_SETTINGS
-				const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
-				const updatedHotkeys = updateHotkeysWithCustomSettings(
-					typedDefaultHotkeys,
-					customHotkeys,
-				);
-				setHotkeys(updatedHotkeys);
-				// No settings available in fallback
-				setHotkeySettings({});
-			}
-		} catch (error) {
-			console.error("Error loading hotkeys from API:", error);
+      if (response && (response as ApiResponse).custom_hotkeys) {
+        // Use API data
+        const apiResponse = response as ApiResponse;
+        const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, apiResponse.custom_hotkeys!);
+        setHotkeys(updatedHotkeys);
+        // Store current settings from API response
+        setHotkeySettings(apiResponse.hotkey_settings || {});
+      } else {
+        // Fallback to window.APP_SETTINGS
+        const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
+        const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, customHotkeys);
+        setHotkeys(updatedHotkeys);
+        // No settings available in fallback
+        setHotkeySettings({});
+      }
+    } catch (error) {
+      console.error("Error loading hotkeys from API:", error);
 
-			// Fallback to window.APP_SETTINGS on error
-			const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
-			const updatedHotkeys = updateHotkeysWithCustomSettings(
-				typedDefaultHotkeys,
-				customHotkeys,
-			);
-			setHotkeys(updatedHotkeys);
-			// No settings available in fallback
-			setHotkeySettings({});
+      // Fallback to window.APP_SETTINGS on error
+      const customHotkeys = window.APP_SETTINGS?.user?.customHotkeys || {};
+      const updatedHotkeys = updateHotkeysWithCustomSettings(typedDefaultHotkeys, customHotkeys);
+      setHotkeys(updatedHotkeys);
+      // No settings available in fallback
+      setHotkeySettings({});
 
-			// Show non-blocking error notification
-			if (toast) {
-				toast.show({
-					message:
-						"Could not load custom hotkeys from server, using cached settings",
-					type: ToastType.error,
-				});
-			}
-		} finally {
-			setIsLoading(false);
-		}
-	}, [api, toast, updateHotkeysWithCustomSettings]);
+      // Show non-blocking error notification
+      if (toast) {
+        toast.show({
+          message: "Could not load custom hotkeys from server, using cached settings",
+          type: ToastType.error,
+        });
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [api, toast, updateHotkeysWithCustomSettings]);
 
-	// Save hotkeys to API function (handles both save and reset operations)
-	const saveHotkeysToAPI = useCallback(
-		async (
-			currentHotkeys: Hotkey[],
-			currentSettings: HotkeySettings,
-		): Promise<SaveResult> => {
-			// Convert current hotkeys to API format - INCLUDE description to maintain API compatibility
-			const customHotkeys: Record<
-				string,
-				{ key: string; active: boolean; description?: string }
-			> = {};
+  // Save hotkeys to API function (handles both save and reset operations)
+  const saveHotkeysToAPI = useCallback(
+    async (currentHotkeys: Hotkey[], currentSettings: HotkeySettings): Promise<SaveResult> => {
+      // Convert current hotkeys to API format - INCLUDE description to maintain API compatibility
+      const customHotkeys: Record<string, { key: string; active: boolean; description?: string }> = {};
 
-			// Process all current hotkeys (if empty, this results in reset)
-			currentHotkeys.forEach((hotkey: Hotkey) => {
-				const keyId = `${hotkey.section}:${hotkey.element}`;
-				customHotkeys[keyId] = {
-					key: hotkey.key,
-					active: hotkey.active,
-					...(hotkey.description && { description: hotkey.description }),
-				};
-			});
+      // Process all current hotkeys (if empty, this results in reset)
+      currentHotkeys.forEach((hotkey: Hotkey) => {
+        const keyId = `${hotkey.section}:${hotkey.element}`;
+        customHotkeys[keyId] = {
+          key: hotkey.key,
+          active: hotkey.active,
+          ...(hotkey.description && { description: hotkey.description }),
+        };
+      });
 
-			const requestBody = {
-				custom_hotkeys: customHotkeys,
-				hotkey_settings: currentSettings,
-			};
+      const requestBody = {
+        custom_hotkeys: customHotkeys,
+        hotkey_settings: currentSettings,
+      };
 
-			try {
-				// Use proper API endpoint name from the config
-				const response = await api.callApi("updateHotkeys" as any, {
-					body: requestBody,
-				});
+      try {
+        // Use proper API endpoint name from the config
+        const response = await api.callApi("updateHotkeys" as any, {
+          body: requestBody,
+        });
 
-				// Check for API-level errors
-				if (response?.error) {
-					return {
-						ok: false,
-						error: response.error,
-						data: response,
-					};
-				}
+        // Check for API-level errors
+        if (response?.error) {
+          return {
+            ok: false,
+            error: response.error,
+            data: response,
+          };
+        }
 
-				// After successful save, reload hotkeys at runtime to apply changes immediately
-				const reloadSuccess = await reloadHotkeysInRuntime(customHotkeys);
+        // After successful save, reload hotkeys at runtime to apply changes immediately
+        const reloadSuccess = await reloadHotkeysInRuntime(customHotkeys);
 
-				// Only log runtime reload status in debug mode
-				if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
-					if (reloadSuccess) {
-						console.log(
-							"Hotkeys successfully applied at runtime - no page refresh needed",
-						);
-					} else {
-						console.warn(
-							"Runtime hotkey reload failed - page refresh may be required",
-						);
-					}
-				}
+        // Only log runtime reload status in debug mode
+        if (typeof window !== "undefined" && window.APP_SETTINGS?.debug) {
+          if (reloadSuccess) {
+            console.log("Hotkeys successfully applied at runtime - no page refresh needed");
+          } else {
+            console.warn("Runtime hotkey reload failed - page refresh may be required");
+          }
+        }
 
-				return {
-					ok: true,
-					error: undefined,
-					data: response,
-					runtimeReloadSuccess: reloadSuccess,
-				};
-			} catch (error: unknown) {
-				const isReset = currentHotkeys.length === 0;
-				const operation = isReset ? "resetting" : "saving";
-				console.error(`Error ${operation} hotkeys:`, error);
+        return {
+          ok: true,
+          error: undefined,
+          data: response,
+          runtimeReloadSuccess: reloadSuccess,
+        };
+      } catch (error: unknown) {
+        const isReset = currentHotkeys.length === 0;
+        const operation = isReset ? "resetting" : "saving";
+        console.error(`Error ${operation} hotkeys:`, error);
 
-				// Provide more specific error messages
-				let errorMessage = `Failed to ${isReset ? "reset" : "save"} hotkeys`;
-				if (error && typeof error === "object" && "response" in error) {
-					const err = error as any;
-					// Server responded with error status
-					if (err.response?.status === 400) {
-						errorMessage =
-							err.response.data?.error ||
-							`Invalid ${isReset ? "reset request" : "hotkeys configuration"}`;
-					} else if (err.response?.status === 401) {
-						errorMessage = "Authentication required";
-					} else if (err.response?.status >= 500) {
-						errorMessage = "Server error - please try again later";
-					}
-				} else if (error && typeof error === "object" && "request" in error) {
-					// Network error
-					errorMessage = "Network error - please check your connection";
-				}
+        // Provide more specific error messages
+        let errorMessage = `Failed to ${isReset ? "reset" : "save"} hotkeys`;
+        if (error && typeof error === "object" && "response" in error) {
+          const err = error as any;
+          // Server responded with error status
+          if (err.response?.status === 400) {
+            errorMessage = err.response.data?.error || `Invalid ${isReset ? "reset request" : "hotkeys configuration"}`;
+          } else if (err.response?.status === 401) {
+            errorMessage = "Authentication required";
+          } else if (err.response?.status >= 500) {
+            errorMessage = "Server error - please try again later";
+          }
+        } else if (error && typeof error === "object" && "request" in error) {
+          // Network error
+          errorMessage = "Network error - please check your connection";
+        }
 
-				return {
-					ok: false,
-					error: errorMessage,
-				};
-			}
-		},
-		[api],
-	);
+        return {
+          ok: false,
+          error: errorMessage,
+        };
+      }
+    },
+    [api],
+  );
 
-	// Handle resetting all hotkeys to defaults
-	const handleResetToDefaults = useCallback(() => {
-		confirm({
-			title: "Reset Hotkeys to Defaults?",
-			body: "Are you sure you want to reset all hotkeys and settings to their default values? This action cannot be undone.",
-			okText: "Reset to Defaults",
-			buttonLook: "negative",
-			style: { width: 500 },
-			onOk: async () => {
-				setIsLoading(true);
+  // Handle resetting all hotkeys to defaults
+  const handleResetToDefaults = useCallback(() => {
+    confirm({
+      title: "Reset Hotkeys to Defaults?",
+      body: "Are you sure you want to reset all hotkeys and settings to their default values? This action cannot be undone.",
+      okText: "Reset to Defaults",
+      buttonLook: "negative",
+      style: { width: 500 },
+      onOk: async () => {
+        setIsLoading(true);
 
-				try {
-					// Reset hotkeys to defaults in the backend API (sets custom_hotkeys to {})
-					const result = await saveHotkeysToAPI([], {});
+        try {
+          // Reset hotkeys to defaults in the backend API (sets custom_hotkeys to {})
+          const result = await saveHotkeysToAPI([], {});
 
-					if (result.ok) {
-						if (toast) {
-							toast.show({
-								message:
-									"All hotkeys and settings have been reset to defaults and saved",
-								type: ToastType.info,
-							});
-						}
-						// Update local state to reflect the reset
-						setHotkeys([...typedDefaultHotkeys]);
-					} else {
-						if (toast) {
-							toast.show({
-								message: `Failed to save reset hotkeys: ${result.error || "Unknown error"}`,
-								type: ToastType.error,
-							});
-						}
-					}
-				} catch (error: unknown) {
-					if (toast) {
-						const errorMessage =
-							error instanceof Error ? error.message : "Unknown error";
-						toast.show({
-							message: `Error resetting hotkeys: ${errorMessage}`,
-							type: ToastType.error,
-						});
-					}
-				} finally {
-					setIsLoading(false);
-				}
-			},
-		});
-	}, [saveHotkeysToAPI, toast]);
+          if (result.ok) {
+            if (toast) {
+              toast.show({
+                message: "All hotkeys and settings have been reset to defaults and saved",
+                type: ToastType.info,
+              });
+            }
+            // Update local state to reflect the reset
+            setHotkeys([...typedDefaultHotkeys]);
+          } else {
+            if (toast) {
+              toast.show({
+                message: `Failed to save reset hotkeys: ${result.error || "Unknown error"}`,
+                type: ToastType.error,
+              });
+            }
+          }
+        } catch (error: unknown) {
+          if (toast) {
+            const errorMessage = error instanceof Error ? error.message : "Unknown error";
+            toast.show({
+              message: `Error resetting hotkeys: ${errorMessage}`,
+              type: ToastType.error,
+            });
+          }
+        } finally {
+          setIsLoading(false);
+        }
+      },
+    });
+  }, [saveHotkeysToAPI, toast]);
 
-	// Handle exporting hotkeys
-	const handleExportHotkeys = useCallback(() => {
-		// Create export data including current settings
-		const exportData: ExportData = {
-			hotkeys: hotkeys,
-			settings: hotkeySettings,
-			exportedAt: new Date().toISOString(),
-			version: "1.0",
-		};
+  // Handle exporting hotkeys
+  const handleExportHotkeys = useCallback(() => {
+    // Create export data including current settings
+    const exportData: ExportData = {
+      hotkeys: hotkeys,
+      settings: hotkeySettings,
+      exportedAt: new Date().toISOString(),
+      version: "1.0",
+    };
 
-		// Create a JSON string of the export data
-		const exportJson = JSON.stringify(exportData, null, 2);
+    // Create a JSON string of the export data
+    const exportJson = JSON.stringify(exportData, null, 2);
 
-		// Create a blob with the JSON
-		const blob = new Blob([exportJson], { type: "application/json" });
-		const url = URL.createObjectURL(blob);
+    // Create a blob with the JSON
+    const blob = new Blob([exportJson], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
 
-		// Create a temporary link and click it to download the file
-		const link = document.createElement("a");
-		link.href = url;
-		link.download = "hotkeys-export.json";
-		document.body.appendChild(link);
-		link.click();
+    // Create a temporary link and click it to download the file
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "hotkeys-export.json";
+    document.body.appendChild(link);
+    link.click();
 
-		// Clean up
-		document.body.removeChild(link);
-		URL.revokeObjectURL(url);
+    // Clean up
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
 
-		if (toast) {
-			toast.show({
-				message: "Hotkeys exported successfully",
-				type: ToastType.info,
-			});
-		}
-	}, [hotkeys, hotkeySettings, toast]);
+    if (toast) {
+      toast.show({
+        message: "Hotkeys exported successfully",
+        type: ToastType.info,
+      });
+    }
+  }, [hotkeys, hotkeySettings, toast]);
 
-	// Handle importing hotkeys
-	const handleImportHotkeys = useCallback(
-		async (importedData: ImportData | Hotkey[]) => {
-			try {
-				setIsLoading(true);
+  // Handle importing hotkeys
+  const handleImportHotkeys = useCallback(
+    async (importedData: ImportData | Hotkey[]) => {
+      try {
+        setIsLoading(true);
 
-				// Handle both old format (just hotkeys array) and new format (with settings)
-				const importedHotkeys = Array.isArray(importedData)
-					? importedData
-					: importedData.hotkeys || [];
-				const importedSettings: HotkeySettings = Array.isArray(importedData)
-					? {}
-					: importedData.settings || {};
+        // Handle both old format (just hotkeys array) and new format (with settings)
+        const importedHotkeys = Array.isArray(importedData) ? importedData : importedData.hotkeys || [];
+        const importedSettings: HotkeySettings = Array.isArray(importedData) ? {} : importedData.settings || {};
 
-				// Save all imported data to API
-				const result = await saveHotkeysToAPI(
-					importedHotkeys,
-					importedSettings,
-				);
+        // Save all imported data to API
+        const result = await saveHotkeysToAPI(importedHotkeys, importedSettings);
 
-				if (!result.ok) {
-					throw new Error(result.error || "Failed to save imported hotkeys");
-				}
+        if (!result.ok) {
+          throw new Error(result.error || "Failed to save imported hotkeys");
+        }
 
-				// Update local state
-				setHotkeys(importedHotkeys);
+        // Update local state
+        setHotkeys(importedHotkeys);
 
-				if (toast) {
-					toast.show({
-						message: "Hotkeys imported successfully",
-						type: ToastType.info,
-					});
-				}
+        if (toast) {
+          toast.show({
+            message: "Hotkeys imported successfully",
+            type: ToastType.info,
+          });
+        }
 
-				// Reload from API to ensure consistency
-				await loadHotkeysFromAPI();
-			} catch (error: unknown) {
-				if (toast) {
-					const errorMessage =
-						error instanceof Error ? error.message : "Unknown error";
-					toast.show({
-						message: `Error importing hotkeys: ${errorMessage}`,
-						type: ToastType.error,
-					});
-				}
-			} finally {
-				setIsLoading(false);
-			}
-		},
-		[saveHotkeysToAPI, loadHotkeysFromAPI, toast],
-	);
+        // Reload from API to ensure consistency
+        await loadHotkeysFromAPI();
+      } catch (error: unknown) {
+        if (toast) {
+          const errorMessage = error instanceof Error ? error.message : "Unknown error";
+          toast.show({
+            message: `Error importing hotkeys: ${errorMessage}`,
+            type: ToastType.error,
+          });
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [saveHotkeysToAPI, loadHotkeysFromAPI, toast],
+  );
 
-	// Load hotkeys on hook mount
-	useEffect(() => {
-		loadHotkeysFromAPI();
-	}, [loadHotkeysFromAPI]);
+  // Load hotkeys on hook mount
+  useEffect(() => {
+    loadHotkeysFromAPI();
+  }, [loadHotkeysFromAPI]);
 
-	return {
-		hotkeys,
-		setHotkeys,
-		hotkeySettings,
-		setHotkeySettings,
-		isLoading,
-		setIsLoading,
-		loadHotkeysFromAPI,
-		saveHotkeysToAPI,
-		handleResetToDefaults,
-		handleExportHotkeys,
-		handleImportHotkeys,
-	};
+  return {
+    hotkeys,
+    setHotkeys,
+    hotkeySettings,
+    setHotkeySettings,
+    isLoading,
+    setIsLoading,
+    loadHotkeysFromAPI,
+    saveHotkeysToAPI,
+    handleResetToDefaults,
+    handleExportHotkeys,
+    handleImportHotkeys,
+  };
 };

--- a/web/libs/app-common/src/pages/AccountSettings/sections/Hotkeys/utils.ts
+++ b/web/libs/app-common/src/pages/AccountSettings/sections/Hotkeys/utils.ts
@@ -48,6 +48,7 @@ export interface SaveResult {
   ok: boolean;
   error?: string;
   data?: unknown;
+  runtimeReloadSuccess?: boolean;
 }
 
 export interface ApiResponse {

--- a/web/libs/editor/src/LabelStudio.tsx
+++ b/web/libs/editor/src/LabelStudio.tsx
@@ -99,7 +99,7 @@ export class LabelStudio {
 
     // @todo whole approach to hotkeys should be rewritten,
     // @todo but for now we need a way to export Hotkey to different app
-    window.Htx.Hotkey = Hotkey;
+    if (window.Htx) window.Htx.Hotkey = Hotkey;
 
     this.supportLegacyEvents();
 

--- a/web/libs/editor/src/LabelStudio.tsx
+++ b/web/libs/editor/src/LabelStudio.tsx
@@ -97,6 +97,10 @@ export class LabelStudio {
       this.createAppV17();
     }
 
+    // @todo whole approach to hotkeys should be rewritten,
+    // @todo but for now we need a way to export Hotkey to different app
+    window.Htx.Hotkey = Hotkey;
+
     this.supportLegacyEvents();
 
     if (options.instanceOptions?.reactVersion !== "v18") {

--- a/web/libs/editor/src/LabelStudio.tsx
+++ b/web/libs/editor/src/LabelStudio.tsx
@@ -18,16 +18,16 @@ import { isDefined } from "./utils/utilities";
 
 // Extend window interface for TypeScript
 declare global {
-	interface Window {
-		LabelStudio?: typeof LabelStudio;
-		Hotkey?: typeof Hotkey;
-		DEFAULT_HOTKEYS?: typeof defaultKeymap;
-		Htx: any;
-	}
+  interface Window {
+    LabelStudio?: typeof LabelStudio;
+    Hotkey?: typeof Hotkey;
+    DEFAULT_HOTKEYS?: typeof defaultKeymap;
+    Htx: any;
+  }
 }
 
 configure({
-	isolateGlobalState: true,
+  isolateGlobalState: true,
 });
 
 type Callback = (...args: any[]) => any;
@@ -39,236 +39,236 @@ type LSFTask = any;
 // because those options will go as initial values for AppStore
 // but it's not types yet, so here is some excerpt of its parameters
 type LSFOptions = Record<string, any> & {
-	interfaces: string[];
-	keymap?: any;
-	user?: LSFUser;
-	users?: LSFUser[];
-	task?: LSFTask;
-	settings?: {
-		forceBottomPanel?: boolean;
-	};
-	instanceOptions?: {
-		reactVersion?: "v18" | "v17";
-	};
+  interfaces: string[];
+  keymap?: any;
+  user?: LSFUser;
+  users?: LSFUser[];
+  task?: LSFTask;
+  settings?: {
+    forceBottomPanel?: boolean;
+  };
+  instanceOptions?: {
+    reactVersion?: "v18" | "v17";
+  };
 };
 
 export class LabelStudio {
-	static Component = LabelStudioReact;
+  static Component = LabelStudioReact;
 
-	static instances = new Set<LabelStudio>();
+  static instances = new Set<LabelStudio>();
 
-	static destroyAll() {
-		LabelStudio.instances.forEach((inst) => inst.destroy?.());
-		LabelStudio.instances.clear();
-	}
+  static destroyAll() {
+    LabelStudio.instances.forEach((inst) => inst.destroy?.());
+    LabelStudio.instances.clear();
+  }
 
-	options: Partial<LSFOptions>;
-	root: Element | string;
-	store: any;
-	reactRoot: any;
+  options: Partial<LSFOptions>;
+  root: Element | string;
+  store: any;
+  reactRoot: any;
 
-	destroy: (() => void) | null = () => {};
-	events = new EventInvoker();
+  destroy: (() => void) | null = () => {};
+  events = new EventInvoker();
 
-	getRootElement(root: Element | string) {
-		let element: Element | null = null;
+  getRootElement(root: Element | string) {
+    let element: Element | null = null;
 
-		if (typeof root === "string") {
-			element = document.getElementById(root);
-		} else {
-			element = root;
-		}
+    if (typeof root === "string") {
+      element = document.getElementById(root);
+    } else {
+      element = root;
+    }
 
-		if (!element) {
-			throw new Error(`Root element not found (selector: ${root})`);
-		}
+    if (!element) {
+      throw new Error(`Root element not found (selector: ${root})`);
+    }
 
-		return element;
-	}
+    return element;
+  }
 
-	constructor(root: Element | string, userOptions: Partial<LSFOptions> = {}) {
-		const options = { ...defaultOptions, ...userOptions };
+  constructor(root: Element | string, userOptions: Partial<LSFOptions> = {}) {
+    const options = { ...defaultOptions, ...userOptions };
 
-		if (options.keymap) {
-			Hotkey.setKeymap(options.keymap);
-		}
+    if (options.keymap) {
+      Hotkey.setKeymap(options.keymap);
+    }
 
-		this.root = root;
-		this.options = options;
-		if (options.instanceOptions?.reactVersion === "v18") {
-			this.createAppV18();
-		} else {
-			this.createAppV17();
-		}
+    this.root = root;
+    this.options = options;
+    if (options.instanceOptions?.reactVersion === "v18") {
+      this.createAppV18();
+    } else {
+      this.createAppV17();
+    }
 
-		this.supportLegacyEvents();
+    this.supportLegacyEvents();
 
-		if (options.instanceOptions?.reactVersion !== "v18") {
-			LabelStudio.instances.add(this);
-		}
-	}
+    if (options.instanceOptions?.reactVersion !== "v18") {
+      LabelStudio.instances.add(this);
+    }
+  }
 
-	on(eventName: string, callback: Callback) {
-		this.events.on(eventName, callback);
-	}
+  on(eventName: string, callback: Callback) {
+    this.events.on(eventName, callback);
+  }
 
-	off(eventName: string, callback: Callback) {
-		if (isDefined(callback)) {
-			this.events.off(eventName, callback);
-		} else {
-			this.events.removeAll(eventName);
-		}
-	}
+  off(eventName: string, callback: Callback) {
+    if (isDefined(callback)) {
+      this.events.off(eventName, callback);
+    } else {
+      this.events.removeAll(eventName);
+    }
+  }
 
-	// This is a temporary solution that allows React 17 to work in the meantime.
-	// and we can update our other usages of LabelStudio to use createRoot, namely tests will likely be affected.
-	async createAppV17() {
-		const { store } = await configureStore(this.options, this.events);
-		const rootElement = this.getRootElement(this.root);
+  // This is a temporary solution that allows React 17 to work in the meantime.
+  // and we can update our other usages of LabelStudio to use createRoot, namely tests will likely be affected.
+  async createAppV17() {
+    const { store } = await configureStore(this.options, this.events);
+    const rootElement = this.getRootElement(this.root);
 
-		this.store = store;
-		window.Htx = this.store;
+    this.store = store;
+    window.Htx = this.store;
 
-		const isRendered = false;
+    const isRendered = false;
 
-		const renderApp = () => {
-			if (isRendered) {
-				clearRenderedApp();
-			}
-			render(<App store={this.store} />, rootElement);
-		};
+    const renderApp = () => {
+      if (isRendered) {
+        clearRenderedApp();
+      }
+      render(<App store={this.store} />, rootElement);
+    };
 
-		const clearRenderedApp = () => {
-			if (!rootElement.childNodes?.length) return;
+    const clearRenderedApp = () => {
+      if (!rootElement.childNodes?.length) return;
 
-			const childNodes = [...rootElement.childNodes];
-			// cleanDomAfterReact needs this key to be sure that cleaning affects only current react subtree
-			const reactKey = findReactKey(childNodes[0]);
+      const childNodes = [...rootElement.childNodes];
+      // cleanDomAfterReact needs this key to be sure that cleaning affects only current react subtree
+      const reactKey = findReactKey(childNodes[0]);
 
-			unmountComponentAtNode(rootElement);
-			/*
+      unmountComponentAtNode(rootElement);
+      /*
         Unmounting doesn't help with clearing React's fibers
         but removing the manually helps
         @see https://github.com/facebook/react/pull/20290 (similar problem)
         That's maybe not relevant in version 18
        */
-			cleanDomAfterReact(childNodes, reactKey);
-			cleanDomAfterReact([rootElement], reactKey);
-		};
+      cleanDomAfterReact(childNodes, reactKey);
+      cleanDomAfterReact([rootElement], reactKey);
+    };
 
-		renderApp();
-		store.setAppControls({
-			isRendered() {
-				return isRendered;
-			},
-			render: renderApp,
-			clear: clearRenderedApp,
-		});
+    renderApp();
+    store.setAppControls({
+      isRendered() {
+        return isRendered;
+      },
+      render: renderApp,
+      clear: clearRenderedApp,
+    });
 
-		this.destroy = () => {
-			if (isFF(FF_LSDV_4620_3_ML)) {
-				clearRenderedApp();
-			}
-			destroySharedStore();
-			if (isFF(FF_LSDV_4620_3_ML)) {
-				/*
+    this.destroy = () => {
+      if (isFF(FF_LSDV_4620_3_ML)) {
+        clearRenderedApp();
+      }
+      destroySharedStore();
+      if (isFF(FF_LSDV_4620_3_ML)) {
+        /*
            It seems that destroying children separately helps GC to collect garbage
            ...
          */
-				this.store.selfDestroy();
-			}
-			destroy(this.store);
-			Hotkey.unbindAll();
-			if (isFF(FF_LSDV_4620_3_ML)) {
-				/*
+        this.store.selfDestroy();
+      }
+      destroy(this.store);
+      Hotkey.unbindAll();
+      if (isFF(FF_LSDV_4620_3_ML)) {
+        /*
             ...
             as well as nulling all these this.store
          */
-				this.store = null;
-				this.destroy = null;
-				LabelStudio.instances.delete(this);
-			}
-		};
-	}
+        this.store = null;
+        this.destroy = null;
+        LabelStudio.instances.delete(this);
+      }
+    };
+  }
 
-	// To support React 18 properly, we need to use createRoot
-	// and render the app with it, and properly unmount it and cleanup all references
-	async createAppV18() {
-		const { store } = await configureStore(this.options, this.events);
-		const rootElement = this.getRootElement(this.root);
+  // To support React 18 properly, we need to use createRoot
+  // and render the app with it, and properly unmount it and cleanup all references
+  async createAppV18() {
+    const { store } = await configureStore(this.options, this.events);
+    const rootElement = this.getRootElement(this.root);
 
-		this.store = store;
-		window.Htx = this.store;
+    this.store = store;
+    window.Htx = this.store;
 
-		let isRendered = false;
+    let isRendered = false;
 
-		const renderApp = () => {
-			if (isRendered) {
-				clearRenderedApp();
-			}
-			this.reactRoot = createRoot(rootElement);
-			const AppComponent = App as any;
-			this.reactRoot.render(<AppComponent store={this.store} />);
-			isRendered = true;
-		};
+    const renderApp = () => {
+      if (isRendered) {
+        clearRenderedApp();
+      }
+      this.reactRoot = createRoot(rootElement);
+      const AppComponent = App as any;
+      this.reactRoot.render(<AppComponent store={this.store} />);
+      isRendered = true;
+    };
 
-		const clearRenderedApp = () => {
-			if (this.reactRoot && isRendered) {
-				this.reactRoot.unmount();
-				this.reactRoot = null;
-				isRendered = false;
-			}
-		};
+    const clearRenderedApp = () => {
+      if (this.reactRoot && isRendered) {
+        this.reactRoot.unmount();
+        this.reactRoot = null;
+        isRendered = false;
+      }
+    };
 
-		renderApp();
+    renderApp();
 
-		store.setAppControls({
-			isRendered() {
-				return isRendered;
-			},
-			render: renderApp,
-			clear: clearRenderedApp,
-		});
+    store.setAppControls({
+      isRendered() {
+        return isRendered;
+      },
+      render: renderApp,
+      clear: clearRenderedApp,
+    });
 
-		this.destroy = () => {
-			// Clear rendered app
-			clearRenderedApp();
+    this.destroy = () => {
+      // Clear rendered app
+      clearRenderedApp();
 
-			// Destroy shared store
-			destroySharedStore();
+      // Destroy shared store
+      destroySharedStore();
 
-			// Destroy store
-			destroy(this.store);
+      // Destroy store
+      destroy(this.store);
 
-			// Unbind all hotkeys
-			Hotkey.unbindAll();
+      // Unbind all hotkeys
+      Hotkey.unbindAll();
 
-			// Clear references
-			this.store = null;
-			window.Htx = null;
-			this.destroy = null;
-		};
-	}
+      // Clear references
+      this.store = null;
+      window.Htx = null;
+      this.destroy = null;
+    };
+  }
 
-	supportLegacyEvents() {
-		const keys = Object.keys(legacyEvents);
+  supportLegacyEvents() {
+    const keys = Object.keys(legacyEvents);
 
-		keys.forEach((key) => {
-			const callback = this.options[key];
+    keys.forEach((key) => {
+      const callback = this.options[key];
 
-			if (isDefined(callback)) {
-				const eventName = toCamelCase(key.replace(/^on/, ""));
+      if (isDefined(callback)) {
+        const eventName = toCamelCase(key.replace(/^on/, ""));
 
-				this.events.on(eventName, callback);
-			}
-		});
-	}
+        this.events.on(eventName, callback);
+      }
+    });
+  }
 }
 
 // Expose LabelStudio and Hotkey classes globally for runtime hotkey reload functionality
 if (typeof window !== "undefined") {
-	window.LabelStudio = LabelStudio;
-	window.Hotkey = Hotkey;
-	// Also expose the original default keymap for runtime reset functionality
-	window.DEFAULT_HOTKEYS = { ...defaultKeymap };
+  window.LabelStudio = LabelStudio;
+  window.Hotkey = Hotkey;
+  // Also expose the original default keymap for runtime reset functionality
+  window.DEFAULT_HOTKEYS = { ...defaultKeymap };
 }

--- a/web/libs/editor/src/LabelStudio.tsx
+++ b/web/libs/editor/src/LabelStudio.tsx
@@ -8,7 +8,6 @@ import App from "./components/App/App";
 import { configureStore } from "./configureStore";
 import legacyEvents from "./core/External";
 import { Hotkey } from "./core/Hotkey";
-import defaultKeymap from "./core/settings/keymap.json";
 import defaultOptions from "./defaultOptions";
 import { destroy as destroySharedStore } from "./mixins/SharedChoiceStore/mixin";
 import { EventInvoker } from "./utils/events";
@@ -19,9 +18,6 @@ import { isDefined } from "./utils/utilities";
 // Extend window interface for TypeScript
 declare global {
   interface Window {
-    LabelStudio?: typeof LabelStudio;
-    Hotkey?: typeof Hotkey;
-    DEFAULT_HOTKEYS?: typeof defaultKeymap;
     Htx: any;
   }
 }
@@ -265,10 +261,4 @@ export class LabelStudio {
   }
 }
 
-// Expose LabelStudio and Hotkey classes globally for runtime hotkey reload functionality
-if (typeof window !== "undefined") {
-  window.LabelStudio = LabelStudio;
-  window.Hotkey = Hotkey;
-  // Also expose the original default keymap for runtime reset functionality
-  window.DEFAULT_HOTKEYS = { ...defaultKeymap };
-}
+

--- a/web/libs/editor/src/LabelStudio.tsx
+++ b/web/libs/editor/src/LabelStudio.tsx
@@ -17,13 +17,13 @@ import { cleanDomAfterReact, findReactKey } from "./utils/reactCleaner";
 import { isDefined } from "./utils/utilities";
 
 declare global {
-	interface Window {
-		Htx: any;
-	}
+  interface Window {
+    Htx: any;
+  }
 }
 
 configure({
-	isolateGlobalState: true,
+  isolateGlobalState: true,
 });
 
 type Callback = (...args: any[]) => any;
@@ -35,236 +35,236 @@ type LSFTask = any;
 // because those options will go as initial values for AppStore
 // but it's not types yet, so here is some excerpt of its parameters
 type LSFOptions = Record<string, any> & {
-	interfaces: string[];
-	keymap?: any;
-	user?: LSFUser;
-	users?: LSFUser[];
-	task?: LSFTask;
-	settings?: {
-		forceBottomPanel?: boolean;
-	};
-	instanceOptions?: {
-		reactVersion?: "v18" | "v17";
-	};
+  interfaces: string[];
+  keymap?: any;
+  user?: LSFUser;
+  users?: LSFUser[];
+  task?: LSFTask;
+  settings?: {
+    forceBottomPanel?: boolean;
+  };
+  instanceOptions?: {
+    reactVersion?: "v18" | "v17";
+  };
 };
 
 export class LabelStudio {
-	static Component = LabelStudioReact;
+  static Component = LabelStudioReact;
 
-	static instances = new Set<LabelStudio>();
+  static instances = new Set<LabelStudio>();
 
-	static destroyAll() {
-		LabelStudio.instances.forEach((inst) => inst.destroy?.());
-		LabelStudio.instances.clear();
-	}
+  static destroyAll() {
+    LabelStudio.instances.forEach((inst) => inst.destroy?.());
+    LabelStudio.instances.clear();
+  }
 
-	options: Partial<LSFOptions>;
-	root: Element | string;
-	store: any;
-	reactRoot: any;
+  options: Partial<LSFOptions>;
+  root: Element | string;
+  store: any;
+  reactRoot: any;
 
-	destroy: (() => void) | null = () => {};
-	events = new EventInvoker();
+  destroy: (() => void) | null = () => {};
+  events = new EventInvoker();
 
-	getRootElement(root: Element | string) {
-		let element: Element | null = null;
+  getRootElement(root: Element | string) {
+    let element: Element | null = null;
 
-		if (typeof root === "string") {
-			element = document.getElementById(root);
-		} else {
-			element = root;
-		}
+    if (typeof root === "string") {
+      element = document.getElementById(root);
+    } else {
+      element = root;
+    }
 
-		if (!element) {
-			throw new Error(`Root element not found (selector: ${root})`);
-		}
+    if (!element) {
+      throw new Error(`Root element not found (selector: ${root})`);
+    }
 
-		return element;
-	}
+    return element;
+  }
 
-	constructor(root: Element | string, userOptions: Partial<LSFOptions> = {}) {
-		const options = { ...defaultOptions, ...userOptions };
+  constructor(root: Element | string, userOptions: Partial<LSFOptions> = {}) {
+    const options = { ...defaultOptions, ...userOptions };
 
-		if (options.keymap) {
-			Hotkey.setKeymap(options.keymap);
-		}
+    if (options.keymap) {
+      Hotkey.setKeymap(options.keymap);
+    }
 
-		this.root = root;
-		this.options = options;
-		if (options.instanceOptions?.reactVersion === "v18") {
-			this.createAppV18();
-		} else {
-			this.createAppV17();
-		}
+    this.root = root;
+    this.options = options;
+    if (options.instanceOptions?.reactVersion === "v18") {
+      this.createAppV18();
+    } else {
+      this.createAppV17();
+    }
 
-		this.supportLegacyEvents();
+    this.supportLegacyEvents();
 
-		if (options.instanceOptions?.reactVersion !== "v18") {
-			LabelStudio.instances.add(this);
-		}
-	}
+    if (options.instanceOptions?.reactVersion !== "v18") {
+      LabelStudio.instances.add(this);
+    }
+  }
 
-	on(eventName: string, callback: Callback) {
-		this.events.on(eventName, callback);
-	}
+  on(eventName: string, callback: Callback) {
+    this.events.on(eventName, callback);
+  }
 
-	off(eventName: string, callback: Callback) {
-		if (isDefined(callback)) {
-			this.events.off(eventName, callback);
-		} else {
-			this.events.removeAll(eventName);
-		}
-	}
+  off(eventName: string, callback: Callback) {
+    if (isDefined(callback)) {
+      this.events.off(eventName, callback);
+    } else {
+      this.events.removeAll(eventName);
+    }
+  }
 
-	// This is a temporary solution that allows React 17 to work in the meantime.
-	// and we can update our other usages of LabelStudio to use createRoot, namely tests will likely be affected.
-	async createAppV17() {
-		const { store } = await configureStore(this.options, this.events);
-		const rootElement = this.getRootElement(this.root);
+  // This is a temporary solution that allows React 17 to work in the meantime.
+  // and we can update our other usages of LabelStudio to use createRoot, namely tests will likely be affected.
+  async createAppV17() {
+    const { store } = await configureStore(this.options, this.events);
+    const rootElement = this.getRootElement(this.root);
 
-		this.store = store;
-		window.Htx = this.store;
+    this.store = store;
+    window.Htx = this.store;
 
-		const isRendered = false;
+    const isRendered = false;
 
-		const renderApp = () => {
-			if (isRendered) {
-				clearRenderedApp();
-			}
-			render(<App store={this.store} />, rootElement);
-		};
+    const renderApp = () => {
+      if (isRendered) {
+        clearRenderedApp();
+      }
+      render(<App store={this.store} />, rootElement);
+    };
 
-		const clearRenderedApp = () => {
-			if (!rootElement.childNodes?.length) return;
+    const clearRenderedApp = () => {
+      if (!rootElement.childNodes?.length) return;
 
-			const childNodes = [...rootElement.childNodes];
-			// cleanDomAfterReact needs this key to be sure that cleaning affects only current react subtree
-			const reactKey = findReactKey(childNodes[0]);
+      const childNodes = [...rootElement.childNodes];
+      // cleanDomAfterReact needs this key to be sure that cleaning affects only current react subtree
+      const reactKey = findReactKey(childNodes[0]);
 
-			unmountComponentAtNode(rootElement);
-			/*
+      unmountComponentAtNode(rootElement);
+      /*
         Unmounting doesn't help with clearing React's fibers
         but removing the manually helps
         @see https://github.com/facebook/react/pull/20290 (similar problem)
         That's maybe not relevant in version 18
        */
-			cleanDomAfterReact(childNodes, reactKey);
-			cleanDomAfterReact([rootElement], reactKey);
-		};
+      cleanDomAfterReact(childNodes, reactKey);
+      cleanDomAfterReact([rootElement], reactKey);
+    };
 
-		renderApp();
-		store.setAppControls({
-			isRendered() {
-				return isRendered;
-			},
-			render: renderApp,
-			clear: clearRenderedApp,
-		});
+    renderApp();
+    store.setAppControls({
+      isRendered() {
+        return isRendered;
+      },
+      render: renderApp,
+      clear: clearRenderedApp,
+    });
 
-		this.destroy = () => {
-			if (isFF(FF_LSDV_4620_3_ML)) {
-				clearRenderedApp();
-			}
-			destroySharedStore();
-			if (isFF(FF_LSDV_4620_3_ML)) {
-				/*
+    this.destroy = () => {
+      if (isFF(FF_LSDV_4620_3_ML)) {
+        clearRenderedApp();
+      }
+      destroySharedStore();
+      if (isFF(FF_LSDV_4620_3_ML)) {
+        /*
            It seems that destroying children separately helps GC to collect garbage
            ...
          */
-				this.store.selfDestroy();
-			}
-			destroy(this.store);
-			Hotkey.unbindAll();
-			if (isFF(FF_LSDV_4620_3_ML)) {
-				/*
+        this.store.selfDestroy();
+      }
+      destroy(this.store);
+      Hotkey.unbindAll();
+      if (isFF(FF_LSDV_4620_3_ML)) {
+        /*
             ...
             as well as nulling all these this.store
          */
-				this.store = null;
-				this.destroy = null;
-				LabelStudio.instances.delete(this);
-			}
-		};
-	}
+        this.store = null;
+        this.destroy = null;
+        LabelStudio.instances.delete(this);
+      }
+    };
+  }
 
-	// To support React 18 properly, we need to use createRoot
-	// and render the app with it, and properly unmount it and cleanup all references
-	async createAppV18() {
-		const { store } = await configureStore(this.options, this.events);
-		const rootElement = this.getRootElement(this.root);
+  // To support React 18 properly, we need to use createRoot
+  // and render the app with it, and properly unmount it and cleanup all references
+  async createAppV18() {
+    const { store } = await configureStore(this.options, this.events);
+    const rootElement = this.getRootElement(this.root);
 
-		this.store = store;
-		window.Htx = this.store;
+    this.store = store;
+    window.Htx = this.store;
 
-		let isRendered = false;
+    let isRendered = false;
 
-		const renderApp = () => {
-			if (isRendered) {
-				clearRenderedApp();
-			}
-			this.reactRoot = createRoot(rootElement);
-			const AppComponent = App as any;
-			this.reactRoot.render(<AppComponent store={this.store} />);
-			isRendered = true;
-		};
+    const renderApp = () => {
+      if (isRendered) {
+        clearRenderedApp();
+      }
+      this.reactRoot = createRoot(rootElement);
+      const AppComponent = App as any;
+      this.reactRoot.render(<AppComponent store={this.store} />);
+      isRendered = true;
+    };
 
-		const clearRenderedApp = () => {
-			if (this.reactRoot && isRendered) {
-				this.reactRoot.unmount();
-				this.reactRoot = null;
-				isRendered = false;
-			}
-		};
+    const clearRenderedApp = () => {
+      if (this.reactRoot && isRendered) {
+        this.reactRoot.unmount();
+        this.reactRoot = null;
+        isRendered = false;
+      }
+    };
 
-		renderApp();
+    renderApp();
 
-		store.setAppControls({
-			isRendered() {
-				return isRendered;
-			},
-			render: renderApp,
-			clear: clearRenderedApp,
-		});
+    store.setAppControls({
+      isRendered() {
+        return isRendered;
+      },
+      render: renderApp,
+      clear: clearRenderedApp,
+    });
 
-		this.destroy = () => {
-			// Clear rendered app
-			clearRenderedApp();
+    this.destroy = () => {
+      // Clear rendered app
+      clearRenderedApp();
 
-			// Destroy shared store
-			destroySharedStore();
+      // Destroy shared store
+      destroySharedStore();
 
-			// Destroy store
-			destroy(this.store);
+      // Destroy store
+      destroy(this.store);
 
-			// Unbind all hotkeys
-			Hotkey.unbindAll();
+      // Unbind all hotkeys
+      Hotkey.unbindAll();
 
-			// Clear references
-			this.store = null;
-			window.Htx = null;
-			this.destroy = null;
-		};
-	}
+      // Clear references
+      this.store = null;
+      window.Htx = null;
+      this.destroy = null;
+    };
+  }
 
-	supportLegacyEvents() {
-		const keys = Object.keys(legacyEvents);
+  supportLegacyEvents() {
+    const keys = Object.keys(legacyEvents);
 
-		keys.forEach((key) => {
-			const callback = this.options[key];
+    keys.forEach((key) => {
+      const callback = this.options[key];
 
-			if (isDefined(callback)) {
-				const eventName = toCamelCase(key.replace(/^on/, ""));
+      if (isDefined(callback)) {
+        const eventName = toCamelCase(key.replace(/^on/, ""));
 
-				this.events.on(eventName, callback);
-			}
-		});
-	}
+        this.events.on(eventName, callback);
+      }
+    });
+  }
 }
 
 // Expose LabelStudio and Hotkey classes globally for runtime hotkey reload functionality
 if (typeof window !== "undefined") {
-	(window as any).LabelStudio = LabelStudio;
-	(window as any).Hotkey = Hotkey;
-	// Also expose the original default keymap for runtime reset functionality
-	(window as any).DEFAULT_HOTKEYS = { ...defaultKeymap };
+  (window as any).LabelStudio = LabelStudio;
+  (window as any).Hotkey = Hotkey;
+  // Also expose the original default keymap for runtime reset functionality
+  (window as any).DEFAULT_HOTKEYS = { ...defaultKeymap };
 }

--- a/web/libs/editor/src/LabelStudio.tsx
+++ b/web/libs/editor/src/LabelStudio.tsx
@@ -8,6 +8,7 @@ import App from "./components/App/App";
 import { configureStore } from "./configureStore";
 import legacyEvents from "./core/External";
 import { Hotkey } from "./core/Hotkey";
+import defaultKeymap from "./core/settings/keymap.json";
 import defaultOptions from "./defaultOptions";
 import { destroy as destroySharedStore } from "./mixins/SharedChoiceStore/mixin";
 import { EventInvoker } from "./utils/events";
@@ -16,13 +17,13 @@ import { cleanDomAfterReact, findReactKey } from "./utils/reactCleaner";
 import { isDefined } from "./utils/utilities";
 
 declare global {
-  interface Window {
-    Htx: any;
-  }
+	interface Window {
+		Htx: any;
+	}
 }
 
 configure({
-  isolateGlobalState: true,
+	isolateGlobalState: true,
 });
 
 type Callback = (...args: any[]) => any;
@@ -34,234 +35,236 @@ type LSFTask = any;
 // because those options will go as initial values for AppStore
 // but it's not types yet, so here is some excerpt of its parameters
 type LSFOptions = Record<string, any> & {
-  interfaces: string[];
-  keymap?: any;
-  user?: LSFUser;
-  users?: LSFUser[];
-  task?: LSFTask;
-  settings?: {
-    forceBottomPanel?: boolean;
-  };
-  instanceOptions?: {
-    reactVersion?: "v18" | "v17";
-  };
+	interfaces: string[];
+	keymap?: any;
+	user?: LSFUser;
+	users?: LSFUser[];
+	task?: LSFTask;
+	settings?: {
+		forceBottomPanel?: boolean;
+	};
+	instanceOptions?: {
+		reactVersion?: "v18" | "v17";
+	};
 };
 
 export class LabelStudio {
-  static Component = LabelStudioReact;
+	static Component = LabelStudioReact;
 
-  static instances = new Set<LabelStudio>();
+	static instances = new Set<LabelStudio>();
 
-  static destroyAll() {
-    LabelStudio.instances.forEach((inst) => inst.destroy?.());
-    LabelStudio.instances.clear();
-  }
+	static destroyAll() {
+		LabelStudio.instances.forEach((inst) => inst.destroy?.());
+		LabelStudio.instances.clear();
+	}
 
-  options: Partial<LSFOptions>;
-  root: Element | string;
-  store: any;
-  reactRoot: any;
+	options: Partial<LSFOptions>;
+	root: Element | string;
+	store: any;
+	reactRoot: any;
 
-  destroy: (() => void) | null = () => {};
-  events = new EventInvoker();
+	destroy: (() => void) | null = () => {};
+	events = new EventInvoker();
 
-  getRootElement(root: Element | string) {
-    let element: Element | null = null;
+	getRootElement(root: Element | string) {
+		let element: Element | null = null;
 
-    if (typeof root === "string") {
-      element = document.getElementById(root);
-    } else {
-      element = root;
-    }
+		if (typeof root === "string") {
+			element = document.getElementById(root);
+		} else {
+			element = root;
+		}
 
-    if (!element) {
-      throw new Error(`Root element not found (selector: ${root})`);
-    }
+		if (!element) {
+			throw new Error(`Root element not found (selector: ${root})`);
+		}
 
-    return element;
-  }
+		return element;
+	}
 
-  constructor(root: Element | string, userOptions: Partial<LSFOptions> = {}) {
-    const options = { ...defaultOptions, ...userOptions };
+	constructor(root: Element | string, userOptions: Partial<LSFOptions> = {}) {
+		const options = { ...defaultOptions, ...userOptions };
 
-    if (options.keymap) {
-      Hotkey.setKeymap(options.keymap);
-    }
+		if (options.keymap) {
+			Hotkey.setKeymap(options.keymap);
+		}
 
-    this.root = root;
-    this.options = options;
-    if (options.instanceOptions?.reactVersion === "v18") {
-      this.createAppV18();
-    } else {
-      this.createAppV17();
-    }
+		this.root = root;
+		this.options = options;
+		if (options.instanceOptions?.reactVersion === "v18") {
+			this.createAppV18();
+		} else {
+			this.createAppV17();
+		}
 
-    this.supportLegacyEvents();
+		this.supportLegacyEvents();
 
-    if (options.instanceOptions?.reactVersion !== "v18") {
-      LabelStudio.instances.add(this);
-    }
-  }
+		if (options.instanceOptions?.reactVersion !== "v18") {
+			LabelStudio.instances.add(this);
+		}
+	}
 
-  on(eventName: string, callback: Callback) {
-    this.events.on(eventName, callback);
-  }
+	on(eventName: string, callback: Callback) {
+		this.events.on(eventName, callback);
+	}
 
-  off(eventName: string, callback: Callback) {
-    if (isDefined(callback)) {
-      this.events.off(eventName, callback);
-    } else {
-      this.events.removeAll(eventName);
-    }
-  }
+	off(eventName: string, callback: Callback) {
+		if (isDefined(callback)) {
+			this.events.off(eventName, callback);
+		} else {
+			this.events.removeAll(eventName);
+		}
+	}
 
-  // This is a temporary solution that allows React 17 to work in the meantime.
-  // and we can update our other usages of LabelStudio to use createRoot, namely tests will likely be affected.
-  async createAppV17() {
-    const { store } = await configureStore(this.options, this.events);
-    const rootElement = this.getRootElement(this.root);
+	// This is a temporary solution that allows React 17 to work in the meantime.
+	// and we can update our other usages of LabelStudio to use createRoot, namely tests will likely be affected.
+	async createAppV17() {
+		const { store } = await configureStore(this.options, this.events);
+		const rootElement = this.getRootElement(this.root);
 
-    this.store = store;
-    window.Htx = this.store;
+		this.store = store;
+		window.Htx = this.store;
 
-    const isRendered = false;
+		const isRendered = false;
 
-    const renderApp = () => {
-      if (isRendered) {
-        clearRenderedApp();
-      }
-      render(<App store={this.store} />, rootElement);
-    };
+		const renderApp = () => {
+			if (isRendered) {
+				clearRenderedApp();
+			}
+			render(<App store={this.store} />, rootElement);
+		};
 
-    const clearRenderedApp = () => {
-      if (!rootElement.childNodes?.length) return;
+		const clearRenderedApp = () => {
+			if (!rootElement.childNodes?.length) return;
 
-      const childNodes = [...rootElement.childNodes];
-      // cleanDomAfterReact needs this key to be sure that cleaning affects only current react subtree
-      const reactKey = findReactKey(childNodes[0]);
+			const childNodes = [...rootElement.childNodes];
+			// cleanDomAfterReact needs this key to be sure that cleaning affects only current react subtree
+			const reactKey = findReactKey(childNodes[0]);
 
-      unmountComponentAtNode(rootElement);
-      /*
+			unmountComponentAtNode(rootElement);
+			/*
         Unmounting doesn't help with clearing React's fibers
         but removing the manually helps
         @see https://github.com/facebook/react/pull/20290 (similar problem)
         That's maybe not relevant in version 18
        */
-      cleanDomAfterReact(childNodes, reactKey);
-      cleanDomAfterReact([rootElement], reactKey);
-    };
+			cleanDomAfterReact(childNodes, reactKey);
+			cleanDomAfterReact([rootElement], reactKey);
+		};
 
-    renderApp();
-    store.setAppControls({
-      isRendered() {
-        return isRendered;
-      },
-      render: renderApp,
-      clear: clearRenderedApp,
-    });
+		renderApp();
+		store.setAppControls({
+			isRendered() {
+				return isRendered;
+			},
+			render: renderApp,
+			clear: clearRenderedApp,
+		});
 
-    this.destroy = () => {
-      if (isFF(FF_LSDV_4620_3_ML)) {
-        clearRenderedApp();
-      }
-      destroySharedStore();
-      if (isFF(FF_LSDV_4620_3_ML)) {
-        /*
+		this.destroy = () => {
+			if (isFF(FF_LSDV_4620_3_ML)) {
+				clearRenderedApp();
+			}
+			destroySharedStore();
+			if (isFF(FF_LSDV_4620_3_ML)) {
+				/*
            It seems that destroying children separately helps GC to collect garbage
            ...
          */
-        this.store.selfDestroy();
-      }
-      destroy(this.store);
-      Hotkey.unbindAll();
-      if (isFF(FF_LSDV_4620_3_ML)) {
-        /*
+				this.store.selfDestroy();
+			}
+			destroy(this.store);
+			Hotkey.unbindAll();
+			if (isFF(FF_LSDV_4620_3_ML)) {
+				/*
             ...
             as well as nulling all these this.store
          */
-        this.store = null;
-        this.destroy = null;
-        LabelStudio.instances.delete(this);
-      }
-    };
-  }
+				this.store = null;
+				this.destroy = null;
+				LabelStudio.instances.delete(this);
+			}
+		};
+	}
 
-  // To support React 18 properly, we need to use createRoot
-  // and render the app with it, and properly unmount it and cleanup all references
-  async createAppV18() {
-    const { store } = await configureStore(this.options, this.events);
-    const rootElement = this.getRootElement(this.root);
+	// To support React 18 properly, we need to use createRoot
+	// and render the app with it, and properly unmount it and cleanup all references
+	async createAppV18() {
+		const { store } = await configureStore(this.options, this.events);
+		const rootElement = this.getRootElement(this.root);
 
-    this.store = store;
-    window.Htx = this.store;
+		this.store = store;
+		window.Htx = this.store;
 
-    let isRendered = false;
+		let isRendered = false;
 
-    const renderApp = () => {
-      if (isRendered) {
-        clearRenderedApp();
-      }
-      this.reactRoot = createRoot(rootElement);
-      const AppComponent = App as any;
-      this.reactRoot.render(<AppComponent store={this.store} />);
-      isRendered = true;
-    };
+		const renderApp = () => {
+			if (isRendered) {
+				clearRenderedApp();
+			}
+			this.reactRoot = createRoot(rootElement);
+			const AppComponent = App as any;
+			this.reactRoot.render(<AppComponent store={this.store} />);
+			isRendered = true;
+		};
 
-    const clearRenderedApp = () => {
-      if (this.reactRoot && isRendered) {
-        this.reactRoot.unmount();
-        this.reactRoot = null;
-        isRendered = false;
-      }
-    };
+		const clearRenderedApp = () => {
+			if (this.reactRoot && isRendered) {
+				this.reactRoot.unmount();
+				this.reactRoot = null;
+				isRendered = false;
+			}
+		};
 
-    renderApp();
+		renderApp();
 
-    store.setAppControls({
-      isRendered() {
-        return isRendered;
-      },
-      render: renderApp,
-      clear: clearRenderedApp,
-    });
+		store.setAppControls({
+			isRendered() {
+				return isRendered;
+			},
+			render: renderApp,
+			clear: clearRenderedApp,
+		});
 
-    this.destroy = () => {
-      // Clear rendered app
-      clearRenderedApp();
+		this.destroy = () => {
+			// Clear rendered app
+			clearRenderedApp();
 
-      // Destroy shared store
-      destroySharedStore();
+			// Destroy shared store
+			destroySharedStore();
 
-      // Destroy store
-      destroy(this.store);
+			// Destroy store
+			destroy(this.store);
 
-      // Unbind all hotkeys
-      Hotkey.unbindAll();
+			// Unbind all hotkeys
+			Hotkey.unbindAll();
 
-      // Clear references
-      this.store = null;
-      window.Htx = null;
-      this.destroy = null;
-    };
-  }
+			// Clear references
+			this.store = null;
+			window.Htx = null;
+			this.destroy = null;
+		};
+	}
 
-  supportLegacyEvents() {
-    const keys = Object.keys(legacyEvents);
+	supportLegacyEvents() {
+		const keys = Object.keys(legacyEvents);
 
-    keys.forEach((key) => {
-      const callback = this.options[key];
+		keys.forEach((key) => {
+			const callback = this.options[key];
 
-      if (isDefined(callback)) {
-        const eventName = toCamelCase(key.replace(/^on/, ""));
+			if (isDefined(callback)) {
+				const eventName = toCamelCase(key.replace(/^on/, ""));
 
-        this.events.on(eventName, callback);
-      }
-    });
-  }
+				this.events.on(eventName, callback);
+			}
+		});
+	}
 }
 
 // Expose LabelStudio and Hotkey classes globally for runtime hotkey reload functionality
 if (typeof window !== "undefined") {
-  (window as any).LabelStudio = LabelStudio;
-  (window as any).Hotkey = Hotkey;
+	(window as any).LabelStudio = LabelStudio;
+	(window as any).Hotkey = Hotkey;
+	// Also expose the original default keymap for runtime reset functionality
+	(window as any).DEFAULT_HOTKEYS = { ...defaultKeymap };
 }

--- a/web/libs/editor/src/LabelStudio.tsx
+++ b/web/libs/editor/src/LabelStudio.tsx
@@ -260,5 +260,3 @@ export class LabelStudio {
     });
   }
 }
-
-

--- a/web/libs/editor/src/LabelStudio.tsx
+++ b/web/libs/editor/src/LabelStudio.tsx
@@ -1,7 +1,8 @@
 import { configure } from "mobx";
+import { destroy } from "mobx-state-tree";
+import { render, unmountComponentAtNode } from "react-dom";
 import { createRoot } from "react-dom/client";
 import { toCamelCase } from "strman";
-import { destroy } from "mobx-state-tree";
 import { LabelStudio as LabelStudioReact } from "./Component";
 import App from "./components/App/App";
 import { configureStore } from "./configureStore";
@@ -10,11 +11,9 @@ import { Hotkey } from "./core/Hotkey";
 import defaultOptions from "./defaultOptions";
 import { destroy as destroySharedStore } from "./mixins/SharedChoiceStore/mixin";
 import { EventInvoker } from "./utils/events";
-import { isDefined } from "./utils/utilities";
+import { FF_LSDV_4620_3_ML, isFF } from "./utils/feature-flags";
 import { cleanDomAfterReact, findReactKey } from "./utils/reactCleaner";
-import { render, unmountComponentAtNode } from "react-dom";
-import { isFF } from "./utils/feature-flags";
-import { FF_LSDV_4620_3_ML } from "./utils/feature-flags";
+import { isDefined } from "./utils/utilities";
 
 declare global {
   interface Window {
@@ -259,4 +258,10 @@ export class LabelStudio {
       }
     });
   }
+}
+
+// Expose LabelStudio and Hotkey classes globally for runtime hotkey reload functionality
+if (typeof window !== "undefined") {
+  (window as any).LabelStudio = LabelStudio;
+  (window as any).Hotkey = Hotkey;
 }

--- a/web/libs/editor/src/LabelStudio.tsx
+++ b/web/libs/editor/src/LabelStudio.tsx
@@ -16,14 +16,18 @@ import { FF_LSDV_4620_3_ML, isFF } from "./utils/feature-flags";
 import { cleanDomAfterReact, findReactKey } from "./utils/reactCleaner";
 import { isDefined } from "./utils/utilities";
 
+// Extend window interface for TypeScript
 declare global {
-  interface Window {
-    Htx: any;
-  }
+	interface Window {
+		LabelStudio?: typeof LabelStudio;
+		Hotkey?: typeof Hotkey;
+		DEFAULT_HOTKEYS?: typeof defaultKeymap;
+		Htx: any;
+	}
 }
 
 configure({
-  isolateGlobalState: true,
+	isolateGlobalState: true,
 });
 
 type Callback = (...args: any[]) => any;
@@ -35,236 +39,236 @@ type LSFTask = any;
 // because those options will go as initial values for AppStore
 // but it's not types yet, so here is some excerpt of its parameters
 type LSFOptions = Record<string, any> & {
-  interfaces: string[];
-  keymap?: any;
-  user?: LSFUser;
-  users?: LSFUser[];
-  task?: LSFTask;
-  settings?: {
-    forceBottomPanel?: boolean;
-  };
-  instanceOptions?: {
-    reactVersion?: "v18" | "v17";
-  };
+	interfaces: string[];
+	keymap?: any;
+	user?: LSFUser;
+	users?: LSFUser[];
+	task?: LSFTask;
+	settings?: {
+		forceBottomPanel?: boolean;
+	};
+	instanceOptions?: {
+		reactVersion?: "v18" | "v17";
+	};
 };
 
 export class LabelStudio {
-  static Component = LabelStudioReact;
+	static Component = LabelStudioReact;
 
-  static instances = new Set<LabelStudio>();
+	static instances = new Set<LabelStudio>();
 
-  static destroyAll() {
-    LabelStudio.instances.forEach((inst) => inst.destroy?.());
-    LabelStudio.instances.clear();
-  }
+	static destroyAll() {
+		LabelStudio.instances.forEach((inst) => inst.destroy?.());
+		LabelStudio.instances.clear();
+	}
 
-  options: Partial<LSFOptions>;
-  root: Element | string;
-  store: any;
-  reactRoot: any;
+	options: Partial<LSFOptions>;
+	root: Element | string;
+	store: any;
+	reactRoot: any;
 
-  destroy: (() => void) | null = () => {};
-  events = new EventInvoker();
+	destroy: (() => void) | null = () => {};
+	events = new EventInvoker();
 
-  getRootElement(root: Element | string) {
-    let element: Element | null = null;
+	getRootElement(root: Element | string) {
+		let element: Element | null = null;
 
-    if (typeof root === "string") {
-      element = document.getElementById(root);
-    } else {
-      element = root;
-    }
+		if (typeof root === "string") {
+			element = document.getElementById(root);
+		} else {
+			element = root;
+		}
 
-    if (!element) {
-      throw new Error(`Root element not found (selector: ${root})`);
-    }
+		if (!element) {
+			throw new Error(`Root element not found (selector: ${root})`);
+		}
 
-    return element;
-  }
+		return element;
+	}
 
-  constructor(root: Element | string, userOptions: Partial<LSFOptions> = {}) {
-    const options = { ...defaultOptions, ...userOptions };
+	constructor(root: Element | string, userOptions: Partial<LSFOptions> = {}) {
+		const options = { ...defaultOptions, ...userOptions };
 
-    if (options.keymap) {
-      Hotkey.setKeymap(options.keymap);
-    }
+		if (options.keymap) {
+			Hotkey.setKeymap(options.keymap);
+		}
 
-    this.root = root;
-    this.options = options;
-    if (options.instanceOptions?.reactVersion === "v18") {
-      this.createAppV18();
-    } else {
-      this.createAppV17();
-    }
+		this.root = root;
+		this.options = options;
+		if (options.instanceOptions?.reactVersion === "v18") {
+			this.createAppV18();
+		} else {
+			this.createAppV17();
+		}
 
-    this.supportLegacyEvents();
+		this.supportLegacyEvents();
 
-    if (options.instanceOptions?.reactVersion !== "v18") {
-      LabelStudio.instances.add(this);
-    }
-  }
+		if (options.instanceOptions?.reactVersion !== "v18") {
+			LabelStudio.instances.add(this);
+		}
+	}
 
-  on(eventName: string, callback: Callback) {
-    this.events.on(eventName, callback);
-  }
+	on(eventName: string, callback: Callback) {
+		this.events.on(eventName, callback);
+	}
 
-  off(eventName: string, callback: Callback) {
-    if (isDefined(callback)) {
-      this.events.off(eventName, callback);
-    } else {
-      this.events.removeAll(eventName);
-    }
-  }
+	off(eventName: string, callback: Callback) {
+		if (isDefined(callback)) {
+			this.events.off(eventName, callback);
+		} else {
+			this.events.removeAll(eventName);
+		}
+	}
 
-  // This is a temporary solution that allows React 17 to work in the meantime.
-  // and we can update our other usages of LabelStudio to use createRoot, namely tests will likely be affected.
-  async createAppV17() {
-    const { store } = await configureStore(this.options, this.events);
-    const rootElement = this.getRootElement(this.root);
+	// This is a temporary solution that allows React 17 to work in the meantime.
+	// and we can update our other usages of LabelStudio to use createRoot, namely tests will likely be affected.
+	async createAppV17() {
+		const { store } = await configureStore(this.options, this.events);
+		const rootElement = this.getRootElement(this.root);
 
-    this.store = store;
-    window.Htx = this.store;
+		this.store = store;
+		window.Htx = this.store;
 
-    const isRendered = false;
+		const isRendered = false;
 
-    const renderApp = () => {
-      if (isRendered) {
-        clearRenderedApp();
-      }
-      render(<App store={this.store} />, rootElement);
-    };
+		const renderApp = () => {
+			if (isRendered) {
+				clearRenderedApp();
+			}
+			render(<App store={this.store} />, rootElement);
+		};
 
-    const clearRenderedApp = () => {
-      if (!rootElement.childNodes?.length) return;
+		const clearRenderedApp = () => {
+			if (!rootElement.childNodes?.length) return;
 
-      const childNodes = [...rootElement.childNodes];
-      // cleanDomAfterReact needs this key to be sure that cleaning affects only current react subtree
-      const reactKey = findReactKey(childNodes[0]);
+			const childNodes = [...rootElement.childNodes];
+			// cleanDomAfterReact needs this key to be sure that cleaning affects only current react subtree
+			const reactKey = findReactKey(childNodes[0]);
 
-      unmountComponentAtNode(rootElement);
-      /*
+			unmountComponentAtNode(rootElement);
+			/*
         Unmounting doesn't help with clearing React's fibers
         but removing the manually helps
         @see https://github.com/facebook/react/pull/20290 (similar problem)
         That's maybe not relevant in version 18
        */
-      cleanDomAfterReact(childNodes, reactKey);
-      cleanDomAfterReact([rootElement], reactKey);
-    };
+			cleanDomAfterReact(childNodes, reactKey);
+			cleanDomAfterReact([rootElement], reactKey);
+		};
 
-    renderApp();
-    store.setAppControls({
-      isRendered() {
-        return isRendered;
-      },
-      render: renderApp,
-      clear: clearRenderedApp,
-    });
+		renderApp();
+		store.setAppControls({
+			isRendered() {
+				return isRendered;
+			},
+			render: renderApp,
+			clear: clearRenderedApp,
+		});
 
-    this.destroy = () => {
-      if (isFF(FF_LSDV_4620_3_ML)) {
-        clearRenderedApp();
-      }
-      destroySharedStore();
-      if (isFF(FF_LSDV_4620_3_ML)) {
-        /*
+		this.destroy = () => {
+			if (isFF(FF_LSDV_4620_3_ML)) {
+				clearRenderedApp();
+			}
+			destroySharedStore();
+			if (isFF(FF_LSDV_4620_3_ML)) {
+				/*
            It seems that destroying children separately helps GC to collect garbage
            ...
          */
-        this.store.selfDestroy();
-      }
-      destroy(this.store);
-      Hotkey.unbindAll();
-      if (isFF(FF_LSDV_4620_3_ML)) {
-        /*
+				this.store.selfDestroy();
+			}
+			destroy(this.store);
+			Hotkey.unbindAll();
+			if (isFF(FF_LSDV_4620_3_ML)) {
+				/*
             ...
             as well as nulling all these this.store
          */
-        this.store = null;
-        this.destroy = null;
-        LabelStudio.instances.delete(this);
-      }
-    };
-  }
+				this.store = null;
+				this.destroy = null;
+				LabelStudio.instances.delete(this);
+			}
+		};
+	}
 
-  // To support React 18 properly, we need to use createRoot
-  // and render the app with it, and properly unmount it and cleanup all references
-  async createAppV18() {
-    const { store } = await configureStore(this.options, this.events);
-    const rootElement = this.getRootElement(this.root);
+	// To support React 18 properly, we need to use createRoot
+	// and render the app with it, and properly unmount it and cleanup all references
+	async createAppV18() {
+		const { store } = await configureStore(this.options, this.events);
+		const rootElement = this.getRootElement(this.root);
 
-    this.store = store;
-    window.Htx = this.store;
+		this.store = store;
+		window.Htx = this.store;
 
-    let isRendered = false;
+		let isRendered = false;
 
-    const renderApp = () => {
-      if (isRendered) {
-        clearRenderedApp();
-      }
-      this.reactRoot = createRoot(rootElement);
-      const AppComponent = App as any;
-      this.reactRoot.render(<AppComponent store={this.store} />);
-      isRendered = true;
-    };
+		const renderApp = () => {
+			if (isRendered) {
+				clearRenderedApp();
+			}
+			this.reactRoot = createRoot(rootElement);
+			const AppComponent = App as any;
+			this.reactRoot.render(<AppComponent store={this.store} />);
+			isRendered = true;
+		};
 
-    const clearRenderedApp = () => {
-      if (this.reactRoot && isRendered) {
-        this.reactRoot.unmount();
-        this.reactRoot = null;
-        isRendered = false;
-      }
-    };
+		const clearRenderedApp = () => {
+			if (this.reactRoot && isRendered) {
+				this.reactRoot.unmount();
+				this.reactRoot = null;
+				isRendered = false;
+			}
+		};
 
-    renderApp();
+		renderApp();
 
-    store.setAppControls({
-      isRendered() {
-        return isRendered;
-      },
-      render: renderApp,
-      clear: clearRenderedApp,
-    });
+		store.setAppControls({
+			isRendered() {
+				return isRendered;
+			},
+			render: renderApp,
+			clear: clearRenderedApp,
+		});
 
-    this.destroy = () => {
-      // Clear rendered app
-      clearRenderedApp();
+		this.destroy = () => {
+			// Clear rendered app
+			clearRenderedApp();
 
-      // Destroy shared store
-      destroySharedStore();
+			// Destroy shared store
+			destroySharedStore();
 
-      // Destroy store
-      destroy(this.store);
+			// Destroy store
+			destroy(this.store);
 
-      // Unbind all hotkeys
-      Hotkey.unbindAll();
+			// Unbind all hotkeys
+			Hotkey.unbindAll();
 
-      // Clear references
-      this.store = null;
-      window.Htx = null;
-      this.destroy = null;
-    };
-  }
+			// Clear references
+			this.store = null;
+			window.Htx = null;
+			this.destroy = null;
+		};
+	}
 
-  supportLegacyEvents() {
-    const keys = Object.keys(legacyEvents);
+	supportLegacyEvents() {
+		const keys = Object.keys(legacyEvents);
 
-    keys.forEach((key) => {
-      const callback = this.options[key];
+		keys.forEach((key) => {
+			const callback = this.options[key];
 
-      if (isDefined(callback)) {
-        const eventName = toCamelCase(key.replace(/^on/, ""));
+			if (isDefined(callback)) {
+				const eventName = toCamelCase(key.replace(/^on/, ""));
 
-        this.events.on(eventName, callback);
-      }
-    });
-  }
+				this.events.on(eventName, callback);
+			}
+		});
+	}
 }
 
 // Expose LabelStudio and Hotkey classes globally for runtime hotkey reload functionality
 if (typeof window !== "undefined") {
-  (window as any).LabelStudio = LabelStudio;
-  (window as any).Hotkey = Hotkey;
-  // Also expose the original default keymap for runtime reset functionality
-  (window as any).DEFAULT_HOTKEYS = { ...defaultKeymap };
+	window.LabelStudio = LabelStudio;
+	window.Hotkey = Hotkey;
+	// Also expose the original default keymap for runtime reset functionality
+	window.DEFAULT_HOTKEYS = { ...defaultKeymap };
 }


### PR DESCRIPTION
## Reason for change
This PR fixes the issue where users had to refresh the page after changing hotkey settings in Account Settings.

## Key changes

- Added reloadHotkeysInRuntime() function that dynamically applies hotkey changes without page refresh
- Function processes custom hotkeys, merges with default editor keymap, and updates window.APP_SETTINGS
- Re-initializes hotkeys in existing editor instances by triggering their hotkey reload mechanisms
- Exposed LabelStudio and Hotkey classes globally on the window object to enable runtime access
- Integrated runtime reload into the hotkey save flow with proper error handling

## Result
Hotkey changes now take effect immediately after saving, improving user experience by eliminating the need for manual page refreshes.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
