### PR TITLE
chore: Update imports to new location for Dropdown

### DIFF
--- a/web/apps/labelstudio/src/components/index.js
+++ b/web/apps/labelstudio/src/components/index.js
@@ -1,7 +1,6 @@
 export { Breadcrumbs } from "./Breadcrumbs/Breadcrumbs";
 export { Card } from "./Card/Card";
 export { Columns } from "./Columns/Columns";
-export { Dropdown } from "./Dropdown/Dropdown";
 export { Hamburger } from "./Hamburger/Hamburger";
 export { Menu } from "./Menu/Menu";
 export { Menubar } from "./Menubar/Menubar";

--- a/web/apps/labelstudio/src/pages/Projects/ProjectsList.jsx
+++ b/web/apps/labelstudio/src/pages/Projects/ProjectsList.jsx
@@ -3,8 +3,8 @@ import { format } from "date-fns";
 import { useMemo } from "react";
 import { NavLink } from "react-router-dom";
 import { IconCheck, IconEllipsis, IconMinus, IconSparks } from "@humansignal/icons";
-import { Userpic, Button } from "@humansignal/ui";
-import { Dropdown, Menu, Pagination } from "../../components";
+import { Userpic, Button, Dropdown } from "@humansignal/ui";
+import { Menu, Pagination } from "../../components";
 import { cn } from "../../utils/bem";
 import { absoluteURL } from "../../utils/helpers";
 

--- a/web/apps/labelstudio/src/pages/Settings/MachineLearningSettings/MachineLearningList.jsx
+++ b/web/apps/labelstudio/src/pages/Settings/MachineLearningSettings/MachineLearningList.jsx
@@ -2,8 +2,8 @@ import { formatDistanceToNow, format, parseISO } from "date-fns";
 import { useCallback, useContext } from "react";
 
 import truncate from "truncate-middle";
-import { Dropdown, Menu } from "../../../components";
-import { Button } from "@humansignal/ui";
+import { Menu } from "../../../components";
+import { Button, Dropdown } from "@humansignal/ui";
 import { confirm } from "../../../components/Modal/Modal";
 import { Oneof } from "../../../components/Oneof/Oneof";
 import { IconEllipsis } from "@humansignal/icons";
@@ -95,7 +95,12 @@ const BackendCard = ({ backend, onStartTrain, onEdit, onDelete, onTestRequest })
         <div className={rootClass.elem("group")}>{truncate(backend.url, 20, 10, "...")}</div>
         <div className={rootClass.elem("group")}>
           <Tooltip title={format(parseISO(backend.created_at), "yyyy-MM-dd HH:mm:ss")}>
-            <span>Created&nbsp;{formatDistanceToNow(parseISO(backend.created_at), { addSuffix: true })}</span>
+            <span>
+              Created&nbsp;
+              {formatDistanceToNow(parseISO(backend.created_at), {
+                addSuffix: true,
+              })}
+            </span>
           </Tooltip>
         </div>
       </div>

--- a/web/apps/labelstudio/src/pages/Settings/PredictionsSettings/PredictionsList.jsx
+++ b/web/apps/labelstudio/src/pages/Settings/PredictionsSettings/PredictionsList.jsx
@@ -1,8 +1,8 @@
 import { useCallback, useContext } from "react";
 
 import { format, formatDistanceToNow, parseISO } from "date-fns";
-import { Dropdown, Menu } from "../../../components";
-import { Button } from "@humansignal/ui";
+import { Menu } from "../../../components";
+import { Button, Dropdown } from "@humansignal/ui";
 import { IconInfoOutline, IconPredictions, IconEllipsis } from "@humansignal/icons";
 import { Tooltip } from "@humansignal/ui";
 import { confirm } from "../../../components/Modal/Modal";
@@ -74,7 +74,11 @@ const VersionCard = ({ version, selected, onSelect, editable, onDelete }) => {
           <div className={rootClass.elem("group")}>
             Last prediction created&nbsp;
             <Tooltip title={format(parseISO(version.latest), "yyyy-MM-dd HH:mm:ss")}>
-              <span>{formatDistanceToNow(parseISO(version.latest), { addSuffix: true })}</span>
+              <span>
+                {formatDistanceToNow(parseISO(version.latest), {
+                  addSuffix: true,
+                })}
+              </span>
             </Tooltip>
           </div>
         </div>

--- a/web/apps/labelstudio/src/pages/Settings/StorageSettings/StorageCard.jsx
+++ b/web/apps/labelstudio/src/pages/Settings/StorageSettings/StorageCard.jsx
@@ -1,6 +1,6 @@
 import { useCallback, useContext, useEffect, useState } from "react";
-import { Card, Dropdown, Menu } from "../../../components";
-import { Button } from "@humansignal/ui";
+import { Card, Menu } from "../../../components";
+import { Button, Dropdown } from "@humansignal/ui";
 import { ApiContext } from "../../../providers/ApiProvider";
 import { StorageSummary } from "./StorageSummary";
 import { IconEllipsisVertical } from "@humansignal/icons";


### PR DESCRIPTION
Updating leftover imports to new location in UI lib.

All dropdowns are building and working correctly:

<img width="3008" height="1668" alt="Screenshot 2025-11-21 at 6 11 39 AM" src="https://github.com/user-attachments/assets/2c503fdf-297c-43fe-a0f8-ef95f800f660" />
