### PR TITLE
fix: FIT-584: Annotator Performance Report page crashes upon clicking User Filter in specific situations

### DIFF
--- a/web/libs/ui/src/lib/select/select.tsx
+++ b/web/libs/ui/src/lib/select/select.tsx
@@ -94,6 +94,7 @@ export const Select = forwardRef(
     const ref = _ref ?? useRef<HTMLSelectElement>();
     const triggerRef = useRef<HTMLDivElement>();
     const [query, setQuery] = useState<string>("");
+    const rawOptions = useRef<any>();
     const valueRef = useRef<any>();
     let initialValue = defaultValue?.value ?? defaultValue ?? externalValue?.value ?? externalValue;
     if (selectFirstIfEmpty && !initialValue) {
@@ -108,6 +109,7 @@ export const Select = forwardRef(
     const [value, setValue] = useState<any>(initialValue);
 
     valueRef.current = value;
+    rawOptions.current = options;
     useEffect(() => {
       if (!isDefined(externalValue)) return;
       let val = externalValue?.value ?? externalValue;
@@ -119,6 +121,10 @@ export const Select = forwardRef(
       valueRef.current = val;
       setValue(val);
     }, [externalValue, multiple]);
+
+    useEffect(() => {
+      rawOptions.current = options;
+    }, [options]);
 
     useEffect(() => {
       if (valueRef.current || !selectFirstIfEmpty || !options?.[0]) return;
@@ -162,7 +168,7 @@ export const Select = forwardRef(
     }, [options]);
 
     const _options = useMemo(() => {
-      if (!searchable || !query.trim()) return options;
+      if (!searchable || !query.trim()) return rawOptions.current;
 
       const filterHandler = (option: any, queryString: string) => {
         const value = option?.value ?? option;
@@ -173,7 +179,7 @@ export const Select = forwardRef(
         );
       };
       return flatOptions.filter((option) => (searchFilter ?? filterHandler)(option, query));
-    }, [options, flatOptions, searchable, query, searchFilter]);
+    }, [flatOptions, searchable, query, searchFilter]);
 
     const isSelected = useCallback(
       (val: any) => {


### PR DESCRIPTION
This pull request refactors the `Select` component in `select.tsx` to improve how the options list is managed, especially in relation to search and filtering. The main change is the introduction of a `rawOptions` ref to consistently track the original options, ensuring that filtering and search always operate on the correct data.

Improvements to options management and filtering:

* Added a `rawOptions` ref to store the original `options` prop, ensuring that search and filtering always use the most up-to-date options. (`web/libs/ui/src/lib/select/select.tsx`) [[1]](diffhunk://#diff-567459e612a12d17fb4237f0381f79f4148ad291939afbf005a1c02e398fe942R97) [[2]](diffhunk://#diff-567459e612a12d17fb4237f0381f79f4148ad291939afbf005a1c02e398fe942R112) [[3]](diffhunk://#diff-567459e612a12d17fb4237f0381f79f4148ad291939afbf005a1c02e398fe942R125-R128)
* Updated the `_options` memoization logic to use `rawOptions.current` instead of `options`, ensuring the component's search functionality always references the latest options. (`web/libs/ui/src/lib/select/select.tsx`)
* Adjusted the dependencies of the `_options` memoization to remove `options`, since the ref now handles updates, preventing unnecessary recomputations. (`web/libs/ui/src/lib/select/select.tsx`)