### PR TITLE
fix: BROS-352: Revert order of returned params in `useCopyText()`

### DIFF
--- a/web/libs/core/src/lib/hooks/useCopyText.tsx
+++ b/web/libs/core/src/lib/hooks/useCopyText.tsx
@@ -13,5 +13,5 @@ export const useCopyText = ({ defaultText = "", timeout = 1200 }: { defaultText?
     [defaultText, timeout],
   );
 
-  return [copied, copyTextCallback] as const;
+  return [copyTextCallback, copied] as const;
 };

--- a/web/libs/ui/src/lib/code-block/code-block.tsx
+++ b/web/libs/ui/src/lib/code-block/code-block.tsx
@@ -21,7 +21,7 @@ export function CodeBlock({
     negative: "bg-negative-background border-negative-border-subtle",
   };
 
-  const [isCopied, copyCode] = useCopyText();
+  const [copyCode, isCopied] = useCopyText();
 
   return (
     <div


### PR DESCRIPTION
This order was not supported by all usages.

<img width="1198" height="582" alt="image (11)" src="https://github.com/user-attachments/assets/ca558e7e-060a-4561-a2d5-bb87c348bf2b" />


<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
