### PR TITLE
fix: FIT-272: Label / Review Stream 'Info Bar' is missing in the new Labeling UI (along with the info as to why the task is served to user)

### DIFF
--- a/web/libs/datamanager/src/stores/DataStores/tasks.js
+++ b/web/libs/datamanager/src/stores/DataStores/tasks.js
@@ -199,6 +199,12 @@ export const create = (columns) => {
           getRoot(self).SDK.invoke("assignedStreamFinished");
         }
 
+        const isLabelStream = getRoot(self).SDK?.mode === "labelstream";
+        if (isLabelStream) {
+          const selectedAnnotationID = getRoot(self).annotationStore.selected?.id;
+          console.log(`[LABEL STREAM] ${task.queue}, task ${task.id}, project ${task.project}, user ${getRoot(self).LSF.lsf.user.id}${selectedAnnotationID ? `, annotation ${selectedAnnotationID}` : ""}`);
+        }
+
         return task;
       }),
 

--- a/web/libs/datamanager/src/stores/DataStores/tasks.js
+++ b/web/libs/datamanager/src/stores/DataStores/tasks.js
@@ -202,7 +202,9 @@ export const create = (columns) => {
         const isLabelStream = getRoot(self).SDK?.mode === "labelstream";
         if (isLabelStream) {
           const selectedAnnotationID = getRoot(self).annotationStore.selected?.id;
-          console.log(`[LABEL STREAM] ${task.queue}, task ${task.id}, project ${task.project}, user ${getRoot(self).LSF.lsf.user.id}${selectedAnnotationID ? `, annotation ${selectedAnnotationID}` : ""}`);
+          console.log(
+            `[LABEL STREAM] ${task.queue}, task ${task.id}, project ${task.project}, user ${getRoot(self).LSF.lsf.user.id}${selectedAnnotationID ? `, annotation ${selectedAnnotationID}` : ""}`,
+          );
         }
 
         return task;


### PR DESCRIPTION
This pull request introduces a small but useful logging enhancement to the task creation process in the data manager. Specifically, it adds a detailed console log for tasks when operating in "labelstream" mode, which will help with debugging and tracking task assignments.

output will look like this:
<img width="1512" height="328" alt="image (1)" src="https://github.com/user-attachments/assets/38553c59-aa98-465e-8650-36b5ea0d991e" />

Logging improvements for label stream mode:

* Added a console log statement in the `create` function of `tasks.js` to output task queue, task ID, project, user ID, and (if available) the selected annotation ID when in "labelstream" mode.