### PR TITLE
fix: UTC-205: Always return comment authors count

### DIFF
--- a/label_studio/tasks/api.py
+++ b/label_studio/tasks/api.py
@@ -318,7 +318,8 @@ class TaskAPI(generics.RetrieveUpdateDestroyAPIView):
             project.evaluate_predictions_automatically or project.show_collab_predictions
         ) and not self.task.predictions.exists():
             evaluate_predictions([self.task])
-            self.task.refresh_from_db()
+            # refresh task from db with prefetches
+            self.task = self.get_object()
 
         serializer = self.get_serializer_class()(
             self.task, many=False, context=context, expand=['annotations.completed_by']

--- a/web/libs/datamanager/src/stores/DataStores/tasks.js
+++ b/web/libs/datamanager/src/stores/DataStores/tasks.js
@@ -38,9 +38,9 @@ export const create = (columns) => {
     updated_by: types.optional(types.array(Assignee), []),
     ...(isFF(FF_DISABLE_GLOBAL_USER_FETCHING)
       ? {
-          annotators_count: types.optional(types.number, 0),
-          reviewers_count: types.optional(types.number, 0),
-          comment_authors_count: types.optional(types.number, 0),
+          annotators_count: types.optional(types.maybeNull(types.number), 0),
+          reviewers_count: types.optional(types.maybeNull(types.number), 0),
+          comment_authors_count: types.optional(types.maybeNull(types.number), 0),
         }
       : {}),
     ...(isFF(FF_LOPS_E_3)


### PR DESCRIPTION
Added extra type safety in the user counters in case they come as null as mobx will fail in such a case.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
