### PR TITLE
ci: Fix node version in "Yarn docs" workflow

### DIFF
--- a/.github/workflows/yarn-docs.yml
+++ b/.github/workflows/yarn-docs.yml
@@ -20,7 +20,7 @@ on:
       - ".github/workflows/yarn-docs.yml"
 
 env:
-  NODE: "18"
+  NODE: "22"
   FRONTEND_MONOREPO_DIR: "web"
 
 jobs:


### PR DESCRIPTION
It's failing now because of node version: https://github.com/HumanSignal/label-studio/actions/runs/16842636449/job/47716876378