### PR TITLE
fix: UTC-306: Fix broken DM due to get_model_versions

### DIFF
--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -974,8 +974,11 @@ class Project(ProjectMixin, models.Model):
             output = {r['model_version']: r['count'] for r in model_versions}
 
             # Ensure that self.model_version exists in output
-            if self.model_version and self.model_version not in output and len(output) < limit:
-                output[self.model_version] = 0
+            if self.model_version and self.model_version not in output:
+                if limit and len(output) < limit:
+                    output[self.model_version] = 0
+                elif not limit:
+                    output[self.model_version] = 0
 
             # Return as per requirement
             return output if with_counters else list(output.keys())


### PR DESCRIPTION
Need to check if `limit` is set or not 

Before
```
  File "/label-studio-enterprise/.venv/lib/python3.13/site-packages/label_studio/projects/models.py", line 977, in get_model_versions
    if self.model_version and self.model_version not in output and len(output) < limit:
                                                                   ^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'int' and 'NoneType'
```

After
```
>>> project.get_model_versions()
['0.0.1', 'Palm Validator']
```
