### PR TITLE
fix: FIT-822: BEM util names had typos remaining after modal refactor

### DIFF
--- a/web/apps/labelstudio/src/components/Breadcrumbs/Breadcrumbs.jsx
+++ b/web/apps/labelstudio/src/components/Breadcrumbs/Breadcrumbs.jsx
@@ -2,13 +2,13 @@ import { useEffect, useState } from "react";
 import { NavLink } from "react-router-dom";
 import { useConfig } from "../../providers/ConfigProvider";
 import { useBreadcrumbs, useFindRouteComponent } from "../../providers/RoutesProvider";
-import { BemWithSpecifiContext } from "../../utils/bem";
+import { BemWithSpecificContext } from "../../utils/bem";
 import { absoluteURL } from "../../utils/helpers";
 import { Dropdown } from "../Dropdown/Dropdown";
 import { Menu } from "../Menu/Menu";
 import "./Breadcrumbs.scss";
 
-const { Block, Elem } = BemWithSpecifiContext();
+const { Block, Elem } = BemWithSpecificContext();
 
 export const Breadcrumbs = () => {
   const config = useConfig();

--- a/web/apps/labelstudio/src/components/Form/Elements/RadioGroup/RadioGroup.jsx
+++ b/web/apps/labelstudio/src/components/Form/Elements/RadioGroup/RadioGroup.jsx
@@ -1,11 +1,11 @@
 import { createContext, useCallback, useContext, useEffect, useState } from "react";
 import { Label } from "..";
-import { BemWithSpecifiContext } from "../../../../utils/bem";
+import { BemWithSpecificContext } from "../../../../utils/bem";
 import { FormField } from "../../FormField";
 import "./RadioGroup.scss";
 
 const RadioContext = createContext();
-const { Block, Elem } = BemWithSpecifiContext();
+const { Block, Elem } = BemWithSpecificContext();
 
 export const RadioGroup = ({
   label,

--- a/web/apps/labelstudio/src/components/Menu/MenuContext.js
+++ b/web/apps/labelstudio/src/components/Menu/MenuContext.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { BemWithSpecifiContext } from "../../utils/bem";
+import { BemWithSpecificContext } from "../../utils/bem";
 
 export const MenuContext = React.createContext();
-export const { Block, Elem } = BemWithSpecifiContext();
+export const { Block, Elem } = BemWithSpecificContext();

--- a/web/apps/labelstudio/src/components/Space/Space.jsx
+++ b/web/apps/labelstudio/src/components/Space/Space.jsx
@@ -1,7 +1,7 @@
-import { BemWithSpecifiContext } from "../../utils/bem";
+import { BemWithSpecificContext } from "../../utils/bem";
 import "./Space.scss";
 
-const { Block } = BemWithSpecifiContext();
+const { Block } = BemWithSpecificContext();
 
 export const Space = ({ direction = "horizontal", size, className, style, children, spread, stretch, align }) => {
   return (

--- a/web/apps/labelstudio/src/pages/ExportPage/ExportPage.jsx
+++ b/web/apps/labelstudio/src/pages/ExportPage/ExportPage.jsx
@@ -6,7 +6,7 @@ import { Modal } from "../../components/Modal/Modal";
 import { Space } from "../../components/Space/Space";
 import { useAPI } from "../../providers/ApiProvider";
 import { useFixedLocation, useParams } from "../../providers/RoutesProvider";
-import { BemWithSpecifiContext } from "../../utils/bem";
+import { BemWithSpecificContext } from "../../utils/bem";
 import { isDefined } from "../../utils/helpers";
 import "./ExportPage.scss";
 
@@ -23,7 +23,7 @@ const downloadFile = (blob, filename) => {
   link.click();
 };
 
-const { Block, Elem } = BemWithSpecifiContext();
+const { Block, Elem } = BemWithSpecificContext();
 
 const wait = () => new Promise((resolve) => setTimeout(resolve, 5000));
 


### PR DESCRIPTION
<img width="1305" height="1663" alt="Screenshot 2025-10-17 at 8 02 45 AM" src="https://github.com/user-attachments/assets/f4f6a53d-5156-4446-a510-c57aba1cf15b" />

The Modal refactor also refactored the BEM utils, and fixed up some long standing typos, however a few instances were missed which broke the app entirely as can be seen in the above screenshot.