### PR TITLE
fix: UTC-248: Annotator Performance workspace dropdown not visible when workspaces name length is too large

### DIFF
--- a/web/libs/ui/src/lib/select/select.tsx
+++ b/web/libs/ui/src/lib/select/select.tsx
@@ -521,7 +521,7 @@ const Option = ({
         data-disabled={disabled}
       >
         {multiple && <Checkbox tabIndex={-1} checked={isOptionSelected} indeterminate={isIndeterminate} readOnly />}
-        <div data-testid="select-option-label" className="w-full">
+        <div data-testid="select-option-label" className="w-full min-w-0 truncate">
           {label}
         </div>
       </div>


### PR DESCRIPTION

Before:

<img width="1721" height="676" alt="Screenshot 2025-09-03 at 12 43 21" src="https://github.com/user-attachments/assets/be54ad07-c697-4ff3-8fb7-7b518ecabf71" />
<img width="1720" height="840" alt="Screenshot 2025-09-03 at 12 45 11" src="https://github.com/user-attachments/assets/b06fdd2a-db6a-4bd8-ac04-b19dd37a2d50" />


After:
<img width="1718" height="639" alt="Screenshot 2025-09-03 at 12 43 44" src="https://github.com/user-attachments/assets/cf76cfbc-be93-4a78-9bc6-c2788340601a" />
<img width="1719" height="729" alt="Screenshot 2025-09-03 at 12 44 19" src="https://github.com/user-attachments/assets/8fef47e2-32ce-4cce-9013-743a16015762" />

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
