### PR TITLE
fix: Allow any non-error status on XHR response in audio media loader

### DIFF
--- a/web/libs/editor/src/lib/AudioUltra/Media/MediaLoader.ts
+++ b/web/libs/editor/src/lib/AudioUltra/Media/MediaLoader.ts
@@ -183,7 +183,7 @@ export class MediaLoader extends Destructable {
       });
 
       xhr.addEventListener("readystatechange", () => {
-        if (xhr.readyState === 4 && xhr.status !== 200 && xhr.status !== 0) {
+        if (xhr.readyState === 4 && xhr.status >= 400 && xhr.status !== 0) {
           errorHandler();
         }
       });


### PR DESCRIPTION
Addresses https://github.com/HumanSignal/label-studio/issues/8576

Without this a perfectly valid partial response status code like 206 will cause the entire promise to fail erroneously.