### PR TITLE
fix: FIT-694: Import from Data Manager is NOT working when navigating via browser Back button from Settings page

### DIFF
--- a/web/apps/labelstudio/src/pages/DataManager/DataManager.jsx
+++ b/web/apps/labelstudio/src/pages/DataManager/DataManager.jsx
@@ -112,27 +112,27 @@ export const DataManagerPage = ({ ...props }) => {
       }
 
       if (isMissingTaskError) {
-        history.push(buildLink("", { id: params.id }));
+        history.push(buildLink("", { id: params?.id ?? project?.id }));
       } else if (isMissingProjectError) {
         history.push("/projects");
       }
     });
 
     dataManager.on("settingsClicked", () => {
-      history.push(buildLink("/settings/labeling", { id: params.id }));
+      history.push(buildLink("/settings/labeling", { id: params?.id ?? project?.id }));
     });
 
     dataManager.on("importClicked", () => {
-      history.push(buildLink("/data/import", { id: params.id }));
+      history.push(buildLink("/data/import", { id: params?.id ?? project?.id }));
     });
 
     // Navigate to Storage Settings and auto-open Add Source Storage modal
     dataManager.on("openSourceStorageModal", () => {
-      history.push(buildLink("/settings/storage?open=source", { id: params.id }));
+      history.push(buildLink("/settings/storage?open=source", { id: params?.id ?? project?.id }));
     });
 
     dataManager.on("exportClicked", () => {
-      history.push(buildLink("/data/export", { id: params.id }));
+      history.push(buildLink("/data/export", { id: params?.id ?? project?.id }));
     });
 
     dataManager.on("error", (response) => {
@@ -146,7 +146,7 @@ export const DataManagerPage = ({ ...props }) => {
     dataManager.on("navigate", (route) => {
       const target = route.replace(/^projects/, "");
 
-      if (target) history.push(buildLink(target, { id: params.id }));
+      if (target) history.push(buildLink(target, { id: params?.id ?? project?.id }));
       else history.push("/projects");
     });
 

--- a/web/libs/frontend-test/src/helpers/utils/media/SyncGroup.ts
+++ b/web/libs/frontend-test/src/helpers/utils/media/SyncGroup.ts
@@ -8,7 +8,7 @@ class SyncGroup {
     this.views = views;
   }
 
-  checkSynchronization(tolerance = 0.01, maxShiftAlias: string | null = null, attempts = 3) {
+  checkSynchronization(tolerance = 0.01, maxShiftAlias: string | null = null, attempts = 5) {
     const mediaChains = this.views.map((view) => view.mediaElement);
 
     mediaChains[0].then((baseMedia) => {


### PR DESCRIPTION
This pull request makes minor improvements to error handling and navigation logic in the `DataManagerPage` component, and adjusts a default parameter in the `SyncGroup` utility. The most important changes are grouped below:

**Navigation and Error Handling Improvements (`DataManagerPage.jsx`):**

* Updated all navigation event handlers to use `params?.id ?? project?.id` instead of just `params.id`, ensuring that navigation works even if `params.id` is missing. This improves robustness when handling errors and user actions.
* Modified the custom navigation event to use the same fallback logic for project IDs, further standardizing navigation behavior.

**Testing Utility Adjustment (`SyncGroup.ts`):**

* Increased the default number of synchronization check attempts from 3 to 5 in the `checkSynchronization` method, potentially improving reliability in media synchronization tests.