### PR TITLE
chore: ROOT-57: Revert - Annotation results filter does not return result, although matching criteria is met

### DIFF
--- a/web/libs/datamanager/src/components/Filters/FilterLine/FilterOperation.jsx
+++ b/web/libs/datamanager/src/components/Filters/FilterLine/FilterOperation.jsx
@@ -66,13 +66,8 @@ export const FilterOperation = observer(({ filter, field, operator, value, disab
   }
   const operators = operatorList.map(({ key, label }) => {
     if (filter.filter.field.isAnnotationResultsFilterColumn) {
-      if (filter.schema?.multiple ?? false) {
-        if (key === "contains") label = "includes all";
-        if (key === "not_contains") label = "does not include all";
-      } else {
-        if (key === "contains") label = "is";
-        if (key === "not_contains") label = "is not";
-      }
+      if (key === "contains") label = "includes all";
+      if (key === "not_contains") label = "does not include all";
     }
     return { value: key, label };
   });
@@ -94,7 +89,6 @@ export const FilterOperation = observer(({ filter, field, operator, value, disab
           key={`${filter.filter.id}-${filter.filter.currentType}`}
           schema={filter.schema}
           filter={filter}
-          multiple={filter.schema?.multiple ?? false}
           value={value}
           onChange={onChange}
           size="small"

--- a/web/libs/datamanager/src/components/Filters/Filters.jsx
+++ b/web/libs/datamanager/src/components/Filters/Filters.jsx
@@ -47,6 +47,8 @@ export const Filters = injector(({ views, currentView, filters }) => {
     [currentView.availableFilters],
   );
 
+  console.trace("Filters", filters);
+
   return (
     <Block name="filters" mod={{ sidebar: sidebarEnabled }}>
       <Elem name="list" mod={{ withFilters: !!filters.length }}>

--- a/web/libs/datamanager/src/components/Filters/types/List.jsx
+++ b/web/libs/datamanager/src/components/Filters/types/List.jsx
@@ -45,13 +45,13 @@ export const ListFilter = [
     key: "contains",
     label: "contains",
     valueType: "single",
-    input: (props) => <VariantSelect {...props} multiple={props.schema?.multiple} />,
+    input: (props) => <VariantSelect {...props} multiple />,
   },
   {
     key: "not_contains",
     label: "not contains",
     valueType: "single",
-    input: (props) => <VariantSelect {...props} multiple={props.schema?.multiple} />,
+    input: (props) => <VariantSelect {...props} multiple />,
   },
   // ... Common,
 ];

--- a/web/libs/datamanager/src/stores/Tabs/filter_utils.ts
+++ b/web/libs/datamanager/src/stores/Tabs/filter_utils.ts
@@ -25,11 +25,6 @@ const filterFormatters: Formatter = {
 
     return String(value);
   },
-  List: (_op, value) => {
-    // Ensure that List filter values are always serialized as arrays.
-    if (Array.isArray(value) || value === null || value === undefined) return value;
-    return [value];
-  },
 };
 
 export const normalizeFilterValue = (type: string, op: string, value: any) => {

--- a/web/libs/datamanager/src/stores/Tabs/tab_filter_type.js
+++ b/web/libs/datamanager/src/stores/Tabs/tab_filter_type.js
@@ -24,7 +24,6 @@ export const FilterItemType = types.union({
 export const FilterValueList = types
   .model("FilterValueList", {
     items: types.array(FilterItemType),
-    multiple: types.maybeNull(types.boolean),
   })
   .views((self) => ({
     get value() {


### PR DESCRIPTION
This pull request refactors how multiple selection is handled in list filters, simplifying the logic and removing unnecessary checks for the `multiple` property. The changes ensure that list filters always use multiple selection, update labeling for annotation result filters, and clean up related type and formatter code.

**Filter UI and behavior changes:**

* List filters now always use multiple selection, removing conditional logic based on the `multiple` property in both the UI and filter configuration (`FilterOperation.jsx`, `List.jsx`). [[1]](diffhunk://#diff-d7e5a75e95cec2dc137241ef7d46e9704f882c4f21ae229ad1ca3666aa84eb5dL69-L75) [[2]](diffhunk://#diff-d7e5a75e95cec2dc137241ef7d46e9704f882c4f21ae229ad1ca3666aa84eb5dL97) [[3]](diffhunk://#diff-a0ca81dca8c1f711a923db92ff91f83a7a6ddf736feeeaa5eaac67b2c651e9f8L48-R54)
* Labeling for annotation results filter columns has been simplified—"includes all" and "does not include all" are used for "contains" and "not_contains" operators, regardless of the `multiple` property.

**Codebase cleanup:**

* The `multiple` property has been removed from the `FilterValueList` model, streamlining filter value handling (`tab_filter_type.js`).
* The custom formatter for list filters has been removed, as list values are now consistently handled as arrays (`filter_utils.ts`).

**Debugging:**

* Added a console trace in `Filters.jsx` to help debug filter state.