### PR TITLE
fix: UTC-219: [FE] Hotkeys do not work in Bulk Annotations drawer

### DIFF
--- a/web/libs/editor/src/stores/AppStore.js
+++ b/web/libs/editor/src/stores/AppStore.js
@@ -359,7 +359,13 @@ export default types
 
           entity?.submissionInProgress();
 
-          if (isReview) {
+          if (self.hasInterface("annotation:bulk")) {
+            const customButtons = self.customButtons?.get("_replace");
+            const submitButton = customButtons?.find((btn) => btn.name === "submit");
+            if (submitButton && !submitButton.disabled) {
+              self.handleCustomButton?.(submitButton);
+            }
+          } else if (isReview) {
             self.acceptAnnotation();
           } else if (!isUpdate && self.hasInterface("submit")) {
             self.submitAnnotation();


### PR DESCRIPTION
Fixed hotkey submission in bulk labeling by hooking into the customButtons which was not working before

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
