### PR TITLE
fix: BROS-205: Tooltip for Skip button is incorrect

### DIFF
--- a/web/libs/editor/src/components/BottomBar/buttons.tsx
+++ b/web/libs/editor/src/components/BottomBar/buttons.tsx
@@ -101,7 +101,7 @@ export const SkipButton = memo(
         aria-label="skip-task"
         disabled={disabled}
         look="outlined"
-        tooltip="Cancel (skip) tapk [ Ctrl+Space ]"
+        tooltip="Cancel (skip) task [ Ctrl+Space ]"
         onClick={async (e) => {
           const action = () => store.skipTask({});
           const selected = store.annotationStore?.selected;


### PR DESCRIPTION
Cherrypick https://github.com/HumanSignal/label-studio/pull/8248