### PR TITLE
fix: FIT-641: 'Label Tasks As Displayed' is displayed outside the Label All Tasks dropdown

### DIFF
--- a/web/libs/datamanager/src/components/DataManager/Toolbar/LabelButton.jsx
+++ b/web/libs/datamanager/src/components/DataManager/Toolbar/LabelButton.jsx
@@ -95,7 +95,7 @@ export const LabelButton = injector(({ store, canLabel, size, target, selectedCo
             Label {selectedCount ? selectedCount : "All"} Task{!selectedCount || selectedCount > 1 ? "s" : ""}
           </Button>
           <Dropdown.Trigger
-            align="right"
+            align="bottom-right"
             content={
               <Menu size="compact">
                 <Menu.Item onClick={onLabelVisible}>Label Tasks As Displayed</Menu.Item>


### PR DESCRIPTION
This pull request makes a minor UI adjustment to the `LabelButton` component in the DataManager toolbar. The change updates the dropdown alignment to improve its positioning.

* UI improvement:
  * Changed the `Dropdown.Trigger` alignment from `"right"` to `"bottom-right"` in `LabelButton.jsx` for better dropdown positioning.