### PR TITLE
chore: OPTIC-1337 Live Tooltips update

### DIFF
--- a/web/apps/labelstudio/src/components/HeidiTips/liveContent.json
+++ b/web/apps/labelstudio/src/components/HeidiTips/liveContent.json
@@ -193,7 +193,7 @@
         "url": "https://humansignal.com/pdf-interest-signup",
         "params": {
           "experiment": "project_settings_tip",
-          "treatment": "connect_ml_models_live"
+          "treatment": "lse_pdf_live"
         }
       }
     }


### PR DESCRIPTION
It fixes treatment name for the PDF tooltip