### PR TITLE
fix: UTC-205: Ensure that DataManager Annotators CellView handles max display value correctly

### DIFF
--- a/web/libs/datamanager/src/components/CellViews/Annotators/Annotators.jsx
+++ b/web/libs/datamanager/src/components/CellViews/Annotators/Annotators.jsx
@@ -18,8 +18,8 @@ const isFilterMembers = isActive(FF_DM_FILTER_MEMBERS);
 export const Annotators = (cell) => {
   const { value, column, original: task } = cell;
   const sdk = useSDK();
-  const maxUsersToDisplay = window.APP_SETTINGS.data_manager.max_users_to_display;
-  const userList = Array.from(value).slice(0, maxUsersToDisplay);
+  const maxUsersToDisplay = window.APP_SETTINGS.data_manager?.max_users_to_display ?? 0;
+  const userList = maxUsersToDisplay > 0 ? Array.from(value).slice(0, maxUsersToDisplay) : value;
   const userPickBadge = cn("userpic-badge");
   const annotatorsCN = cn("annotators");
   const isEnterprise = window.APP_SETTINGS.billing?.enterprise;


### PR DESCRIPTION
This pull request includes a small but important change to improve the robustness of the `Annotators` component in `Annotators.jsx`. The change ensures that the `max_users_to_display` setting is safely accessed and applies a fallback value if it is undefined or null.

Key change:

* Updated the `maxUsersToDisplay` assignment to use optional chaining (`?.`) and a nullish coalescing operator (`??`) to provide a default value of `0`. This prevents potential runtime errors when `max_users_to_display` is not defined in `window.APP_SETTINGS.data_manager`. Additionally, the logic for slicing the `userList` was adjusted to handle cases where `maxUsersToDisplay` is `0` by defaulting to the full list of users. (`[web/libs/datamanager/src/components/CellViews/Annotators/Annotators.jsxL21-R22](diffhunk://#diff-c25ae79a750b0d8750fff03e6a58ce327f8eed4c01f720ac93fcbba5690c75ffL21-R22)`)