### PR TITLE
fix: BROS-274: Fix app crash when no hotkeys found

### DIFF
--- a/web/libs/datamanager/src/sdk/hotkeys.ts
+++ b/web/libs/datamanager/src/sdk/hotkeys.ts
@@ -33,7 +33,7 @@ export const useShortcut = (
 
   // Check for custom shortcut in app settings
   const customMapping = window.APP_SETTINGS?.lookupHotkey?.(`data_manager:${actionName}`);
-  if (customMapping !== undefined) {
+  if (customMapping) {
     // Explicitly use the custom key even if it's null
     shortcut = customMapping.key;
   }

--- a/web/libs/editor/tests/integration/e2e/video/timeline_region_loop.cy.ts
+++ b/web/libs/editor/tests/integration/e2e/video/timeline_region_loop.cy.ts
@@ -8,7 +8,16 @@ import {
 } from "../../data/video_segmentation/timeline_regions";
 import { TWO_FRAMES_TIMEOUT } from "../utils/constants";
 
-describe("Video Timeline Region Loop Playback", () => {
+// This test suite has exhibited flakiness in CI environments, so we are using retries
+// while we work on improving CI stability for visual comparisons.
+const suiteConfig = {
+  retries: {
+    runMode: 3, // Retry 3 times in CI (headless mode)
+    openMode: 0, // No retries in local development (interactive mode)
+  },
+};
+
+describe("Video Timeline Region Loop Playback", suiteConfig, () => {
   beforeEach(() => {
     LabelStudio.addFeatureFlagsOnPageLoad({
       fflag_fix_front_optic_1608_improve_video_frame_seek_precision_short: true,


### PR DESCRIPTION
<img width="887" height="323" alt="Screenshot 2025-08-05 at 09 36 50" src="https://github.com/user-attachments/assets/adbcdb00-a745-475e-ae47-7ab160910c86" />

<img width="378" height="149" alt="Screenshot 2025-08-05 at 09 37 15" src="https://github.com/user-attachments/assets/c0167ec8-4de1-46b3-bc33-758d7a4613a6" />

Follow-up for https://github.com/HumanSignal/label-studio/pull/8085