### PR TITLE
test: BROS-320: Fix flaky tests

### DIFF
--- a/web/libs/editor/tests/integration/data/video_segmentation/timeline_regions.ts
+++ b/web/libs/editor/tests/integration/data/video_segmentation/timeline_regions.ts
@@ -49,6 +49,31 @@ export const multipleTimelineRegionsResult = [
   },
 ];
 
+export const multipleTimelineRegionsLongResult = [
+  {
+    value: {
+      ranges: [{ start: 5, end: 10 }],
+      timelinelabels: ["Movement"],
+    },
+    id: "timeline_region_1",
+    from_name: "timeline",
+    to_name: "video",
+    type: "timeserieslabels",
+    origin: "manual",
+  },
+  {
+    value: {
+      ranges: [{ start: 15, end: 50 }],
+      timelinelabels: ["Nothing"],
+    },
+    id: "timeline_region_2",
+    from_name: "timeline",
+    to_name: "video",
+    type: "timeserieslabels",
+    origin: "manual",
+  },
+];
+
 // Overlapping timeline regions (frames 8-12 and 10-18)
 export const overlappingTimelineRegionsResult = [
   {

--- a/web/libs/editor/tests/integration/e2e/video/regions.cy.ts
+++ b/web/libs/editor/tests/integration/e2e/video/regions.cy.ts
@@ -47,23 +47,21 @@ describe("Video segmentation", suiteConfig, () => {
 
     VideoView.canvasShouldChange("canvas", 0);
   });
-  // @todo: This test is flaky in CI, needs to be fixed
-  it.skip("Should be invisible out of the lifespan (rectangle)", () => {
+  it("Should be invisible out of the lifespan (rectangle)", () => {
     LabelStudio.params().config(simpleVideoConfig).data(simpleVideoData).withResult(simpleVideoResult).init();
     LabelStudio.waitForObjectsReady();
     // Wait for video and regions to be fully loaded
-    cy.wait(1000);
+    VideoView.waitForRegionInKonvaByIndex(0);
+    VideoView.waitForStableState();
 
     Sidebar.hasRegions(1);
 
     VideoView.captureCanvas("canvas");
 
-    cy.wait(1000);
-
     VideoView.clickAtFrame(4);
-
-    // Ensure drawing operations are complete before comparison
-    cy.wait(1000);
+    VideoView.waitForFrame(4);
+    VideoView.waitForRegionNotInKonvaByIndex(0);
+    VideoView.waitForStableState();
 
     VideoView.canvasShouldChange("canvas", 0);
   });
@@ -72,7 +70,8 @@ describe("Video segmentation", suiteConfig, () => {
     LabelStudio.params().config(simpleVideoConfig).data(simpleVideoData).withResult(simpleVideoResult).init();
     LabelStudio.waitForObjectsReady();
     // Wait for frame change to be fully processed
-    cy.wait(1000);
+    VideoView.waitForRegionInKonvaByIndex(0);
+    VideoView.waitForStableState();
     Sidebar.hasRegions(1);
 
     cy.log("Remember an empty canvas state");

--- a/web/libs/editor/tests/integration/e2e/video/timeline_region_loop.cy.ts
+++ b/web/libs/editor/tests/integration/e2e/video/timeline_region_loop.cy.ts
@@ -5,6 +5,7 @@ import {
   singleTimelineRegionResult,
   multipleTimelineRegionsResult,
   overlappingTimelineRegionsResult,
+  multipleTimelineRegionsLongResult,
 } from "../../data/video_segmentation/timeline_regions";
 import { TWO_FRAMES_TIMEOUT } from "../utils/constants";
 
@@ -261,7 +262,7 @@ describe("Video Timeline Region Loop Playback", suiteConfig, () => {
       LabelStudio.params()
         .config(timelineVideoConfig)
         .data(timelineVideoData)
-        .withResult(multipleTimelineRegionsResult)
+        .withResult(multipleTimelineRegionsLongResult)
         .init();
 
       LabelStudio.waitForObjectsReady();

--- a/web/libs/editor/tests/integration/e2e/visual_tags/collapse.cy.ts
+++ b/web/libs/editor/tests/integration/e2e/visual_tags/collapse.cy.ts
@@ -36,17 +36,18 @@ describe("Visual Tags - Collapse", () => {
       cy.get(".ant-collapse-content-active").should("have.length", 0);
 
       // Click to expand first panel
-      Collapse.findPanel("Panel 1").click();
+      Collapse.findTab("Panel 1").click();
       cy.get(".ant-collapse-content-active").should("have.length", 1);
       cy.contains("Content for panel 1").should("be.visible");
 
       // Click to collapse first panel
-      Collapse.findPanel("Panel 1").click();
+      Collapse.findTab("Panel 1").click();
+
       cy.get(".ant-collapse-content-active").should("have.length", 0);
       cy.contains("Content for panel 1").should("not.be.visible");
 
       // Click to expand second panel
-      Collapse.findPanel("Panel 2").click();
+      Collapse.findTab("Panel 2").click();
       cy.get(".ant-collapse-content-active").should("have.length", 1);
       cy.contains("Content for panel 2").should("be.visible");
 

--- a/web/libs/frontend-test/src/helpers/LSF/Collapse.ts
+++ b/web/libs/frontend-test/src/helpers/LSF/Collapse.ts
@@ -21,6 +21,10 @@ class CollapseHelper {
     return this.panels.contains(".ant-collapse-item", text);
   }
 
+  findTab(text: string) {
+    return this.panels.contains(".ant-collapse-header", text);
+  }
+
   getPanelByIdx(idx: number) {
     return this.panels.eq(idx);
   }


### PR DESCRIPTION
Fixes for video tests and collapse test.

- `multipleTimelineRegionsLongResult` gives more time for region playing to avoid pause at the end of it before we can switch to another one.
- using `waitForRegionNotInKonvaByIndex` and `waitForStableState` to make sure that the video is rendered with the right frame
- collapse will be closed by the click on the header instead of the center of panel

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
