### PR TITLE
fix: BROS-378: Fix text copying

### DIFF
--- a/web/apps/labelstudio/src/pages/Settings/StorageSettings/StorageSummary.jsx
+++ b/web/apps/labelstudio/src/pages/Settings/StorageSettings/StorageSummary.jsx
@@ -4,14 +4,14 @@ import { DescriptionList } from "../../../components/DescriptionList/Description
 import { modal } from "../../../components/Modal/Modal";
 import { Oneof } from "../../../components/Oneof/Oneof";
 import { getLastTraceback } from "../../../utils/helpers";
-import { useCopyText } from "@humansignal/core/lib/hooks/useCopyText";
+import { useCopyText } from "@humansignal/core";
 
 // Component to handle copy functionality within the modal
 const CopyButton = ({ msg }) => {
-  const [copyText, copied] = useCopyText(msg);
+  const [copyText, copied] = useCopyText({ defaultText: msg });
 
   return (
-    <Button variant="neutral" icon={<IconFileCopy />} onClick={copyText} disabled={copied} className="w-[7rem]">
+    <Button variant="neutral" icon={<IconFileCopy />} onClick={() => copyText()} disabled={copied} className="w-[7rem]">
       {copied ? "Copied!" : "Copy"}
     </Button>
   );

--- a/web/libs/app-common/src/pages/AccountSettings/sections/PersonalAccessToken.tsx
+++ b/web/libs/app-common/src/pages/AccountSettings/sections/PersonalAccessToken.tsx
@@ -1,4 +1,4 @@
-import { useCopyText } from "@humansignal/core/lib/hooks/useCopyText";
+import { useCopyText } from "@humansignal/core";
 import { Button, IconFileCopy, IconLaunch, Label, Typography } from "@humansignal/ui";
 /**
  * FIXME: This is legacy imports. We're not supposed to use such statements
@@ -44,8 +44,8 @@ export const PersonalAccessToken = () => {
   const token = useAtomValue(currentTokenAtom);
   const reset = useAtomValue(resetTokenAtom);
   const curl = useAtomValue(curlStringAtom);
-  const [copyToken, tokenCopied] = useCopyText(token);
-  const [copyCurl, curlCopied] = useCopyText(curl);
+  const [copyToken, tokenCopied] = useCopyText({ defaultText: token });
+  const [copyCurl, curlCopied] = useCopyText({ defaultText: curl });
 
   return (
     <div id="personal-access-token">
@@ -56,7 +56,7 @@ export const PersonalAccessToken = () => {
             <Input name="token" className={styles.input} readOnly value={token} />
             <Button
               leading={<IconFileCopy />}
-              onClick={copyToken}
+              onClick={() => copyToken()}
               disabled={tokenCopied}
               variant="primary"
               look="outlined"
@@ -81,7 +81,7 @@ export const PersonalAccessToken = () => {
             />
             <Button
               leading={<IconFileCopy />}
-              onClick={copyCurl}
+              onClick={() => copyCurl()}
               disabled={curlCopied}
               variant="primary"
               look="outlined"

--- a/web/libs/app-common/src/pages/AccountSettings/sections/PersonalJWTToken.tsx
+++ b/web/libs/app-common/src/pages/AccountSettings/sections/PersonalJWTToken.tsx
@@ -5,7 +5,7 @@ import { useAtomValue } from "jotai";
 import clsx from "clsx";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { format } from "date-fns";
-import { useCopyText } from "@humansignal/core/lib/hooks/useCopyText";
+import { useCopyText } from "@humansignal/core";
 import styles from "./PersonalJWTToken.module.scss";
 import { Button } from "@humansignal/ui";
 
@@ -188,7 +188,7 @@ export function PersonalJWTToken() {
 
 function CreateTokenForm() {
   const { data, mutate: createToken } = useAtomValue(refreshTokenAtom);
-  const [copy, copied] = useCopyText(data ?? "");
+  const [copy, copied] = useCopyText({ defaultText: data ?? "" });
 
   useEffect(() => {
     createToken();
@@ -206,7 +206,7 @@ function CreateTokenForm() {
           readOnly
           value={data}
         />
-        <Button onClick={copy} disabled={copied} variant="neutral" look="outlined">
+        <Button onClick={() => copy()} disabled={copied} variant="neutral" look="outlined">
           {copied ? "Copied!" : "Copy"}
         </Button>
       </div>

--- a/web/libs/datamanager/src/components/Common/Table/Table.jsx
+++ b/web/libs/datamanager/src/components/Common/Table/Table.jsx
@@ -6,7 +6,7 @@ import { Icon } from "../Icon/Icon";
 import { modal } from "../Modal/Modal";
 import { IconCode, IconGear, IconGearNewUI, IconCopyOutline } from "@humansignal/icons";
 import { AutoSizerTable, Tooltip, Button } from "@humansignal/ui";
-import { useCopyText } from "@humansignal/core/lib/hooks/useCopyText";
+import { useCopyText } from "@humansignal/core";
 import "./Table.scss";
 import { TableCheckboxCell } from "./TableCheckbox";
 import { tableCN, TableContext } from "./TableContext";
@@ -448,7 +448,7 @@ const TaskSourceView = ({ content, onTaskLoad, sdkType }) => {
     return source ? JSON.stringify(source, null, 2) : "";
   }, [source]);
 
-  const [handleCopy, copied] = useCopyText(jsonString);
+  const [handleCopy, copied] = useCopyText({ defaultText: jsonString });
 
   return (
     <div
@@ -470,7 +470,7 @@ const TaskSourceView = ({ content, onTaskLoad, sdkType }) => {
               zIndex: 10,
               color: "var(--color-neutral-content-subtle)",
             }}
-            onClick={handleCopy}
+            onClick={() => handleCopy()}
             leading={<Icon icon={IconCopyOutline} style={{ color: "var(--color-neutral-content-subtle)" }} />}
           />
         </Tooltip>

--- a/web/libs/editor/src/components/AnnotationsCarousel/AnnotationButton.tsx
+++ b/web/libs/editor/src/components/AnnotationsCarousel/AnnotationButton.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { inject, observer } from "mobx-react";
-import { useCopyText } from "@humansignal/core/lib/hooks/useCopyText";
+import { useCopyText } from "@humansignal/core";
 import { isDefined, userDisplayName } from "@humansignal/core/lib/utils/helpers";
 import { Block, cn, Elem } from "../../utils/bem";
 import {
@@ -114,7 +114,7 @@ export const AnnotationButton = observer(
           url.searchParams.delete("region");
           return url.toString();
         }, [entity.pk]);
-        const [copyLink] = useCopyText(annotationLink);
+        const [copyLink] = useCopyText({ defaultText: annotationLink });
         const toast = useToast();
         const dropdown = useDropdown();
         const clickHandler = () => {

--- a/web/libs/editor/src/components/SidePanels/Components/RegionContextMenu.tsx
+++ b/web/libs/editor/src/components/SidePanels/Components/RegionContextMenu.tsx
@@ -1,4 +1,4 @@
-import { useCopyText } from "@humansignal/core/lib/hooks/useCopyText";
+import { useCopyText } from "@humansignal/core";
 import { IconEllipsis, IconLink } from "@humansignal/icons";
 import { Button, ToastType, useToast } from "@humansignal/ui";
 import { observer } from "mobx-react";
@@ -18,7 +18,7 @@ export const RegionContextMenu: FC<{ item: any }> = observer(({ item }: { item: 
     }
     return url.toString();
   }, [item]);
-  const [copyLink] = useCopyText(regionLink);
+  const [copyLink] = useCopyText({ defaultText: regionLink });
   const toast = useToast();
 
   const onCopyLink = useCallback<MenuActionOnClick>(


### PR DESCRIPTION
This pull request refactors how the `useCopyText` hook is imported and used across several components. The main improvements are updating the import path for the hook and changing its invocation to use an options object, ensuring consistency and compatibility with the latest API.

**Refactor of `useCopyText` usage across the codebase:**

* All imports of `useCopyText` are updated from `@humansignal/core/lib/hooks/useCopyText` to `@humansignal/core` for a cleaner, more maintainable import path. [[1]](diffhunk://#diff-56406119ea810b88b02cfe427b50ba6014ef8c784419fc698227c0d66f49fd3dL1-R1) [[2]](diffhunk://#diff-c3a40f9593a41fe97315e32c914b588cc41fad60344b364595ca04a77b53b1ceL8-R8) [[3]](diffhunk://#diff-48b6bcad2c2fed9de478fb8e01bc194bb39a2253bf45a1f8404ff92ef7390732L9-R9) [[4]](diffhunk://#diff-ef873179597f217159c06cb03e519cae3037c8d2d7ca19aaa9905729405aaa6eL3-R3) [[5]](diffhunk://#diff-20992b80215c09348898530efb725ef915345d30c0f4eaeb8e958d6dbabb919aL1-R1) [[6]](diffhunk://#diff-466e193f97b7964093f7265d6b60555d477712bac726e7ce754e7814f38868b2L7-R14)
* All usages of `useCopyText` are refactored to accept an options object, e.g., `{ defaultText: value }`, instead of passing the text value directly. This aligns with the updated API and prevents potential issues. [[1]](diffhunk://#diff-56406119ea810b88b02cfe427b50ba6014ef8c784419fc698227c0d66f49fd3dL47-R48) [[2]](diffhunk://#diff-c3a40f9593a41fe97315e32c914b588cc41fad60344b364595ca04a77b53b1ceL191-R191) [[3]](diffhunk://#diff-48b6bcad2c2fed9de478fb8e01bc194bb39a2253bf45a1f8404ff92ef7390732L451-R451) [[4]](diffhunk://#diff-ef873179597f217159c06cb03e519cae3037c8d2d7ca19aaa9905729405aaa6eL117-R117) [[5]](diffhunk://#diff-20992b80215c09348898530efb725ef915345d30c0f4eaeb8e958d6dbabb919aL21-R21) [[6]](diffhunk://#diff-466e193f97b7964093f7265d6b60555d477712bac726e7ce754e7814f38868b2L7-R14)

**Button click handler adjustments:**

* All `onClick` handlers for copy buttons are updated to use an arrow function, e.g., `onClick={() => copyText()}` instead of `onClick={copyText}`. This ensures the copy action is triggered correctly with the new hook signature. [[1]](diffhunk://#diff-56406119ea810b88b02cfe427b50ba6014ef8c784419fc698227c0d66f49fd3dL59-R59) [[2]](diffhunk://#diff-56406119ea810b88b02cfe427b50ba6014ef8c784419fc698227c0d66f49fd3dL84-R84) [[3]](diffhunk://#diff-c3a40f9593a41fe97315e32c914b588cc41fad60344b364595ca04a77b53b1ceL209-R209) [[4]](diffhunk://#diff-48b6bcad2c2fed9de478fb8e01bc194bb39a2253bf45a1f8404ff92ef7390732L473-R473) [[5]](diffhunk://#diff-466e193f97b7964093f7265d6b60555d477712bac726e7ce754e7814f38868b2L7-R14)

These changes improve code consistency and compatibility with the latest version of the `useCopyText` hook.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
