### PR TITLE
feat: FIT-493: Make left column of User Assigner infinitely paginated and searchable

### DIFF
--- a/web/libs/ui/src/lib/select/select.tsx
+++ b/web/libs/ui/src/lib/select/select.tsx
@@ -377,7 +377,7 @@ export const Select = forwardRef(
                             itemData={renderedOptions}
                             itemSize={() => VARIABLE_LIST_ITEM_HEIGHT}
                             itemCount={renderedOptions.length}
-                            height={VARIABLE_LIST_COUNT_RENDERED * VARIABLE_LIST_ITEM_HEIGHT} // this makes the height based on available items
+                            height={5 * VARIABLE_LIST_ITEM_HEIGHT} // only render 5 items
                             // width={VARIABLE_LIST_WIDTH}
                             onItemsRendered={onItemsRendered}
                             ref={infiniteLoaderRef}


### PR DESCRIPTION
This pull request makes a small adjustment to the `Select` component to improve its dropdown behavior. The visible height of the dropdown is now fixed to display exactly 5 items, regardless of the number of available options.

- UI behavior update:
  * [`select.tsx`](diffhunk://#diff-567459e612a12d17fb4237f0381f79f4148ad291939afbf005a1c02e398fe942L380-R380): Changed the dropdown height in the `Select` component to always render 5 items instead of dynamically adjusting based on the number of available items.