### PR TITLE
Fix: Prevent Grid overlay from blocking interactions

### DIFF
--- a/web/libs/editor/src/components/ImageGrid/ImageGrid.jsx
+++ b/web/libs/editor/src/components/ImageGrid/ImageGrid.jsx
@@ -34,7 +34,7 @@ export default observer(
       );
 
       return (
-        <Layer opacity={0.15} name="ruler">
+        <Layer opacity={0.15} name="ruler" listening={false}>
           {Object.values(grid).map((n, i) => (
             <Rect
               key={i}


### PR DESCRIPTION
Fixed grid blocking interactions by adding listening={false} to the Layer component in ImageGrid.jsx
closes #3378
<!--
 - Reason for change: 
 When users add a grid overlay to their annotation setup, they lose the ability to annotate.
 This is because the grid overlay is capturing mouse interactions.
 Disabling listening for the grid overlay stops it from capturing mouse interactions.
 - Screenshots: Not visible
 - Rollout strategy: Small change, shouldn't require anything. If necessary, a feature flag.
 - Testing: 
When grid is not in the annotation config, clicking and dragging to make annotations adds annotations to the image.
```
<View>
  <Image name="image" value="$image"/>
  <RectangleLabels name="label" toName="image">
    <Label value="Airplane" background="green"/>
    <Label value="Car" background="blue"/>
  </RectangleLabels>
</View>
```
When grid is enabled in annotation config, user cannot create annotations through clicking and dragging
```
<View>
  <Image name="image" value="$image" grid="true"/>
  <RectangleLabels name="label" toName="image">
    <Label value="Airplane" background="green"/>
    <Label value="Car" background="blue"/>
  </RectangleLabels>
</View>
```
When fix is applied with same config, it now works again.
 - Risks: No security or performance risks.
 - Notes:
 The only line that uses ImageGrid is in ImageView.jsx:
`      {item.grid && item.sizeUpdated && <ImageGrid item={item} />}
` which does not use any event listeners, so it cannot break anything else.

This is my first time making a contribution to label studio, so if I made any mistakes, please let me know. 
-->