### PR TITLE
feat: FIT-784: Split member performance analytics into tabbed interface

### DIFF
--- a/web/libs/ui/src/index.ts
+++ b/web/libs/ui/src/index.ts
@@ -15,7 +15,6 @@ export * from "./lib/enterprise-badge/enterprise-badge";
 export * from "./lib/label/label";
 export * from "./lib/select/select";
 export * from "./lib/skeleton/skeleton";
-export * from "./lib/tabs/tabs";
 export * from "./lib/toast/toast";
 export * from "./lib/toggle/toggle";
 export * from "./lib/typography/typography";

--- a/web/libs/ui/src/index.ts
+++ b/web/libs/ui/src/index.ts
@@ -15,6 +15,7 @@ export * from "./lib/enterprise-badge/enterprise-badge";
 export * from "./lib/label/label";
 export * from "./lib/select/select";
 export * from "./lib/skeleton/skeleton";
+export * from "./lib/tabs/tabs";
 export * from "./lib/toast/toast";
 export * from "./lib/toggle/toggle";
 export * from "./lib/typography/typography";

--- a/web/libs/ui/src/lib/tabs/index.ts
+++ b/web/libs/ui/src/lib/tabs/index.ts
@@ -1,0 +1,1 @@
+export * from "./tabs";

--- a/web/libs/ui/src/lib/tabs/tabs.tsx
+++ b/web/libs/ui/src/lib/tabs/tabs.tsx
@@ -1,0 +1,1 @@
+export * from "../../shad/components/ui/tabs";

--- a/web/libs/ui/src/shad/components/ui/tabs.tsx
+++ b/web/libs/ui/src/shad/components/ui/tabs.tsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@humansignal/shad/utils";
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/web/libs/ui/src/shad/components/ui/tabs.tsx
+++ b/web/libs/ui/src/shad/components/ui/tabs.tsx
@@ -1,53 +1,88 @@
-import * as React from "react"
-import * as TabsPrimitive from "@radix-ui/react-tabs"
-
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
 import { cn } from "@humansignal/shad/utils";
+import { cva } from "class-variance-authority";
 
-const Tabs = TabsPrimitive.Root
+type TabsContextType = {
+  variant: "default";
+};
 
+const TabsContext = React.createContext<TabsContextType>({
+  variant: "default",
+});
+
+const Tabs = ({
+  variant = "default",
+  ...props
+}: React.ComponentPropsWithoutRef<typeof TabsPrimitive.Root> & {
+  variant?: "default";
+}) => {
+  return (
+    <TabsContext.Provider value={{ variant }}>
+      <TabsPrimitive.Root {...props} />
+    </TabsContext.Provider>
+  );
+};
+const tabsListVariants = cva("inline-flex justify-center items-center h-10 bg-neutral-surface p-1 gap-1", {
+  variants: {
+    variant: {
+      default: "border border-neutral-border rounded-smaller",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+  },
+});
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.List
-    ref={ref}
-    className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
-      className
-    )}
-    {...props}
-  />
-))
-TabsList.displayName = TabsPrimitive.List.displayName
+>(({ className, ...props }, ref) => {
+  const { variant } = React.useContext(TabsContext);
+  return <TabsPrimitive.List ref={ref} className={cn(tabsListVariants({ variant }), className)} {...props} />;
+});
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const tabsTriggerVariants = cva(
+  "inline-flex justify-center items-center h-8 px-tight text-body-regular font-medium transition-colors",
+  {
+    variants: {
+      variant: {
+        default:
+          "rounded-smaller data-[state=active]:bg-primary-background data-[state=active]:text-primary-content data-[state=active]:shadow-sm data-[state=inactive]:text-neutral-content-subtle hover:text-neutral-content",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
 
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
-      className
-    )}
-    {...props}
-  />
-))
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+>(({ className, ...props }, ref) => {
+  const { variant } = React.useContext(TabsContext);
+  return <TabsPrimitive.Trigger ref={ref} className={cn(tabsTriggerVariants({ variant }), className)} {...props} />;
+});
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const tabsContentVariants = cva("mt-2", {
+  variants: {
+    variant: {
+      default: "",
+    },
+  },
+});
 
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Content
-    ref={ref}
-    className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-      className
-    )}
-    {...props}
-  />
-))
-TabsContent.displayName = TabsPrimitive.Content.displayName
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content> & {
+    variant?: "default";
+  }
+>(({ className, ...props }, ref) => {
+  const { variant } = React.useContext(TabsContext);
+  return <TabsPrimitive.Content ref={ref} className={cn(tabsContentVariants({ variant }), className)} {...props} />;
+});
+TabsContent.displayName = TabsPrimitive.Content.displayName;
 
-export { Tabs, TabsList, TabsTrigger, TabsContent }
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/web/package.json
+++ b/web/package.json
@@ -61,6 +61,7 @@
     "@radix-ui/react-popover": "^1.1.6",
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-switch": "^1.2.5",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-toast": "^1.1.5",
     "@tanstack/query-core": "^5.66.0",
     "@tanstack/react-query": "^4",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -3951,6 +3951,11 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.2.tgz#83f415c4425f21e3d27914c12b3272a32e3dae65"
   integrity sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==
 
+"@radix-ui/primitive@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.3.tgz#e2dbc13bdc5e4168f4334f75832d7bdd3e2de5ba"
+  integrity sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==
+
 "@radix-ui/react-accordion@^1.2.11":
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-accordion/-/react-accordion-1.2.11.tgz#7837dd4d44aeed56aabad2b098727b8b4f89ae4c"
@@ -4196,6 +4201,14 @@
     "@radix-ui/react-compose-refs" "1.1.2"
     "@radix-ui/react-use-layout-effect" "1.1.1"
 
+"@radix-ui/react-presence@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.5.tgz#5d8f28ac316c32f078afce2996839250c10693db"
+  integrity sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
 "@radix-ui/react-primitive@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz#d49ea0f3f0b2fe3ab1cb5667eb03e8b843b914d0"
@@ -4217,6 +4230,21 @@
   integrity sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==
   dependencies:
     "@radix-ui/react-slot" "1.2.3"
+
+"@radix-ui/react-roving-focus@1.1.11":
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz#ef54384b7361afc6480dcf9907ef2fedb5080fd9"
+  integrity sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-collection" "1.1.7"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-direction" "1.1.1"
+    "@radix-ui/react-id" "1.1.1"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-callback-ref" "1.1.1"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
 
 "@radix-ui/react-slot@1.0.2":
   version "1.0.2"
@@ -4260,6 +4288,20 @@
     "@radix-ui/react-use-previous" "1.1.1"
     "@radix-ui/react-use-size" "1.1.1"
 
+"@radix-ui/react-tabs@^1.1.13":
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz#3537ce379d7e7ff4eeb6b67a0973e139c2ac1f15"
+  integrity sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-direction" "1.1.1"
+    "@radix-ui/react-id" "1.1.1"
+    "@radix-ui/react-presence" "1.1.5"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-roving-focus" "1.1.11"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+
 "@radix-ui/react-toast@^1.1.5":
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-toast/-/react-toast-1.1.5.tgz#f5788761c0142a5ae9eb97f0051fd3c48106d9e6"
@@ -4290,6 +4332,11 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz#bce938ca413675bc937944b0d01ef6f4a6dc5bf1"
   integrity sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==
+
+"@radix-ui/react-use-callback-ref@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz#62a4dba8b3255fdc5cc7787faeac1c6e4cc58d40"
+  integrity sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==
 
 "@radix-ui/react-use-controllable-state@1.0.1":
   version "1.0.1"


### PR DESCRIPTION
This pull request introduces a new reusable `Tabs` UI component to the shared UI library, making it available for use across the application. The implementation is based on the Radix UI Tabs primitive, wrapped with custom styling and re-exported through the library's public API.

New Tabs component:

* Added a new `Tabs` component (along with `TabsList`, `TabsTrigger`, and `TabsContent`) in `web/libs/ui/src/shad/components/ui/tabs.tsx`, using `@radix-ui/react-tabs` for accessibility and behavior, and applying custom styles.
* Re-exported the new `Tabs` component from `web/libs/ui/src/lib/tabs/tabs.tsx` and created an index file for easier imports. [[1]](diffhunk://#diff-f6ed64b39ad8a597e37902de61bafb8064720e37c12815ee8ecee97ab9361cceR1) [[2]](diffhunk://#diff-06d2229096e54cd95a640305da8067b9a17841c56477c2ba0e82acb5c03be373R1)
* Added the new `Tabs` component to the main UI library export in `web/libs/ui/src/index.ts`, making it available for consumers of the library.

Dependency update:

* Added `@radix-ui/react-tabs` as a new dependency in `web/package.json` to support the new Tabs component.