### PR TITLE
docs: Edits to API ref page and access token pages

### DIFF
--- a/docs/source/guide/access_tokens.md
+++ b/docs/source/guide/access_tokens.md
@@ -11,7 +11,7 @@ section: "Manage Your Organization"
 date: 2025-02-18 12:03:59
 ---
 
-Label Studio has personal access tokens and legacy tokens. The options available to users are set at the Organization level. Se [Access settings for orgs](#Access-token-settings-for-orgs) below. 
+Label Studio has personal access tokens and legacy tokens. The options available to users are set at the Organization level.  
 
 <table>
 <thead>
@@ -41,6 +41,34 @@ Label Studio has personal access tokens and legacy tokens. The options available
   </td>
   </tr>
 </table>
+
+## Make API keys available to users
+
+You can access your API keys ("Legacy Tokens" and "Personal Access Tokens") by clicking your user icon in the upper right and selecting **Account & Settings**. 
+
+The options that users see depend on your settings at the organization level. 
+
+From the **Organization** page, click **Access Token Settings** in the upper right. 
+
+<div class="enterprise-only">
+
+!!! note
+    The **Organization** page is only available to users in the Admin and Owner role.
+
+</div>
+
+From here you can enable and disable token types. 
+
+* When a certain token type is disabled, existing tokens will not be able to authenticate to the Label Studio platform. 
+
+* Use the Personal Access Token Time-to-Live to set an expiration date for personal access tokens. 
+  
+  Note that time-to live is only available for Label Studio Enterprise users. 
+
+
+![Screenshot of Access Token window](/images/admin/token-settings.png)
+
+
 
 ## Personal access tokens and the API
 
@@ -104,31 +132,7 @@ exp = decoded.get("exp")
 token_is_expired = (exp <= datetime.now(timezone.utc).timestamp())
 ```
 
-## Access token settings for orgs
-
-The options that are available to users depend on options selected at the organization level. 
-
-From the **Organization** page, click **Access Token Settings** in the upper right. 
-
-<div class="enterprise-only">
-
-!!! note
-    The **Organization** page is only available to users in the Admin and Owner role.
-
-</div>
-
-From here you can enable and disable token types. 
-
-* When a certain token type is disabled, existing tokens will not be able to authenticate to the Label Studio platform. 
-
-* Use the Personal Access Token Time-to-Live to set an expiration date for personal access tokens. This is only available for Label Studio Enterprise users. 
 
 
-![Screenshot of Access Token window](/images/admin/token-settings.png)
-
-
-## Finding your access token
-
-You can create/manage your access token from your [**Account & Settings** page](user_account) (click your username in the upper right in Label Studio). 
 
 

--- a/docs/source/guide/api.md
+++ b/docs/source/guide/api.md
@@ -11,8 +11,6 @@ section: "Integrate & Extend"
 
 ---
 
-<div class="opensource-only">
-
 You can use the Label Studio API to import data for labeling, export annotations, set up machine learning with Label Studio, and sync tasks with cloud storage. 
 
 See the [API reference documentation](https://api.labelstud.io/api-reference/introduction/getting-started) for further guidance and interactive examples. If you want to write Python scripts using the API, use the [Label Studio Python SDK](sdk.html). 
@@ -57,53 +55,5 @@ Retrieve a paginated list of tasks for a specific project. If you want, you can 
 
 To export annotations, first see [which formats are available to export for your project](https://api.labelstud.io/api-reference/api-reference/projects/exports/list-formats). 
 
-Choose your selected format from the response and then call the export endpoint. See the [export annotations](https://api.labelstud.io/api-reference/api-reference/tasks/list) endpoint documentation for more details.
+Choose your selected format from the response and then call the export endpoint. See the [export annotations](https://api.labelstud.io/api-reference/api-reference/projects/exports/download-sync) endpoint documentation for more details.
 
-</div>
-
-<div class="enterprise-only">
-
-You can use the Label Studio API to import data for labeling, export annotations, set up machine learning with Label Studio, and sync tasks with cloud storage. 
-
-See the [API reference documentation](https://app.humansignal.com/docs/api) for further guidance and interactive examples. If you want to write Python scripts using the API, use the [Label Studio Python SDK](sdk.html). 
-
-!!! info Tip
-    For additional guidance on using our API, see [5 Tips and Tricks for Label Studio’s API and SDK](https://labelstud.io/blog/5-tips-and-tricks-for-label-studio-s-api-and-sdk/).
-
-### Authenticate to the API
-
-You must retrieve your access token so that you can authenticate to the API.
-
-1. In the Label Studio UI, click the user icon in the upper right.
-2. Click **Account & Settings**.
-3. Copy the access token. For more information, see [Access tokens](access_tokens). 
-
-In your first API call, specify the access token in the headers: 
-```bash
-curl -X <method> <Label Studio URL>/api/<endpoint> -H 'Authorization: Bearer <token>'
-```
-
-### List all projects
-
-To perform most tasks with the Label Studio API, you must specify the project ID, sometimes referred to as the `pk`, or primary key. If you don't know what your project ID is, you might want to get a list of all projects in Label Studio that you can access. See the [List your projects API endpoint documentation](https://app.humansignal.com/docs/api#tag/Projects/operation/api_projects_list).
-
-### Create and set up a project
-
-Create a project and set up the labeling interface in Label Studio using the API. See the [Create new project API endpoint documentation](https://app.humansignal.com/docs/api#tag/Projects/operation/api_projects_create).
-
-If you want to make sure the configuration for your labeling interface is valid before submitting it using the API, you can use the [validate label config](https://app.humansignal.com/docs/api#tag/Projects/operation/api_projects_validate_create) API endpoint.
-
-### Import tasks using the API
-
-To import tasks using the API, make sure you know the project ID that you want to add tasks to. See additional examples and parameter descriptions in the [import data endpoint documentation](https://app.humansignal.com/docs/api#tag/Tasks/operation/api_tasks_create)
-
-### Retrieve tasks
-Retrieve a paginated list of tasks for a specific project. If you want, you can also retrieve tasks and annotations using this API endpoint, as an alternative to exporting annotations. See details and parameters in the [list project tasks endpoint documentation](https://app.humansignal.com/docs/api#tag/Tasks/operation/api_tasks_list).
-
-### Export annotations
-
-To export annotations, first see [which formats are available to export for your project](https://app.humansignal.com/docs/api#tag/Export/operation/api_projects_export_formats_read). 
-
-Choose your selected format from the response and then call the export endpoint. See the [export annotations](https://app.humansignal.com/docs/api#tag/Export/operation/api_projects_exports_create) endpoint documentation for more details.
-
-</div>


### PR DESCRIPTION
- Removed old links in API ref page
- Moved up the part about enabling token visibility, and lots of users miss this 