### PR TITLE
fix: image loading in BitmaskRegion (fix: #8544)

### DIFF
--- a/web/libs/editor/src/regions/BitmaskRegion.jsx
+++ b/web/libs/editor/src/regions/BitmaskRegion.jsx
@@ -176,16 +176,19 @@ const Model = types
 
           image.src = self.imageDataURL;
 
-          try {
-            await image.decode();
+          // Fallback onload
+          image.onload = () => {
             context.canvas.width = image.naturalWidth;
             context.canvas.height = image.naturalHeight;
             bitmask.width = image.naturalWidth;
             bitmask.height = image.naturalHeight;
-
             context.drawImage(image, 0, 0);
-
             self.finalizeRegion();
+          };
+
+          try {
+            await image.decode();
+            image.onload(); // on success of decode() onload() get called manually
           } catch (err) {
             console.log(err);
           }

--- a/web/libs/editor/src/regions/BitmaskRegion.jsx
+++ b/web/libs/editor/src/regions/BitmaskRegion.jsx
@@ -176,7 +176,7 @@ const Model = types
 
           image.src = self.imageDataURL;
 
-          // Fallback onload
+          // Fallback onload()
           image.onload = () => {
             context.canvas.width = image.naturalWidth;
             context.canvas.height = image.naturalHeight;
@@ -188,7 +188,7 @@ const Model = types
 
           try {
             await image.decode();
-            image.onload(); // on success of decode() onload() get called manually
+            image.onload(); // on success of decode() onload() get called manually to fix a Bug known for Chromium: https://issues.chromium.org/issues/40792189
           } catch (err) {
             console.log(err);
           }


### PR DESCRIPTION
Refactors image loading to use the onload event as a fallback, ensuring region finalization. Calls onload manually after successful decode to maintain consistent behavior. The Bug is known for Chromium: https://issues.chromium.org/issues/40792189 This change fixes the problem by using  onload as seperate call.
fixes: #8544 
