### PR TITLE
fix: BROS-264: Incorrect relations order + small image fix

### DIFF
--- a/web/libs/editor/src/components/ImageView/ImageView.jsx
+++ b/web/libs/editor/src/components/ImageView/ImageView.jsx
@@ -460,7 +460,7 @@ const PixelGridLayer = observer(({ item }) => {
   const ZOOM_THRESHOLD = 20;
 
   const visible = item.zoomScale > ZOOM_THRESHOLD;
-  const { naturalWidth, naturalHeight } = item.currentImageEntity;
+  const { naturalWidth, naturalHeight } = item.currentImageEntity ?? {};
   const { stageWidth, stageHeight } = item;
   const imageSmallerThanStage = naturalWidth < stageWidth || naturalHeight < stageHeight;
 

--- a/web/libs/editor/src/components/SidePanels/DetailsPanel/Relations.tsx
+++ b/web/libs/editor/src/components/SidePanels/DetailsPanel/Relations.tsx
@@ -32,8 +32,8 @@ interface RelationsListProps {
 const RelationsList: FC<RelationsListProps> = observer(({ relations }) => {
   return (
     <>
-      {relations.map((rel, i) => {
-        return <RelationItem key={i} relation={rel} />;
+      {relations.map((rel) => {
+        return <RelationItem key={rel.id} relation={rel} />;
       })}
     </>
   );


### PR DESCRIPTION
This pull request makes small improvements to the UI components for image viewing and relation listing. The changes enhance robustness and improve rendering efficiency by using more appropriate React keys.

- Image View Robustness:
  * In `ImageView.jsx`, the destructuring of `naturalWidth` and `naturalHeight` from `item.currentImageEntity` now safely handles cases where `currentImageEntity` might be undefined, preventing potential runtime errors.

- Relations List Rendering:
  * In `Relations.tsx`, the `key` prop for `RelationItem` components is changed from using the array index to using `rel.id`, improving React's rendering performance and avoiding potential issues with list reordering.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
