### PR TITLE
fix: FIT-284: Browser Webpage Title Not Updating

### DIFF
--- a/label_studio/templates/base.html
+++ b/label_studio/templates/base.html
@@ -191,6 +191,7 @@
     },
 
     {% block app_more_settings %}
+      page_title: "Label Studio",
       flags: {
         allow_organization_webhooks: {{settings.ALLOW_ORGANIZATION_WEBHOOKS|yesno:"true,false"}},
         storage_persistence: {{ settings.STORAGE_PERSISTENCE|yesno:"true,false" }}, 

--- a/web/apps/labelstudio/src/pages/Home/HomePage.tsx
+++ b/web/apps/labelstudio/src/pages/Home/HomePage.tsx
@@ -3,6 +3,7 @@ import { Button, SimpleCard, Spinner, Typography } from "@humansignal/ui";
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { Link } from "react-router-dom";
+import { useUpdatePageTitle } from "@humansignal/core";
 import { HeidiTips } from "../../components/HeidiTips/HeidiTips";
 import { useAPI } from "../../providers/ApiProvider";
 import { CreateProject } from "../CreateProject/CreateProject";
@@ -53,6 +54,8 @@ export const HomePage: Page = () => {
   const api = useAPI();
   const [creationDialogOpen, setCreationDialogOpen] = useState(false);
   const [invitationOpen, setInvitationOpen] = useState(false);
+
+  useUpdatePageTitle("Home");
   const { data, isFetching, isSuccess, isError } = useQuery({
     queryKey: ["projects", { page_size: 10 }],
     async queryFn() {

--- a/web/apps/labelstudio/src/pages/Organization/Models/ModelsPage.tsx
+++ b/web/apps/labelstudio/src/pages/Organization/Models/ModelsPage.tsx
@@ -1,10 +1,13 @@
 import { buttonVariant, Space } from "@humansignal/ui";
+import { useUpdatePageTitle } from "@humansignal/core";
 import { Block } from "apps/labelstudio/src/utils/bem";
 import { Link } from "react-router-dom";
 import type { Page } from "../../types/Page";
 import { EmptyList } from "./@components/EmptyList";
 
 export const ModelsPage: Page = () => {
+  useUpdatePageTitle("Models");
+
   return (
     <Block name="prompter">
       <EmptyList />

--- a/web/apps/labelstudio/src/pages/Organization/PeoplePage/PeoplePage.jsx
+++ b/web/apps/labelstudio/src/pages/Organization/PeoplePage/PeoplePage.jsx
@@ -1,5 +1,6 @@
 import { Button } from "@humansignal/ui";
 import { useCallback, useMemo, useRef, useState } from "react";
+import { useUpdatePageTitle } from "@humansignal/core";
 import { HeidiTips } from "../../../components/HeidiTips/HeidiTips";
 import { modal } from "../../../components/Modal/Modal";
 import { Space } from "../../../components/Space/Space";
@@ -19,6 +20,8 @@ export const PeoplePage = () => {
   const toast = useToast();
   const [selectedUser, setSelectedUser] = useState(null);
   const [invitationOpen, setInvitationOpen] = useState(false);
+
+  useUpdatePageTitle("People");
 
   const selectUser = useCallback(
     (user) => {

--- a/web/apps/labelstudio/src/pages/Projects/Projects.jsx
+++ b/web/apps/labelstudio/src/pages/Projects/Projects.jsx
@@ -11,7 +11,7 @@ import { CreateProject } from "../CreateProject/CreateProject";
 import { DataManagerPage } from "../DataManager/DataManager";
 import { SettingsPage } from "../Settings";
 import { EmptyProjectsList, ProjectsList } from "./ProjectsList";
-import { useAbortController } from "@humansignal/core";
+import { useAbortController, useUpdatePageTitle } from "@humansignal/core";
 import "./Projects.scss";
 
 const getCurrentPage = () => {
@@ -28,6 +28,8 @@ export const ProjectsPage = () => {
   const [currentPage, setCurrentPage] = useState(getCurrentPage());
   const [totalItems, setTotalItems] = useState(1);
   const setContextProps = useContextProps();
+
+  useUpdatePageTitle("Projects");
   const defaultPageSize = Number.parseInt(localStorage.getItem("pages:projects-list") ?? 30);
 
   const [modal, setModal] = React.useState(false);

--- a/web/apps/labelstudio/src/pages/Settings/AnnotationSettings.jsx
+++ b/web/apps/labelstudio/src/pages/Settings/AnnotationSettings.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { Button } from "@humansignal/ui";
+import { useUpdatePageTitle, createTitleFromSegments } from "@humansignal/core";
 import { Form, TextArea, Toggle } from "../../components/Form";
 import { MenubarContext } from "../../components/Menubar/Menubar";
 import { Block, Elem } from "../../utils/bem";
@@ -13,6 +14,8 @@ export const AnnotationSettings = () => {
   const pageContext = useContext(MenubarContext);
   const formRef = useRef();
   const [collab, setCollab] = useState(null);
+
+  useUpdatePageTitle(createTitleFromSegments([project?.title, "Annotation Settings"]));
 
   useEffect(() => {
     pageContext.setProps({ formRef });

--- a/web/apps/labelstudio/src/pages/Settings/DangerZone.jsx
+++ b/web/apps/labelstudio/src/pages/Settings/DangerZone.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { useHistory } from "react-router";
 import { Button } from "@humansignal/ui";
+import { useUpdatePageTitle, createTitleFromSegments } from "@humansignal/core";
 import { Label } from "../../components/Form";
 import { confirm } from "../../components/Modal/Modal";
 import { Spinner } from "../../components/Spinner/Spinner";
@@ -13,6 +14,8 @@ export const DangerZone = () => {
   const api = useAPI();
   const history = useHistory();
   const [processing, setProcessing] = useState(null);
+
+  useUpdatePageTitle(createTitleFromSegments([project?.title, "Danger Zone"]));
 
   const handleOnClick = (type) => () => {
     confirm({

--- a/web/apps/labelstudio/src/pages/Settings/LabelingSettings.jsx
+++ b/web/apps/labelstudio/src/pages/Settings/LabelingSettings.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
+import { useUpdatePageTitle, createTitleFromSegments } from "@humansignal/core";
 import { useAPI } from "../../providers/ApiProvider";
 import { useProject } from "../../providers/ProjectProvider";
 import { FF_UNSAVED_CHANGES, isFF } from "../../utils/feature-flags";
@@ -11,6 +12,8 @@ export const LabelingSettings = () => {
   const [essentialDataChanged, setEssentialDataChanged] = useState(false);
   const hasChanges = isFF(FF_UNSAVED_CHANGES) && config !== project.label_config;
   const api = useAPI();
+
+  useUpdatePageTitle(createTitleFromSegments([project?.title, "Labeling Interface Settings"]));
 
   const saveConfig = useCallback(
     isFF(FF_UNSAVED_CHANGES)

--- a/web/apps/labelstudio/src/pages/Settings/MachineLearningSettings/MachineLearningSettings.jsx
+++ b/web/apps/labelstudio/src/pages/Settings/MachineLearningSettings/MachineLearningSettings.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useContext, useEffect, useState } from "react";
 import { NavLink } from "react-router-dom";
 import { Button, Typography, Spinner, EmptyState, SimpleCard } from "@humansignal/ui";
+import { useUpdatePageTitle, createTitleFromSegments } from "@humansignal/core";
 import { Form, Label, Toggle } from "../../../components/Form";
 import { modal } from "../../../components/Modal/Modal";
 import { IconModels, IconExternal } from "@humansignal/icons";
@@ -18,6 +19,8 @@ export const MachineLearningSettings = () => {
   const [backends, setBackends] = useState([]);
   const [loading, setLoading] = useState(false);
   const [loaded, setLoaded] = useState(false);
+
+  useUpdatePageTitle(createTitleFromSegments([project?.title, "Model Settings"]));
 
   const fetchBackends = useCallback(async () => {
     setLoading(true);

--- a/web/apps/labelstudio/src/pages/Settings/PredictionsSettings/PredictionsSettings.jsx
+++ b/web/apps/labelstudio/src/pages/Settings/PredictionsSettings/PredictionsSettings.jsx
@@ -2,6 +2,7 @@ import { useCallback, useContext, useEffect, useState } from "react";
 import { Divider } from "../../../components/Divider/Divider";
 import { EmptyState, SimpleCard } from "@humansignal/ui";
 import { IconPredictions, Typography, IconExternal } from "@humansignal/ui";
+import { useUpdatePageTitle, createTitleFromSegments } from "@humansignal/core";
 import { useAPI } from "../../../providers/ApiProvider";
 import { ProjectContext } from "../../../providers/ProjectProvider";
 import { Spinner } from "../../../components/Spinner/Spinner";
@@ -13,6 +14,8 @@ export const PredictionsSettings = () => {
   const [versions, setVersions] = useState([]);
   const [loading, setLoading] = useState(false);
   const [loaded, setLoaded] = useState(false);
+
+  useUpdatePageTitle(createTitleFromSegments([project?.title, "Predictions Settings"]));
 
   const fetchVersions = useCallback(async () => {
     setLoading(true);

--- a/web/apps/labelstudio/src/pages/Settings/StorageSettings/StorageSettings.jsx
+++ b/web/apps/labelstudio/src/pages/Settings/StorageSettings/StorageSettings.jsx
@@ -1,6 +1,8 @@
 import { Typography } from "@humansignal/ui";
 import { useEffect, useRef } from "react";
 import { useHistory, useLocation } from "react-router-dom";
+import { useUpdatePageTitle, createTitleFromSegments } from "@humansignal/core";
+import { useProject } from "../../../providers/ProjectProvider";
 import { cn } from "../../../utils/bem";
 import { isInLicense, LF_CLOUD_STORAGE_FOR_MANAGERS } from "../../../utils/license-flags";
 import { StorageSet } from "./StorageSet";
@@ -8,10 +10,13 @@ import { StorageSet } from "./StorageSet";
 const isAllowCloudStorage = !isInLicense(LF_CLOUD_STORAGE_FOR_MANAGERS);
 
 export const StorageSettings = () => {
+  const { project } = useProject();
   const rootClass = cn("storage-settings"); // TODO: Remove in the next BEM cleanup
   const history = useHistory();
   const location = useLocation();
   const sourceStorageRef = useRef();
+
+  useUpdatePageTitle(createTitleFromSegments([project?.title, "Cloud Storage Settings"]));
 
   // Handle auto-open query parameter
   useEffect(() => {

--- a/web/libs/app-common/src/pages/AccountSettings/AccountSettings.tsx
+++ b/web/libs/app-common/src/pages/AccountSettings/AccountSettings.tsx
@@ -1,6 +1,7 @@
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from "@humansignal/ui/lib/card-new/card";
 import { useMemo, isValidElement } from "react";
 import { Redirect, Route, Switch, useParams, useRouteMatch } from "react-router-dom";
+import { useUpdatePageTitle, createTitleFromSegments } from "@humansignal/core";
 import styles from "./AccountSettings.module.scss";
 import { accountSettingsSections } from "./sections";
 import { HotkeysHeaderButtons } from "./sections/Hotkeys";
@@ -31,6 +32,26 @@ const AccountSettingsSection = () => {
     () => resolvedSections.find((section) => section.id === sectionId),
     [resolvedSections, sectionId],
   );
+
+  // Update page title to reflect the current section
+  const pageTitleText = useMemo(() => {
+    if (!currentSection) return "My Account";
+
+    // If title is a string, use it directly
+    if (typeof currentSection.title === "string") {
+      return createTitleFromSegments([currentSection.title, "My Account"]);
+    }
+
+    // For non-string titles (like JSX elements), derive from the section ID
+    const titleFromId = currentSection.id
+      .split("-")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ");
+
+    return createTitleFromSegments([titleFromId, "My Account"]);
+  }, [currentSection]);
+
+  useUpdatePageTitle(pageTitleText);
 
   if (!currentSection && resolvedSections.length > 0) {
     return <Redirect to={`${AccountSettingsPage.path}/${resolvedSections[0].id}`} />;

--- a/web/libs/core/src/hooks/usePageTitle.ts
+++ b/web/libs/core/src/hooks/usePageTitle.ts
@@ -1,0 +1,44 @@
+import { useEffect } from "react";
+
+export const PAGE_TITLE_SEPARATOR = " | ";
+
+export const getBasePageTitle = () => {
+	return (
+		(window.APP_SETTINGS as Record<string, unknown>)?.page_title as string
+	)
+		?.split(PAGE_TITLE_SEPARATOR)
+		.at(-1);
+};
+
+export const getPageTitle = (pageTitle?: string) => {
+	const baseTitle = getBasePageTitle();
+	return pageTitle && baseTitle
+		? `${pageTitle}${PAGE_TITLE_SEPARATOR}${baseTitle}`
+		: pageTitle || baseTitle;
+};
+
+export const createTitleFromSegments = (
+	titleSegments: (string | undefined)[],
+) => {
+	return titleSegments.filter(Boolean).join(PAGE_TITLE_SEPARATOR);
+};
+
+export const setPageTitle = (pageTitle?: string, includeBaseTitle = true) => {
+	const title = includeBaseTitle ? getPageTitle(pageTitle) : pageTitle;
+	if (title && typeof document !== "undefined") {
+		document.title = title;
+	}
+};
+
+export const useUpdatePageTitle = (title?: string, includeBaseTitle = true) => {
+	useEffect(() => {
+		if (!title) return;
+		// Debounce title update to avoid flickering when navigating between pages
+		const requestId = requestAnimationFrame(() => {
+			setPageTitle(title, includeBaseTitle);
+		});
+		return () => {
+			if (requestId) cancelAnimationFrame(requestId);
+		};
+	}, [title, includeBaseTitle]);
+};

--- a/web/libs/core/src/hooks/usePageTitle.ts
+++ b/web/libs/core/src/hooks/usePageTitle.ts
@@ -3,42 +3,34 @@ import { useEffect } from "react";
 export const PAGE_TITLE_SEPARATOR = " | ";
 
 export const getBasePageTitle = () => {
-	return (
-		(window.APP_SETTINGS as Record<string, unknown>)?.page_title as string
-	)
-		?.split(PAGE_TITLE_SEPARATOR)
-		.at(-1);
+  return ((window.APP_SETTINGS as Record<string, unknown>)?.page_title as string)?.split(PAGE_TITLE_SEPARATOR).at(-1);
 };
 
 export const getPageTitle = (pageTitle?: string) => {
-	const baseTitle = getBasePageTitle();
-	return pageTitle && baseTitle
-		? `${pageTitle}${PAGE_TITLE_SEPARATOR}${baseTitle}`
-		: pageTitle || baseTitle;
+  const baseTitle = getBasePageTitle();
+  return pageTitle && baseTitle ? `${pageTitle}${PAGE_TITLE_SEPARATOR}${baseTitle}` : pageTitle || baseTitle;
 };
 
-export const createTitleFromSegments = (
-	titleSegments: (string | undefined)[],
-) => {
-	return titleSegments.filter(Boolean).join(PAGE_TITLE_SEPARATOR);
+export const createTitleFromSegments = (titleSegments: (string | undefined)[]) => {
+  return titleSegments.filter(Boolean).join(PAGE_TITLE_SEPARATOR);
 };
 
 export const setPageTitle = (pageTitle?: string, includeBaseTitle = true) => {
-	const title = includeBaseTitle ? getPageTitle(pageTitle) : pageTitle;
-	if (title && typeof document !== "undefined") {
-		document.title = title;
-	}
+  const title = includeBaseTitle ? getPageTitle(pageTitle) : pageTitle;
+  if (title && typeof document !== "undefined") {
+    document.title = title;
+  }
 };
 
 export const useUpdatePageTitle = (title?: string, includeBaseTitle = true) => {
-	useEffect(() => {
-		if (!title) return;
-		// Debounce title update to avoid flickering when navigating between pages
-		const requestId = requestAnimationFrame(() => {
-			setPageTitle(title, includeBaseTitle);
-		});
-		return () => {
-			if (requestId) cancelAnimationFrame(requestId);
-		};
-	}, [title, includeBaseTitle]);
+  useEffect(() => {
+    if (!title) return;
+    // Debounce title update to avoid flickering when navigating between pages
+    const requestId = requestAnimationFrame(() => {
+      setPageTitle(title, includeBaseTitle);
+    });
+    return () => {
+      if (requestId) cancelAnimationFrame(requestId);
+    };
+  }, [title, includeBaseTitle]);
 };

--- a/web/libs/core/src/index.ts
+++ b/web/libs/core/src/index.ts
@@ -7,5 +7,6 @@ export * from "./lib/utils/helpers";
 export * from "./lib/utils/string";
 export * from "./hooks/useAbortController";
 export * from "./lib/hooks/useCopyText";
+export * from "./hooks/usePageTitle";
 
 export { ff };

--- a/web/libs/editor/src/tags/Custom.jsx
+++ b/web/libs/editor/src/tags/Custom.jsx
@@ -5,7 +5,6 @@ import React from "react";
 import { destroy, types, getRoot } from "mobx-state-tree";
 import { observer } from "mobx-react";
 import { EnterpriseBadge } from "@humansignal/ui";
-import Registry from "../core/Registry";
 import ControlBase from "./control/Base";
 import ClassificationBase from "./control/ClassificationBase";
 


### PR DESCRIPTION
This pull request introduces a unified mechanism for dynamically updating the browser page title across the Label Studio web application. The main enhancement is the addition and integration of the `useUpdatePageTitle` hook and supporting utilities, which allow each page to set a contextually appropriate title, often including both the page name and project name. This improves user experience and navigation clarity.

### Page Title Management

* Added the `useUpdatePageTitle` hook and supporting utilities (`setPageTitle`, `getPageTitle`, `createTitleFromSegments`) in `web/libs/core/src/hooks/usePageTitle.ts`, enabling consistent dynamic page title updates throughout the app. [[1]](diffhunk://#diff-b56b428b12982df57451dd6c3599bdaf1f740a68cb862b3c4dc4cf23321842e9R1-R44) [[2]](diffhunk://#diff-ec443aacc52867d5b85e5ab52940e677b43c1993879f71d9f3d045a20534085aR10)

### Integration Across Pages

* Integrated `useUpdatePageTitle` into key pages (`HomePage`, `ProjectsPage`, `ModelsPage`, `PeoplePage`, and all major settings pages) to set descriptive titles, often combining project name and page context. [[1]](diffhunk://#diff-5beb2cd206dd6c5d34a094f966f0b306e197713ce75e3d11d4b55a1af603f4efR6) [[2]](diffhunk://#diff-5beb2cd206dd6c5d34a094f966f0b306e197713ce75e3d11d4b55a1af603f4efR57-R58) [[3]](diffhunk://#diff-a01098cf7e3c4560cdca8bcedb7ed1fbb8d08f77d05b12b3f4c5e5db93bbff49L14-R14) [[4]](diffhunk://#diff-a01098cf7e3c4560cdca8bcedb7ed1fbb8d08f77d05b12b3f4c5e5db93bbff49R31-R32) [[5]](diffhunk://#diff-3e1211df47400be9fa5f62307023bab810cdb7d7ea5b3003ca5de8b6b12c858bR2-R10) [[6]](diffhunk://#diff-3e1211df47400be9fa5f62307023bab810cdb7d7ea5b3003ca5de8b6b12c858bR2-R10) [[7]](diffhunk://#diff-b53012bb76fc0b8874c5f4d215da3ec5aeb82d5ea261d0f6787546e30de4a711R3) [[8]](diffhunk://#diff-b53012bb76fc0b8874c5f4d215da3ec5aeb82d5ea261d0f6787546e30de4a711R24-R25) [[9]](diffhunk://#diff-c09c1160b7a4f5173b83306219ebf279a4e084507cb4ef4b1984b6443681829eR3) [[10]](diffhunk://#diff-c09c1160b7a4f5173b83306219ebf279a4e084507cb4ef4b1984b6443681829eR18-R19) [[11]](diffhunk://#diff-663e6a5f6c3d8bf49c5eeda8ca06a6c7f5366101d43cd2beed79386a8445f6e4R4) [[12]](diffhunk://#diff-663e6a5f6c3d8bf49c5eeda8ca06a6c7f5366101d43cd2beed79386a8445f6e4R18-R19) [[13]](diffhunk://#diff-2e8f9598df92383916945086751cc4b39267ab0b91c6388d8d30057d5884327aR2) [[14]](diffhunk://#diff-2e8f9598df92383916945086751cc4b39267ab0b91c6388d8d30057d5884327aR16-R17) [[15]](diffhunk://#diff-ba18b13cf15409cea8efe37f5a1966c301364f14c1550ff835f03c43c52289c4R4) [[16]](diffhunk://#diff-ba18b13cf15409cea8efe37f5a1966c301364f14c1550ff835f03c43c52289c4R23-R24) [[17]](diffhunk://#diff-e821433162d590c9cd9036f5d55acc496fd29e8e2a005d16cc0958fb75467757R5) [[18]](diffhunk://#diff-e821433162d590c9cd9036f5d55acc496fd29e8e2a005d16cc0958fb75467757R18-R19) [[19]](diffhunk://#diff-30d0ea36f6e9224504be5a6afcfbd0c5d2a861db8b5e440c9dda399db8ce10fdR4-R20) [[20]](diffhunk://#diff-30d0ea36f6e9224504be5a6afcfbd0c5d2a861db8b5e440c9dda399db8ce10fdR4-R20)

* Extended page title logic to the account settings section, ensuring the title reflects the current subsection or defaults to "My Account". [[1]](diffhunk://#diff-65fad14bf4e82331ef161bf2ef465f8b0f294338e2447564391049a34979b0d4R4) [[2]](diffhunk://#diff-65fad14bf4e82331ef161bf2ef465f8b0f294338e2447564391049a34979b0d4R36-R55)

### Backend Support

* Added the `page_title` property to the template context in `label_studio/templates/base.html`, allowing the frontend to access and use the base title for dynamic updates.

These changes collectively enhance navigation clarity and branding by ensuring the browser tab title always reflects the user's current context in the application.