### PR TITLE
fix: FIT-645: Empty Data Manager is displayed when navigating via browser Back button from Settings page

### DIFF
--- a/web/libs/datamanager/src/sdk/dm-sdk.js
+++ b/web/libs/datamanager/src/sdk/dm-sdk.js
@@ -147,7 +147,7 @@ export class DataManager {
   constructor(config) {
     this.root = config.root;
     this.project = config.project;
-    this.projectId = config.projectId;
+    this.projectId = config.projectId ?? this?.project?.id;
     this.dataset = config.dataset;
     this.datasetId = config.datasetId;
     this.settings = config.settings;


### PR DESCRIPTION
This pull request makes a small improvement to the `DataManager` class constructor. The change ensures that if `projectId` is not provided in the config, it will default to the `id` property of the `project` object if available.