### PR TITLE
docs: Add table of contents to Tutorials

### DIFF
--- a/docs/themes/v2/layout/page.ejs
+++ b/docs/themes/v2/layout/page.ejs
@@ -1,5 +1,5 @@
 <% const isEnterpriseTheme=theme.tier==="enterprise" %>
-<% const tocPageTypes = page.type === "guide" || page.type === "blog" || page.type === "templates" || page.type === "tags" || page.type === "plugins" %>
+<% const tocPageTypes = page.type === "guide" || page.type === "blog" || page.type === "templates" || page.type === "tags" || page.type === "plugins" || page.tutorial %>
 
 <% const formattedContent=removeContent(page.content) %>
 <% const tocContent=replaceContent(formattedContent) %>


### PR DESCRIPTION
Add table of contents to Tutorials pages

To review: https://deploy-preview-8795--heartex-docs.netlify.app/tutorials/how_to_compare_two_ai_models_with_label_studio
