### PR TITLE
feat: FIT-718: Add disabled Databricks option with Enterprise badge on LSO (#8454)

### DIFF
--- a/web/apps/labelstudio/src/pages/Settings/StorageSettings/StorageSet.jsx
+++ b/web/apps/labelstudio/src/pages/Settings/StorageSettings/StorageSet.jsx
@@ -35,7 +35,7 @@ export const StorageSet = forwardRef(({ title, target, rootClass, buttonLabel },
       const modalRef = modal({
         title,
         closeOnClickOutside: false,
-        style: { width: 960 },
+        style: { width: 840 },
         bare: useNewStorageScreen,
         onHidden: () => {
           // Reset state when modal is closed (including Escape key)

--- a/web/apps/labelstudio/src/pages/Settings/StorageSettings/providers/azure_spi.tsx
+++ b/web/apps/labelstudio/src/pages/Settings/StorageSettings/providers/azure_spi.tsx
@@ -1,0 +1,40 @@
+import { EnterpriseBadge, IconSpark } from "@humansignal/ui";
+import { Alert, AlertTitle, AlertDescription } from "@humansignal/shad/components/ui/alert";
+import { IconCloudProviderAzure } from "@humansignal/icons";
+import type { ProviderConfig } from "@humansignal/app-common/blocks/StorageProviderForm/types/provider";
+
+const azureSpiProvider: ProviderConfig = {
+  name: "azure_spi",
+  title: "Azure Blob Storage\nwith Service Principal",
+  description:
+    "Configure your Azure Blob Storage connection using Service Principal authentication for enhanced security (proxy only)",
+  icon: IconCloudProviderAzure,
+  disabled: true,
+  badge: <EnterpriseBadge />,
+  fields: [
+    {
+      name: "enterprise_info",
+      type: "message",
+      content: (
+        <Alert variant="gradient">
+          <IconSpark />
+          <AlertTitle>Enterprise Feature</AlertTitle>
+          <AlertDescription>
+            Azure Blob Storage with Service Principal is available in Label Studio Enterprise.{" "}
+            <a
+              href="https://docs.humansignal.com/guide/storage.html#Azure-Blob-Storage-with-Service-Principal-authentication"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:no-underline"
+            >
+              Learn more
+            </a>
+          </AlertDescription>
+        </Alert>
+      ),
+    },
+  ],
+  layout: [{ fields: ["enterprise_info"] }],
+};
+
+export default azureSpiProvider;

--- a/web/apps/labelstudio/src/pages/Settings/StorageSettings/providers/databricks.tsx
+++ b/web/apps/labelstudio/src/pages/Settings/StorageSettings/providers/databricks.tsx
@@ -1,0 +1,39 @@
+import { EnterpriseBadge, IconSpark } from "@humansignal/ui";
+import { Alert, AlertTitle, AlertDescription } from "@humansignal/shad/components/ui/alert";
+import { IconCloudProviderDatabricks } from "@humansignal/icons";
+import type { ProviderConfig } from "@humansignal/app-common/blocks/StorageProviderForm/types/provider";
+
+const databricksProvider: ProviderConfig = {
+  name: "databricks",
+  title: "Databricks Files\n(UC Volumes)",
+  description: "Configure your Databricks Unity Catalog Volumes connection with all required settings (proxy only)",
+  icon: IconCloudProviderDatabricks,
+  disabled: true,
+  badge: <EnterpriseBadge />,
+  fields: [
+    {
+      name: "enterprise_info",
+      type: "message",
+      content: (
+        <Alert variant="gradient">
+          <IconSpark />
+          <AlertTitle>Enterprise Feature</AlertTitle>
+          <AlertDescription>
+            Databricks Files (UC Volumes) is available in Label Studio Enterprise.{" "}
+            <a
+              href="https://docs.humansignal.com/guide/storage.html#Databricks-Files-UC-Volumes"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:no-underline"
+            >
+              Learn more
+            </a>
+          </AlertDescription>
+        </Alert>
+      ),
+    },
+  ],
+  layout: [{ fields: ["enterprise_info"] }],
+};
+
+export default databricksProvider;

--- a/web/apps/labelstudio/src/pages/Settings/StorageSettings/providers/gcswif.tsx
+++ b/web/apps/labelstudio/src/pages/Settings/StorageSettings/providers/gcswif.tsx
@@ -1,0 +1,40 @@
+import { EnterpriseBadge, IconSpark } from "@humansignal/ui";
+import { Alert, AlertTitle, AlertDescription } from "@humansignal/shad/components/ui/alert";
+import { IconCloudProviderGCS } from "@humansignal/icons";
+import type { ProviderConfig } from "@humansignal/app-common/blocks/StorageProviderForm/types/provider";
+
+const gcsWifProvider: ProviderConfig = {
+  name: "gcswif",
+  title: "Google Cloud Storage\n(WIF Auth)",
+  description:
+    "Configure your Google Cloud Storage connection with Workload Identity Federation authentication (proxy only)",
+  icon: IconCloudProviderGCS,
+  disabled: true,
+  badge: <EnterpriseBadge />,
+  fields: [
+    {
+      name: "enterprise_info",
+      type: "message",
+      content: (
+        <Alert variant="gradient">
+          <IconSpark />
+          <AlertTitle>Enterprise Feature</AlertTitle>
+          <AlertDescription>
+            Google Cloud Storage with Workload Identity Federation is available in Label Studio Enterprise.{" "}
+            <a
+              href="https://docs.humansignal.com/guide/storage.html#Google-Cloud-Storage-with-Workload-Identity-Federation-WIF"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:no-underline"
+            >
+              Learn more
+            </a>
+          </AlertDescription>
+        </Alert>
+      ),
+    },
+  ],
+  layout: [{ fields: ["enterprise_info"] }],
+};
+
+export default gcsWifProvider;

--- a/web/apps/labelstudio/src/pages/Settings/StorageSettings/providers/index.ts
+++ b/web/apps/labelstudio/src/pages/Settings/StorageSettings/providers/index.ts
@@ -1,13 +1,24 @@
 import azureProvider from "./azure";
+import azureSpiProvider from "./azure_spi";
+import databricksProvider from "./databricks";
 import gcsProvider from "./gcs";
+import gcsWifProvider from "./gcswif";
 import localFilesProvider from "./localFiles";
 import redisProvider from "./redis";
 import { s3Provider } from "./s3";
+import s3sProvider from "./s3s";
 
 export const providers = {
+  // Standard providers
   s3: s3Provider,
   gcs: gcsProvider,
   azure: azureProvider,
   redis: redisProvider,
+  // Enterprise providers
+  databricks: databricksProvider,
+  s3s: s3sProvider,
+  gcswif: gcsWifProvider,
+  azure_spi: azureSpiProvider,
+  // Local provider
   localfiles: localFilesProvider,
 };

--- a/web/apps/labelstudio/src/pages/Settings/StorageSettings/providers/s3s.tsx
+++ b/web/apps/labelstudio/src/pages/Settings/StorageSettings/providers/s3s.tsx
@@ -1,0 +1,39 @@
+import { EnterpriseBadge, IconSpark } from "@humansignal/ui";
+import { Alert, AlertTitle, AlertDescription } from "@humansignal/shad/components/ui/alert";
+import { IconCloudProviderS3 } from "@humansignal/icons";
+import type { ProviderConfig } from "@humansignal/app-common/blocks/StorageProviderForm/types/provider";
+
+const s3sProvider: ProviderConfig = {
+  name: "s3s",
+  title: "Amazon S3\nwith IAM Role",
+  description: "Configure your AWS S3 connection using IAM role access for enhanced security (proxy only)",
+  icon: IconCloudProviderS3,
+  disabled: true,
+  badge: <EnterpriseBadge />,
+  fields: [
+    {
+      name: "enterprise_info",
+      type: "message",
+      content: (
+        <Alert variant="gradient">
+          <IconSpark />
+          <AlertTitle>Enterprise Feature</AlertTitle>
+          <AlertDescription>
+            Amazon S3 with IAM Role is available in Label Studio Enterprise.{" "}
+            <a
+              href="https://docs.humansignal.com/guide/storage.html#Set-up-an-S3-connection-with-IAM-role-access"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:no-underline"
+            >
+              Learn more
+            </a>
+          </AlertDescription>
+        </Alert>
+      ),
+    },
+  ],
+  layout: [{ fields: ["enterprise_info"] }],
+};
+
+export default s3sProvider;

--- a/web/libs/app-common/src/blocks/StorageProviderForm/Steps/provider-selection-step.tsx
+++ b/web/libs/app-common/src/blocks/StorageProviderForm/Steps/provider-selection-step.tsx
@@ -26,9 +26,27 @@ export const ProviderSelectionStep = ({
   // Set default provider if none is selected and we have options
   useEffect(() => {
     if (!formData.provider && Object.entries(providers).length > 0) {
-      handleSelectChange("provider", providers[0].name);
+      // Find the first non-disabled provider
+      const enabledProviders = Object.values(providers).filter((provider) => !provider.disabled);
+      if (enabledProviders.length > 0) {
+        handleSelectChange("provider", enabledProviders[0].name);
+      }
     }
   }, [providers, formData.provider, handleSelectChange]);
+
+  // Get the selected provider config
+  const selectedProvider = formData.provider ? providers[formData.provider] : null;
+  const isSelectedProviderDisabled = selectedProvider?.disabled || false;
+
+  // Get the message content from the provider config
+  const getMessageContent = () => {
+    if (!selectedProvider?.fields) return null;
+
+    const messageField = selectedProvider.fields.find((field) => field.type === "message");
+    return messageField?.content || null;
+  };
+
+  const messageContent = getMessageContent();
 
   return (
     <div className="space-y-6">
@@ -37,16 +55,21 @@ export const ProviderSelectionStep = ({
         <p className="text-muted-foreground">Select the cloud storage service where your data is stored</p>
       </div>
 
-      <div className="space-y-2">
-        <Label htmlFor="provider" required>
-          Storage Provider
-        </Label>
-        <ProviderGrid
-          providers={providers}
-          selectedProvider={formData.provider}
-          onProviderSelect={(providerName) => handleSelectChange("provider", providerName)}
-          error={errors.provider}
-        />
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label text="Storage Provider" required />
+          <ProviderGrid
+            providers={providers}
+            selectedProvider={formData.provider}
+            onProviderSelect={(providerName) => handleSelectChange("provider", providerName)}
+            error={errors.provider}
+          />
+        </div>
+
+        {/* Show alert message when disabled provider is selected */}
+        {isSelectedProviderDisabled && messageContent && (
+          <div>{typeof messageContent === "function" ? messageContent({}) : messageContent}</div>
+        )}
       </div>
     </div>
   );

--- a/web/libs/app-common/src/blocks/StorageProviderForm/components/form-footer.tsx
+++ b/web/libs/app-common/src/blocks/StorageProviderForm/components/form-footer.tsx
@@ -24,6 +24,7 @@ interface FormFooterProps {
     isLoading: boolean;
   };
   target?: "import" | "export";
+  isProviderDisabled?: boolean;
 }
 
 export const FormFooter = ({
@@ -40,6 +41,7 @@ export const FormFooter = ({
   createStorage,
   saveStorage,
   target,
+  isProviderDisabled = false,
 }: FormFooterProps) => {
   return (
     <div className="flex items-center justify-between p-wide border-t border-neutral-border bg-neutral-background">
@@ -74,9 +76,17 @@ export const FormFooter = ({
         <Button
           onClick={onNext}
           waiting={currentStep === totalSteps - 1 && createStorage.isLoading}
-          disabled={!isEditMode && currentStep === 1 && !connectionChecked}
+          disabled={
+            (!isEditMode && currentStep === 1 && !connectionChecked) || (currentStep === 0 && isProviderDisabled)
+          }
           look={currentStep === totalSteps - 1 && target !== "export" ? "outlined" : undefined}
-          tooltip={currentStep === 1 && !connectionChecked ? "Test connection before continuing" : undefined}
+          tooltip={
+            currentStep === 1 && !connectionChecked
+              ? "Test connection before continuing"
+              : currentStep === 0 && isProviderDisabled
+                ? "This provider is not available in the current version"
+                : undefined
+          }
         >
           {currentStep < totalSteps - 1 ? "Next" : target === "export" ? "Save" : "Save & Sync"}
         </Button>

--- a/web/libs/app-common/src/blocks/StorageProviderForm/components/provider-grid.tsx
+++ b/web/libs/app-common/src/blocks/StorageProviderForm/components/provider-grid.tsx
@@ -1,13 +1,8 @@
 import { cn } from "@humansignal/ui";
 import type { ProviderConfig } from "../types/provider";
 
-interface Provider {
-  name: string;
-  title: string;
-}
-
 interface ProviderGridProps {
-  providers: ProviderConfig[];
+  providers: Record<string, ProviderConfig>;
   selectedProvider?: string;
   onProviderSelect: (providerName: string) => void;
   error?: string;
@@ -15,10 +10,11 @@ interface ProviderGridProps {
 
 export const ProviderGrid = ({ providers, selectedProvider, onProviderSelect, error }: ProviderGridProps) => {
   return (
-    <div className="flex flex-col gap-2">
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-tight">
+    <div className="flex flex-col gap-tight">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-base">
         {Object.entries(providers).map(([_, provider]) => {
           const isSelected = selectedProvider === provider.name;
+          const isDisabled = provider.disabled;
           const Icon = provider.icon;
 
           return (
@@ -26,20 +22,27 @@ export const ProviderGrid = ({ providers, selectedProvider, onProviderSelect, er
               key={provider.name}
               type="button"
               onClick={() => onProviderSelect(provider.name)}
+              data-testid={`storage-provider-${provider.name}`}
               className={cn(
-                "relative p-base border-2 rounded-lg transition-all duration-200 text-center",
-                "hover:border-primary-border hover:bg-primary-emphasis-subtle",
-                "focus:outline-none focus:ring-2 focus:ring-primary-focus-outline focus:ring-offset-2",
-                "flex flex-col items-center gap-2",
+                "relative p-base border-2 rounded-lg transition-all duration-200 text-center min-h-[120px]",
+                "flex flex-col items-center gap-tight relative text-neutral-content",
+                "hover:border-primary-border-subtle hover:bg-primary-emphasis-subtle",
+                "hover:-translate-y-tightest focus:outline-none focus:ring-2 focus:ring-primary-focus-outline focus:ring-offset-2",
                 isSelected
-                  ? "border-primary-border bg-primary-emphasis-subtle shadow-sm"
+                  ? "border-primary-border-subtle bg-primary-emphasis-subtle shadow-sm"
                   : "border-neutral-border hover:border-primary-border-subtle",
               )}
               aria-pressed={isSelected}
+              aria-disabled={isDisabled}
             >
               {Icon && <Icon className="w-8 h-8" />}
-              <div className="flex-1 min-w-0">
-                <h3 className="text-body-medium text-neutral-content truncate whitespace-pre">{provider.title}</h3>
+              <div className="flex-1 min-w-0 text-center">
+                <h3 className="text-body-medium truncate whitespace-pre">{provider.title}</h3>
+                {provider.badge && (
+                  <div className="mt-1 flex justify-center whitespace-pre absolute -bottom-tight left-1/2 -translate-x-[40px]">
+                    {provider.badge}
+                  </div>
+                )}
               </div>
             </button>
           );

--- a/web/libs/app-common/src/blocks/StorageProviderForm/index.tsx
+++ b/web/libs/app-common/src/blocks/StorageProviderForm/index.tsx
@@ -342,6 +342,7 @@ export const StorageProviderForm = forwardRef<unknown, StorageProviderFormProps>
             isLoading: saveStorageMutation.isLoading,
           }}
           target={effectiveTarget}
+          isProviderDisabled={providers[formData.provider]?.disabled || false}
         />
       </div>
     );

--- a/web/libs/app-common/src/blocks/StorageProviderForm/types/common.ts
+++ b/web/libs/app-common/src/blocks/StorageProviderForm/types/common.ts
@@ -1,4 +1,4 @@
-import type { CalloutVariant } from "@humansignal/ui";
+import type { CalloutVariant } from "@humansignal/ui/lib/callout/callout";
 import type { FC } from "react";
 import type { z } from "zod";
 
@@ -53,4 +53,6 @@ export interface ProviderConfig {
   fields: (FieldDefinition | MessageDefinition)[];
   layout: LayoutRow[];
   icon?: FC<any>;
+  disabled?: boolean;
+  badge?: JSX.Element;
 }

--- a/web/libs/ui/src/lib/enterprise-badge/enterprise-badge.module.scss
+++ b/web/libs/ui/src/lib/enterprise-badge/enterprise-badge.module.scss
@@ -1,7 +1,7 @@
 .badge {
   display: inline-block;
   border-radius: 4px;
-  background: linear-gradient(135deg, var(--color-accent-cantaloupe-base) 0%, var(--color-accent-persimmon-base) 51.56%, var(--color-accent-plum-base) 100%);
+  background: linear-gradient(135deg, var(--color-accent-canteloupe-base) 0%, var(--color-accent-persimmon-base) 50%, var(--color-accent-plum-base) 100%);
   vertical-align: middle;
   height: 20px;
 }
@@ -21,7 +21,7 @@
 
 .label {
   margin: 1px;
-  background: var(--color-accent-persimmon-subtlest);
+  background: linear-gradient(135deg, var(--color-accent-canteloupe-subtlest) 0%, var(--color-accent-persimmon-subtlest) 50%, var(--color-accent-plum-subtlest) 100%);
   color: var(--color-accent-persimmon-base);
   border-radius: 3px;
   font-size: 11px;

--- a/web/libs/ui/src/shad/components/ui/alert.tsx
+++ b/web/libs/ui/src/shad/components/ui/alert.tsx
@@ -11,6 +11,8 @@ const alertVariants = cva(
         default: "bg-neutral-background text-card-foreground",
         destructive:
           "text-negative-content bg-negative-background border-negative-border-subtler [&>svg]:text-current *:data-[slot=alert-description]:text-negative-content/90",
+        gradient:
+          "text-[var(--color-accent-persimmon-base)] bg-gradient-to-br from-[var(--color-accent-canteloupe-subtlest)] via-[var(--color-accent-persimmon-subtlest)] to-[var(--color-accent-plum-subtlest)] border-[var(--color-accent-persimmon-border)] [&>svg]:text-current [&>[data-slot=alert-description]]:!block [&>[data-slot=alert-description]]:!col-start-2 [&>[data-slot=alert-description]]:text-sm has-[>svg]:!grid-cols-[16px_1fr] has-[>svg]:!gap-x-3",
       },
     },
     defaultVariants: {
@@ -38,7 +40,7 @@ function AlertDescription({ className, ...props }: React.ComponentProps<"div">) 
     <div
       data-slot="alert-description"
       className={cn(
-        "text-neutral-content-subtler col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed",
+        "text-neutral-content col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed",
         className,
       )}
       {...props}


### PR DESCRIPTION
This pull request introduces support for new enterprise cloud storage providers in the Label Studio settings UI, improves provider selection and messaging for disabled (enterprise-only) options, and refines UI components for clarity and consistency. The main changes are the addition of enterprise provider configs, enhanced selection logic, improved messaging for disabled providers, and minor style updates.

### Enterprise provider support and configuration

* Added new enterprise cloud storage provider configs for Databricks, Amazon S3 with IAM Role, Google Cloud Storage with Workload Identity Federation, and Azure Blob Storage with Service Principal. These are marked as disabled and display an enterprise badge and informational alert linking to documentation. (`databricks.tsx`, `s3s.tsx`, `gcswif.tsx`, `azure_spi.tsx`) [[1]](diffhunk://#diff-55212219f93bd7f37a5be8a98c0f6f340afd2cda35b6fa9e13f444fa4d4b9e02R1-R39) [[2]](diffhunk://#diff-6f213631dcf6015500ab68b096a9db550ea338aff198a52fd38034633ef040a5R1-R39) [[3]](diffhunk://#diff-02312bb2e195ac8982696de98e4533f9fa74705426cae36e9e8c9e6c0ff28669R1-R40) [[4]](diffhunk://#diff-fe30e3c0ee1badca5c2f6c14940bc3379217cc4f0b4a7b388716348c1f83a2bdR1-R40)
* Registered the new enterprise providers in the main provider registry, grouping them separately from standard providers for clarity. (`providers/index.ts`)

### Provider selection and messaging improvements

* Updated the provider selection step to skip disabled providers when setting the default, and display a custom alert message when a disabled (enterprise-only) provider is selected. (`provider-selection-step.tsx`)
* Enhanced the provider grid to support disabled states, show enterprise badges, and improve visual layout and accessibility. (`provider-grid.tsx`)
* Updated the form footer to disable the "Next" button when a disabled provider is selected, and display an appropriate tooltip message. (`form-footer.tsx`, `StorageProviderForm/index.tsx`) [[1]](diffhunk://#diff-6ee20684430fe291492f521b369809881bd3bf76a102c6ae1a38debe8e0a49fcR27) [[2]](diffhunk://#diff-6ee20684430fe291492f521b369809881bd3bf76a102c6ae1a38debe8e0a49fcR44) [[3]](diffhunk://#diff-6ee20684430fe291492f521b369809881bd3bf76a102c6ae1a38debe8e0a49fcL77-R89) [[4]](diffhunk://#diff-eaa05d22a8a9a3a3328351000cd1a4e08c1c56564c9e4da789665b00ac29b975R345)

### UI and style refinements

* Improved the alert component to support a "gradient" variant for enterprise messaging and tweaked alert description styling for better readability. (`alert.tsx`) [[1]](diffhunk://#diff-21e9a1fa30796fdabe1dd199aaf8317e7216655742d381cc4483a3f554cec420R14-R15) [[2]](diffhunk://#diff-21e9a1fa30796fdabe1dd199aaf8317e7216655742d381cc4483a3f554cec420L41-R43)
* Updated the enterprise badge and label styles to use a consistent gradient background and color scheme. (`enterprise-badge.module.scss`) [[1]](diffhunk://#diff-2c93615264ddbfb92a639a665b0644bdc874040a54ef780c5d299f248e51722dL4-R4) [[2]](diffhunk://#diff-2c93615264ddbfb92a639a665b0644bdc874040a54ef780c5d299f248e51722dL24-R24)

### Minor adjustments

* Reduced the modal width for storage settings from 960px to 840px for a more compact appearance. (`StorageSet.jsx`)
* Corrected import path for `CalloutVariant` type to avoid potential issues. (`types/common.ts`) [[1]](diffhunk://#diff-4d8e7246714d58740f5fadddc8217153eaba694b5f6e127980bcdee288beffdfL1-R1) [[2]](diffhunk://#diff-4d8e7246714d58740f5fadddc8217153eaba694b5f6e127980bcdee288beffdfR56-R57)