### PR TITLE
chore: ROOT-74: use HOSTNAME to set servers in fern

### DIFF
--- a/label_studio/core/settings/base.py
+++ b/label_studio/core/settings/base.py
@@ -386,6 +386,12 @@ SPECTACULAR_SETTINGS = {
     'AUTHENTICATION_WHITELIST': [
         'jwt_auth.auth.TokenAuthenticationPhaseout',
     ],
+    'SERVERS': [
+        {
+            'url': HOSTNAME,
+            'description': 'Label Studio',
+        },
+    ],
     'CONTACT': {'url': 'https://labelstud.io'},
     'X_LOGO': {'url': '../../static/icons/logo-black.svg'},
 }


### PR DESCRIPTION
<img width="598" height="258" alt="image" src="https://github.com/user-attachments/assets/0d30b4f3-b4d3-45c9-b355-1adf5ae30ce0" />

set URL using the HOSTNAME variable