### PR TITLE
fix: UTC-283: Display Order by Start Media Time depending on the labeling config rather than regions

### DIFF
--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
@@ -44,35 +44,22 @@ export const ViewControls: FC<ViewControlsProps> = observer(
     const grouping = regions.group;
     const context = useContext(SidePanelsContext);
 
-    // Check if any regions have media time information
-    const hasMediaTimeRegions = useMemo(() => {
-      return (
-        regions.filteredRegions?.some((region) => {
-          // Check for audio regions
-          if (
-            (region.type === "audioregion" || region.type === "timeseriesregion") &&
-            typeof region.start === "number"
-          ) {
-            return true;
-          }
-          // Check for timeline regions (video)
-          if (region.type === "timelineregion" && region.ranges && region.ranges.length > 0) {
-            const firstRange = region.ranges[0];
-            if (firstRange && typeof firstRange.start === "number") {
-              return true;
-            }
-          }
-          return false;
-        }) ?? false
+    // Check labeling configuration for media-time-capable object tags
+    const hasMediaTimeSupport = useMemo(() => {
+      const names = regions.annotation?.names;
+      if (!names) return false;
+      // Any object tag of type audio, video, or timeseries enables the option
+      return Array.from(names.values()).some(
+        (tag: any) => tag?.isObjectTag && ["audio", "video", "timeseries"].includes(tag.type),
       );
-    }, [regions.filteredRegions]);
+    }, [regions.annotation?.names]);
 
-    // Auto-fallback to "date" if current ordering is "mediaStartTime" but no media regions exist
+    // Auto-fallback to "date" if current ordering is "mediaStartTime" but no media-time support in config
     useEffect(() => {
-      if (ordering === "mediaStartTime" && !hasMediaTimeRegions) {
+      if (ordering === "mediaStartTime" && !hasMediaTimeSupport) {
         onOrderingChange("date");
       }
-    }, [ordering, hasMediaTimeRegions, onOrderingChange]);
+    }, [ordering, hasMediaTimeSupport, onOrderingChange]);
 
     const getGroupingLabels = useCallback((value: GroupingOptions): LabelInfo => {
       switch (value) {
@@ -162,7 +149,7 @@ export const ViewControls: FC<ViewControlsProps> = observer(
             <Grouping
               value={ordering}
               direction={orderingDirection}
-              options={hasMediaTimeRegions ? ["score", "date", "mediaStartTime"] : ["score", "date"]}
+              options={hasMediaTimeSupport ? ["score", "date", "mediaStartTime"] : ["score", "date"]}
               onChange={(value) => onOrderingChange(value)}
               readableValueForKey={getOrderingLabels}
               allowClickSelected

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
@@ -45,9 +45,9 @@ export const ViewControls: FC<ViewControlsProps> = observer(
     const context = useContext(SidePanelsContext);
 
     // Check labeling configuration for media-time-capable object tags
-    const hasMediaTimeSupport = useMemo(() => {
+    const mediaTimeSupport: boolean | null = useMemo(() => {
       const names = regions.annotation?.names;
-      if (!names) return false;
+      if (!names || names.size === 0) return null;
       // Any object tag of type audio, video, or timeseries enables the option
       return Array.from(names.values()).some(
         (tag: any) => tag?.isObjectTag && ["audio", "video", "timeseries"].includes(tag.type),
@@ -56,10 +56,10 @@ export const ViewControls: FC<ViewControlsProps> = observer(
 
     // Auto-fallback to "date" if current ordering is "mediaStartTime" but no media-time support in config
     useEffect(() => {
-      if (ordering === "mediaStartTime" && !hasMediaTimeSupport) {
+      if (ordering === "mediaStartTime" && mediaTimeSupport === false) {
         onOrderingChange("date");
       }
-    }, [ordering, hasMediaTimeSupport, onOrderingChange]);
+    }, [ordering, mediaTimeSupport, onOrderingChange]);
 
     const getGroupingLabels = useCallback((value: GroupingOptions): LabelInfo => {
       switch (value) {
@@ -149,7 +149,7 @@ export const ViewControls: FC<ViewControlsProps> = observer(
             <Grouping
               value={ordering}
               direction={orderingDirection}
-              options={hasMediaTimeSupport ? ["score", "date", "mediaStartTime"] : ["score", "date"]}
+              options={mediaTimeSupport ? ["score", "date", "mediaStartTime"] : ["score", "date"]}
               onChange={(value) => onOrderingChange(value)}
               readableValueForKey={getOrderingLabels}
               allowClickSelected

--- a/web/libs/editor/src/stores/RegionStore.js
+++ b/web/libs/editor/src/stores/RegionStore.js
@@ -136,12 +136,12 @@ export default types
   .model("RegionStore", {
     sort: types.optional(
       types.enumeration(["date", "score", "mediaStartTime"]),
-      window.localStorage.getItem(localStorageKeys.sort) ?? "date",
+      () => window.localStorage.getItem(localStorageKeys.sort) ?? "date",
     ),
 
     sortOrder: types.optional(
       types.enumeration(["asc", "desc"]),
-      window.localStorage.getItem(localStorageKeys.sortDirection) ?? "asc",
+      () => window.localStorage.getItem(localStorageKeys.sortDirection) ?? "asc",
     ),
 
     group: types.optional(


### PR DESCRIPTION
Detecting Start Media time mode by labeling config rather than regions. Additionally fixed, sort and sortingOrder not being up to date when changing tasks

Before:

https://github.com/user-attachments/assets/9a0f1f9a-31a5-42fc-97e8-cc7cd9b1f6ab



After:

https://github.com/user-attachments/assets/21610e89-5c30-4066-9dd9-640cef5c041c


<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
