### PR TITLE
Fix: Enable RQ_QUEUES configuration via environment variables (#8455) 

### DIFF
--- a/label_studio/core/settings/label_studio.py
+++ b/label_studio/core/settings/label_studio.py
@@ -28,7 +28,7 @@ SESSION_COOKIE_SECURE = get_bool_env('SESSION_COOKIE_SECURE', False)
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
 
-RQ_QUEUES = {}
+RQ_QUEUES = json.loads(get_env("RQ_QUEUES", "{}"))
 
 SENTRY_DSN = get_env('SENTRY_DSN', 'https://68b045ab408a4d32a910d339be8591a4@o227124.ingest.sentry.io/5820521')
 SENTRY_ENVIRONMENT = get_env('SENTRY_ENVIRONMENT', 'opensource')


### PR DESCRIPTION
## Reason for change
**Problem:** RQ_QUEUES was hardcoded to an empty dictionary `{}` in `label_studio/core/settings/label_studio.py`, preventing Redis Queue
configuration via environment variables and breaking background job processing.

**Solution:** Changed `RQ_QUEUES = {}` to `RQ_QUEUES = json.loads(get_env("RQ_QUEUES", "{}"))` to enable environment variable
configuration while maintaining backward compatibility.

## Rollout strategy
This change uses an existing environment variable pattern (`get_env`) and maintains backward compatibility with empty dict default. No
feature flags required - the change is safe to deploy immediately.

## Testing
**Manual verification:**
- [x] Verified RQ_QUEUES defaults to `{}` when `RQ_QUEUES` environment variable is not set
- [x] Verified RQ_QUEUES correctly parses JSON configuration from `RQ_QUEUES` environment variable
- [x] Tested that existing deployments without the env var continue working unchanged

**Unit tests:** Not required for this change as it's a simple Django settings configuration modification. Existing RQ functionality tests
will verify the configuration works correctly.

## Risks
**Low risk:**
- Backward compatible change - existing deployments unaffected
- Uses established `get_env` pattern consistent with other settings in the same file
- JSON parsing could theoretically fail with malformed input, but this follows the same pattern as other env var configurations

## Reviewer notes
- Single line change in settings file
- Follows existing code patterns in the same file (see other `get_env` usage)
- Addresses issue raised in #8455
- No additional tests needed - this is a configuration-level change

## General notes
This fix enables proper Redis Queue configuration for production deployments where Redis might be running on different hosts/ports or
require authentication, while maintaining the current behavior for existing installations.

Fixes #8455