### PR TITLE
fix: FIT-756: Ongoing Annotator Evaluation back‑loads Ground Truth tasks under Uniform Sampling

### DIFF
--- a/label_studio/projects/functions/next_task.py
+++ b/label_studio/projects/functions/next_task.py
@@ -206,13 +206,24 @@ def get_not_solved_tasks_qs(
         # otherwise, filtering out completed tasks is sufficient
         else:
             # In Ongoing mode, we need to keep GT tasks available even if they're labeled
+            # BUT exclude GT tasks that are locked by this user to prevent task-lock re-serving
             # In Onboarding mode, GT tasks will be prioritized via the GT queue later
             if not project.show_ground_truth_first:
-                # Annotate tasks with GT status to exclude them from the is_labeled filter
+                from tasks.models import TaskLock
+
+                # Annotate tasks with GT status
                 gt_subq = Annotation.objects.filter(task=OuterRef('pk'), ground_truth=True)
                 not_solved_tasks = not_solved_tasks.annotate(has_ground_truths=Exists(gt_subq))
-                # Keep unlabeled tasks + GT tasks (even if labeled)
-                not_solved_tasks = not_solved_tasks.filter(Q(is_labeled=False) | Q(has_ground_truths=True))
+
+                # Annotate tasks with user lock status
+                user_lock_subq = TaskLock.objects.filter(task=OuterRef('pk'), user=user)
+                not_solved_tasks = not_solved_tasks.annotate(has_user_lock=Exists(user_lock_subq))
+
+                # Keep unlabeled tasks + GT tasks that aren't locked by this user
+                # This allows GT uniform distribution while preventing task-lock re-serving
+                not_solved_tasks = not_solved_tasks.filter(
+                    Q(is_labeled=False) | (Q(has_ground_truths=True) & Q(has_user_lock=False))
+                )
 
     if not flag_set('fflag_fix_back_lsdv_4523_show_overlap_first_order_27022023_short'):
         # show tasks with overlap > 1 first (unless tasks are already prioritized on agreement)

--- a/label_studio/projects/functions/next_task.py
+++ b/label_studio/projects/functions/next_task.py
@@ -79,10 +79,13 @@ def _try_tasks_with_overlap(tasks: QuerySet[Task]) -> Tuple[Union[Task, None], Q
 
 
 def _try_breadth_first(tasks: QuerySet[Task], user: User, project: Project) -> Union[Task, None]:
-    """Try to find tasks with maximum amount of annotations, since we are trying to label tasks as fast as possible"""
+    """Try to find tasks with maximum amount of annotations, since we are trying to label tasks as fast as possible
 
-    # Exclude ground truth annotations from the count when not in onboarding mode
-    # to prevent GT tasks from being prioritized via breadth-first logic
+    Exclude ground truth annotations from the count when not in onboarding mode
+    to prevent GT tasks from being prioritized via breadth-first logic
+    """
+
+    # Exclude ground truth annotations from the count
     annotation_filter = ~Q(annotations__completed_by=user)
     if not project.show_ground_truth_first:
         annotation_filter &= ~Q(annotations__ground_truth=True)
@@ -192,24 +195,24 @@ def get_not_solved_tasks_qs(
             )
             capacity_pred = Q(annotators__lt=F('overlap') + (lse_project.max_additional_annotators_assignable or 0))
 
-            if project.show_ground_truth_first:
-                gt_subq = Annotation.objects.filter(task=OuterRef('pk'), ground_truth=True)
-                qs = qs.annotate(has_ground_truths=Exists(gt_subq))
-                # Keep all GT tasks + apply low-agreement+capacity to the rest. For sure, we can do:
-                # - if user.solved_tasks_array.count < lse_project.annotator_evaluation_minimum_tasks
-                # - else, apply low-agreement+capacity to the rest (maybe performance will be better)
-                # but it's a question - what is better here. This version is simpler at least from the code perspective.
-                not_solved_tasks = qs.filter(Q(has_ground_truths=True) | (low_agreement_pred & capacity_pred))
-            else:
-                not_solved_tasks = qs.filter(low_agreement_pred & capacity_pred)
+            # Annotate all tasks with ground truth status for proper filtering
+            gt_subq = Annotation.objects.filter(task=OuterRef('pk'), ground_truth=True)
+            qs = qs.annotate(has_ground_truths=Exists(gt_subq))
+
+            not_solved_tasks = qs.filter(Q(has_ground_truths=True) | (low_agreement_pred & capacity_pred))
 
             prioritized_on_agreement, not_solved_tasks = _prioritize_low_agreement_tasks(not_solved_tasks, lse_project)
 
         # otherwise, filtering out completed tasks is sufficient
         else:
-            # ignore tasks that are already labeled for onboarding mode
+            # In Ongoing mode, we need to keep GT tasks available even if they're labeled
+            # In Onboarding mode, GT tasks will be prioritized via the GT queue later
             if not project.show_ground_truth_first:
-                not_solved_tasks = not_solved_tasks.filter(is_labeled=False)
+                # Annotate tasks with GT status to exclude them from the is_labeled filter
+                gt_subq = Annotation.objects.filter(task=OuterRef('pk'), ground_truth=True)
+                not_solved_tasks = not_solved_tasks.annotate(has_ground_truths=Exists(gt_subq))
+                # Keep unlabeled tasks + GT tasks (even if labeled)
+                not_solved_tasks = not_solved_tasks.filter(Q(is_labeled=False) | Q(has_ground_truths=True))
 
     if not flag_set('fflag_fix_back_lsdv_4523_show_overlap_first_order_27022023_short'):
         # show tasks with overlap > 1 first (unless tasks are already prioritized on agreement)
@@ -274,10 +277,10 @@ def get_next_task_without_dm_queue(
         if next_task:
             queue_info += (' & ' if queue_info else '') + 'Low agreement queue'
 
-    # Breadth first: label in-progress tasks first;
+    # Breadth first: label in-progress tasks first
     if not next_task and project.maximum_annotations > 1:
         # if there are already labeled tasks, but task.overlap still < project.maximum_annotations, randomly sampling from them
-        logger.debug(f'User={user} tries depth first from prepared tasks')
+        logger.debug(f'User={user} tries breadth first from prepared tasks')
         next_task = _try_breadth_first(not_solved_tasks, user, project)
         if next_task:
             queue_info += (' & ' if queue_info else '') + 'Breadth first queue'


### PR DESCRIPTION
## Problem

In **Ongoing Evaluation** mode with **Uniform Sampling**, Ground Truth (GT) tasks were being front/back-loaded to all annotators instead of being randomly distributed throughout the task stream, effectively mirroring "Onboarding" behavior.

## Root Causes

### 1. GT Tasks Filtered from Candidate Pool
In Ongoing mode, GT tasks were excluded from selection due to:
- **With agreement threshold**: Filter only applied `low_agreement & capacity`, excluding GT tasks with NULL agreement
- **Without agreement threshold**: Filter only included `is_labeled=False`, excluding GT tasks (which have `is_labeled=True`)

### 2. GT Annotations Inflated Breadth-First Count
Breadth-first logic counted **all** annotations, including GT annotations:
- GT task with 1 GT annotation appeared to have 1 annotation → looked "in-progress" → prioritized
- Multiple annotators would then receive the same GT task → cascade effect → front-loading

## Visual: The Fix

### BEFORE: Buggy Flow
```mermaid
flowchart LR
    A[Get Candidates] -->|Ongoing mode| B[❌ Filter excludes GT<br/>low_agreement only<br/>OR is_labeled=False]
    B --> C[Regular tasks only]
    C --> D[Breadth-First counts<br/>❌ ALL annotations]
    D --> E[GT task: 1 GT annotation<br/>= count 1 = in-progress<br/>→ PRIORITIZED]
    
    style B fill:#ffcccc,stroke:#cc0000,stroke-width:2px,color:#000
    style D fill:#fff3cd,stroke:#cc8800,stroke-width:2px,color:#000
    style E fill:#ffcccc,stroke:#cc0000,stroke-width:2px,color:#000
```

**Problems:**
- 🔴 GT tasks excluded from candidate pool in Ongoing mode
- 🟡 Breadth-first counts GT annotations → GT tasks look "in-progress"
- 🔴 Cascade: Same GT task assigned to multiple annotators consecutively

### AFTER: Fixed Flow
```mermaid
flowchart LR
    A[Get Candidates] -->|Any mode| B[✅ Filter includes GT<br/>has_ground_truths=True<br/>OR other conditions]
    B --> C[GT + Regular tasks]
    C --> D[Breadth-First counts<br/>✅ ONLY regular annotations]
    D --> E[GT task: 1 GT annotation<br/>= count 0 = NOT prioritized<br/>→ Random selection]
    
    style B fill:#ccffcc,stroke:#00aa00,stroke-width:2px,color:#000
    style D fill:#ccffcc,stroke:#00aa00,stroke-width:2px,color:#000
    style E fill:#ccffcc,stroke:#00aa00,stroke-width:2px,color:#000
```

**Fixes:**
- ✅ GT tasks explicitly included: `Q(has_ground_truths=True)`
- ✅ Breadth-first excludes GT annotations: `~Q(annotations__ground_truth=True)`
- ✅ GT tasks not artificially prioritized → scattered throughout stream

## Code Changes

### 1. Include GT Tasks in Candidate Pool

**File:** `label_studio/projects/functions/next_task.py`

#### Scenario A: With Agreement Threshold (lines 198-202)
```python
# BEFORE: Only Onboarding mode included GT tasks
if project.show_ground_truth_first:
    not_solved_tasks = qs.filter(Q(has_ground_truths=True) | (low_agreement_pred & capacity_pred))
else:
    not_solved_tasks = qs.filter(low_agreement_pred & capacity_pred)  # ❌ No GT tasks

# AFTER: Both modes include GT tasks
gt_subq = Annotation.objects.filter(task=OuterRef('pk'), ground_truth=True)
qs = qs.annotate(has_ground_truths=Exists(gt_subq))
not_solved_tasks = qs.filter(Q(has_ground_truths=True) | (low_agreement_pred & capacity_pred))
```

#### Scenario B: Without Agreement Threshold (lines 208-215)
```python
# BEFORE: Ongoing mode excluded GT tasks
if not project.show_ground_truth_first:
    not_solved_tasks = not_solved_tasks.filter(is_labeled=False)  # ❌ GT tasks have is_labeled=True

# AFTER: Ongoing mode includes GT tasks
if not project.show_ground_truth_first:
    gt_subq = Annotation.objects.filter(task=OuterRef('pk'), ground_truth=True)
    not_solved_tasks = not_solved_tasks.annotate(has_ground_truths=Exists(gt_subq))
    not_solved_tasks = not_solved_tasks.filter(
        Q(is_labeled=False) | Q(has_ground_truths=True)  # ✅ Include GT even if labeled
    )
```

### 2. Exclude GT Annotations from Breadth-First Count

**File:** `label_studio/projects/functions/next_task.py` (lines 81-93)

```python
# BEFORE: Counted all annotations
def _try_breadth_first(tasks, user, project):
    annotation_filter = ~Q(annotations__completed_by=user)
    tasks = tasks.annotate(annotations_count=Count('annotations', filter=annotation_filter))
    # ❌ GT task with 1 GT annotation: count = 1 → prioritized

# AFTER: Exclude GT annotations in Ongoing mode
def _try_breadth_first(tasks, user, project):
    annotation_filter = ~Q(annotations__completed_by=user)
    if not project.show_ground_truth_first:  # Ongoing mode
        annotation_filter &= ~Q(annotations__ground_truth=True)  # ✅ Exclude GT annotations
    tasks = tasks.annotate(annotations_count=Count('annotations', filter=annotation_filter))
    # ✅ GT task with only GT annotation: count = 0 → not prioritized
```

## Impact

### What Changes
- **Ongoing Mode + Agreement Threshold**: GT tasks now included in candidate pool (were excluded before)
- **Ongoing Mode + No Agreement Threshold**: GT tasks now included even if `is_labeled=True` (were excluded before)
- **Breadth-First in Ongoing Mode**: No longer counts GT annotations when determining "in-progress" tasks

### Expected Behaviour

| Mode | GT in Pool? | Breadth-First Counts GT? | Result |
|------|-------------|-------------------------|--------|
| **Onboarding** | ✅ (via GT queue) | ✅ (doesn't matter) | GT tasks served first |
| **Ongoing** | ✅ (in candidate pool) | ❌ No | GT tasks scattered randomly |

### Backwards Compatibility
- **Behaviour Change**: Projects using Ongoing evaluation will now see GT tasks properly distributed
- **Fix**: Corrects broken behaviour where GT tasks were either excluded or front/back-loaded
- **No Breaking Changes**: Onboarding mode unchanged, API unchanged, database unchanged

### Performance Considerations
- **Added**: One `Exists()` subquery annotation for `has_ground_truths` (minimal overhead)
- **Added**: One filter condition in breadth-first count (minimal overhead)
- **No additional database queries**

## Key Insight

**The solution: Make breadth-first "GT-aware" rather than disabling it.**

Instead of preventing breadth-first from running for certain sampling methods (which would break overlap functionality), the fix makes breadth-first smarter by excluding GT annotations from the count. This way:

- GT tasks with only GT annotations (count=0) aren't prioritized
- GT tasks with regular annotations are treated like any other task
- Breadth-first still optimizes overlap completion
- No cascade effect causing front-loading

## Files Modified

- ✏️ `label_studio/projects/functions/next_task.py`
  - Lines 81-93: Exclude GT annotations from breadth-first count
  - Lines 198-202: Include GT tasks in candidate pool (agreement threshold scenario)
  - Lines 208-215: Include GT tasks in candidate pool (no agreement threshold scenario)

## Summary

**Root Causes:**
1. GT tasks filtered from candidate pool in Ongoing mode
2. Breadth-first counted GT annotations, making GT tasks look "in-progress"

**Solution:**
1. Explicitly include GT tasks: `Q(has_ground_truths=True)`
2. Exclude GT annotations from breadth-first count: `~Q(annotations__ground_truth=True)`

**Result:** GT tasks properly distributed throughout the stream in Ongoing mode, while Onboarding mode remains unchanged.

