### PR TITLE
docs: Update troubleshooting page to reflect PDF support

### DIFF
--- a/docs/source/guide/troubleshooting.md
+++ b/docs/source/guide/troubleshooting.md
@@ -104,10 +104,6 @@ ffmpeg -y -i audio.mp3 -ar 8k -ac 1 audio.wav
 
 See [Pre-annotations](#Pre-annotations) below. 
 
-### Can't label PDF data
-
-Label Studio does not support labeling PDF files directly. However, you can convert files to HTML using your PDF viewer or another tool and label the PDF as part of the HTML. See an example labeling configuration in the [Label Studio playground](/playground/?config=%3CView%3E%3Cbr%3E%20%20%3CHyperText%20name%3D%22pdf%22%20value%3D%22%24pdf%22%2F%3E%3Cbr%3E%3Cbr%3E%20%20%3CHeader%20value%3D%22Rate%20this%20article%22%2F%3E%3Cbr%3E%20%20%3CRating%20name%3D%22rating%22%20toName%3D%22pdf%22%20maxRating%3D%2210%22%20icon%3D%22star%22%20size%3D%22medium%22%20%2F%3E%3Cbr%3E%3Cbr%3E%20%20%3CChoices%20name%3D%22choices%22%20choice%3D%22single-radio%22%20toName%3D%22pdf%22%20showInline%3D%22true%22%3E%3Cbr%3E%20%20%20%20%3CChoice%20value%3D%22Important%20article%22%2F%3E%3Cbr%3E%20%20%20%20%3CChoice%20value%3D%22Yellow%20press%22%2F%3E%3Cbr%3E%20%20%3C%2FChoices%3E%3Cbr%3E%3C%2FView%3E%3Cbr%3E).
-
 ## Cloud and local storage
 
 When working with an external Cloud Storage connection (S3, GCS, Azure), keep the following in mind:


### PR DESCRIPTION
Removed section in troubleshooting page that says PDF is not supported