### PR TITLE
fix: FIT-1030: Agreement Selected dropdown is broken

### DIFF
--- a/web/libs/datamanager/src/components/Common/Table/TableHead/TableHead.jsx
+++ b/web/libs/datamanager/src/components/Common/Table/TableHead/TableHead.jsx
@@ -1,6 +1,6 @@
 import { observer, useLocalStore } from "mobx-react";
 import { toJS } from "mobx";
-import React, { forwardRef, useCallback, useEffect, useRef, useState } from "react";
+import React, { forwardRef, useCallback, useEffect, useRef } from "react";
 import { ViewColumnType, ViewColumnTypeName, ViewColumnTypeShort } from "../../../../stores/Tabs/tab_column";
 import { Button } from "@humansignal/ui";
 import { Dropdown } from "@humansignal/ui";
@@ -72,34 +72,27 @@ const AgreementSelectedWrapper = observer(({ column, children }) => {
   const root = getRoot(column.original);
   const selectedView = root.viewsStore.selected;
   const agreementFilters = selectedView.agreement_selected;
-  const [isOpen, setIsOpen] = useState(false);
   const ref = useRef(null);
   const closeHandler = () => {
     ref.current?.close();
-    setIsOpen(false);
   };
   const onSave = (agreementFilters) => {
     selectedView.setAgreementFilters(agreementFilters);
     closeHandler();
     return selectedView.save();
   };
-  const onToggle = (isOpen) => {
-    setIsOpen(isOpen);
-  };
+
   return (
     <Dropdown.Trigger
       ref={ref}
       content={
-        isOpen ? (
-          <AgreementSelected.HeaderCell
-            agreementFilters={agreementFilters}
-            onSave={onSave}
-            align="left"
-            onClose={closeHandler}
-          />
-        ) : null
+        <AgreementSelected.HeaderCell
+          agreementFilters={agreementFilters}
+          onSave={onSave}
+          align="left"
+          onClose={closeHandler}
+        />
       }
-      onToggle={onToggle}
     >
       <Button
         look="outlined"


### PR DESCRIPTION
This pull request simplifies the `AgreementSelectedWrapper` component in the `TableHead` by removing unnecessary state management related to the dropdown's open/close state. The logic now relies solely on the dropdown's internal state, streamlining the component.

[screen-recorder-thu-nov-20-2025-21-57-32.webm](https://github.com/user-attachments/assets/f6b19011-0ec1-441a-b0b8-4de94556246a)


**Component simplification:**

* Removed the `useState` hook and all related logic (`isOpen`, `setIsOpen`, and `onToggle`) from the `AgreementSelectedWrapper` component, relying instead on the dropdown's own state management. (`[[1]](diffhunk://#diff-51ab382cac0e258f4e4a21289401f0fda6d405059dae8badcc56b0c9e2bc8d5dL3-R3)`, `[[2]](diffhunk://#diff-51ab382cac0e258f4e4a21289401f0fda6d405059dae8badcc56b0c9e2bc8d5dL75-L102)`)