### PR TITLE
fix: BROS-479: Fix drawing continuation after region deletion

### DIFF
--- a/web/libs/editor/src/mixins/KonvaRegion.js
+++ b/web/libs/editor/src/mixins/KonvaRegion.js
@@ -51,6 +51,9 @@ export const KonvaRegionMixin = types
   })
   .actions((self) => {
     let deferredSelectId = null;
+    const Super = {
+      deleteRegion: self.deleteRegion,
+    };
 
     return {
       updateCursor(isHovered = false) {
@@ -165,6 +168,11 @@ export const KonvaRegionMixin = types
         // `selectArea` does nothing when there's a selected region already, but it should rerender to make `requestPerRegionFocus` work,
         // so it needs to use `selectAreas` instead. It contains `unselectAll` for this purpose.
         self.annotation.selectAreas([self]);
+      },
+      deleteRegion() {
+        const selectedTool = self.parent?.getToolsManager().findSelectedTool();
+        selectedTool?.enable?.();
+        Super.deleteRegion();
       },
     };
   });

--- a/web/libs/editor/src/regions/VectorRegion.jsx
+++ b/web/libs/editor/src/regions/VectorRegion.jsx
@@ -361,18 +361,8 @@ const Model = types
         try {
           const selection = self.vectorRef.getSelectedPointIds();
           const result = selection.length > 1;
-          if (result) {
-            console.log("🔍 VectorRegion.isTransforming() returning true", {
-              regionId: self.id,
-              selected: self.selected,
-              selectionLength: selection.length,
-              selection: selection,
-            });
-          }
           return result;
         } catch (error) {
-          // If there's an error accessing the selection, assume not transforming
-          console.log("🔍 VectorRegion.isTransforming() error", error);
           return false;
         }
       },

--- a/web/libs/editor/src/regions/VectorRegion.jsx
+++ b/web/libs/editor/src/regions/VectorRegion.jsx
@@ -211,20 +211,6 @@ const Model = types
         // For vector regions, we don't need to do anything special here
       },
 
-      deleteRegion() {
-        // Remove this region from the parent object
-        if (self.parent) {
-          const index = self.parent.regions.indexOf(self);
-          if (index > -1) {
-            self.parent.regions.splice(index, 1);
-          }
-        }
-        // Remove from annotation
-        if (self.annotation) {
-          self.annotation.removeArea(self);
-        }
-      },
-
       onSelection(type) {
         if (type === "reset") {
           self.vectorRef.clearSelection();
@@ -368,8 +354,27 @@ const Model = types
       // Checks is the region is being transformed or at least in
       // transformable state (has at least 2 points selected)
       isTransforming() {
-        const selection = self.vectorRef.getSelectedPointIds();
-        return selection.length > 1;
+        // If the region has no vectorRef or is not selected, it's not transforming
+        if (!self.vectorRef || !self.selected) {
+          return false;
+        }
+        try {
+          const selection = self.vectorRef.getSelectedPointIds();
+          const result = selection.length > 1;
+          if (result) {
+            console.log("🔍 VectorRegion.isTransforming() returning true", {
+              regionId: self.id,
+              selected: self.selected,
+              selectionLength: selection.length,
+              selection: selection,
+            });
+          }
+          return result;
+        } catch (error) {
+          // If there's an error accessing the selection, assume not transforming
+          console.log("🔍 VectorRegion.isTransforming() error", error);
+          return false;
+        }
       },
 
       segGroupRef(ref) {


### PR DESCRIPTION
In some cases after deleting a region it was impossible to draw another shape without page reload. This PR addresses this issue.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
