### PR TITLE
fix: FIT-752: AuthProvider cannot be exported top level or it creates implicit dependency on app related code

### DIFF
--- a/web/libs/app-common/src/pages/AccountSettings/AccountSettings.tsx
+++ b/web/libs/app-common/src/pages/AccountSettings/AccountSettings.tsx
@@ -7,7 +7,7 @@ import { HotkeysHeaderButtons } from "./sections/Hotkeys";
 import clsx from "clsx";
 import { useAtomValue } from "jotai";
 import { settingsAtom } from "./atoms";
-import { useAuth } from "@humansignal/core";
+import { useAuth } from "@humansignal/core/providers/AuthProvider";
 
 /**
  * FIXME: This is legacy imports. We're not supposed to use such statements

--- a/web/libs/app-common/src/pages/AccountSettings/sections/index.tsx
+++ b/web/libs/app-common/src/pages/AccountSettings/sections/index.tsx
@@ -6,7 +6,8 @@ import { HotkeysManager } from "./Hotkeys";
 import type React from "react";
 import { PersonalJWTToken } from "./PersonalJWTToken";
 import type { AuthTokenSettings } from "../types";
-import { ABILITY, type AuthPermissions, ff } from "@humansignal/core";
+import { ABILITY, type AuthPermissions } from "@humansignal/core/providers/AuthProvider";
+import { ff } from "@humansignal/core";
 import { Badge } from "@humansignal/ui";
 
 export type SectionType = {

--- a/web/libs/core/src/index.ts
+++ b/web/libs/core/src/index.ts
@@ -7,7 +7,5 @@ export * from "./lib/utils/helpers";
 export * from "./lib/utils/string";
 export * from "./hooks/useAbortController";
 export * from "./lib/hooks/useCopyText";
-export * from "./providers/AuthProvider";
-export * from "./types/user";
 
 export { ff };


### PR DESCRIPTION
This pull request primarily updates import paths for the `AuthProvider` and related types, ensuring that modules are imported from their correct locations. Additionally, it removes some exports from the `core` package index to enforce proper encapsulation.

**Import path corrections:**

* Changed the import path for `useAuth` in `AccountSettings.tsx` to import from `@humansignal/core/providers/AuthProvider` instead of `@humansignal/core`.
* Updated imports in `sections/index.tsx` to import `ABILITY` and `AuthPermissions` from `@humansignal/core/providers/AuthProvider` and moved the `ff` import to come from `@humansignal/core`.

**Export removal for encapsulation:**

* Removed exports for `AuthProvider` and `user` types from `web/libs/core/src/index.ts` to prevent direct access and encourage importing from their specific modules.