### PR TITLE
fix: FIT-630: Apply sentry_skip pattern to configuration errors in ed…

### DIFF
--- a/web/apps/labelstudio/src/app/ErrorBoundary.jsx
+++ b/web/apps/labelstudio/src/app/ErrorBoundary.jsx
@@ -20,11 +20,14 @@ export default class ErrorBoundary extends Component {
 
   componentDidCatch(error, { componentStack }) {
     console.error(error);
+
     // Capture the error in Sentry, so we can fix it directly
     // Don't make the users copy and paste the stacktrace, it's not actionable
+    // Check if error has sentry_skip property (e.g., from ConfigurationError)
     captureException(error, {
       extra: {
         component_stacktrace: componentStack,
+        sentry_skip: error.sentry_skip || false,
       },
     });
     this.setState({

--- a/web/libs/editor/src/core/Registry.ts
+++ b/web/libs/editor/src/core/Registry.ts
@@ -1,3 +1,5 @@
+import { ConfigurationError } from "../utils/errors";
+
 interface ObjectTag {
   name: string;
 }
@@ -116,7 +118,7 @@ class _Registry {
     if (!model) {
       const models = Object.keys(this.models);
 
-      throw new Error(`No model registered for tag: ${tag}\nAvailable models:\n\t${models.join("\n\t")}`);
+      throw new ConfigurationError(`No model registered for tag: ${tag}\nAvailable models:\n\t${models.join("\n\t")}`);
     }
 
     return model;

--- a/web/libs/editor/src/core/Types.js
+++ b/web/libs/editor/src/core/Types.js
@@ -1,6 +1,7 @@
 import { getParent, getType, isRoot, types } from "mobx-state-tree";
 
 import Registry from "./Registry";
+import { ConfigurationError } from "../utils/errors";
 
 function _mixedArray(fn) {
   return (arr) => types.maybeNull(types.array(fn(arr)));
@@ -13,7 +14,7 @@ function _oneOf(lookup, err) {
         if (arr.find((val) => sn.type === val)) {
           return lookup(sn.type);
         }
-        throw Error(err + sn.type);
+        throw new ConfigurationError(err + sn.type);
       },
     });
 }
@@ -48,7 +49,7 @@ function allModelsTypes() {
         if (Registry.tags.includes(sn.type)) {
           return Registry.getModelByTag(sn.type);
         }
-        throw Error(`Not expecting tag: ${sn.type}`);
+        throw new ConfigurationError(`Not expecting tag: ${sn.type}`);
       },
     },
     Registry.modelsArr(),

--- a/web/libs/editor/src/utils/errors.js
+++ b/web/libs/editor/src/utils/errors.js
@@ -1,0 +1,12 @@
+/**
+ * Custom error class for configuration errors that should not be sent to Sentry
+ * Used for user/configuration issues rather than code bugs
+ */
+export class ConfigurationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ConfigurationError";
+    // Mark this error to be skipped by Sentry
+    this.sentry_skip = true;
+  }
+}


### PR DESCRIPTION
Apply sentry_skip pattern to editor configuration errors

Problem:
Configuration errors like "Not expecting tag" and "No model registered for tag" are sent to Sentry as code bugs, creating noise in error monitoring.

Solution:
Created ConfigurationError class with built-in sentry_skip: true property
Updated Types.js and Registry.ts to throw ConfigurationError instead of generic Error
Modified ErrorBoundary to respect error.sentry_skip property

Impact:
✅ Reduces Sentry noise from user/config issues
✅ Preserves error visibility for users to debug configs
✅ Maintains Sentry reporting for actual code bugs