### PR TITLE
fix: UTC-325: By Media Start Time sort doesn't work with Video Object Tracking template

### DIFF
--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
@@ -40,6 +40,7 @@ interface ViewControlsProps {
 
 const mediaStartTimeSupportedTags = [
   ["labels", "audio"],
+  ["labels", "videorectangle", "video"],
   ["timelinelabels", "video"],
   ["timeserieslabels", "timeseries"],
 ];

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/__tests__/OutlinerPanel.test.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/__tests__/OutlinerPanel.test.tsx
@@ -331,6 +331,34 @@ describe("OutlinerPanel", () => {
       expect(viewControls).toHaveAttribute("ordering", "mediaStartTime");
     });
 
+    it("supports mediaStartTime sorting option when labels, videorectangle and video tags are in config", () => {
+      const regionsWithVideoRectangleConfig = {
+        ...mockRegions,
+        sort: "mediaStartTime",
+        annotation: {
+          names: new Map([
+            ["myLabels", { name: "myLabels", type: "labels" }],
+            ["myVideoRectangle", { name: "myVideoRectangle", type: "videorectangle" }],
+            ["myVideo", { name: "myVideo", type: "video" }],
+          ]),
+        },
+        regions: [
+          { id: "1", type: "videorectangleregion", sequence: [{ frame: 30, enabled: true, x: 10, y: 10 }] },
+          { id: "2", type: "videorectangleregion", sequence: [{ frame: 10, enabled: true, x: 20, y: 20 }] },
+        ],
+        filter: [
+          { id: "1", type: "videorectangleregion", sequence: [{ frame: 30, enabled: true, x: 10, y: 10 }] },
+          { id: "2", type: "videorectangleregion", sequence: [{ frame: 10, enabled: true, x: 20, y: 20 }] },
+        ],
+      };
+
+      render(<OutlinerPanel {...defaultProps} regions={regionsWithVideoRectangleConfig} />);
+
+      const viewControls = screen.getByTestId("view-controls");
+      expect(viewControls).toBeInTheDocument();
+      expect(viewControls).toHaveAttribute("ordering", "mediaStartTime");
+    });
+
     it("does not support mediaStartTime when only labels tag is in config", () => {
       const regionsWithoutMediaConfig = {
         ...mockRegions,

--- a/web/libs/editor/src/stores/RegionStore.js
+++ b/web/libs/editor/src/stores/RegionStore.js
@@ -280,6 +280,15 @@ export default types
           }
         }
 
+        // Handle video rectangle regions - they have sequence with frames
+        if (region.type === "videorectangleregion" && region.sequence && region.sequence.length > 0) {
+          // Get the first keyframe's frame number
+          const firstKeyframe = region.sequence[0];
+          if (firstKeyframe && typeof firstKeyframe.frame === "number") {
+            return firstKeyframe.frame;
+          }
+        }
+
         // Return null for regions without media time information
         return null;
       },

--- a/web/libs/editor/src/stores/RegionStore.js
+++ b/web/libs/editor/src/stores/RegionStore.js
@@ -272,21 +272,13 @@ export default types
         }
 
         // Handle timeline regions (video) - they have ranges with start frame
-        if (region.type === "timelineregion" && region.ranges && region.ranges.length > 0) {
-          // Get the first range's start frame
-          const firstRange = region.ranges[0];
-          if (firstRange && typeof firstRange.start === "number") {
-            return firstRange.start;
-          }
+        if (region.type === "timelineregion" && region.ranges?.[0]) {
+          return region.ranges[0].start;
         }
 
         // Handle video rectangle regions - they have sequence with frames
-        if (region.type === "videorectangleregion" && region.sequence && region.sequence.length > 0) {
-          // Get the first keyframe's frame number
-          const firstKeyframe = region.sequence[0];
-          if (firstKeyframe && typeof firstKeyframe.frame === "number") {
-            return firstKeyframe.frame;
-          }
+        if (region.type === "videorectangleregion" && region.sequence?.[0]) {
+          return region.sequence[0].frame;
         }
 
         // Return null for regions without media time information


### PR DESCRIPTION
Extended the allow list of tag combinations to trigger the sorting via `start media time` and handled the `videorectangleregion` data to sort accordingly

After:

https://github.com/user-attachments/assets/2e5bdea1-5925-4b57-8193-b87f64a0ccc8



<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
