### PR TITLE
fix: FIT-676: Image labelling use cases were broken in LS Playground

### DIFF
--- a/web/libs/ui/src/lib/code-block/code-block.tsx
+++ b/web/libs/ui/src/lib/code-block/code-block.tsx
@@ -1,6 +1,6 @@
 import { Button, cnm, IconCheck, IconCopy } from "@humansignal/ui";
 import styles from "./code-block.module.scss";
-import { useCopyText } from "@humansignal/core";
+import { useCopyText } from "@humansignal/core/lib/hooks/useCopyText";
 
 export function CodeBlock({
   code,


### PR DESCRIPTION
The import path used for useCopyText in the code-block component caused issues with labelling use cases in the Playground. The problem stems from the resolution of the paths used in the various libraries, and in particular with respect to how the hooks were imported from core lib into the UI lib. The generous index import was causing interference in the app build of playground.

Before:

<img width="2995" height="1661" alt="Screenshot 2025-09-08 at 5 04 34 PM" src="https://github.com/user-attachments/assets/564bc51a-6344-4ae6-a005-e527d4edc0a1" />


After:

<img width="2995" height="1661" alt="Screenshot 2025-09-08 at 5 04 13 PM" src="https://github.com/user-attachments/assets/51a08114-475c-4dd3-8493-21f2c3a0de6d" />
