### PR TITLE
ci: ECHO-413: Remove LSO Server Dependency from E2E Workflow

### DIFF
--- a/.github/workflows/tests-yarn-e2e.yml
+++ b/.github/workflows/tests-yarn-e2e.yml
@@ -41,12 +41,6 @@ jobs:
         working-directory: ${{ env.FRONTEND_MONOREPO_DIR }}/libs/editor/tests/e2e
         run: yarn install
 
-      - name: Run LSO server
-        id: run-lso-server
-        run: |
-          container_id=$(docker run --rm -d -p 8080:8080 heartexlabs/label-studio:develop)
-          echo "container_id=${container_id}" >> $GITHUB_OUTPUT
-
       - name: Run LSF server
         id: run-lsf-server
         timeout-minutes: 2
@@ -92,11 +86,6 @@ jobs:
           path: |
             web/libs/editor/tests/e2e/output
             web/libs/editor/tests/coverage
-
-      - name: Kill LSO server
-        if: always()
-        continue-on-error: true
-        run: docker rm -f "${{ steps.run-lso-server.outputs.container_id }}"
 
       - name: Kill LSF server
         if: always()


### PR DESCRIPTION
🎯 Purpose
Remove unnecessary LSO server dependency from the yarn e2e workflow to simplify CI pipeline and reduce potential failure points.

📋 Changes
❌ Removed "Run LSO server" step that starts Docker container
❌ Removed corresponding "Kill LSO server" cleanup step
✅ Maintained all frontend e2e testing capabilities
✅ Reduced workflow complexity and execution time

🔍 Background
The e2e workflow was starting a full Label Studio backend server via Docker, but the frontend e2e tests don't actually require backend connectivity. This was adding unnecessary complexity, Docker dependencies, and potential failure points to our CI pipeline.

✅ Testing
[x] Verified workflow runs successfully with act - current pr too
[x] Confirmed frontend e2e tests pass without backend server
[x] Validated no tests depend on LSO server endpoints
[x] Checked workflow execution time improvement

