### PR TITLE
fix: FIT-688: Closing a temporary DM tab makes the page crash (#8449)

### DIFF
--- a/web/libs/datamanager/src/stores/Tabs/store.js
+++ b/web/libs/datamanager/src/stores/Tabs/store.js
@@ -158,7 +158,6 @@ export const TabStore = types
     deleteView: flow(function* (view, { autoselect = true } = {}) {
       if (autoselect && self.selected === view) {
         let newView;
-
         if (self.selected.opener) {
           newView = self.opener.referrer;
         } else {
@@ -167,7 +166,7 @@ export const TabStore = types
           newView = index === 0 ? self.views[index + 1] : self.views[index - 1];
         }
 
-        self.setSelected(newView.key);
+        yield self.setSelected(newView.key);
       }
 
       if (view.saved) {


### PR DESCRIPTION
This pull request introduces a minor update to the tab selection logic in the `TabStore` within `web/libs/datamanager/src/stores/Tabs/store.js`. The main change is ensuring that the tab selection update is handled asynchronously when deleting a view.

Tab selection logic improvement:

* Changed the call to `self.setSelected(newView.key)` to use `yield`, making the tab selection asynchronous within the `deleteView` flow.