### PR TITLE
fix: FIT-746: Child filter criteria that is unset is removed when navigating away and back to the datamanager tab (#8618)

### DIFF
--- a/web/libs/datamanager/src/stores/Tabs/tab_filter.js
+++ b/web/libs/datamanager/src/stores/Tabs/tab_filter.js
@@ -45,7 +45,7 @@ export const TabFilter = types
       try {
         while (current) {
           parent = getParent(current);
-          if (parent && parent.filters && Array.isArray(parent.filters)) {
+          if (parent?.filters && Array.isArray(parent.filters)) {
             return parent;
           }
           current = parent;
@@ -118,6 +118,12 @@ export const TabFilter = types
       }
       if (self.operator === null) {
         self.setOperator(self.component[0].key);
+      }
+
+      // If this filter's column has child_filter metadata and no child filter exists, create it
+      // This ensures child filters are automatically recreated after navigation
+      if (!self.child_filter && self.filter?.field?.child_filter) {
+        self.view?.applyChildFilter(self);
       }
     },
 


### PR DESCRIPTION
cherrypicks: 420f8b9127b5f4a1cab5cb39b2c7ad91d1384b5a