### PR TITLE
bug fix: entry point script contents use wrong relative path.

### DIFF
--- a/deploy/docker-entrypoint.d/app-init/11-configure-custom-cabundle.sh
+++ b/deploy/docker-entrypoint.d/app-init/11-configure-custom-cabundle.sh
@@ -1,1 +1,1 @@
-../common/11-configure-custom-cabundle.sh
+deploy/docker-entrypoint.d/common/11-configure-custom-cabundle.sh

--- a/deploy/docker-entrypoint.d/app-init/20-wait-for-db.sh
+++ b/deploy/docker-entrypoint.d/app-init/20-wait-for-db.sh
@@ -1,1 +1,1 @@
-../common/20-wait-for-db.sh
+deploy/docker-entrypoint.d/common/20-wait-for-db.sh

--- a/deploy/docker-entrypoint.d/app/11-configure-custom-cabundle.sh
+++ b/deploy/docker-entrypoint.d/app/11-configure-custom-cabundle.sh
@@ -1,1 +1,1 @@
-../common/11-configure-custom-cabundle.sh
+deploy/docker-entrypoint.d/common/11-configure-custom-cabundle.sh

--- a/deploy/docker-entrypoint.d/app/20-wait-for-db.sh
+++ b/deploy/docker-entrypoint.d/app/20-wait-for-db.sh
@@ -1,1 +1,1 @@
-../common/20-wait-for-db.sh
+deploy/docker-entrypoint.d/common/20-wait-for-db.sh

--- a/deploy/docker-entrypoint.d/app/30-run-db-migrations.sh
+++ b/deploy/docker-entrypoint.d/app/30-run-db-migrations.sh
@@ -1,1 +1,1 @@
-../common/30-run-db-migrations.sh
+deploy/docker-entrypoint.d/common/30-run-db-migrations.sh

--- a/deploy/docker-entrypoint.d/nginx/10-configure-nginx.sh
+++ b/deploy/docker-entrypoint.d/nginx/10-configure-nginx.sh
@@ -1,1 +1,1 @@
-../common/10-configure-nginx.sh
+deploy/docker-entrypoint.d/common/10-configure-nginx.sh


### PR DESCRIPTION
https://github.com/HumanSignal/label-studio/issues/8300

Describe the bug
local built docker image execution error:
./deploy/docker-entrypoint.sh: Looking for init scripts in /label-studio/deploy/docker-entrypoint.d/app/
./deploy/docker-entrypoint.sh: Launching /label-studio/deploy/docker-entrypoint.d/app/11-configure-custom-cabundle.sh
/label-studio/deploy/docker-entrypoint.d/app/11-configure-custom-cabundle.sh: line 1: ../common/11-configure-custom-cabundle.sh: No such file or directory

To Reproduce
Steps to reproduce the behavior:
git clone latest code from github (develop branch) to windows machine.
docker build -t heartexlabs/label-studio:latest .
docker compose -f docker-compose.yml -f docker-compose.minio.yml up -d
app container logs errors:
```
./deploy/docker-entrypoint.sh: Looking for init scripts in /label-studio/deploy/docker-entrypoint.d/app/

./deploy/docker-entrypoint.sh: Launching /label-studio/deploy/docker-entrypoint.d/app/11-configure-custom-cabundle.sh

/label-studio/deploy/docker-entrypoint.d/app/11-configure-custom-cabundle.sh: line 1: ../common/11-configure-custom-cabundle.sh: No such file or directory
```