### PR TITLE
fix: FIT-639: Remove strman library dependency and replace with lodash

### DIFF
--- a/web/apps/labelstudio/src/pages/CreateProject/Config/Config.jsx
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/Config.jsx
@@ -17,7 +17,7 @@ import { TemplatesList } from "./TemplatesList";
 import tags from "@humansignal/core/lib/utils/schema/tags.json";
 import { UnsavedChanges } from "./UnsavedChanges";
 import { Checkbox, CodeEditor, Select } from "@humansignal/ui";
-import { toSnakeCase } from "strman";
+import { snakeCase } from "lodash";
 
 const wizardClass = cn("wizard");
 const configClass = cn("configure");
@@ -601,7 +601,7 @@ export const ConfigPage = ({
   const setSelectedGroup = React.useCallback(
     (group) => {
       _setSelectedGroup(group);
-      __lsa(`labeling_setup.list.${toSnakeCase(group)}`);
+      __lsa(`labeling_setup.list.${snakeCase(group)}`);
     },
     [_setSelectedGroup],
   );
@@ -659,7 +659,7 @@ export const ConfigPage = ({
       setTemplate(recipe.config);
       setSelectedRecipe(recipe);
       setMode("view");
-      __lsa(`labeling_setup.view.${toSnakeCase(recipe.group)}.${toSnakeCase(recipe.title)}`);
+      __lsa(`labeling_setup.view.${snakeCase(recipe.group)}.${snakeCase(recipe.title)}`);
     }
   });
 

--- a/web/apps/labelstudio/src/pages/CreateProject/Config/Config.jsx
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/Config.jsx
@@ -17,7 +17,7 @@ import { TemplatesList } from "./TemplatesList";
 import tags from "@humansignal/core/lib/utils/schema/tags.json";
 import { UnsavedChanges } from "./UnsavedChanges";
 import { Checkbox, CodeEditor, Select } from "@humansignal/ui";
-import { snakeCase } from "lodash";
+import snakeCase from "lodash/snakeCase";
 
 const wizardClass = cn("wizard");
 const configClass = cn("configure");

--- a/web/libs/core/src/index.ts
+++ b/web/libs/core/src/index.ts
@@ -4,6 +4,7 @@ export * from "./lib/Tour";
 export * from "./lib/utils/analytics";
 export * from "./lib/utils/urlJSON";
 export * from "./lib/utils/helpers";
+export * from "./lib/utils/string";
 export * from "./hooks/useAbortController";
 export * from "./lib/hooks/useCopyText";
 

--- a/web/libs/core/src/lib/utils/string.ts
+++ b/web/libs/core/src/lib/utils/string.ts
@@ -1,0 +1,11 @@
+import { camelCase } from "lodash";
+
+/**
+ * Convert string to PascalCase (StudlyCase)
+ * This is essentially camelCase with the first letter capitalized
+ * This is the only utility we need since lodash doesn't provide PascalCase
+ */
+export const toStudlyCaps = (str: string): string => {
+  const camelCased = camelCase(str);
+  return camelCased.charAt(0).toUpperCase() + camelCased.slice(1);
+};

--- a/web/libs/core/src/lib/utils/string.ts
+++ b/web/libs/core/src/lib/utils/string.ts
@@ -1,4 +1,4 @@
-import { camelCase } from "lodash";
+import camelCase from "lodash/camelCase";
 
 /**
  * Convert string to PascalCase (StudlyCase)

--- a/web/libs/datamanager/package.json
+++ b/web/libs/datamanager/package.json
@@ -21,8 +21,7 @@
     "react-hotkeys-hook": "^2.4.0",
     "react-virtualized-auto-sizer": "^1.0.20",
     "react-window": "^1.8.9",
-    "react-window-infinite-loader": "^1.0.5",
-    "strman": "^2.0.1"
+    "react-window-infinite-loader": "^1.0.5"
   },
   "main": "src/index.js"
 }

--- a/web/libs/datamanager/src/components/CellViews/index.js
+++ b/web/libs/datamanager/src/components/CellViews/index.js
@@ -1,4 +1,4 @@
-import { toStudlyCaps } from "strman";
+import { toStudlyCaps } from "@humansignal/core";
 
 export { Agreement } from "./Agreement/Agreement";
 export {

--- a/web/libs/datamanager/src/sdk/dm-sdk.js
+++ b/web/libs/datamanager/src/sdk/dm-sdk.js
@@ -42,7 +42,7 @@
 import { inject, observer } from "mobx-react";
 import { destroy } from "mobx-state-tree";
 import { unmountComponentAtNode } from "react-dom";
-import { camelCase } from "lodash";
+import camelCase from "lodash/camelCase";
 import { instruments } from "../components/DataManager/Toolbar/instruments";
 import { APIProxy } from "../utils/api-proxy";
 import { FF_LSDV_4620_3_ML, isFF } from "../utils/feature-flags";

--- a/web/libs/datamanager/src/sdk/dm-sdk.js
+++ b/web/libs/datamanager/src/sdk/dm-sdk.js
@@ -42,7 +42,7 @@
 import { inject, observer } from "mobx-react";
 import { destroy } from "mobx-state-tree";
 import { unmountComponentAtNode } from "react-dom";
-import { toCamelCase } from "strman";
+import { camelCase } from "lodash";
 import { instruments } from "../components/DataManager/Toolbar/instruments";
 import { APIProxy } from "../utils/api-proxy";
 import { FF_LSDV_4620_3_ML, isFF } from "../utils/feature-flags";
@@ -306,7 +306,7 @@ export class DataManager {
    */
   on(eventName, callback) {
     if (this.lsf && eventName.startsWith("lsf:")) {
-      const evt = toCamelCase(eventName.replace(/^lsf:/, ""));
+      const evt = camelCase(eventName.replace(/^lsf:/, ""));
 
       this.lsf?.lsfInstance?.on(evt, callback);
     }
@@ -325,7 +325,7 @@ export class DataManager {
    */
   off(eventName, callback) {
     if (this.lsf && eventName.startsWith("lsf:")) {
-      const evt = toCamelCase(eventName.replace(/^lsf:/, ""));
+      const evt = camelCase(eventName.replace(/^lsf:/, ""));
 
       this.lsf?.lsfInstance?.off(evt, callback);
     }
@@ -344,7 +344,7 @@ export class DataManager {
 
     lsfEvents.forEach((evt) => {
       const callbacks = Array.from(this.getEventCallbacks(evt));
-      const eventName = toCamelCase(evt.replace(/^lsf:/, ""));
+      const eventName = camelCase(evt.replace(/^lsf:/, ""));
 
       callbacks.forEach((clb) => this.lsf?.lsfInstance?.off(eventName, clb));
     });

--- a/web/libs/datamanager/src/sdk/hotkeys.ts
+++ b/web/libs/datamanager/src/sdk/hotkeys.ts
@@ -1,5 +1,5 @@
 import { useHotkeys } from "react-hotkeys-hook";
-import { toStudlyCaps } from "strman";
+import { toStudlyCaps } from "@humansignal/core";
 import { keymap } from "./keymap";
 
 export type Hotkey = {

--- a/web/libs/datamanager/src/utils/helpers.ts
+++ b/web/libs/datamanager/src/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { toCamelCase } from "strman";
+import { camelCase } from "lodash";
 
 export const formDataToJPO = (formData: FormData) => {
   if (formData instanceof FormData) {
@@ -96,10 +96,10 @@ export const camelizeKeys = <T extends AnyObject>(source: T): KeysToCamelCase<T>
 
   const pairs: Pair[] = split.map<Pair>(([key, value]) => {
     if (Object.prototype.toString.call(value) === "[object Object]") {
-      return [toCamelCase(key), camelizeKeys(value as T)];
+      return [camelCase(key), camelizeKeys(value as T)];
     }
 
-    return [toCamelCase(key), value];
+    return [camelCase(key), value];
   });
 
   return Object.fromEntries(pairs) as KeysToCamelCase<T>;

--- a/web/libs/datamanager/src/utils/helpers.ts
+++ b/web/libs/datamanager/src/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { camelCase } from "lodash";
+import camelCase from "lodash/camelCase";
 
 export const formDataToJPO = (formData: FormData) => {
   if (formData instanceof FormData) {

--- a/web/libs/editor/package.json
+++ b/web/libs/editor/package.json
@@ -35,7 +35,7 @@
     "react-virtualized-auto-sizer": "^1.0.20",
     "react-window": "^1.8.9",
     "sanitize-html": "^2.12.1",
-    "strman": "^2.0.1",
+
     "webfft": "^1.0.3",
     "xpath-range": "^1.1.1"
   },

--- a/web/libs/editor/src/LabelStudio.tsx
+++ b/web/libs/editor/src/LabelStudio.tsx
@@ -2,7 +2,7 @@ import { configure } from "mobx";
 import { destroy } from "mobx-state-tree";
 import { render, unmountComponentAtNode } from "react-dom";
 import { createRoot } from "react-dom/client";
-import { camelCase } from "lodash";
+import camelCase from "lodash/camelCase";
 import { LabelStudio as LabelStudioReact } from "./Component";
 import App from "./components/App/App";
 import { configureStore } from "./configureStore";

--- a/web/libs/editor/src/LabelStudio.tsx
+++ b/web/libs/editor/src/LabelStudio.tsx
@@ -2,7 +2,7 @@ import { configure } from "mobx";
 import { destroy } from "mobx-state-tree";
 import { render, unmountComponentAtNode } from "react-dom";
 import { createRoot } from "react-dom/client";
-import { toCamelCase } from "strman";
+import { camelCase } from "lodash";
 import { LabelStudio as LabelStudioReact } from "./Component";
 import App from "./components/App/App";
 import { configureStore } from "./configureStore";
@@ -257,7 +257,7 @@ export class LabelStudio {
       const callback = this.options[key];
 
       if (isDefined(callback)) {
-        const eventName = toCamelCase(key.replace(/^on/, ""));
+        const eventName = camelCase(key.replace(/^on/, ""));
 
         this.events.on(eventName, callback);
       }

--- a/web/libs/editor/src/tools/Base.jsx
+++ b/web/libs/editor/src/tools/Base.jsx
@@ -1,12 +1,12 @@
 import { getEnv, getSnapshot, getType, types } from "mobx-state-tree";
 import { observer } from "mobx-react";
 import { Tool } from "../components/Toolbar/Tool";
-import { toKebabCase } from "strman";
+import { kebabCase } from "lodash";
 
 const ToolView = observer(({ item }) => {
   return (
     <Tool
-      ariaLabel={toKebabCase(getType(item).name)}
+      ariaLabel={kebabCase(getType(item).name)}
       active={item.selected}
       icon={item.iconClass}
       label={item.viewTooltip}

--- a/web/libs/editor/src/tools/Base.jsx
+++ b/web/libs/editor/src/tools/Base.jsx
@@ -1,7 +1,7 @@
 import { getEnv, getSnapshot, getType, types } from "mobx-state-tree";
 import { observer } from "mobx-react";
 import { Tool } from "../components/Toolbar/Tool";
-import { kebabCase } from "lodash";
+import kebabCase from "lodash/kebabCase";
 
 const ToolView = observer(({ item }) => {
   return (

--- a/web/libs/editor/src/utils/utilities.ts
+++ b/web/libs/editor/src/utils/utilities.ts
@@ -1,6 +1,6 @@
 import { formatDistanceToNow } from "date-fns";
 import { destroy, detach } from "mobx-state-tree";
-import { toCamelCase, toSnakeCase } from "strman";
+import { camelCase, snakeCase } from "lodash";
 
 /**
  * Internal helper to check if parameter is a string
@@ -219,9 +219,9 @@ export const camelizeKeys = (object: any): Record<string, unknown> => {
   return Object.fromEntries(
     Object.entries(object).map(([key, value]) => {
       if (Object.prototype.toString.call(value) === "[object Object]") {
-        return [toCamelCase(key), camelizeKeys(value)];
+        return [camelCase(key), camelizeKeys(value)];
       }
-      return [toCamelCase(key), value];
+      return [camelCase(key), value];
     }),
   );
 };
@@ -230,9 +230,9 @@ export const snakeizeKeys = (object: any): Record<string, unknown> => {
   return Object.fromEntries(
     Object.entries(object).map(([key, value]) => {
       if (Object.prototype.toString.call(value) === "[object Object]") {
-        return [toSnakeCase(key), snakeizeKeys(value)];
+        return [snakeCase(key), snakeizeKeys(value)];
       }
-      return [toSnakeCase(key), value];
+      return [snakeCase(key), value];
     }),
   );
 };

--- a/web/libs/editor/src/utils/utilities.ts
+++ b/web/libs/editor/src/utils/utilities.ts
@@ -1,6 +1,7 @@
 import { formatDistanceToNow } from "date-fns";
 import { destroy, detach } from "mobx-state-tree";
-import { camelCase, snakeCase } from "lodash";
+import camelCase from "lodash/camelCase";
+import snakeCase from "lodash/snakeCase";
 
 /**
  * Internal helper to check if parameter is a string

--- a/web/libs/editor/tests/e2e/package.json
+++ b/web/libs/editor/tests/e2e/package.json
@@ -39,7 +39,7 @@
     "playwright": "^1.16.3",
     "puppeteer": "^24.6.1",
     "rimraf": "^3.0.2",
-    "strman": "2.0.1",
+
     "ts-node": "^10.0.0",
     "typescript": "^4.5.3",
     "v8-to-istanbul": "^9.0.0",

--- a/web/libs/editor/tests/e2e/tests/image-labels.test.js
+++ b/web/libs/editor/tests/e2e/tests/image-labels.test.js
@@ -1,5 +1,5 @@
 const assert = require("assert");
-const { toKebabCase } = require("strman");
+const { kebabCase } = require("lodash");
 
 Feature("Images' labels type matching");
 
@@ -168,7 +168,7 @@ DataStore.Scenario(
         }, 0);
       };
 
-      const toolSelector = `[aria-label=${toKebabCase(`${shape}-tool`)}]`;
+      const toolSelector = `[aria-label=${kebabCase(`${shape}-tool`)}]`;
 
       LabelStudio.init(params);
       LabelStudio.waitForObjectsReady();

--- a/web/package.json
+++ b/web/package.json
@@ -111,7 +111,7 @@
     "shadcn": "^2.1.8",
     "simplify-js": "^1.2.4",
     "storybook": "^9.0.13",
-    "strman": "^2.0.1",
+
     "tailwind-merge": "^2.6.0",
     "webfft": "^1.0.3",
     "xpath-range": "^1.1.1",
@@ -171,7 +171,7 @@
     "@types/react-window-infinite-loader": "^1.0.9",
     "@types/sanitize-html": "^2.13.0",
     "@types/sinon": "^17.0.3",
-    "@types/strman": "^2.0.0",
+
     "autoprefixer": "^10.4.20",
     "babel-jest": "29.7.0",
     "babel-loader": "^8.2.2",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -5714,11 +5714,6 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
 
-"@types/strman@^2.0.0":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@types/strman/-/strman-2.0.3.tgz#2cc5d3106b9cdc3f0e2681f2350b6af0ebf988ae"
-  integrity sha512-CnGRn6OdRB6j5aR6724bZYzMQsPBYCIW4TuRNdSHqwDKXgDbR1H6O0rtT7T5MRisyiBM/kNWxkEM++AWcRT+qQ==
-
 "@types/tough-cookie@*":
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
@@ -17423,11 +17418,6 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
-
-strman@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strman/-/strman-2.0.1.tgz#d43bb91c91e100609f336fd4a6539fd8e980e1de"
-  integrity sha512-00kB9pulmzaQUBl8DJQ4255QXnQn/MHnJzYqKz4a/W5KqCMSaqmv0VReOzkSg2u4FYkKpNhxpp6bs6aEMZeLPw==
 
 strtok3@^9.0.1:
   version "9.1.1"


### PR DESCRIPTION
# Remove strman library and replace with lodash

## 🎯 Purpose
Remove the strman library dependency and replace its usage with lodash functions and a minimal custom utility.

## 🔧 Changes Made

### Dependencies Removed
- `strman` package from all package.json files
- `strman.tostudlycaps` package  
- `@types/strman` type definitions
- Updated webpack externals configuration

### Function Replacements
| strman Function | Replacement |
|----------------|-------------|
| `toCamelCase` | `camelCase` (lodash) |
| `toSnakeCase` | `snakeCase` (lodash) |
| `toKebabCase` | `kebabCase` (lodash) |
| `toStudlyCaps` | Custom utility (PascalCase not in lodash) |


## 🧪 Testing
- [x] Linter passes with no new errors
- [x] All existing functionality preserved
- [x] Yarn install successful
- [x] String conversion functions work identically

## 📊 Impact
- **Bundle size reduction**: Removed unnecessary dependency
- **Consistency**: All string utilities now use lodash or minimal custom code
- **Maintainability**: Fewer dependencies to manage
- **Architecture**: Clean separation with utilities only in open source

## 🔍 Architecture Notes
- Custom utilities only exist in open source (`@humansignal/core`)
- Enterprise version imports utilities via `@humansignal/core` at build time
- Direct lodash usage preferred over wrapper functions
- Only one custom utility needed (`toStudlyCaps` for PascalCase)


<img width="1903" height="1075" alt="Screenshot 2025-08-29 at 10 25 14 AM" src="https://github.com/user-attachments/assets/32df3a65-68b2-49d7-88d8-65ee577e2523" />
<img width="349" height="413" alt="Screenshot 2025-08-28 at 2 57 15 PM" src="https://github.com/user-attachments/assets/ea121cd6-8b99-4d0e-af45-ff2338030257" />
<img width="346" height="395" alt="Screenshot 2025-08-28 at 2 57 08 PM" src="https://github.com/user-attachments/assets/a609d542-61cb-4d87-b778-5182967207d7" />
