### PR TITLE
docs: Potential fix for code scanning alert no. 794: DOM text reinterpreted as HTML

### DIFF
--- a/docs/themes/v2/source/js/code-tabs.js
+++ b/docs/themes/v2/source/js/code-tabs.js
@@ -31,6 +31,18 @@ Test 1!
 
 
 
+function escapeHTML(str) {
+  return str.replace(/[&<>"']/g, function (char) {
+    return {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;'
+    }[char];
+  });
+}
+
 function openCodeTab(id, event) {
   const tabObj = document.querySelector(`${'#' + id}`);
   const anchorObj = document.querySelector(`${'#' + id + '-anchor'}`);
@@ -75,7 +87,7 @@ function openCodeTab(id, event) {
               'class="Heading XXSmall"' +
               'onclick="openCodeTab(\'' + id + '\', event)" ' +
               'href="#' + id + '-anchor">' +
-              name +
+              escapeHTML(name) +
             '</a>';
     })
 


### PR DESCRIPTION
Potential fix for [https://github.com/HumanSignal/label-studio/security/code-scanning/794](https://github.com/HumanSignal/label-studio/security/code-scanning/794)

To fix the issue, we need to ensure that the `name` value derived from `tab.dataset.name` is properly sanitized or escaped before being used in the `buttons` string. The best approach is to use a utility function to escape special HTML characters (`<`, `>`, `&`, `"`, `'`) in the `name` value. This ensures that any potentially malicious input is rendered as plain text rather than being interpreted as HTML.

The fix involves:
1. Adding a helper function `escapeHTML` to escape special HTML characters.
2. Using this function to sanitize the `name` value before appending it to the `buttons` string.

### Testing

Tabs component under https://deploy-preview-8172--heartex-docs.netlify.app/guide/export#COCO should work as before

<img width="1902" height="1988" alt="Screenshot 2025-08-18 at 9 18 58 AM" src="https://github.com/user-attachments/assets/51138f79-246c-46e8-9736-f5d963587fa1" />

