### PR TITLE
fix: Fix wrong reference to URL_CORS_DOCS

### DIFF
--- a/web/libs/editor/src/utils/messages.jsx
+++ b/web/libs/editor/src/utils/messages.jsx
@@ -80,7 +80,7 @@ export default {
       <p>
         There was an issue loading URL from <code>${attr}</code> value.
         Most likely that's because static server has wide-open CORS.
-        <a href="${this.URL_CORS_DOCS}" target="_blank">Read more on that here.</a>
+        <a href="${URL_CORS_DOCS}" target="_blank">Read more on that here.</a>
       </p>
       <p>
         Also check that:
@@ -106,7 +106,7 @@ export default {
           <li>URL scheme matches the service scheme, i.e. https and https</li>
           <li>
             The static server has wide-open CORS,
-            <a href=${this.URL_CORS_DOCS} target="_blank">more on that here</a>
+            <a href=${URL_CORS_DOCS} target="_blank">more on that here</a>
           </li>
         </ul>
       </p>


### PR DESCRIPTION
[Usages like this](https://github.com/HumanSignal/label-studio/blob/2660ec9857597f35130ce0e1e7e2ccde225cda4f/web/libs/editor/src/core/DataValidator/ConfigValidator.js#L97-L101) will have wrong `this` causing errors in [references](https://github.com/HumanSignal/label-studio/blob/2660ec9857597f35130ce0e1e7e2ccde225cda4f/web/libs/editor/src/utils/messages.jsx#L112) to `this.URL_CORS_DOCS`

<img width="671" height="70" alt="Screenshot 2025-10-16 at 15 18 07" src="https://github.com/user-attachments/assets/81a44999-3e69-49c1-bb57-18d2b7dc971d" />

