### PR TITLE
feat: FIT-852: Add decoder=none option to Audio to allow fast progressive labeling of large video data

### DIFF
--- a/docs/source/includes/tags/audio.md
+++ b/docs/source/includes/tags/audio.md
@@ -14,7 +14,7 @@
 | [waveheight] | <code>string</code> | <code>32</code> | Minimum height of a waveform when in `splitchannels` mode with multiple channels to display. |
 | [spectrogram] | <code>boolean</code> | <code>false</code> | Determines whether an audio spectrogram is automatically displayed upon loading. |
 | [splitchannels] | <code>boolean</code> | <code>false</code> | Display multiple audio channels separately, if the audio file has more than one channel. (**NOTE: Requires more memory to operate.**) |
-| [decoder] | <code>string</code> | <code>&quot;webaudio&quot;</code> | Decoder type to use to decode audio data. (`"webaudio"` or `"ffmpeg"`) |
+| [decoder] | <code>string</code> | <code>&quot;webaudio&quot;</code> | Decoder type to use to decode audio data. (`"webaudio"`, `"ffmpeg"`, or `"none"` for no decoding - provides fast loading for large files but disables waveform visualization) |
 | [player] | <code>string</code> | <code>&quot;html5&quot;</code> | Player type to use to play audio data. (`"html5"` or `"webaudio"`) |
 
 ### Result parameters

--- a/web/libs/core/src/lib/utils/schema/tags.json
+++ b/web/libs/core/src/lib/utils/schema/tags.json
@@ -85,7 +85,7 @@
       },
       "decoder": {
         "name": "decoder",
-        "description": "Decoder type to use to decode audio data. (`\"webaudio\"` or `\"ffmpeg\"`)",
+        "description": "Decoder type to use to decode audio data. (`\"webaudio\"`, `\"ffmpeg\"`, or `\"none\"` for no decoding - provides fast loading for large files but disables waveform visualization)",
         "type": "string",
         "required": false,
         "default": "webaudio"

--- a/web/libs/editor/src/lib/AudioUltra/Visual/Visualizer.ts
+++ b/web/libs/editor/src/lib/AudioUltra/Visual/Visualizer.ts
@@ -326,9 +326,8 @@ export class Visualizer extends Events<VisualizerEvents> {
         this.maxZoom = Math.max(1, Math.ceil(this.audio.dataLength / this.width));
       }
     } else {
-      // No decoded data - render placeholder
+      // No decoded data
       this.renderers = [];
-      this.renderNoWaveformPlaceholder();
     }
 
     // Compose all layers together so that we cache the composition of the layers.
@@ -428,32 +427,6 @@ export class Visualizer extends Events<VisualizerEvents> {
       (this._loader as any).error = error;
       (this._loader as any).update();
     }
-  }
-
-  /**
-   * Render a placeholder in the waveform area when decoder is "none"
-   */
-  private renderNoWaveformPlaceholder() {
-    const waveformLayer = this.getLayer("waveform");
-    if (!waveformLayer) return;
-
-    const ctx = waveformLayer.context;
-    if (!ctx) return;
-
-    // Fill with background color
-    ctx.fillStyle = this.backgroundColor.toString();
-    ctx.fillRect(0, 0, waveformLayer.width, waveformLayer.height);
-
-    // Add centered text
-    ctx.fillStyle = "rgba(128, 128, 128, 0.5)";
-    ctx.font = "14px sans-serif";
-    ctx.textAlign = "center";
-    ctx.textBaseline = "middle";
-    ctx.fillText(
-      'Waveform rendering disabled (decoder="none" for fast loading)',
-      waveformLayer.width / 2,
-      waveformLayer.height / 2,
-    );
   }
 
   setZoom(value: number) {

--- a/web/libs/editor/src/lib/AudioUltra/Visual/Visualizer.ts
+++ b/web/libs/editor/src/lib/AudioUltra/Visual/Visualizer.ts
@@ -305,21 +305,30 @@ export class Visualizer extends Events<VisualizerEvents> {
       regionsLayer.height = this.height;
     }
 
-    // Set renderers array
-    this.renderers = [this.waveformRenderer];
-    if (this.waveformResizeRenderer) {
-      this.renderers.push(this.waveformResizeRenderer);
-    }
-    if (isFF(FF_AUDIO_SPECTROGRAMS) && this.spectrogramRenderer) {
-      this.renderers.push(this.spectrogramRenderer);
-      if (this.spectrogramResizeRenderer) {
-        this.renderers.push(this.spectrogramResizeRenderer);
-      }
-    }
+    // Check if we have decoded data
+    const hasDecodedData = this.wf.params.decoderType !== "none";
 
-    // Dynamically set maxZoom so you can zoom to 1:1 (one sample per pixel)
-    if (this.audio && this.width > 0) {
-      this.maxZoom = Math.max(1, Math.ceil(this.audio.dataLength / this.width));
+    if (hasDecodedData) {
+      // Set renderers array - only add waveform renderers if we have decoded data
+      this.renderers = [this.waveformRenderer];
+      if (this.waveformResizeRenderer) {
+        this.renderers.push(this.waveformResizeRenderer);
+      }
+      if (isFF(FF_AUDIO_SPECTROGRAMS) && this.spectrogramRenderer) {
+        this.renderers.push(this.spectrogramRenderer);
+        if (this.spectrogramResizeRenderer) {
+          this.renderers.push(this.spectrogramResizeRenderer);
+        }
+      }
+
+      // Dynamically set maxZoom so you can zoom to 1:1 (one sample per pixel)
+      if (this.audio && this.width > 0) {
+        this.maxZoom = Math.max(1, Math.ceil(this.audio.dataLength / this.width));
+      }
+    } else {
+      // No decoded data - render placeholder
+      this.renderers = [];
+      this.renderNoWaveformPlaceholder();
     }
 
     // Compose all layers together so that we cache the composition of the layers.
@@ -419,6 +428,32 @@ export class Visualizer extends Events<VisualizerEvents> {
       (this._loader as any).error = error;
       (this._loader as any).update();
     }
+  }
+
+  /**
+   * Render a placeholder in the waveform area when decoder is "none"
+   */
+  private renderNoWaveformPlaceholder() {
+    const waveformLayer = this.getLayer("waveform");
+    if (!waveformLayer) return;
+
+    const ctx = waveformLayer.context;
+    if (!ctx) return;
+
+    // Fill with background color
+    ctx.fillStyle = this.backgroundColor.toString();
+    ctx.fillRect(0, 0, waveformLayer.width, waveformLayer.height);
+
+    // Add centered text
+    ctx.fillStyle = "rgba(128, 128, 128, 0.5)";
+    ctx.font = "14px sans-serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(
+      'Waveform rendering disabled (decoder="none" for fast loading)',
+      waveformLayer.width / 2,
+      waveformLayer.height / 2,
+    );
   }
 
   setZoom(value: number) {
@@ -663,7 +698,12 @@ export class Visualizer extends Events<VisualizerEvents> {
       isVisible: false,
       height: this.waveformLayerHeight,
     });
-    this.createLayer({ name: "waveform", offscreen: true, zIndex: 100, height: this.waveformLayerHeight });
+    this.createLayer({
+      name: "waveform",
+      offscreen: true,
+      zIndex: 100,
+      height: this.waveformLayerHeight,
+    });
     this.createLayer({
       name: "waveform-resize",
       offscreen: true,
@@ -689,7 +729,13 @@ export class Visualizer extends Events<VisualizerEvents> {
         height: this.spectrogramLayerHeight,
         compositeOperation: "difference", // Use blend mode for better visibility
       });
-      this.createLayer({ name: "progress", offscreen: true, zIndex: 1020, isVisible: true, height: 0 });
+      this.createLayer({
+        name: "progress",
+        offscreen: true,
+        zIndex: 1020,
+        isVisible: true,
+        height: 0,
+      });
       this.createLayer({
         name: "spectrogram-grid",
         offscreen: true,

--- a/web/libs/editor/src/lib/AudioUltra/Waveform.ts
+++ b/web/libs/editor/src/lib/AudioUltra/Waveform.ts
@@ -105,8 +105,9 @@ export interface WaveformOptions {
 
   /**
    * Decoder used to decode the audio to waveform data.
+   * Use "none" to skip decoding for fast loading of large files (disables waveform visualization).
    */
-  decoderType?: "webaudio" | "ffmpeg";
+  decoderType?: "webaudio" | "ffmpeg" | "none";
 
   /**
    * Player used to play the audio data.
@@ -300,6 +301,16 @@ export class Waveform extends Events<WaveformEventTypes> {
 
   async load() {
     if (this.isDestroyed) return;
+
+    // Warn about incompatible features when decoder is "none"
+    if (this.params.decoderType === "none") {
+      if (this.params.splitChannels) {
+        console.warn('splitChannels is not available when decoder="none" (requires decoded audio data)');
+      }
+      if (this.params.playerType === "webaudio") {
+        console.warn('playerType="webaudio" is not available when decoder="none", forcing HTML5 player');
+      }
+    }
 
     const loader = this.media.load({
       muted: this.params.muted ?? false,

--- a/web/libs/editor/src/tags/object/Audio/model.js
+++ b/web/libs/editor/src/tags/object/Audio/model.js
@@ -90,7 +90,7 @@ const isSyncedBuffering = ff.isActive(ff.FF_SYNCED_BUFFERING);
  * @param {string} [waveheight=32] - Minimum height of a waveform when in `splitchannels` mode with multiple channels to display.
  * @param {boolean} [spectrogram=false] - Determines whether an audio spectrogram is automatically displayed upon loading.
  * @param {boolean} [splitchannels=false] - Display multiple audio channels separately, if the audio file has more than one channel. (**NOTE: Requires more memory to operate.**)
- * @param {string} [decoder=webaudio] - Decoder type to use to decode audio data. (`"webaudio"` or `"ffmpeg"`)
+ * @param {string} [decoder=webaudio] - Decoder type to use to decode audio data. (`"webaudio"`, `"ffmpeg"`, or `"none"` for no decoding - provides fast loading for large files but disables waveform visualization)
  * @param {string} [player=html5] - Player type to use to play audio data. (`"html5"` or `"webaudio"`)
  */
 const TagAttrs = types.model({
@@ -114,7 +114,7 @@ const TagAttrs = types.model({
   autocenter: types.optional(types.boolean, true),
   scrollparent: types.optional(types.boolean, true),
   splitchannels: types.optional(types.boolean, false),
-  decoder: types.optional(types.enumeration(["ffmpeg", "webaudio"]), "webaudio"),
+  decoder: types.optional(types.enumeration(["ffmpeg", "webaudio", "none"]), "webaudio"),
   player: types.optional(types.enumeration(["html5", "webaudio"]), "html5"),
   spectrogram: types.optional(types.boolean, false),
 });


### PR DESCRIPTION
This pull request introduces a new `"none"` decoder option for audio loading, enabling fast loading of large audio files by skipping waveform decoding and visualization. The changes ensure that when `"none"` is selected, only basic metadata is loaded, and features dependent on decoded data are disabled or handled gracefully. The implementation also adds warnings for incompatible options and updates documentation and type definitions to reflect the new decoder type.

**Support for fast loading without decoding:**

<img width="2428" height="224" alt="Screenshot 2025-10-23 at 9 45 32 AM" src="https://github.com/user-attachments/assets/bc1c94e2-d13d-4ebd-8d2e-04748c56a774" />

* Added `"none"` as a valid value for the `decoderType` option in audio-related interfaces and models (`WaveformAudioOptions`, `WaveformOptions`, and MST model) to allow skipping waveform decoding for large files. [[1]](diffhunk://#diff-0bb42b2a8307795a1233827e3fa685eb7f8105ef6085ec021600fb0d4cc59f0aL12-R12) [[2]](diffhunk://#diff-718fbaf07d4007a063f3219b8d8f72914e5a9ac9806e03cd12f294b775cc5093R108-R110) [[3]](diffhunk://#diff-e2a858f525c1edfcf6fc71dbe94a552fb00596317fe5fbe463367c35c2f2c403L117-R117)
* Implemented `loadWithoutDecoding` in `MediaLoader` to load only metadata when `decoderType` is `"none"`, bypassing decoding and waveform generation. [[1]](diffhunk://#diff-d502602e4c2c4ddcf82dc8d9213cfa92bd854d0d1318be747b3ff3485cd60779R70-R74) [[2]](diffhunk://#diff-d502602e4c2c4ddcf82dc8d9213cfa92bd854d0d1318be747b3ff3485cd60779R139-R204)

**Waveform and visualization adjustments:**

* Updated `WaveformAudio` and `Visualizer` classes to disable waveform rendering and related features when `decoderType` is `"none"`, including checks for decoded data and skipping renderer setup. [[1]](diffhunk://#diff-840324f862f81f5870f0146d988d96794250c39ac63f53ba1d75301e7288ec68L308-R312) [[2]](diffhunk://#diff-840324f862f81f5870f0146d988d96794250c39ac63f53ba1d75301e7288ec68R328-R331)
* Added logic to override duration and skip decoder creation, decoding, and waiting for decoded source in `WaveformAudio` when using `"none"`. [[1]](diffhunk://#diff-0bb42b2a8307795a1233827e3fa685eb7f8105ef6085ec021600fb0d4cc59f0aL34-R39) [[2]](diffhunk://#diff-0bb42b2a8307795a1233827e3fa685eb7f8105ef6085ec021600fb0d4cc59f0aR56-R57) [[3]](diffhunk://#diff-0bb42b2a8307795a1233827e3fa685eb7f8105ef6085ec021600fb0d4cc59f0aR85-R92) [[4]](diffhunk://#diff-0bb42b2a8307795a1233827e3fa685eb7f8105ef6085ec021600fb0d4cc59f0aR117-R119) [[5]](diffhunk://#diff-0bb42b2a8307795a1233827e3fa685eb7f8105ef6085ec021600fb0d4cc59f0aR151-R155) [[6]](diffhunk://#diff-0bb42b2a8307795a1233827e3fa685eb7f8105ef6085ec021600fb0d4cc59f0aR236-R238)

**User experience and warnings:**

* Added warnings in `Waveform` for incompatible features (like split channels and WebAudio player) when `"none"` decoder is selected, and forced HTML5 player for compatibility.

**Documentation and type updates:**

* Updated descriptions and documentation for the `decoderType` option in JSON schema and JSDoc comments to reflect the new `"none"` value and its behavior. [[1]](diffhunk://#diff-7ec5dd72ea263fd969cf59251dddf9f9e77c466aa220e712eb43359fa97dba4fL88-R88) [[2]](diffhunk://#diff-e2a858f525c1edfcf6fc71dbe94a552fb00596317fe5fbe463367c35c2f2c403L93-R93)

**Layer creation consistency:**

* Refactored layer creation in `Visualizer` for clarity and maintainability, though this is mostly stylistic and not directly related to the new feature. [[1]](diffhunk://#diff-840324f862f81f5870f0146d988d96794250c39ac63f53ba1d75301e7288ec68L666-R679) [[2]](diffhunk://#diff-840324f862f81f5870f0146d988d96794250c39ac63f53ba1d75301e7288ec68L692-R711)