### PR TITLE
feat: UTC-270: Allow users to sort region by audio/video start time (timestamp) in outliner for audio and video

### DIFF
--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerPanel.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerPanel.tsx
@@ -12,7 +12,7 @@ import { getDocsUrl } from "../../../utils/docs";
 
 // Local type definitions based on ViewControls and RegionStore
 type GroupingOptions = "manual" | "label" | "type";
-type OrderingOptions = "score" | "date" | "mediaTime";
+type OrderingOptions = "score" | "date" | "mediaStartTime";
 type Region = {
   id: string;
   [key: string]: any; // Allow other properties for flexibility

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerPanel.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerPanel.tsx
@@ -12,7 +12,7 @@ import { getDocsUrl } from "../../../utils/docs";
 
 // Local type definitions based on ViewControls and RegionStore
 type GroupingOptions = "manual" | "label" | "type";
-type OrderingOptions = "score" | "date";
+type OrderingOptions = "score" | "date" | "mediaTime";
 type Region = {
   id: string;
   [key: string]: any; // Allow other properties for flexibility

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
@@ -26,7 +26,7 @@ const { Block, Elem } = BemWithSpecifiContext();
 
 export type GroupingOptions = "manual" | "label" | "type";
 
-export type OrderingOptions = "score" | "date" | "mediaTime";
+export type OrderingOptions = "score" | "date" | "mediaStartTime";
 
 export type OrderingDirection = "asc" | "desc";
 
@@ -103,7 +103,7 @@ export const ViewControls: FC<ViewControlsProps> = observer(
             selectedLabel: "By Score",
             icon: <IconPredictions width={16} height={16} />,
           };
-        case "mediaTime":
+        case "mediaStartTime":
           return {
             label: (
               <>
@@ -131,7 +131,7 @@ export const ViewControls: FC<ViewControlsProps> = observer(
             <Grouping
               value={ordering}
               direction={orderingDirection}
-              options={["score", "date", "mediaTime"]}
+              options={["score", "date", "mediaStartTime"]}
               onChange={(value) => onOrderingChange(value)}
               readableValueForKey={getOrderingLabels}
               allowClickSelected

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
@@ -8,6 +8,7 @@ import {
   IconPredictions,
   IconSortDown,
   IconSortUp,
+  IconTimelineRegion,
 } from "@humansignal/icons";
 import { Button } from "@humansignal/ui";
 import { type FC, useCallback, useContext, useMemo } from "react";
@@ -106,11 +107,11 @@ export const ViewControls: FC<ViewControlsProps> = observer(
           return {
             label: (
               <>
-                <IconClockTimeFourOutline /> Order by Media Time
+                <IconTimelineRegion /> Order by Media Start Time
               </>
             ),
-            selectedLabel: "By Media Time",
-            icon: <IconClockTimeFourOutline width={16} height={16} />,
+            selectedLabel: "By Media Start Time",
+            icon: <IconTimelineRegion width={16} height={16} />,
           };
       }
     }, []);
@@ -135,6 +136,7 @@ export const ViewControls: FC<ViewControlsProps> = observer(
               readableValueForKey={getOrderingLabels}
               allowClickSelected
               extraIcon={renderOrderingDirectionIcon}
+              width={230}
             />
           </Elem>
         )}
@@ -159,6 +161,7 @@ interface GroupingProps<T extends string> {
   onChange: (value: T) => void;
   readableValueForKey: (value: T) => LabelInfo;
   extraIcon?: JSX.Element;
+  width?: number;
 }
 
 const Grouping = <T extends string>({
@@ -169,6 +172,7 @@ const Grouping = <T extends string>({
   onChange,
   readableValueForKey,
   extraIcon,
+  width = 200,
 }: GroupingProps<T>) => {
   const readableValue = useMemo(() => {
     return readableValueForKey(value);
@@ -183,8 +187,8 @@ const Grouping = <T extends string>({
       <Menu
         size="medium"
         style={{
-          width: 200,
-          minWidth: 200,
+          width,
+          minWidth: width,
           borderRadius: isFF(FF_DEV_3873) && 4,
         }}
         selectedKeys={[value]}
@@ -205,7 +209,7 @@ const Grouping = <T extends string>({
   }, [value, optionsList, readableValue, direction, onChange]);
 
   return (
-    <Dropdown.Trigger content={dropdownContent} style={{ width: 200 }}>
+    <Dropdown.Trigger content={dropdownContent} style={{ width }}>
       <Button
         variant="neutral"
         size="smaller"

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
@@ -25,7 +25,7 @@ const { Block, Elem } = BemWithSpecifiContext();
 
 export type GroupingOptions = "manual" | "label" | "type";
 
-export type OrderingOptions = "score" | "date";
+export type OrderingOptions = "score" | "date" | "mediaTime";
 
 export type OrderingDirection = "asc" | "desc";
 
@@ -102,6 +102,16 @@ export const ViewControls: FC<ViewControlsProps> = observer(
             selectedLabel: "By Score",
             icon: <IconPredictions width={16} height={16} />,
           };
+        case "mediaTime":
+          return {
+            label: (
+              <>
+                <IconClockTimeFourOutline /> Order by Media Time
+              </>
+            ),
+            selectedLabel: "By Media Time",
+            icon: <IconClockTimeFourOutline width={16} height={16} />,
+          };
       }
     }, []);
 
@@ -120,7 +130,7 @@ export const ViewControls: FC<ViewControlsProps> = observer(
             <Grouping
               value={ordering}
               direction={orderingDirection}
-              options={["score", "date"]}
+              options={["score", "date", "mediaTime"]}
               onChange={(value) => onOrderingChange(value)}
               readableValueForKey={getOrderingLabels}
               allowClickSelected

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
@@ -11,7 +11,7 @@ import {
   IconTimelineRegion,
 } from "@humansignal/icons";
 import { Button } from "@humansignal/ui";
-import { type FC, useCallback, useContext, useMemo } from "react";
+import { type FC, useCallback, useContext, useEffect, useMemo } from "react";
 import { Dropdown } from "../../../common/Dropdown/Dropdown";
 // eslint-disable-next-line
 // @ts-ignore
@@ -43,6 +43,38 @@ export const ViewControls: FC<ViewControlsProps> = observer(
   ({ ordering, regions, orderingDirection, onOrderingChange, onGroupingChange, onFilterChange }) => {
     const grouping = regions.group;
     const context = useContext(SidePanelsContext);
+
+    // Check if any regions have media time information
+    const hasMediaTimeRegions = useMemo(() => {
+      return (
+        regions.filteredRegions?.some((region) => {
+          // Check for audio regions
+          console.log("region", region.type);
+          if (
+            (region.type === "audioregion" || region.type === "timeseriesregion") &&
+            typeof region.start === "number"
+          ) {
+            return true;
+          }
+          // Check for timeline regions (video)
+          if (region.type === "timelineregion" && region.ranges && region.ranges.length > 0) {
+            const firstRange = region.ranges[0];
+            if (firstRange && typeof firstRange.start === "number") {
+              return true;
+            }
+          }
+          return false;
+        }) ?? false
+      );
+    }, [regions.filteredRegions]);
+
+    // Auto-fallback to "date" if current ordering is "mediaStartTime" but no media regions exist
+    useEffect(() => {
+      if (ordering === "mediaStartTime" && !hasMediaTimeRegions) {
+        onOrderingChange("date");
+      }
+    }, [ordering, hasMediaTimeRegions, onOrderingChange]);
+
     const getGroupingLabels = useCallback((value: GroupingOptions): LabelInfo => {
       switch (value) {
         case "manual":
@@ -131,7 +163,7 @@ export const ViewControls: FC<ViewControlsProps> = observer(
             <Grouping
               value={ordering}
               direction={orderingDirection}
-              options={["score", "date", "mediaStartTime"]}
+              options={hasMediaTimeRegions ? ["score", "date", "mediaStartTime"] : ["score", "date"]}
               onChange={(value) => onOrderingChange(value)}
               readableValueForKey={getOrderingLabels}
               allowClickSelected

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
@@ -49,7 +49,6 @@ export const ViewControls: FC<ViewControlsProps> = observer(
       return (
         regions.filteredRegions?.some((region) => {
           // Check for audio regions
-          console.log("region", region.type);
           if (
             (region.type === "audioregion" || region.type === "timeseriesregion") &&
             typeof region.start === "number"

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/__tests__/OutlinerPanel.test.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/__tests__/OutlinerPanel.test.tsx
@@ -275,4 +275,31 @@ describe("OutlinerPanel", () => {
       expect(panelBase).toBeInTheDocument();
     });
   });
+
+  describe("Media time sorting", () => {
+    it("supports mediaTime sorting option", () => {
+      const regionsWithMediaTime = {
+        ...mockRegions,
+        sort: "mediaTime",
+        regions: [
+          { id: "1", type: "audioregion", start: 5.0, end: 10.0 },
+          { id: "2", type: "audioregion", start: 2.0, end: 7.0 },
+          { id: "3", type: "timelineregion", ranges: [{ start: 15, end: 20 }] },
+          { id: "4", type: "timelineregion", ranges: [{ start: 8, end: 12 }] },
+        ],
+        filter: [
+          { id: "1", type: "audioregion", start: 5.0, end: 10.0 },
+          { id: "2", type: "audioregion", start: 2.0, end: 7.0 },
+          { id: "3", type: "timelineregion", ranges: [{ start: 15, end: 20 }] },
+          { id: "4", type: "timelineregion", ranges: [{ start: 8, end: 12 }] },
+        ],
+      };
+
+      render(<OutlinerPanel {...defaultProps} regions={regionsWithMediaTime} />);
+
+      const viewControls = screen.getByTestId("view-controls");
+      expect(viewControls).toBeInTheDocument();
+      expect(viewControls).toHaveAttribute("ordering", "mediaTime");
+    });
+  });
 });

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/__tests__/OutlinerPanel.test.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/__tests__/OutlinerPanel.test.tsx
@@ -277,7 +277,7 @@ describe("OutlinerPanel", () => {
   });
 
   describe("Media time sorting", () => {
-    it("supports mediaStartTime sorting option", () => {
+    it("supports mediaStartTime sorting option when media regions are present", () => {
       const regionsWithMediaTime = {
         ...mockRegions,
         sort: "mediaStartTime",
@@ -300,6 +300,29 @@ describe("OutlinerPanel", () => {
       const viewControls = screen.getByTestId("view-controls");
       expect(viewControls).toBeInTheDocument();
       expect(viewControls).toHaveAttribute("ordering", "mediaStartTime");
+    });
+
+    it("hides mediaStartTime sorting option when no media regions are present", () => {
+      const regionsWithoutMediaTime = {
+        ...mockRegions,
+        sort: "date",
+        regions: [
+          { id: "1", type: "rectangle" },
+          { id: "2", type: "polygon" },
+          { id: "3", type: "ellipse" },
+        ],
+        filter: [
+          { id: "1", type: "rectangle" },
+          { id: "2", type: "polygon" },
+          { id: "3", type: "ellipse" },
+        ],
+      };
+
+      render(<OutlinerPanel {...defaultProps} regions={regionsWithoutMediaTime} />);
+
+      const viewControls = screen.getByTestId("view-controls");
+      expect(viewControls).toBeInTheDocument();
+      expect(viewControls).toHaveAttribute("ordering", "date");
     });
   });
 });

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/__tests__/OutlinerPanel.test.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/__tests__/OutlinerPanel.test.tsx
@@ -277,10 +277,10 @@ describe("OutlinerPanel", () => {
   });
 
   describe("Media time sorting", () => {
-    it("supports mediaTime sorting option", () => {
+    it("supports mediaStartTime sorting option", () => {
       const regionsWithMediaTime = {
         ...mockRegions,
-        sort: "mediaTime",
+        sort: "mediaStartTime",
         regions: [
           { id: "1", type: "audioregion", start: 5.0, end: 10.0 },
           { id: "2", type: "audioregion", start: 2.0, end: 7.0 },
@@ -299,7 +299,7 @@ describe("OutlinerPanel", () => {
 
       const viewControls = screen.getByTestId("view-controls");
       expect(viewControls).toBeInTheDocument();
-      expect(viewControls).toHaveAttribute("ordering", "mediaTime");
+      expect(viewControls).toHaveAttribute("ordering", "mediaStartTime");
     });
   });
 });

--- a/web/libs/editor/src/stores/RegionStore.js
+++ b/web/libs/editor/src/stores/RegionStore.js
@@ -267,7 +267,7 @@ export default types
 
       getRegionMediaTime(region) {
         // Handle audio regions - they have start time in seconds
-        if (region.type === "audioregion" && typeof region.start === "number") {
+        if ((region.type === "audioregion" || region.type === "timeseriesregion") && typeof region.start === "number") {
           return region.start;
         }
 
@@ -278,11 +278,6 @@ export default types
           if (firstRange && typeof firstRange.start === "number") {
             return firstRange.start;
           }
-        }
-
-        // Handle other region types that might have start time properties
-        if (typeof region.start === "number") {
-          return region.start;
         }
 
         // Return null for regions without media time information

--- a/web/libs/editor/src/stores/RegionStore.js
+++ b/web/libs/editor/src/stores/RegionStore.js
@@ -135,7 +135,7 @@ const SelectionMap = types
 export default types
   .model("RegionStore", {
     sort: types.optional(
-      types.enumeration(["date", "score", "mediaTime"]),
+      types.enumeration(["date", "score", "mediaStartTime"]),
       window.localStorage.getItem(localStorageKeys.sort) ?? "date",
     ),
 
@@ -238,7 +238,7 @@ export default types
             [...self.filteredRegions].sort(isDesc ? (a, b) => b.ouid - a.ouid : (a, b) => a.ouid - b.ouid),
           score: (isDesc) =>
             [...self.filteredRegions].sort(isDesc ? (a, b) => b.score - a.score : (a, b) => a.score - b.score),
-          mediaTime: (isDesc) =>
+          mediaStartTime: (isDesc) =>
             [...self.filteredRegions].sort((a, b) => {
               const aTime = self.getRegionMediaTime(a);
               const bTime = self.getRegionMediaTime(b);

--- a/web/libs/editor/src/stores/RegionStore.js
+++ b/web/libs/editor/src/stores/RegionStore.js
@@ -135,7 +135,7 @@ const SelectionMap = types
 export default types
   .model("RegionStore", {
     sort: types.optional(
-      types.enumeration(["date", "score"]),
+      types.enumeration(["date", "score", "mediaTime"]),
       window.localStorage.getItem(localStorageKeys.sort) ?? "date",
     ),
 
@@ -238,6 +238,18 @@ export default types
             [...self.filteredRegions].sort(isDesc ? (a, b) => b.ouid - a.ouid : (a, b) => a.ouid - b.ouid),
           score: (isDesc) =>
             [...self.filteredRegions].sort(isDesc ? (a, b) => b.score - a.score : (a, b) => a.score - b.score),
+          mediaTime: (isDesc) =>
+            [...self.filteredRegions].sort((a, b) => {
+              const aTime = self.getRegionMediaTime(a);
+              const bTime = self.getRegionMediaTime(b);
+
+              // Handle regions without media time (put them at the end)
+              if (aTime === null && bTime === null) return 0;
+              if (aTime === null) return 1;
+              if (bTime === null) return -1;
+
+              return isDesc ? bTime - aTime : aTime - bTime;
+            }),
         };
 
         const sorted = sorts[self.sort](self.sortOrder === "desc");
@@ -251,6 +263,30 @@ export default types
           map[region.id] = idx + 1;
         });
         return map;
+      },
+
+      getRegionMediaTime(region) {
+        // Handle audio regions - they have start time in seconds
+        if (region.type === "audioregion" && typeof region.start === "number") {
+          return region.start;
+        }
+
+        // Handle timeline regions (video) - they have ranges with start frame
+        if (region.type === "timelineregion" && region.ranges && region.ranges.length > 0) {
+          // Get the first range's start frame
+          const firstRange = region.ranges[0];
+          if (firstRange && typeof firstRange.start === "number") {
+            return firstRange.start;
+          }
+        }
+
+        // Handle other region types that might have start time properties
+        if (typeof region.start === "number") {
+          return region.start;
+        }
+
+        // Return null for regions without media time information
+        return null;
       },
 
       getRegionsTree(enrich) {


### PR DESCRIPTION
Implemented new region sorting by `Media Start Time` which will appear as an option in the Outliner panel whenever video, audio or timeseries regions are created.

If this sorting option has been stored in local storage as default and the user moves to another project without these kind of tags, it will switch back to the default sort by time.


https://github.com/user-attachments/assets/82bc9661-8619-4ff3-8ea5-64cb3af517d5

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
