### PR TITLE
docs: remove whitespace from bibtex citation key

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ You can use Label Studio as an independent part of your machine learning workflo
 Include a citation for Label Studio in the **References** section of your articles:
 
 ```tex
-@misc{Label Studio,
+@misc{labelStudio,
   title={{Label Studio}: Data labeling software},
   url={https://github.com/HumanSignal/label-studio},
   note={Open source software available from https://github.com/HumanSignal/label-studio},


### PR DESCRIPTION
<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->

It has been reported several times that the current citation key in the README was invalid (#5939 and #3067) but the associated change has never got merged for some reason.

The current citation key is invalid because it contains a whitespace, confirmed by multiple sources:
1. https://bibdesk.sourceforge.io/manual/BibDeskHelp_2.html
2. https://tex.stackexchange.com/questions/224674/can-i-have-a-reference-with-spacing-using-bibtex-like-citeauthor-year (cited by #3067)

This makes it impossible to automatically import the reference in reference management systems such as Zotero, e.g.:

```
Studio = value expected, equals sign missing: ",\n title={{Label St"... at line 6762, column 19 in "misc"
```
