### PR TITLE
chore: Updating resolutions to transitive dep koa to patched version

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -111,11 +111,10 @@
     "shadcn": "^2.1.8",
     "simplify-js": "^1.2.4",
     "storybook": "^9.0.13",
-
+    "sucrase": "^3.35.0",
     "tailwind-merge": "^2.6.0",
     "webfft": "^1.0.3",
     "xpath-range": "^1.1.1",
-    "sucrase": "^3.35.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
@@ -172,7 +171,6 @@
     "@types/react-window-infinite-loader": "^1.0.9",
     "@types/sanitize-html": "^2.13.0",
     "@types/sinon": "^17.0.3",
-
     "autoprefixer": "^10.4.20",
     "babel-jest": "29.7.0",
     "babel-loader": "^8.2.2",
@@ -197,6 +195,7 @@
     "jest-fetch-mock": "^3.0.3",
     "jsdoc-to-markdown": "8.0.1",
     "jsdom": "~22.1.0",
+    "koa": "2.16.2",
     "loader-utils": "^3.2.1",
     "mini-css-extract-plugin": "^2.7.6",
     "nx": "21.2.2",
@@ -238,6 +237,7 @@
     "diff": ">=3.5.0",
     "esbuild": ">=0.25.5",
     "jpeg-js": "0.4.4",
+    "koa": ">=2.16.2",
     "lodash": "4.17.21",
     "merge": "2.1.1",
     "ws": "8.17.1",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -12838,6 +12838,35 @@ koa@2.16.1:
     type-is "^1.6.16"
     vary "^1.1.2"
 
+koa@2.16.2:
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/koa/-/koa-2.16.2.tgz#1292a3b415a9b9f3dd6872c1835229630a4ecae3"
+  integrity sha512-+CCssgnrWKx9aI3OeZwroa/ckG4JICxvIFnSiOUyl2Uv+UTI+xIw0FfFrWS7cQFpoePpr9o8csss7KzsTzNL8Q==
+  dependencies:
+    accepts "^1.3.5"
+    cache-content-type "^1.0.0"
+    content-disposition "~0.5.2"
+    content-type "^1.0.4"
+    cookies "~0.9.0"
+    debug "^4.3.2"
+    delegates "^1.0.0"
+    depd "^2.0.0"
+    destroy "^1.0.4"
+    encodeurl "^1.0.2"
+    escape-html "^1.0.3"
+    fresh "~0.5.2"
+    http-assert "^1.3.0"
+    http-errors "^1.6.3"
+    is-generator-function "^1.0.7"
+    koa-compose "^4.1.0"
+    koa-convert "^2.0.0"
+    on-finished "^2.3.0"
+    only "~0.0.2"
+    parseurl "^1.3.2"
+    statuses "^1.5.0"
+    type-is "^1.6.16"
+    vary "^1.1.2"
+
 konva@^8.1.3:
   version "8.4.3"
   resolved "https://registry.yarnpkg.com/konva/-/konva-8.4.3.tgz#d6754fdb53e69295c24dbdfe967a27f92da51e47"


### PR DESCRIPTION
We don't use the transitive dependency anywhere in our code, but we will patch it so that it doesn't continue to get caught in security scanners. Very low risk, just want to quell the noise potential.