### PR TITLE
fix: UTC-325: 'By Media Start Time' sort doesn't work with Video Object Tracking template

### DIFF
--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerPanel.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerPanel.tsx
@@ -13,10 +13,6 @@ import { getDocsUrl } from "../../../utils/docs";
 // Local type definitions based on ViewControls and RegionStore
 type GroupingOptions = "manual" | "label" | "type";
 type OrderingOptions = "score" | "date" | "mediaStartTime";
-type Region = {
-  id: string;
-  [key: string]: any; // Allow other properties for flexibility
-};
 
 interface OutlinerPanelProps extends PanelProps {
   regions: any;
@@ -47,13 +43,6 @@ const OutlinerPanelComponent: FC<OutlinerPanelProps> = ({ regions, ...props }) =
     [regions],
   );
 
-  const onFilterChange = useCallback(
-    (value: Region[] | null) => {
-      regions.setFilteredRegions(value);
-    },
-    [regions],
-  );
-
   useEffect(() => {
     setGroup(regions.group);
   }, []);
@@ -68,7 +57,6 @@ const OutlinerPanelComponent: FC<OutlinerPanelProps> = ({ regions, ...props }) =
         orderingDirection={regions.sortOrder}
         onOrderingChange={onOrderingChange}
         onGroupingChange={onGroupingChange}
-        onFilterChange={onFilterChange}
       />
       <OutlinerTreeComponent regions={regions} />
     </PanelBase>
@@ -90,13 +78,6 @@ const OutlinerStandAlone: FC<OutlinerPanelProps> = ({ regions }) => {
     [regions],
   );
 
-  const onFilterChange = useCallback(
-    (value: Region[] | null) => {
-      regions.setFilteredRegions(value);
-    },
-    [regions],
-  );
-
   return (
     <Block name="outliner" mix={OutlinerFFClasses}>
       <ViewControls
@@ -105,7 +86,6 @@ const OutlinerStandAlone: FC<OutlinerPanelProps> = ({ regions }) => {
         orderingDirection={regions.sortOrder}
         onOrderingChange={onOrderingChange}
         onGroupingChange={onGroupingChange}
-        onFilterChange={onFilterChange}
       />
       <OutlinerTreeComponent regions={regions} />
     </Block>

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
@@ -39,8 +39,14 @@ interface ViewControlsProps {
   onFilterChange: (filter: any) => void;
 }
 
+const mediaStartTimeSupportedTags = [
+  ["labels", "audio"],
+  ["timelinelabels", "video"],
+  ["timeserieslabels", "timeseries"],
+];
+
 export const ViewControls: FC<ViewControlsProps> = observer(
-  ({ ordering, regions, orderingDirection, onOrderingChange, onGroupingChange, onFilterChange }) => {
+  ({ ordering, regions, orderingDirection, onOrderingChange, onGroupingChange }) => {
     const grouping = regions.group;
     const context = useContext(SidePanelsContext);
 
@@ -48,10 +54,14 @@ export const ViewControls: FC<ViewControlsProps> = observer(
     const mediaTimeSupport: boolean | null = useMemo(() => {
       const names = regions.annotation?.names;
       if (!names || names.size === 0) return null;
-      // Any object tag of type audio, video, or timeseries enables the option
-      return Array.from(names.values()).some(
-        (tag: any) => tag?.isObjectTag && ["audio", "video", "timeseries"].includes(tag.type),
-      );
+
+      // Check if any tag combination matches the supported tuples
+      const tags = Array.from(names.values());
+
+      return mediaStartTimeSupportedTags.some((requiredTagTypes) => {
+        // Check if all tag names from the tuple exist in the configuration
+        return requiredTagTypes.every((requiredType) => tags.some((tag: any) => tag?.type === requiredType));
+      });
     }, [regions.annotation?.names]);
 
     // Auto-fallback to "date" if current ordering is "mediaStartTime" but no media-time support in config

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
@@ -55,11 +55,9 @@ export const ViewControls: FC<ViewControlsProps> = observer(
       const names = regions.annotation?.names;
       if (!names || names.size === 0) return null;
 
-      // Check if any tag combination matches the supported tuples
       const tags = Array.from(names.values());
-
+      // Check if all tag types from the tuple exist in the configuration
       return mediaStartTimeSupportedTags.some((requiredTagTypes) => {
-        // Check if all tag names from the tuple exist in the configuration
         return requiredTagTypes.every((requiredType) => tags.some((tag: any) => tag?.type === requiredType));
       });
     }, [regions.annotation?.names]);

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
@@ -36,7 +36,6 @@ interface ViewControlsProps {
   regions: any;
   onOrderingChange: (ordering: OrderingOptions) => void;
   onGroupingChange: (grouping: GroupingOptions) => void;
-  onFilterChange: (filter: any) => void;
 }
 
 const mediaStartTimeSupportedTags = [

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/__tests__/OutlinerPanel.test.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/__tests__/OutlinerPanel.test.tsx
@@ -277,52 +277,111 @@ describe("OutlinerPanel", () => {
   });
 
   describe("Media time sorting", () => {
-    it("supports mediaStartTime sorting option when media regions are present", () => {
-      const regionsWithMediaTime = {
+    it("supports mediaStartTime sorting option when labels and audio tags are in config", () => {
+      const regionsWithAudioConfig = {
         ...mockRegions,
         sort: "mediaStartTime",
+        annotation: {
+          names: new Map([
+            ["myLabels", { name: "myLabels", type: "labels" }],
+            ["myAudio", { name: "myAudio", type: "audio" }],
+          ]),
+        },
         regions: [
           { id: "1", type: "audioregion", start: 5.0, end: 10.0 },
           { id: "2", type: "audioregion", start: 2.0, end: 7.0 },
-          { id: "3", type: "timelineregion", ranges: [{ start: 15, end: 20 }] },
-          { id: "4", type: "timelineregion", ranges: [{ start: 8, end: 12 }] },
         ],
         filter: [
           { id: "1", type: "audioregion", start: 5.0, end: 10.0 },
           { id: "2", type: "audioregion", start: 2.0, end: 7.0 },
-          { id: "3", type: "timelineregion", ranges: [{ start: 15, end: 20 }] },
-          { id: "4", type: "timelineregion", ranges: [{ start: 8, end: 12 }] },
         ],
       };
 
-      render(<OutlinerPanel {...defaultProps} regions={regionsWithMediaTime} />);
+      render(<OutlinerPanel {...defaultProps} regions={regionsWithAudioConfig} />);
 
       const viewControls = screen.getByTestId("view-controls");
       expect(viewControls).toBeInTheDocument();
       expect(viewControls).toHaveAttribute("ordering", "mediaStartTime");
     });
 
-    it("hides mediaStartTime sorting option when no media regions are present", () => {
-      const regionsWithoutMediaTime = {
+    it("supports mediaStartTime sorting option when timelinelabels and video tags are in config", () => {
+      const regionsWithVideoConfig = {
+        ...mockRegions,
+        sort: "mediaStartTime",
+        annotation: {
+          names: new Map([
+            ["myTimelineLabels", { name: "myTimelineLabels", type: "timelinelabels" }],
+            ["myVideo", { name: "myVideo", type: "video" }],
+          ]),
+        },
+        regions: [
+          { id: "1", type: "timelineregion", ranges: [{ start: 15, end: 20 }] },
+          { id: "2", type: "timelineregion", ranges: [{ start: 8, end: 12 }] },
+        ],
+        filter: [
+          { id: "1", type: "timelineregion", ranges: [{ start: 15, end: 20 }] },
+          { id: "2", type: "timelineregion", ranges: [{ start: 8, end: 12 }] },
+        ],
+      };
+
+      render(<OutlinerPanel {...defaultProps} regions={regionsWithVideoConfig} />);
+
+      const viewControls = screen.getByTestId("view-controls");
+      expect(viewControls).toBeInTheDocument();
+      expect(viewControls).toHaveAttribute("ordering", "mediaStartTime");
+    });
+
+    it("does not support mediaStartTime when only labels tag is in config", () => {
+      const regionsWithoutMediaConfig = {
         ...mockRegions,
         sort: "date",
+        annotation: {
+          names: new Map([["myLabels", { name: "myLabels", type: "labels" }]]),
+        },
         regions: [
           { id: "1", type: "rectangle" },
           { id: "2", type: "polygon" },
-          { id: "3", type: "ellipse" },
         ],
         filter: [
           { id: "1", type: "rectangle" },
           { id: "2", type: "polygon" },
-          { id: "3", type: "ellipse" },
         ],
       };
 
-      render(<OutlinerPanel {...defaultProps} regions={regionsWithoutMediaTime} />);
+      render(<OutlinerPanel {...defaultProps} regions={regionsWithoutMediaConfig} />);
 
       const viewControls = screen.getByTestId("view-controls");
       expect(viewControls).toBeInTheDocument();
       expect(viewControls).toHaveAttribute("ordering", "date");
+      expect(viewControls).not.toHaveAttribute("ordering", "mediaStartTime");
+
+      // Verify setSort was not called (mediaStartTime option should not be available/attempted)
+      expect(regionsWithoutMediaConfig.setSort).not.toHaveBeenCalled();
+    });
+
+    it("does not support mediaStartTime when tags are mismatched (labels + video)", () => {
+      const regionsWithMismatchedConfig = {
+        ...mockRegions,
+        sort: "date",
+        annotation: {
+          names: new Map([
+            ["myLabels", { name: "myLabels", type: "labels" }],
+            ["myVideo", { name: "myVideo", type: "video" }],
+          ]),
+        },
+        regions: [],
+        filter: [],
+      };
+
+      render(<OutlinerPanel {...defaultProps} regions={regionsWithMismatchedConfig} />);
+
+      const viewControls = screen.getByTestId("view-controls");
+      expect(viewControls).toBeInTheDocument();
+      expect(viewControls).toHaveAttribute("ordering", "date");
+      expect(viewControls).not.toHaveAttribute("ordering", "mediaStartTime");
+
+      // Verify setSort was not called (mediaStartTime option should not be available/attempted)
+      expect(regionsWithMismatchedConfig.setSort).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Improved the detection to enable `Order by Media Start Time` to tuples rather than single tag types to avoid displaying the sorting option in label configs that cannot be sorted this way in the Region Panel of the Editor. Enabled tuples for now:

```typescript
const mediaStartTimeSupportedTags = [
  ["labels", "audio"],
  ["timelinelabels", "video"],
  ["timeserieslabels", "timeseries"],
];
```

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
