### PR TITLE
fix: FIT-411: Child Choices are disabled when `leafsOnly` is used

### DIFF
--- a/web/libs/editor/src/components/NewTaxonomy/NewTaxonomy.tsx
+++ b/web/libs/editor/src/components/NewTaxonomy/NewTaxonomy.tsx
@@ -85,14 +85,15 @@ const convert = (
 
   const convertItem = (item: TaxonomyItem): AntTaxonomyItem => {
     const value = item.path.join(options.pathSeparator);
-    const disabledNode = options.leafsOnly && (item.isLeaf === false || !!item.children);
+    const isLeaf = item.isLeaf !== false && !item.children?.length;
+    const disabledNode = options.leafsOnly && !isLeaf;
     const maxUsagesReached = options.maxUsagesReached && !selectedPaths.includes(value);
 
     return {
       title: enrich(item),
       value,
       key: value,
-      isLeaf: item.isLeaf !== false && !item.children,
+      isLeaf,
       disableCheckbox: disabledNode || maxUsagesReached,
       children: item.children?.map(convertItem),
     };


### PR DESCRIPTION
Fixing the error where child nodes are not selectable due to Taxonomy provided via `$values` with `leafsOnly="true"`.

Example:

<img width="339" height="268" alt="Screenshot 2025-08-13 at 12 31 16" src="https://github.com/user-attachments/assets/339948a8-7f02-42ba-aad0-33d9e5e1a0d5" />

Three nested choices are leaves, they have empty `children`, but they are disabled and look as nodes.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
