### PR TITLE
docs: quick fix for tutorials

### DIFF
--- a/docs/source/tutorials/how_to_connect_Hugging_Face_with_Label_Studio_SDK.md
+++ b/docs/source/tutorials/how_to_connect_Hugging_Face_with_Label_Studio_SDK.md
@@ -103,9 +103,6 @@ This integration creates a powerful, automated ML workflow that transforms how y
 %pip install -q label-studio-sdk datasets transformers torch huggingface_hub accelerate
 
 print("✅ All packages installed successfully!")
-
-# 💡 Note: This installation snippet is also available in the Common Snippets notebook:
-# https://colab.research.google.com/drive/1nGTR48BzDshNvEAWjCa-R0GsHl_vRbwQ#scrollTo=zCXBqLUtJfWd (Section 1: Installation)
 ```
 
 ---

--- a/docs/source/tutorials/how_to_embed_evaluation_workflows_in_your_research_stack_with_Label_Studio.md
+++ b/docs/source/tutorials/how_to_embed_evaluation_workflows_in_your_research_stack_with_Label_Studio.md
@@ -11,7 +11,7 @@ report_bug_url: https://github.com/HumanSignal/awesome-label-studio-tutorials/is
 ---
 ## Label Studio Requirements
 
-This tutorial showcases one or more features available only in Label Studio Enterprise. We recommend [connecting with our team](mailto:sales@humansignal.com) to request a trial or to enable them in your account.
+This tutorial showcases one or more features available only in Label Studio Enterprise. We recommend [connecting with our team](https://humansignal.com/contact-sales/) to request a trial or to enable them in your account.
 
 ## The Context-Switching Tax
 
@@ -43,7 +43,7 @@ This tutorial has two parts:
 
 ### 👤 **Part 1: Admin Setup (One-Time, ~5 minutes)**
 Your Label Studio **Owner/Admin** needs to:
-- Enable embedding for your organization ([request access](mailto:sales@humansignal.com))
+- Enable embedding for your organization ([request access](https://humansignal.com/contact-sales/))
 - Run Part 1 to generate keys and configure organization
 - **Share the private key** with ML engineers (via secure channel)
 


### PR DESCRIPTION
- removed common script mention
- push people to contact sales instead of mail sales