### PR TITLE
docs: Add tutorials tab

### DIFF
--- a/docs/themes/v2/layout/partials/header.ejs
+++ b/docs/themes/v2/layout/partials/header.ejs
@@ -171,6 +171,11 @@
         tier: "all"
       },
       {
+        label: "Tutorials",
+        href: "/tutorials/",
+        tier: "all"
+      },
+      {
         label: "Templates",
         href: "/templates/",
         tier: "all"


### PR DESCRIPTION
This PR makes the new tutorials page public and adds a `Tutorials` tab to the header