### PR TITLE
fix: FIT-272: Label / Review Stream 'Info Bar' is missing in the new Labeling UI (along with the info as to why the task is served to user)

### DIFF
--- a/web/libs/datamanager/src/stores/DataStores/tasks.js
+++ b/web/libs/datamanager/src/stores/DataStores/tasks.js
@@ -203,7 +203,7 @@ export const create = (columns) => {
         if (isLabelStream) {
           const selectedAnnotationID = getRoot(self).annotationStore.selected?.id;
           console.log(
-            `[LABEL STREAM] ${task.queue}, task ${task.id}, project ${task.project}, user ${getRoot(self).LSF.lsf.user.id}${selectedAnnotationID ? `, annotation ${selectedAnnotationID}` : ""}`,
+            `[LABEL STREAM] ${task.queue}, task ${task.id}, project ${getRoot(self)?.SDK?.project?.id}, user ${getRoot(self).LSF.lsf.user.id}${selectedAnnotationID ? `, annotation ${selectedAnnotationID}` : ""}`,
           );
         }
 


### PR DESCRIPTION
This pull request makes a minor update to the logging statement in the `tasks.js` store to improve the accuracy of the project ID being logged for label streaming events.

before: 
<img width="436" height="44" alt="image" src="https://github.com/user-attachments/assets/ade812ca-7807-4bb7-bc2c-3b241e4d8617" />

after:
<img width="422" height="31" alt="image" src="https://github.com/user-attachments/assets/02409bfa-3073-460e-bd8a-87bf9d259d37" />


* Logging improvement:
  * Updated the label stream log statement to use the project ID from `getRoot(self).SDK.project.id` instead of from the `task` object, ensuring the correct project ID is logged.