### PR TITLE
fix: BROS-264: External id

### DIFF
--- a/web/apps/labelstudio/src/pages/Settings/StorageSettings/providers/azure.ts
+++ b/web/apps/labelstudio/src/pages/Settings/StorageSettings/providers/azure.ts
@@ -62,6 +62,10 @@ export const azureProvider: ProviderConfig = {
       schema: z.number().min(1).max(10080).default(15),
       target: "import",
       resetConnection: false,
+      dependsOn: {
+        field: "presign",
+        value: true,
+      },
     },
   ],
   layout: [

--- a/web/apps/labelstudio/src/pages/Settings/StorageSettings/providers/gcs.ts
+++ b/web/apps/labelstudio/src/pages/Settings/StorageSettings/providers/gcs.ts
@@ -59,7 +59,10 @@ export const gcsProvider: ProviderConfig = {
       schema: z.number().min(1).max(10080).default(15),
       target: "import",
       resetConnection: false,
-      // dependency: "presign" // Not implemented in UI yet
+      dependsOn: {
+        field: "presign",
+        value: true,
+      },
     },
   ],
   layout: [

--- a/web/apps/labelstudio/src/pages/Settings/StorageSettings/providers/s3.ts
+++ b/web/apps/labelstudio/src/pages/Settings/StorageSettings/providers/s3.ts
@@ -86,6 +86,10 @@ export const s3Provider: ProviderConfig = {
       schema: z.number().min(1).max(10080).default(15),
       target: "import",
       resetConnection: false,
+      dependsOn: {
+        field: "presign",
+        value: true,
+      },
     },
   ],
   layout: [

--- a/web/libs/app-common/src/blocks/StorageProviderForm/README.md
+++ b/web/libs/app-common/src/blocks/StorageProviderForm/README.md
@@ -110,12 +110,21 @@ export const providerRegistry: Record<string, ProviderConfig> = {
   step?: number;         // For number/counter fields
   autoComplete?: string; // For input fields
   gridCols?: number;     // How many columns this field should span (1-12)
+  readOnly?: boolean;    // Whether field is read-only (not editable by user)
+  dependsOn?: {          // Field dependency configuration
+    field: string;       // Name of the field this depends on
+    value: any | ((dependencyValue: any, formData: Record<string, any>) => boolean); // The value or function to check if field should be enabled
+  };
 }
 ```
 
 ## Default Values
 
-Default values are now defined directly in the Zod schema using `.default()`:
+Default values can be defined in two ways:
+
+### 1. Schema Defaults (Recommended)
+
+Default values are defined directly in the Zod schema using `.default()`:
 
 ```typescript
 {
@@ -139,6 +148,182 @@ Default values are now defined directly in the Zod schema using `.default()`:
 ```
 
 The system automatically extracts these default values from the schemas using the `extractDefaultValues()` function.
+
+### 2. Custom Default Values
+
+You can also provide custom default values when using the `StorageProviderForm` component:
+
+```typescript
+const customDefaults = {
+  s3: {
+    region: "us-west-2",
+    bucket: "my-default-bucket",
+  },
+  gcp: {
+    project_id: "my-default-project",
+    bucket: "my-default-bucket",
+  },
+};
+
+<StorageProviderForm
+  // ... other props
+  defaultValues={customDefaults}
+/>
+```
+
+Custom defaults take precedence over schema defaults. The structure is:
+```typescript
+{
+  [providerName: string]: {
+    [fieldName: string]: any
+  }
+}
+```
+
+## Read-Only Fields
+
+You can mark fields as read-only by setting the `readOnly` property to `true`. Read-only fields will be displayed but cannot be edited by users:
+
+```typescript
+{
+  name: "api_endpoint",
+  type: "text",
+  label: "API Endpoint",
+  description: "The endpoint URL for the API",
+  schema: z.string().url("Must be a valid URL"),
+  readOnly: true, // This field cannot be edited
+},
+{
+  name: "region",
+  type: "select",
+  label: "Region",
+  schema: z.string().default("us-east-1"),
+  options: [
+    { value: "us-east-1", label: "US East (N. Virginia)" },
+    { value: "us-west-2", label: "US West (Oregon)" },
+  ],
+  readOnly: true, // This field cannot be edited
+},
+```
+
+Read-only fields are useful for:
+- Pre-configured values that shouldn't be changed
+- System-generated values
+- Fields that are set by environment variables
+- Default configurations that should remain fixed
+
+## Field Dependencies
+
+You can create field dependencies using the `dependsOn` property. This allows you to disable fields based on the state of other fields. The `value` property can be either a static value or a dynamic function.
+
+### Static Value Dependencies
+
+```typescript
+{
+  name: "presigned_urls",
+  type: "toggle",
+  label: "Use Presigned URLs",
+  description: "Generate presigned URLs for file access",
+  schema: z.boolean().default(false),
+},
+{
+  name: "ttl",
+  type: "counter",
+  label: "TTL (seconds)",
+  description: "Time to live for presigned URLs",
+  schema: z.number().min(1).max(3600).default(3600),
+  dependsOn: {
+    field: "presigned_urls",
+    value: true, // TTL field is only enabled when presigned_urls is true
+  },
+},
+```
+
+### Dynamic Function Dependencies
+
+For more complex logic, you can use a function that receives the dependency value and the entire form data:
+
+```typescript
+{
+  name: "encryption_type",
+  type: "select",
+  label: "Encryption Type",
+  schema: z.string().default("none"),
+  options: [
+    { value: "none", label: "No Encryption" },
+    { value: "aes", label: "AES-256" },
+    { value: "custom", label: "Custom Encryption" },
+  ],
+},
+{
+  name: "encryption_key",
+  type: "password",
+  label: "Encryption Key",
+  description: "Key for encryption",
+  schema: z.string().min(1, "Encryption key is required"),
+  dependsOn: {
+    field: "encryption_type",
+    value: (encryptionType, formData) => {
+      // Enable only when encryption type is not "none"
+      return encryptionType !== "none";
+    },
+  },
+},
+{
+  name: "custom_algorithm",
+  type: "text",
+  label: "Custom Algorithm",
+  description: "Custom encryption algorithm",
+  schema: z.string().min(1, "Algorithm is required"),
+  dependsOn: {
+    field: "encryption_type",
+    value: (encryptionType, formData) => {
+      // Enable only when encryption type is "custom"
+      return encryptionType === "custom";
+    },
+  },
+},
+```
+
+### Toggle Field Dependencies
+
+For toggle fields, you can check the `checked` state:
+
+```typescript
+{
+  name: "use_ssl",
+  type: "toggle",
+  label: "Use SSL",
+  description: "Enable SSL for secure connections",
+  schema: z.boolean().default(true),
+},
+{
+  name: "ssl_certificate",
+  type: "textarea",
+  label: "SSL Certificate",
+  description: "Paste your SSL certificate",
+  schema: z.string().min(1, "SSL certificate is required"),
+  dependsOn: {
+    field: "use_ssl",
+    value: (useSsl, formData) => {
+      // Enable only when SSL is enabled
+      return useSsl === true;
+    },
+  },
+},
+```
+
+In these examples:
+- Static values work for simple equality checks
+- Dynamic functions allow complex conditional logic
+- Functions receive the dependency field value and the entire form data
+- Toggle fields can be checked for their boolean state
+
+Field dependencies are useful for:
+- Conditional field visibility
+- Multi-step form logic
+- Feature toggles
+- Optional configuration sections
 
 ## Layout Configuration
 
@@ -186,6 +371,217 @@ The system provides several helper functions:
 ## Example: Complete Provider
 
 See `providers/example.ts` for a complete example of a new provider configuration.
+
+## Example: Using Custom Default Values
+
+Here's a complete example of how to use the `StorageProviderForm` with custom default values:
+
+```typescript
+import { StorageProviderForm } from '@humansignal/app-common';
+
+// Define custom default values for different providers
+const customDefaults = {
+  s3: {
+    region: "us-west-2",
+    bucket: "my-default-bucket",
+    prefix: "data/",
+  },
+  gcp: {
+    project_id: "my-default-project",
+    bucket: "my-default-bucket",
+    prefix: "annotations/",
+  },
+  azure: {
+    container: "my-default-container",
+    account_name: "myaccount",
+    prefix: "exports/",
+  },
+};
+
+// Use the form with custom defaults
+function MyStorageForm() {
+  const handleSubmit = () => {
+    // Handle form submission
+  };
+
+  return (
+    <StorageProviderForm
+      onSubmit={handleSubmit}
+      target="import"
+      project={123}
+      storageTypes={[
+        { title: "Amazon S3", name: "s3" },
+        { title: "Google Cloud Storage", name: "gcp" },
+        { title: "Azure Blob Storage", name: "azure" },
+      ]}
+      providers={providerRegistry}
+      defaultValues={customDefaults}
+      title="Configure Storage Provider"
+    />
+  );
+}
+```
+
+In this example:
+- When a user selects "S3", the form will be pre-filled with `region: "us-west-2"`, `bucket: "my-default-bucket"`, and `prefix: "data/"`
+- When a user selects "GCP", the form will be pre-filled with `project_id: "my-default-project"`, `bucket: "my-default-bucket"`, and `prefix: "annotations/"`
+- Custom defaults take precedence over any defaults defined in the provider schemas
+
+## Example: Using Read-Only Fields
+
+Here's an example of how to use read-only fields in a provider configuration:
+
+```typescript
+export const myProvider: ProviderConfig = {
+  name: "myprovider",
+  title: "My Storage Provider",
+  description: "Configure your My Storage Provider connection",
+  fields: [
+    {
+      name: "api_endpoint",
+      type: "text",
+      label: "API Endpoint",
+      description: "The endpoint URL for the API",
+      schema: z.string().url("Must be a valid URL"),
+      readOnly: true, // This field cannot be edited
+    },
+    {
+      name: "api_key",
+      type: "password",
+      label: "API Key",
+      required: true,
+      placeholder: "Enter your API key",
+      schema: z.string().min(1, "API Key is required"),
+    },
+    {
+      name: "region",
+      type: "select",
+      label: "Region",
+      schema: z.string().default("us-east-1"),
+      options: [
+        { value: "us-east-1", label: "US East (N. Virginia)" },
+        { value: "us-west-2", label: "US West (Oregon)" },
+      ],
+      readOnly: true, // This field cannot be edited
+    },
+    {
+      name: "use_ssl",
+      type: "toggle",
+      label: "Use SSL",
+      description: "Enable SSL for secure connections",
+      schema: z.boolean().default(true),
+    },
+  ],
+  layout: [
+    {
+      fields: ["api_endpoint"],
+    },
+    {
+      fields: ["api_key"],
+    },
+    {
+      fields: ["region", "use_ssl"],
+    },
+  ],
+};
+```
+
+In this example:
+- The `api_endpoint` field is read-only and will be pre-filled but cannot be changed by users
+- The `region` field is also read-only and will show the default value but cannot be modified
+- The `api_key` and `use_ssl` fields are editable as normal
+
+## Example: Combining Read-Only Fields and Dependencies
+
+Here's an example that combines both read-only fields and field dependencies:
+
+```typescript
+export const advancedProvider: ProviderConfig = {
+  name: "advancedprovider",
+  title: "Advanced Storage Provider",
+  description: "Configure your advanced storage provider with conditional features",
+  fields: [
+    {
+      name: "api_endpoint",
+      type: "text",
+      label: "API Endpoint",
+      description: "The endpoint URL for the API",
+      schema: z.string().url("Must be a valid URL"),
+      readOnly: true, // This field cannot be edited
+    },
+    {
+      name: "api_key",
+      type: "password",
+      label: "API Key",
+      required: true,
+      placeholder: "Enter your API key",
+      schema: z.string().min(1, "API Key is required"),
+    },
+    {
+      name: "use_presigned_urls",
+      type: "toggle",
+      label: "Use Presigned URLs",
+      description: "Generate presigned URLs for secure file access",
+      schema: z.boolean().default(false),
+    },
+    {
+      name: "ttl_seconds",
+      type: "counter",
+      label: "TTL (seconds)",
+      description: "Time to live for presigned URLs",
+      schema: z.number().min(1).max(3600).default(3600),
+      dependsOn: {
+        field: "use_presigned_urls",
+        value: (usePresignedUrls, formData) => {
+          // Only enabled when presigned URLs are enabled
+          return usePresignedUrls === true;
+        },
+      },
+    },
+    {
+      name: "encryption_enabled",
+      type: "toggle",
+      label: "Enable Encryption",
+      description: "Enable client-side encryption",
+      schema: z.boolean().default(false),
+    },
+    {
+      name: "encryption_key",
+      type: "password",
+      label: "Encryption Key",
+      description: "Key for client-side encryption",
+      schema: z.string().min(1, "Encryption key is required"),
+      dependsOn: {
+        field: "encryption_enabled",
+        value: (encryptionEnabled, formData) => {
+          // Only enabled when encryption is enabled
+          return encryptionEnabled === true;
+        },
+      },
+    },
+  ],
+  layout: [
+    {
+      fields: ["api_endpoint"],
+    },
+    {
+      fields: ["api_key"],
+    },
+    {
+      fields: ["use_presigned_urls", "ttl_seconds"],
+    },
+    {
+      fields: ["encryption_enabled", "encryption_key"],
+    },
+  ],
+};
+```
+
+In this example:
+- `api_endpoint` is read-only and cannot be changed
+- `ttl_seconds` is only enabled when `use_presigned_urls` is `true`
+- `encryption_key` is only enabled when `encryption_enabled` is `true`
+- The form dynamically shows/hides fields based on user selections
 
 ## Benefits
 

--- a/web/libs/app-common/src/blocks/StorageProviderForm/components/field-renderer.tsx
+++ b/web/libs/app-common/src/blocks/StorageProviderForm/components/field-renderer.tsx
@@ -12,6 +12,7 @@ interface FieldRendererProps {
   onBlur?: (name: string, value: any) => void;
   error?: string;
   isEditMode?: boolean;
+  formData?: Record<string, any>; // Add formData to check dependencies
 }
 
 export const FieldRenderer: React.FC<FieldRendererProps> = ({
@@ -21,8 +22,36 @@ export const FieldRenderer: React.FC<FieldRendererProps> = ({
   onBlur,
   error,
   isEditMode = false,
+  formData = {},
 }) => {
+  // Check if field should be disabled based on dependencies
+  const isDisabledByDependency = () => {
+    if (!field.dependsOn || !formData) {
+      return false;
+    }
+
+    const dependencyValue = formData[field.dependsOn.field];
+    const dependsOnValue = field.dependsOn.value;
+
+    // If dependsOn.value is a function, call it with the dependency value and form data
+    if (typeof dependsOnValue === 'function') {
+      const shouldEnable = dependsOnValue(dependencyValue, formData);
+      return !shouldEnable;
+    }
+
+    // Otherwise, do a simple equality check
+    return dependencyValue !== dependsOnValue;
+  };
+
+  // Check if field should be disabled (either read-only or by dependency)
+  const isFieldDisabled = () => {
+    return field.readOnly || isDisabledByDependency();
+  };
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    // Don't allow changes if field is disabled
+    if (isFieldDisabled()) {
+      return;
+    }
     const { name, value: inputValue, type } = e.target;
     const parsedValue = type === "number" ? Number(inputValue) : inputValue;
     onChange(name, parsedValue);
@@ -37,14 +66,26 @@ export const FieldRenderer: React.FC<FieldRendererProps> = ({
   };
 
   const handleToggleChange = (checked: boolean) => {
+    // Don't allow changes if field is disabled
+    if (isFieldDisabled()) {
+      return;
+    }
     onChange(field.name, checked);
   };
 
   const handleSelectChange = (value: string) => {
+    // Don't allow changes if field is disabled
+    if (isFieldDisabled()) {
+      return;
+    }
     onChange(field.name, value);
   };
 
   const handleCounterChange = (e: any) => {
+    // Don't allow changes if field is disabled
+    if (isFieldDisabled()) {
+      return;
+    }
     onChange(field.name, Number(e.target.value));
   };
 
@@ -63,6 +104,8 @@ export const FieldRenderer: React.FC<FieldRendererProps> = ({
     className: error ? "border-negative-content" : "",
     placeholder: field.placeholder,
     autoComplete: field.autoComplete,
+    readOnly: field.readOnly || false,
+    disabled: isFieldDisabled(),
   });
 
   // Enhanced description for access key fields in edit mode
@@ -122,12 +165,15 @@ export const FieldRenderer: React.FC<FieldRendererProps> = ({
             onChange={(selectedValue) => handleSelectChange(selectedValue)}
             options={field.options || []}
             placeholder={field.placeholder}
+            disabled={isFieldDisabled()}
           />
           {error && <p className="text-sm text-negative-content">{error}</p>}
         </div>
       );
 
     case "toggle":
+      const isDisabled = isFieldDisabled();
+      console.log(`Toggle ${field.name} disabled state:`, isDisabled);
       return (
         <div className="flex items-start space-x-4">
           <Toggle
@@ -136,12 +182,15 @@ export const FieldRenderer: React.FC<FieldRendererProps> = ({
             aria-label={field.label}
             label={field.label}
             description={field.description}
+            disabled={isDisabled}
           />
         </div>
       );
 
     case "counter": {
       const counterValue = value !== undefined && value !== null ? value : field.min || 0;
+      const isDisabled = isFieldDisabled();
+      console.log(`Counter ${field.name} disabled state:`, isDisabled, `value:`, counterValue);
       return (
         <Counter
           name={field.name}
@@ -156,6 +205,8 @@ export const FieldRenderer: React.FC<FieldRendererProps> = ({
           required={isFieldRequired(field, isEditMode)}
           skip={false}
           labelProps={{}}
+          disabled={isDisabled}
+          key={`${field.name}-${isDisabled}`} // Force re-render when disabled state changes
         />
       );
     }

--- a/web/libs/app-common/src/blocks/StorageProviderForm/components/field-renderer.tsx
+++ b/web/libs/app-common/src/blocks/StorageProviderForm/components/field-renderer.tsx
@@ -34,7 +34,7 @@ export const FieldRenderer: React.FC<FieldRendererProps> = ({
     const dependsOnValue = field.dependsOn.value;
 
     // If dependsOn.value is a function, call it with the dependency value and form data
-    if (typeof dependsOnValue === 'function') {
+    if (typeof dependsOnValue === "function") {
       const shouldEnable = dependsOnValue(dependencyValue, formData);
       return !shouldEnable;
     }
@@ -173,7 +173,6 @@ export const FieldRenderer: React.FC<FieldRendererProps> = ({
 
     case "toggle":
       const isDisabled = isFieldDisabled();
-      console.log(`Toggle ${field.name} disabled state:`, isDisabled);
       return (
         <div className="flex items-start space-x-4">
           <Toggle
@@ -190,7 +189,6 @@ export const FieldRenderer: React.FC<FieldRendererProps> = ({
     case "counter": {
       const counterValue = value !== undefined && value !== null ? value : field.min || 0;
       const isDisabled = isFieldDisabled();
-      console.log(`Counter ${field.name} disabled state:`, isDisabled, `value:`, counterValue);
       return (
         <Counter
           name={field.name}

--- a/web/libs/app-common/src/blocks/StorageProviderForm/components/provider-form.tsx
+++ b/web/libs/app-common/src/blocks/StorageProviderForm/components/provider-form.tsx
@@ -51,6 +51,7 @@ export const ProviderForm: React.FC<ProviderFormProps> = ({
                       onBlur={onBlur}
                       error={errors[field.name]}
                       isEditMode={isEditMode}
+                        formData={formData}
                     />
                   )}
                 </div>

--- a/web/libs/app-common/src/blocks/StorageProviderForm/hooks/useStorageForm.ts
+++ b/web/libs/app-common/src/blocks/StorageProviderForm/hooks/useStorageForm.ts
@@ -12,9 +12,10 @@ interface UseStorageFormProps {
   isEditMode: boolean;
   steps: Array<{ title: string; schema?: z.ZodSchema }>;
   storage?: any;
+  defaultValues?: Record<string, Record<string, any>>;
 }
 
-export const useStorageForm = ({ project, isEditMode, steps, storage }: UseStorageFormProps) => {
+export const useStorageForm = ({ project, isEditMode, steps, storage, defaultValues }: UseStorageFormProps) => {
   const [formState, setFormState] = useState<FormState>({
     currentStep: 0,
     formData: {
@@ -36,17 +37,27 @@ export const useStorageForm = ({ project, isEditMode, steps, storage }: UseStora
     if (formData.provider && !isEditMode) {
       const providerConfig = getProviderConfig(formData.provider);
       if (providerConfig) {
-        const defaultValues = extractDefaultValues(providerConfig.fields);
+        const schemaDefaults = extractDefaultValues(providerConfig.fields);
+
+        // Get custom defaults for this provider if available
+        const customDefaults = defaultValues?.[formData.provider] || {};
+
+        // Merge schema defaults with custom defaults (custom defaults take precedence)
+        const mergedDefaults = {
+          ...schemaDefaults,
+          ...customDefaults,
+        };
+
         setFormState((prevState) => ({
           ...prevState,
           formData: {
             ...prevState.formData,
-            ...defaultValues,
+            ...mergedDefaults,
           },
         }));
       }
     }
-  }, [formData.provider, setFormState, isEditMode]);
+  }, [formData.provider, setFormState, isEditMode, defaultValues]);
 
   // Initialize form data with existing storage data in edit mode (only once)
   useEffect(() => {
@@ -247,12 +258,22 @@ export const useStorageForm = ({ project, isEditMode, steps, storage }: UseStora
       if (name === "provider" && !isEditMode) {
         const providerConfig = getProviderConfig(value);
         if (providerConfig) {
-          const defaultValues = extractDefaultValues(providerConfig.fields);
+          const schemaDefaults = extractDefaultValues(providerConfig.fields);
+
+          // Get custom defaults for this provider if available
+          const customDefaults = defaultValues?.[value] || {};
+
+          // Merge schema defaults with custom defaults (custom defaults take precedence)
+          const mergedDefaults = {
+            ...schemaDefaults,
+            ...customDefaults,
+          };
+
           setFormState((prev) => ({
             ...prev,
             formData: {
               ...prev.formData,
-              ...defaultValues,
+              ...mergedDefaults,
               [name]: value,
             },
           }));
@@ -286,7 +307,7 @@ export const useStorageForm = ({ project, isEditMode, steps, storage }: UseStora
         onConnectionChange?.();
       }
     },
-    [formData, setFormState, isEditMode],
+    [formData, setFormState, isEditMode, defaultValues],
   );
 
   // Handle field blur

--- a/web/libs/app-common/src/blocks/StorageProviderForm/index.tsx
+++ b/web/libs/app-common/src/blocks/StorageProviderForm/index.tsx
@@ -21,12 +21,13 @@ interface StorageProviderFormProps {
     name: string;
   }[];
   providers: Record<string, ProviderConfig>;
+  defaultValues?: Record<string, Record<string, any>>;
   onClose?: () => void;
   onHide?: () => void;
 }
 
 export const StorageProviderForm = forwardRef<unknown, StorageProviderFormProps>(
-  ({ onSubmit, target, project, storage, title, storageTypes, providers, onClose = () => {}, onHide }, ref) => {
+  ({ onSubmit, target, project, storage, title, storageTypes, providers, defaultValues, onClose = () => { }, onHide }, ref) => {
     const modal = useModalControls();
     const [type, setType] = useState<string | undefined>(storage?.type || storage?.provider || "s3");
     const [filesPreview, setFilesPreview] = useState<any[] | null>(null);
@@ -88,6 +89,7 @@ export const StorageProviderForm = forwardRef<unknown, StorageProviderFormProps>
       isEditMode,
       steps: currentSteps,
       storage,
+      defaultValues,
     });
 
     const { currentStep, formData } = formState;

--- a/web/libs/app-common/src/blocks/StorageProviderForm/types/common.ts
+++ b/web/libs/app-common/src/blocks/StorageProviderForm/types/common.ts
@@ -23,6 +23,11 @@ export interface FieldDefinition {
   accessKey?: boolean; // Whether this field is an access key/credential that should be handled specially in edit mode
   target?: "import" | "export"; // Only show this field for the specified storage type (undefined = show for both)
   resetConnection?: boolean; // Whether changing this field should reset the connection check (default: true)
+  readOnly?: boolean; // Whether this field should be read-only (not editable by user)
+  dependsOn?: {
+    field: string; // Name of the field this depends on
+    value: any | ((dependencyValue: any, formData: Record<string, any>) => boolean); // The value or function to check if field should be enabled
+  };
 }
 
 export interface MessageDefinition {


### PR DESCRIPTION
This pull request introduces significant improvements to the `StorageProviderForm` system, focusing on enhanced field configurability and user experience. The main changes add support for read-only fields, dynamic field dependencies (enabling/disabling fields based on other field values), and custom default values per provider. These features are documented extensively and integrated into the provider configuration and form logic.

**Key changes include:**

### Field Configuration Enhancements

* Added support for `readOnly` fields, allowing certain form fields to be displayed as non-editable based on configuration. [[1]](diffhunk://#diff-779a72836f7db0e3a4410e62a68d2a05edce061aa70acdc256726327849792bcR113-R127) [[2]](diffhunk://#diff-779a72836f7db0e3a4410e62a68d2a05edce061aa70acdc256726327849792bcR152-R327) [[3]](diffhunk://#diff-779a72836f7db0e3a4410e62a68d2a05edce061aa70acdc256726327849792bcR375-R585) [[4]](diffhunk://#diff-946a108f8a17759f8384936ce47c53b8f10fa19cbdac3ced4f9fe902189956b3R25-R54) [[5]](diffhunk://#diff-946a108f8a17759f8384936ce47c53b8f10fa19cbdac3ced4f9fe902189956b3R107-R108)
* Introduced the `dependsOn` property for fields, enabling dynamic enabling/disabling of fields based on the value or state of another field. Supports both static values and custom functions for complex logic. [[1]](diffhunk://#diff-779a72836f7db0e3a4410e62a68d2a05edce061aa70acdc256726327849792bcR113-R127) [[2]](diffhunk://#diff-779a72836f7db0e3a4410e62a68d2a05edce061aa70acdc256726327849792bcR152-R327) [[3]](diffhunk://#diff-779a72836f7db0e3a4410e62a68d2a05edce061aa70acdc256726327849792bcR375-R585) [[4]](diffhunk://#diff-946a108f8a17759f8384936ce47c53b8f10fa19cbdac3ced4f9fe902189956b3R25-R54) [[5]](diffhunk://#diff-946a108f8a17759f8384936ce47c53b8f10fa19cbdac3ced4f9fe902189956b3R107-R108) [[6]](diffhunk://#diff-76ba7b5be200d2767fe89bc0e811b0bfab9fcce815902e914ad027c1807cc481R65-R68) [[7]](diffhunk://#diff-e0b189f72e3fcb986afe7e4562cb50abbec3147f5b4721485b0af46c8579b2feL62-R65) [[8]](diffhunk://#diff-13a99fcdb23da383ad8c308cd64490492b012309db276b1452aab6c69145adccR89-R92)

### Provider Form and Field Renderer Logic

* Updated the `FieldRenderer` component to respect `readOnly` and `dependsOn` properties, disabling input, toggle, select, and counter fields as needed. Prevents user interaction with disabled fields and ensures proper UI feedback. [[1]](diffhunk://#diff-946a108f8a17759f8384936ce47c53b8f10fa19cbdac3ced4f9fe902189956b3R25-R54) [[2]](diffhunk://#diff-946a108f8a17759f8384936ce47c53b8f10fa19cbdac3ced4f9fe902189956b3R69-R88) [[3]](diffhunk://#diff-946a108f8a17759f8384936ce47c53b8f10fa19cbdac3ced4f9fe902189956b3R107-R108) [[4]](diffhunk://#diff-946a108f8a17759f8384936ce47c53b8f10fa19cbdac3ced4f9fe902189956b3R168-R176) [[5]](diffhunk://#diff-946a108f8a17759f8384936ce47c53b8f10fa19cbdac3ced4f9fe902189956b3R185-R193) [[6]](diffhunk://#diff-946a108f8a17759f8384936ce47c53b8f10fa19cbdac3ced4f9fe902189956b3R208-R209)
* Passed `formData` to `FieldRenderer` from `ProviderForm` to enable dependency checks at the field level. [[1]](diffhunk://#diff-946a108f8a17759f8384936ce47c53b8f10fa19cbdac3ced4f9fe902189956b3R15) [[2]](diffhunk://#diff-ed79999d5981130402bc18b50b9ef4895df6d004f5ba644b798bafbb0fd37792R54)

### Default Value Handling

* Added support for custom default values per provider, allowing the parent component to specify initial values that override schema defaults. Custom defaults are merged with schema defaults, with custom values taking precedence. [[1]](diffhunk://#diff-779a72836f7db0e3a4410e62a68d2a05edce061aa70acdc256726327849792bcR152-R327) [[2]](diffhunk://#diff-779a72836f7db0e3a4410e62a68d2a05edce061aa70acdc256726327849792bcR375-R585) [[3]](diffhunk://#diff-15a8f10371cb1c98d6f8133ad076243d7b02851dbc798e55a5e6ba8aa565433eR15-R18) [[4]](diffhunk://#diff-15a8f10371cb1c98d6f8133ad076243d7b02851dbc798e55a5e6ba8aa565433eL39-R60) [[5]](diffhunk://#diff-15a8f10371cb1c98d6f8133ad076243d7b02851dbc798e55a5e6ba8aa565433eL250-R276)

### Documentation

* Expanded the `README.md` documentation for `StorageProviderForm` to cover the new `readOnly`, `dependsOn`, and custom default value features, including detailed usage examples and best practices. [[1]](diffhunk://#diff-779a72836f7db0e3a4410e62a68d2a05edce061aa70acdc256726327849792bcR113-R127) [[2]](diffhunk://#diff-779a72836f7db0e3a4410e62a68d2a05edce061aa70acdc256726327849792bcR152-R327) [[3]](diffhunk://#diff-779a72836f7db0e3a4410e62a68d2a05edce061aa70acdc256726327849792bcR375-R585)

### Provider Configuration Updates

* Updated S3, GCS, and Azure provider configs to use the new `dependsOn` property for TTL fields, ensuring these fields are only enabled when presigned URLs are in use. [[1]](diffhunk://#diff-76ba7b5be200d2767fe89bc0e811b0bfab9fcce815902e914ad027c1807cc481R65-R68) [[2]](diffhunk://#diff-e0b189f72e3fcb986afe7e4562cb50abbec3147f5b4721485b0af46c8579b2feL62-R65) [[3]](diffhunk://#diff-13a99fcdb23da383ad8c308cd64490492b012309db276b1452aab6c69145adccR89-R92)

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
