### PR TITLE
chore: FIT-1017: Add Annotation ID data attribute to Annotation tab

### DIFF
--- a/web/libs/editor/src/components/AnnotationTabs/AnnotationTabs.jsx
+++ b/web/libs/editor/src/components/AnnotationTabs/AnnotationTabs.jsx
@@ -15,6 +15,7 @@ export const EntityTab = observer(
       return (
         <div
           ref={ref}
+          data-annotation-id={entity.pk ?? entity.id}
           className={cn("entity-tab").mod({ selected, bordered }).toClassName()}
           style={style}
           onClick={(e) => {

--- a/web/libs/editor/src/components/AnnotationsCarousel/AnnotationButton.tsx
+++ b/web/libs/editor/src/components/AnnotationsCarousel/AnnotationButton.tsx
@@ -287,7 +287,10 @@ export const AnnotationButton = observer(
     );
 
     return (
-      <div className={cn("annotation-button").mod({ selected: entity.selected }).toClassName()}>
+      <div
+        className={cn("annotation-button").mod({ selected: entity.selected }).toClassName()}
+        data-annotation-id={entity.pk ?? entity.id}
+      >
         <div className={cn("annotation-button").elem("mainSection").toClassName()} onClick={clickHandler}>
           <div className={cn("annotation-button").elem("picSection").toClassName()}>
             <Userpic

--- a/web/libs/editor/tests/integration/e2e/core/annotation-id.cy.ts
+++ b/web/libs/editor/tests/integration/e2e/core/annotation-id.cy.ts
@@ -1,0 +1,149 @@
+import { LabelStudio, ToolBar } from "@humansignal/frontend-test/helpers/LSF";
+import { FF_DEV_3873 } from "../../../../src/utils/feature-flags";
+
+describe("Annotation ID", () => {
+  beforeEach(() => {
+    LabelStudio.addFeatureFlagsOnPageLoad({
+      [FF_DEV_3873]: true,
+    });
+  });
+
+  it("should have data-annotation-id attribute matching the copied annotation ID", () => {
+    // Initialize with multiple annotations to test with different IDs
+    LabelStudio.init({
+      config: `<View>
+        <Text name="text" value="$text"/>
+        <Choices name="choice" toName="text">
+          <Choice value="Choice1"/>
+          <Choice value="Choice2"/>
+        </Choices>
+      </View>`,
+      task: {
+        id: 1,
+        annotations: [
+          { id: 1001, result: [] },
+          { id: 1002, result: [] },
+          { id: 1003, result: [] },
+        ],
+        predictions: [],
+        data: {
+          text: "Sample text for annotation testing",
+        },
+      },
+    });
+
+    LabelStudio.waitForObjectsReady();
+
+    // Get all annotation buttons
+    cy.get(".lsf-annotation-button").should("have.length", 3);
+
+    // Test the first annotation (ID 1001)
+    cy.log("Testing annotation ID 1001");
+    cy.get(".lsf-annotation-button")
+      .eq(0)
+      .should("have.attr", "data-annotation-id", "1001");
+
+    // Open the context menu for the first annotation
+    cy.get(".lsf-annotation-button__trigger").eq(0).click();
+
+    // Click "Copy Annotation ID" from the dropdown
+    cy.get(".lsf-dropdown")
+      .should("be.visible")
+      .find('[class*="option--"]')
+      .contains("Copy Annotation ID")
+      .click();
+
+    // Verify the clipboard contains the correct annotation ID
+    cy.window().then((win) => {
+      win.navigator.clipboard.readText().then((text) => {
+        expect(text).to.equal("1001");
+      });
+    });
+
+    // Test the second annotation (ID 1002)
+    cy.log("Testing annotation ID 1002");
+    cy.get(".lsf-annotation-button")
+      .eq(1)
+      .should("have.attr", "data-annotation-id", "1002");
+
+    // Open the context menu for the second annotation
+    cy.get(".lsf-annotation-button__trigger").eq(1).click();
+
+    // Click "Copy Annotation ID" from the dropdown
+    cy.get(".lsf-dropdown")
+      .should("be.visible")
+      .find('[class*="option--"]')
+      .contains("Copy Annotation ID")
+      .click();
+
+    // Verify the clipboard contains the correct annotation ID
+    cy.window().then((win) => {
+      win.navigator.clipboard.readText().then((text) => {
+        expect(text).to.equal("1002");
+      });
+    });
+
+    // Test the third annotation (ID 1003)
+    cy.log("Testing annotation ID 1003");
+    cy.get(".lsf-annotation-button")
+      .eq(2)
+      .should("have.attr", "data-annotation-id", "1003");
+
+    // Open the context menu for the third annotation
+    cy.get(".lsf-annotation-button__trigger").eq(2).click();
+
+    // Click "Copy Annotation ID" from the dropdown
+    cy.get(".lsf-dropdown")
+      .should("be.visible")
+      .find('[class*="option--"]')
+      .contains("Copy Annotation ID")
+      .click();
+
+    // Verify the clipboard contains the correct annotation ID
+    cy.window().then((win) => {
+      win.navigator.clipboard.readText().then((text) => {
+        expect(text).to.equal("1003");
+      });
+    });
+  });
+
+  it("should allow selecting annotation by data-annotation-id attribute", () => {
+    LabelStudio.init({
+      config: `<View>
+        <Text name="text" value="$text"/>
+        <Choices name="choice" toName="text">
+          <Choice value="Choice1"/>
+        </Choices>
+      </View>`,
+      task: {
+        id: 1,
+        annotations: [
+          { id: 2001, result: [] },
+          { id: 2002, result: [] },
+        ],
+        predictions: [],
+        data: {
+          text: "Sample text",
+        },
+      },
+    });
+
+    LabelStudio.waitForObjectsReady();
+
+    // Verify we can select annotation by data-annotation-id
+    cy.log("Selecting annotation with ID 2002 using data attribute");
+    cy.get('[data-annotation-id="2002"]').should("exist").click();
+
+    // Verify the annotation is selected
+    cy.get('[data-annotation-id="2002"]').should("have.class", "lsf-annotation-button_selected");
+
+    // Select different annotation
+    cy.log("Selecting annotation with ID 2001 using data attribute");
+    cy.get('[data-annotation-id="2001"]').should("exist").click();
+
+    // Verify the new annotation is selected and the previous one is not
+    cy.get('[data-annotation-id="2001"]').should("have.class", "lsf-annotation-button_selected");
+    cy.get('[data-annotation-id="2002"]').should("not.have.class", "lsf-annotation-button_selected");
+  });
+});
+

--- a/web/libs/editor/tests/integration/e2e/core/annotation-id.cy.ts
+++ b/web/libs/editor/tests/integration/e2e/core/annotation-id.cy.ts
@@ -1,4 +1,4 @@
-import { LabelStudio, ToolBar } from "@humansignal/frontend-test/helpers/LSF";
+import { LabelStudio } from "@humansignal/frontend-test/helpers/LSF";
 import { FF_DEV_3873 } from "../../../../src/utils/feature-flags";
 
 describe("Annotation ID", () => {
@@ -39,19 +39,13 @@ describe("Annotation ID", () => {
 
     // Test the first annotation (ID 1001)
     cy.log("Testing annotation ID 1001");
-    cy.get(".lsf-annotation-button")
-      .eq(0)
-      .should("have.attr", "data-annotation-id", "1001");
+    cy.get(".lsf-annotation-button").eq(0).should("have.attr", "data-annotation-id", "1001");
 
     // Open the context menu for the first annotation
     cy.get(".lsf-annotation-button__trigger").eq(0).click();
 
     // Click "Copy Annotation ID" from the dropdown
-    cy.get(".lsf-dropdown")
-      .should("be.visible")
-      .find('[class*="option--"]')
-      .contains("Copy Annotation ID")
-      .click();
+    cy.get(".lsf-dropdown").should("be.visible").find('[class*="option--"]').contains("Copy Annotation ID").click();
 
     // Verify the clipboard contains the correct annotation ID
     cy.window().then((win) => {
@@ -62,19 +56,13 @@ describe("Annotation ID", () => {
 
     // Test the second annotation (ID 1002)
     cy.log("Testing annotation ID 1002");
-    cy.get(".lsf-annotation-button")
-      .eq(1)
-      .should("have.attr", "data-annotation-id", "1002");
+    cy.get(".lsf-annotation-button").eq(1).should("have.attr", "data-annotation-id", "1002");
 
     // Open the context menu for the second annotation
     cy.get(".lsf-annotation-button__trigger").eq(1).click();
 
     // Click "Copy Annotation ID" from the dropdown
-    cy.get(".lsf-dropdown")
-      .should("be.visible")
-      .find('[class*="option--"]')
-      .contains("Copy Annotation ID")
-      .click();
+    cy.get(".lsf-dropdown").should("be.visible").find('[class*="option--"]').contains("Copy Annotation ID").click();
 
     // Verify the clipboard contains the correct annotation ID
     cy.window().then((win) => {
@@ -85,19 +73,13 @@ describe("Annotation ID", () => {
 
     // Test the third annotation (ID 1003)
     cy.log("Testing annotation ID 1003");
-    cy.get(".lsf-annotation-button")
-      .eq(2)
-      .should("have.attr", "data-annotation-id", "1003");
+    cy.get(".lsf-annotation-button").eq(2).should("have.attr", "data-annotation-id", "1003");
 
     // Open the context menu for the third annotation
     cy.get(".lsf-annotation-button__trigger").eq(2).click();
 
     // Click "Copy Annotation ID" from the dropdown
-    cy.get(".lsf-dropdown")
-      .should("be.visible")
-      .find('[class*="option--"]')
-      .contains("Copy Annotation ID")
-      .click();
+    cy.get(".lsf-dropdown").should("be.visible").find('[class*="option--"]').contains("Copy Annotation ID").click();
 
     // Verify the clipboard contains the correct annotation ID
     cy.window().then((win) => {
@@ -146,4 +128,3 @@ describe("Annotation ID", () => {
     cy.get('[data-annotation-id="2002"]').should("not.have.class", "lsf-annotation-button_selected");
   });
 });
-

--- a/web/libs/editor/tests/integration/e2e/core/annotation-id.cy.ts
+++ b/web/libs/editor/tests/integration/e2e/core/annotation-id.cy.ts
@@ -8,7 +8,7 @@ describe("Annotation ID", () => {
     });
   });
 
-  it("should have data-annotation-id attribute matching the copied annotation ID", () => {
+  it("should have data-annotation-id attribute on all annotation buttons", () => {
     // Initialize with multiple annotations to test with different IDs
     LabelStudio.init({
       config: `<View>
@@ -37,55 +37,55 @@ describe("Annotation ID", () => {
     // Get all annotation buttons
     cy.get(".lsf-annotation-button").should("have.length", 3);
 
-    // Test the first annotation (ID 1001)
-    cy.log("Testing annotation ID 1001");
-    cy.get(".lsf-annotation-button").eq(0).should("have.attr", "data-annotation-id", "1001");
+    // Annotations are displayed in reverse order (newest first)
+    // Verify each annotation button has the correct data-annotation-id attribute
+    cy.log("Verifying data-annotation-id attributes");
+    cy.get('[data-annotation-id="1003"]').should("exist");
+    cy.get('[data-annotation-id="1002"]').should("exist");
+    cy.get('[data-annotation-id="1001"]').should("exist");
 
-    // Open the context menu for the first annotation
-    cy.get(".lsf-annotation-button__trigger").eq(0).click();
-
-    // Click "Copy Annotation ID" from the dropdown
-    cy.get(".lsf-dropdown").should("be.visible").find('[class*="option--"]').contains("Copy Annotation ID").click();
-
-    // Verify the clipboard contains the correct annotation ID
-    cy.window().then((win) => {
-      win.navigator.clipboard.readText().then((text) => {
-        expect(text).to.equal("1001");
-      });
-    });
-
-    // Test the second annotation (ID 1002)
-    cy.log("Testing annotation ID 1002");
+    // Verify the attributes are on the annotation buttons in the correct order
+    cy.get(".lsf-annotation-button").eq(0).should("have.attr", "data-annotation-id", "1003");
     cy.get(".lsf-annotation-button").eq(1).should("have.attr", "data-annotation-id", "1002");
+    cy.get(".lsf-annotation-button").eq(2).should("have.attr", "data-annotation-id", "1001");
+  });
 
-    // Open the context menu for the second annotation
-    cy.get(".lsf-annotation-button__trigger").eq(1).click();
-
-    // Click "Copy Annotation ID" from the dropdown
-    cy.get(".lsf-dropdown").should("be.visible").find('[class*="option--"]').contains("Copy Annotation ID").click();
-
-    // Verify the clipboard contains the correct annotation ID
-    cy.window().then((win) => {
-      win.navigator.clipboard.readText().then((text) => {
-        expect(text).to.equal("1002");
-      });
+  it("should copy the correct annotation ID to clipboard", () => {
+    // Initialize with a single annotation for simpler clipboard testing
+    LabelStudio.init({
+      config: `<View>
+        <Text name="text" value="$text"/>
+        <Choices name="choice" toName="text">
+          <Choice value="Choice1"/>
+        </Choices>
+      </View>`,
+      task: {
+        id: 1,
+        annotations: [{ id: 5001, result: [] }],
+        predictions: [],
+        data: {
+          text: "Sample text",
+        },
+      },
     });
 
-    // Test the third annotation (ID 1003)
-    cy.log("Testing annotation ID 1003");
-    cy.get(".lsf-annotation-button").eq(2).should("have.attr", "data-annotation-id", "1003");
+    LabelStudio.waitForObjectsReady();
 
-    // Open the context menu for the third annotation
-    cy.get(".lsf-annotation-button__trigger").eq(2).click();
-
-    // Click "Copy Annotation ID" from the dropdown
-    cy.get(".lsf-dropdown").should("be.visible").find('[class*="option--"]').contains("Copy Annotation ID").click();
-
-    // Verify the clipboard contains the correct annotation ID
+    // Stub the clipboard API
     cy.window().then((win) => {
-      win.navigator.clipboard.readText().then((text) => {
-        expect(text).to.equal("1003");
-      });
+      cy.stub(win.navigator.clipboard, "writeText").resolves();
+    });
+
+    // Verify the data-annotation-id attribute matches what gets copied
+    cy.get('[data-annotation-id="5001"]').should("exist");
+
+    // Open context menu and copy annotation ID
+    cy.get(".lsf-annotation-button__trigger").click();
+    cy.get(".lsf-dropdown:visible").find('[class*="option--"]').contains("Copy Annotation ID").click();
+
+    // Verify clipboard was called with the same ID as the data attribute
+    cy.window().then((win) => {
+      expect(win.navigator.clipboard.writeText).to.have.been.calledWith("5001");
     });
   });
 


### PR DESCRIPTION
This pull request adds a new `data-annotation-id` attribute to annotation-related UI components, making it easier to uniquely identify and interact with annotations in the DOM. It also introduces comprehensive end-to-end tests to verify the correct behavior of this attribute, including clipboard interactions and selection logic.

**UI attribute enhancements:**

* Added `data-annotation-id={entity.pk ?? entity.id}` to the root element of the `EntityTab` component in `AnnotationTabs.jsx`, ensuring each annotation tab is uniquely identifiable in the DOM.
* Added `data-annotation-id={entity.pk ?? entity.id}` to the root element of the `AnnotationButton` component in `AnnotationButton.tsx`, enabling consistent identification of annotation buttons.

**Testing improvements:**

* Introduced a new end-to-end test suite (`annotation-id.cy.ts`) to verify that the `data-annotation-id` attribute is correctly set, matches the annotation ID, supports clipboard copy functionality, and allows selection of annotations via the data attribute.