### PR TITLE
fix: BROS-477: Prevent closing project creation window when pressing Esc to exit region

### DIFF
--- a/web/libs/editor/src/stores/AppStore.js
+++ b/web/libs/editor/src/stores/AppStore.js
@@ -470,7 +470,10 @@ export default types
         if (!annotation.isDrawing) annotation.redo();
       });
 
-      hotkeys.addNamed("region:exit", () => {
+      hotkeys.addNamed("region:exit", (e) => {
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+
         const c = self.annotationStore.selected;
         const managers = ToolsManager.allInstances();
         const tools = managers

--- a/web/libs/editor/src/stores/AppStore.js
+++ b/web/libs/editor/src/stores/AppStore.js
@@ -471,7 +471,6 @@ export default types
       });
 
       hotkeys.addNamed("region:exit", (e) => {
-        e.stopPropagation();
         e.stopImmediatePropagation();
 
         const c = self.annotationStore.selected;


### PR DESCRIPTION
When pressing Esc to unselect region, the Project Creation dialog will close abruptly.

This PR fixes this issue.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
