### PR TITLE
fix: FIT-139: Fixes Taxonomy dropdown disabled style on Dark Mode

### DIFF
--- a/web/libs/editor/src/tags/control/Taxonomy/Taxonomy.scss
+++ b/web/libs/editor/src/tags/control/Taxonomy/Taxonomy.scss
@@ -30,7 +30,7 @@
 }
 
 body :global(.ant-select:not(.ant-select-customize-input) .ant-select-selector) {
-  background-color: var(--color-neutral-surface);
+  background-color: var(--color-neutral-background);
   border-color: var(--color-neutral-border);
 }
 

--- a/web/libs/editor/src/tags/control/Taxonomy/Taxonomy.scss
+++ b/web/libs/editor/src/tags/control/Taxonomy/Taxonomy.scss
@@ -85,6 +85,19 @@ body :global(.ant-select-multiple .ant-select-selection-item-remove) {
   color: var(--color-neutral-content-subtler);
 }
 
+body :global(.ant-select-multiple.ant-select-disabled.ant-select:not(.ant-select-customize-input) .ant-select-selector) {
+  background-color: var(--color-neutral-surface);
+}
+
+body :global(.ant-select-disabled.ant-select-multiple .ant-select-selection-item) {
+  border-color: transparent;
+  color: var(--color-neutral-content-subtle);
+}
+
+body :global(.ant-select-disabled .ant-select-arrow) {
+  color: var(--color-neutral-content-subtlest);
+}
+
 body :global(.ant-select-arrow) {
   color: var(--color-neutral-icon);
 }


### PR DESCRIPTION
This pull request introduces several style adjustments to improve the appearance and accessibility of disabled multi-select dropdowns in the taxonomy control. The main focus is on ensuring consistent visual cues for disabled states.

**Disabled multi-select dropdown styling:**

* Updated the background color of disabled multi-select dropdown selectors to use `var(--color-neutral-surface)` for clearer differentiation.
* Changed the border color to transparent and text color to `var(--color-neutral-content-subtle)` for selection items in disabled multi-selects, making the disabled state more visually apparent.
* Modified the color of the dropdown arrow in disabled selects to use `var(--color-neutral-content-subtlest)`, further reinforcing the disabled state.

## Screenshots

### Before
<img width="313" height="178" alt="image" src="https://github.com/user-attachments/assets/d3387688-741a-4939-a0b2-ed696488b6cb" />

### After
<img width="336" height="164" alt="image" src="https://github.com/user-attachments/assets/c77a37d6-166e-4532-bf0c-37d2c0b27302" />

