### PR TITLE
fix: BROS-195: Create New Token button should be primary/filled

### DIFF
--- a/web/libs/app-common/src/pages/AccountSettings/sections/PersonalJWTToken.tsx
+++ b/web/libs/app-common/src/pages/AccountSettings/sections/PersonalJWTToken.tsx
@@ -177,12 +177,7 @@ export function PersonalJWTToken() {
       </div>
       <Tooltip title="You can only have one active token" disabled={!disallowAddingTokens}>
         <div style={{ width: "max-content" }}>
-          <Button
-            disabled={disallowAddingTokens || dialogOpened}
-            variant="neutral"
-            look="outlined"
-            onClick={openDialog}
-          >
+          <Button disabled={disallowAddingTokens || dialogOpened} onClick={openDialog}>
             Create New Token
           </Button>
         </div>


### PR DESCRIPTION
This PR changes the Create New Token button from neutral / outlined to primary / filled.

## Before
<img width="1109" height="407" alt="image" src="https://github.com/user-attachments/assets/3b44e879-fb2c-4b85-b64c-dd6a13377d74" />


## After
<img width="992" height="381" alt="image" src="https://github.com/user-attachments/assets/c980b73f-7bd0-47fa-9146-062ee56a52fc" />


<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
