### PR TITLE
fix: ROOT-72: unblock docker image by removing transitional package reference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,10 +143,6 @@ RUN --mount=type=cache,target="/var/cache/apt",sharing=locked \
 RUN --mount=type=cache,target="/var/cache/apt",sharing=locked \
     --mount=type=cache,target="/var/lib/apt/lists",sharing=locked \
     set -eux; \
-    curl -sSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /etc/apt/keyrings/nginx-archive-keyring.gpg >/dev/null; \
-    DEBIAN_VERSION=$(awk -F '=' '/^VERSION_CODENAME=/ {print $2}' /etc/os-release); \
-    printf "deb [signed-by=/etc/apt/keyrings/nginx-archive-keyring.gpg] http://nginx.org/packages/debian ${DEBIAN_VERSION} nginx\n" > /etc/apt/sources.list.d/nginx.list; \
-    printf "Package: *\nPin: origin nginx.org\nPin: release o=nginx\nPin-Priority: 900\n" > /etc/apt/preferences.d/99nginx; \
     apt-get update; \
     apt-get install --no-install-recommends -y nginx; \
     apt-get autoremove -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -135,7 +135,7 @@ RUN --mount=type=cache,target="/var/cache/apt",sharing=locked \
     set -eux; \
     apt-get update; \
     apt-get upgrade -y; \
-    apt-get install --no-install-recommends -y libexpat1 libgl1-mesa-glx libglib2.0-0 \
+    apt-get install --no-install-recommends -y libexpat1 libgl1 libglx-mesa0 libglib2.0-0 \
         gnupg2 curl; \
     apt-get autoremove -y
 


### PR DESCRIPTION
When it rains, it pours - this package isn't in the newer Linux image we seem to have started using during Docker builds.

https://askubuntu.com/a/1520333

Also, stop trying to get nginx from nginx.org for now - there is no build for `trixie` listed here: http://nginx.org/packages/debian/dists/