### PR TITLE
fix: UTC-231: Fix prediction validation FF usage

### DIFF
--- a/label_studio/data_import/functions.py
+++ b/label_studio/data_import/functions.py
@@ -54,7 +54,9 @@ def async_import_background(
         tasks = reformat_predictions(tasks, project_import.preannotated_from_fields, project, raise_errors)
 
     # Always validate predictions regardless of commit_to_project setting
-    if project.label_config_is_not_default:
+    if project.label_config_is_not_default and flag_set(
+        'fflag_feat_utc_210_prediction_validation_15082025', user=project.organization.created_by
+    ):
         validation_errors = []
         li = LabelInterface(project.label_config)
 

--- a/label_studio/tasks/serializers.py
+++ b/label_studio/tasks/serializers.py
@@ -456,7 +456,9 @@ class BaseTaskSerializerBulk(serializers.ListSerializer):
         db_predictions = []
         validation_errors = []
 
-        should_validate = self.project.label_config_is_not_default
+        should_validate = self.project.label_config_is_not_default and flag_set(
+            'fflag_feat_utc_210_prediction_validation_15082025', user='auto'
+        )
 
         # add predictions
         last_model_version = None


### PR DESCRIPTION
Couple places were missing the FF check causing users to still hit validation errors with the FF off 