### PR TITLE
docs: fix How to Debug Agents with LangSmith and Label Studio tutorial code block 

### DIFF
--- a/docs/source/tutorials/how_to_debug_agents_with_LangSmith_and_Label_Studio.md
+++ b/docs/source/tutorials/how_to_debug_agents_with_LangSmith_and_Label_Studio.md
@@ -185,7 +185,7 @@ for i, question in enumerate(questions, 1):
 ```
 
     
-    
+```
     [1m> Entering new AgentExecutor chain...[0m
     [32;1m[1;3mTo answer this question, I should search for the latest research articles on Visual Language Models on arXiv. This will provide me with the most recent developments and studies in this field.
     Action: arxiv
@@ -497,7 +497,7 @@ for i, question in enumerate(questions, 1):
     ✓ Run 3 completed. Run ID: ae390f69-6922-43f1-a98a-36c5da9f1af8
     Question: Explain the latest innovations in transformer architectures based on recent papers
     Response: Recent innovations in transformer architectures include their application to ECG diagnostics for better capturing temporal relationships, and advancements like Edge-MoE, which enhance computational ef...
-
+```
 
 ## 3. Collecting Traces
 


### PR DESCRIPTION
The text is getting treated as an inline code block because it’s not wrapped in backticks

Preview: https://deploy-preview-8734--heartex-docs.netlify.app/tutorials/how_to_debug_agents_with_langsmith_and_label_studio