### PR TITLE
fix: BROS-305: Unable to reset bucket prefix

### DIFF
--- a/web/libs/app-common/src/blocks/StorageProviderForm/hooks/useStorageApi.ts
+++ b/web/libs/app-common/src/blocks/StorageProviderForm/hooks/useStorageApi.ts
@@ -33,7 +33,10 @@ export const useStorageApi = ({ target, storage, project, onSubmit, onClose }: U
         const isAccessKey = field && "type" in field && (field as any).accessKey;
 
         // Only remove empty values for access key fields
-        if (isAccessKey && (cleanedData[key] === "" || cleanedData[key] === undefined || cleanedData[key] === "••••••••••••••••")) {
+        if (
+          isAccessKey &&
+          (cleanedData[key] === "" || cleanedData[key] === undefined || cleanedData[key] === "••••••••••••••••")
+        ) {
           delete cleanedData[key];
         }
       });

--- a/web/libs/app-common/src/blocks/StorageProviderForm/hooks/useStorageApi.ts
+++ b/web/libs/app-common/src/blocks/StorageProviderForm/hooks/useStorageApi.ts
@@ -2,6 +2,7 @@ import { useContext, useCallback } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { ApiContext } from "apps/labelstudio/src/providers/ApiProvider";
 import { isDefined } from "apps/labelstudio/src/utils/helpers";
+import { getProviderConfig } from "../providers";
 
 interface UseStorageApiProps {
   target?: "import" | "export";
@@ -22,9 +23,17 @@ export const useStorageApi = ({ target, storage, project, onSubmit, onClose }: U
       if (!isEditMode) return data;
 
       const cleanedData = { ...data };
-      // Remove empty access key fields in edit mode
+
+      // Get the current provider config to identify access key fields
+      const providerConfig = getProviderConfig(data.provider);
+
+      // Remove empty values only for access key fields in edit mode
       Object.keys(cleanedData).forEach((key) => {
-        if (cleanedData[key] === "" || cleanedData[key] === undefined || cleanedData[key] === "••••••••••••••••") {
+        const field = providerConfig?.fields.find((f) => f.name === key);
+        const isAccessKey = field && "type" in field && (field as any).accessKey;
+
+        // Only remove empty values for access key fields
+        if (isAccessKey && (cleanedData[key] === "" || cleanedData[key] === undefined || cleanedData[key] === "••••••••••••••••")) {
           delete cleanedData[key];
         }
       });


### PR DESCRIPTION
This pull request updates the logic for cleaning storage provider form data in edit mode, ensuring that only empty access key fields are removed rather than all empty fields. This makes the form handling more precise and avoids unintended data loss.

Form data cleaning improvements:

* Updated the logic in `useStorageApi` to fetch the provider configuration using `getProviderConfig` and selectively remove empty values only for fields marked as access keys, instead of removing all empty fields in edit mode.
* Added import of `getProviderConfig` in `useStorageApi.ts` to support the new logic.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
