### PR TITLE
Align close button in filter row

### DIFF
--- a/web/libs/datamanager/src/components/Filters/FilterLine/FilterLine.scss
+++ b/web/libs/datamanager/src/components/Filters/FilterLine/FilterLine.scss
@@ -5,7 +5,7 @@
   min-width: min-content;
   padding: 5px 10px;
   box-sizing: content-box;
-  align-items: flex-start;
+  align-items: center;
   grid-gap: 2px;
   grid-template-columns: 70px 110px 100px 120px 24px;
 
@@ -49,7 +49,7 @@
     display: grid;
     grid-template-columns: min-content 1fr;
     grid-gap: 2px;
-    align-items: flex-start;
+    align-items: center;
   }
 
   &__selector {


### PR DESCRIPTION
<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
**Reason for change:**
Previously, the close button (blue X) in the first filter line was misaligned to the top of the row. This PR corrects the vertical alignment of the close button and other filter line elements to be centered, matching the consistent alignment seen in subsequent filter lines.

**Screenshots:**
Please provide screenshots of the filter lines after this change to demonstrate the correct alignment of the close button.

**Rollout strategy:**
Standard deployment. No specific feature flags or environment variables are needed.

**Testing:**
Manually verify that the close button (blue X) and other elements within all filter lines are vertically centered.

**Risks:**
Low risk. This is a purely visual CSS alignment fix.

**Reviewer notes:**
The core change involves updating `align-items` from `flex-start` to `center` on both the `.filter-line` and `&__group` elements in `FilterLine.scss`.

**General notes:**
The `align-items: center` property ensures that items within a flex or grid container are vertically centered along the cross-axis, resolving the previous top-alignment issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-8bbf3574-a5d6-4522-ad2e-d73dc0cacd78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8bbf3574-a5d6-4522-ad2e-d73dc0cacd78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

