### PR TITLE
fix: UTC-353: VideoRectangle interpolation (size/rotation) not applied between keyframes in video labeling UI

### DIFF
--- a/web/libs/editor/src/tags/object/Video/Rectangle.tsx
+++ b/web/libs/editor/src/tags/object/Video/Rectangle.tsx
@@ -61,7 +61,7 @@ const RectanglePure: FC<RectProps> = ({
   };
 
   return (
-    <Group id={id}>
+    <Group>
       <LabelOnVideoBbox
         reg={reg}
         box={newBox}
@@ -71,6 +71,7 @@ const RectanglePure: FC<RectProps> = ({
         adjacent
       />
       <Rect
+        id={id}
         {...newBox}
         fill={style.fillColor ?? "#fff"}
         stroke={style.strokeColor}


### PR DESCRIPTION
Repositioned the ids in the correct structures to restore the resize and rotation shape updating in the keyframe

Before:
https://github.com/user-attachments/assets/fa1a75cd-d705-4072-91e7-402b56a7b9ce


After:
https://github.com/user-attachments/assets/e3c36bca-6033-48a2-a7a3-7e9cb910aabe




<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
