### PR TITLE
fix: BROS-366: Fix resuming drawing for unfinished region

### DIFF
--- a/web/libs/editor/src/mixins/DrawingTool.js
+++ b/web/libs/editor/src/mixins/DrawingTool.js
@@ -141,6 +141,9 @@ const DrawingTool = types
         self.annotation.setIsDrawing(true);
         self.annotation.regionStore.selection.drawingSelect(self.currentArea);
         self.listenForClose?.();
+        if (self.manager.findSelectedTool() !== self) {
+          self.manager.selectTool(self, true);
+        }
       },
       commitDrawingRegion() {
         const { currentArea, control, obj } = self;

--- a/web/libs/editor/src/mixins/Tool.js
+++ b/web/libs/editor/src/mixins/Tool.js
@@ -63,9 +63,9 @@ const ToolMixin = types
     },
 
     get shouldPreserveSelectedState() {
-      if (!self.obj) return false;
+      if ((!ff.isActive(FF_DEV_3391) && !self.obj) || !self.control) return false;
 
-      const settings = getRoot(self.obj).settings;
+      const settings = getRoot(ff.isActive(FF_DEV_3391) ? self.control : self.obj).settings;
 
       return settings.preserveSelectedTool;
     },


### PR DESCRIPTION
With the feature flag `FF_DEV_3391` have  we missed the case of resuming drawing for an unfinished region.

Mostly it was inability to get `preserveSelectedTool` setting while `obj` is not ready.

But it also highlights the issue when the setting `preserveSelectedTool` is switched off. So now we are also going to set the right tool on resume if needed.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
