### PR TITLE
fix: FIT-986: Visual regression affecting Filters in Datamanager

### DIFF
--- a/web/libs/editor/src/tags/Custom.jsx
+++ b/web/libs/editor/src/tags/Custom.jsx
@@ -1,6 +1,3 @@
-// Function-based CustomInterface available only in Label Studio Enterprise
-import React from "react";
-
 import { types } from "mobx-state-tree";
 import { observer } from "mobx-react";
 import { EnterpriseBadge } from "@humansignal/ui";

--- a/web/libs/ui/src/lib/select/select.tsx
+++ b/web/libs/ui/src/lib/select/select.tsx
@@ -394,23 +394,8 @@ export const Select = forwardRef(
                         ref: infiniteLoaderRef,
                       }: { onItemsRendered: (params: any) => void; ref: any }) => {
                         // Calculate height based on actual item count from flatOptions
-                        // When searching, _options is already flattened; when not searching, we need to count children
-                        const actualItemCount =
-                          searchable && query.trim()
-                            ? _options.length // Already flattened when searching
-                            : flatOptions.filter((flatOption) => {
-                                // Find which flat options are part of the current _options
-                                return _options.some((opt) => {
-                                  const optValue = opt?.value ?? opt;
-                                  const flatValue = flatOption?.value ?? flatOption;
-                                  if (optValue === flatValue) return true;
-                                  // Check if this flat option is a child of an option group
-                                  return opt?.children?.some((child) => {
-                                    const childValue = child?.value ?? child;
-                                    return childValue === flatValue;
-                                  });
-                                });
-                              }).length;
+                        // When searching, _options is filtered and flat; when not searching, _options === options (all items)
+                        const actualItemCount = searchable && query.trim() ? _options.length : flatOptions.length;
                         const maxVisibleItems = VARIABLE_LIST_COUNT_RENDERED;
                         const listHeight = Math.min(actualItemCount, maxVisibleItems) * VARIABLE_LIST_ITEM_HEIGHT;
 

--- a/web/libs/ui/src/lib/select/select.tsx
+++ b/web/libs/ui/src/lib/select/select.tsx
@@ -393,8 +393,24 @@ export const Select = forwardRef(
                         onItemsRendered,
                         ref: infiniteLoaderRef,
                       }: { onItemsRendered: (params: any) => void; ref: any }) => {
-                        // Calculate height based on actual item count, max 5 items
-                        const actualItemCount = renderedOptions.length;
+                        // Calculate height based on actual item count from flatOptions
+                        // When searching, _options is already flattened; when not searching, we need to count children
+                        const actualItemCount =
+                          searchable && query.trim()
+                            ? _options.length // Already flattened when searching
+                            : flatOptions.filter((flatOption) => {
+                                // Find which flat options are part of the current _options
+                                return _options.some((opt) => {
+                                  const optValue = opt?.value ?? opt;
+                                  const flatValue = flatOption?.value ?? flatOption;
+                                  if (optValue === flatValue) return true;
+                                  // Check if this flat option is a child of an option group
+                                  return opt?.children?.some((child) => {
+                                    const childValue = child?.value ?? child;
+                                    return childValue === flatValue;
+                                  });
+                                });
+                              }).length;
                         const maxVisibleItems = VARIABLE_LIST_COUNT_RENDERED;
                         const listHeight = Math.min(actualItemCount, maxVisibleItems) * VARIABLE_LIST_ITEM_HEIGHT;
 


### PR DESCRIPTION
This pull request makes targeted improvements to the UI component logic in `select.tsx` and cleans up imports in `Custom.jsx`. The most significant change is a refinement to how the Select dropdown calculates the number of visible items, ensuring more accurate rendering when options are grouped or filtered.

before:
<img width="523" height="235" alt="Screenshot 2025-11-12 at 3 42 18 PM" src="https://github.com/user-attachments/assets/0cc4ddba-0237-451f-bb48-f6d05243f75b" />

after:
<img width="621" height="374" alt="Screenshot 2025-11-12 at 3 42 40 PM" src="https://github.com/user-attachments/assets/7cff258a-f018-4341-b562-964812d7d853" />


**UI component improvements:**

* Improved the logic for calculating the number of visible items in the Select dropdown by accurately counting items from `flatOptions` and handling both searching and non-searching states, including support for option groups.

**Code cleanup:**

* Removed unused imports from `Custom.jsx` to streamline the file.