### PR TITLE
fix: BROS-369: Wrap selected items with long labels in Taxonomy

### DIFF
--- a/docs/source/includes/tags/taxonomy.md
+++ b/docs/source/includes/tags/taxonomy.md
@@ -9,9 +9,9 @@
 | [showFullPath] | <code>boolean</code> | <code>false</code> | Whether to show the full path of selected items |
 | [pathSeparator] | <code>string</code> | <code>&quot;/&quot;</code> | Separator to show in the full path (default is " / "). To avoid errors, ensure that your data does not include this separator |
 | [maxUsages] | <code>number</code> |  | Maximum number of times a choice can be selected per task or per region |
-| [maxWidth] | <code>number</code> |  | Maximum width for dropdown |
-| [minWidth] | <code>number</code> |  | Minimum width for dropdown |
-| [required] | <code>boolean</code> | <code>false</code> | Whether taxonomy validation is required |
+| [maxWidth] | <code>number</code> |  | Maximum width for dropdown with units (eg: "500px") |
+| [minWidth] | <code>number</code> |  | Minimum width for dropdown with units (eg: "300px") |
+| [required] | <code>boolean</code> | <code>false</code> | Whether it is required to have selected at least one option |
 | [requiredMessage] | <code>string</code> |  | Message to show if validation fails |
 | [placeholder=] | <code>string</code> |  | What to display as prompt on the input |
 | [perRegion] | <code>boolean</code> |  | Use this tag to classify specific regions instead of the whole object |

--- a/web/libs/core/src/lib/utils/schema/tags.json
+++ b/web/libs/core/src/lib/utils/schema/tags.json
@@ -2318,19 +2318,19 @@
       },
       "maxWidth": {
         "name": "maxWidth",
-        "description": "Maximum width for dropdown",
+        "description": "Maximum width for dropdown with units (eg: \"500px\")",
         "type": "number",
         "required": false
       },
       "minWidth": {
         "name": "minWidth",
-        "description": "Minimum width for dropdown",
+        "description": "Minimum width for dropdown with units (eg: \"300px\")",
         "type": "number",
         "required": false
       },
       "required": {
         "name": "required",
-        "description": "Whether taxonomy validation is required",
+        "description": "Whether it is required to have selected at least one option",
         "type": ["true", "false"],
         "required": false,
         "default": false

--- a/web/libs/editor/src/components/NewTaxonomy/NewTaxonomy.scss
+++ b/web/libs/editor/src/components/NewTaxonomy/NewTaxonomy.scss
@@ -8,3 +8,16 @@
   // Create Project popup has 2000
   z-index: 3000;
 }
+
+// wrap long labels for selected items
+// we need to increase specificity this way to override the default styles
+:global(.htx-taxonomy.ant-select-multiple) {
+  :global(.ant-select-selection-item) {
+    height: auto;
+  }
+
+  :global(.ant-select-selection-item-content) {
+    white-space: normal;
+    word-break: break-word;
+  }
+}

--- a/web/libs/editor/src/tags/control/Taxonomy/Taxonomy.jsx
+++ b/web/libs/editor/src/tags/control/Taxonomy/Taxonomy.jsx
@@ -71,9 +71,9 @@ import { errorBuilder } from "../../../core/DataValidator/ConfigValidator";
  * @param {boolean} [showFullPath=false]  - Whether to show the full path of selected items
  * @param {string} [pathSeparator= / ]    - Separator to show in the full path (default is " / "). To avoid errors, ensure that your data does not include this separator
  * @param {number} [maxUsages]            - Maximum number of times a choice can be selected per task or per region
- * @param {number} [maxWidth]             - Maximum width for dropdown
- * @param {number} [minWidth]             - Minimum width for dropdown
- * @param {boolean} [required=false]      - Whether taxonomy validation is required
+ * @param {number} [maxWidth]             - Maximum width for dropdown with units (eg: "500px")
+ * @param {number} [minWidth]             - Minimum width for dropdown with units (eg: "300px")
+ * @param {boolean} [required=false]      - Whether it is required to have selected at least one option
  * @param {string} [requiredMessage]      - Message to show if validation fails
  * @param {string} [placeholder=]         - What to display as prompt on the input
  * @param {boolean} [perRegion]           - Use this tag to classify specific regions instead of the whole object


### PR DESCRIPTION
This will be a default behavior for all taxonomies and should not break usual cases with not that long labels.

<img width="389" height="380" alt="Screenshot 2025-09-02 at 19 33 03" src="https://github.com/user-attachments/assets/44576604-b445-438d-9fe7-8832992c7920" />
