### PR TITLE
fix: Prevent Grid overlay from blocking interactions (fixed formatting) #8826

### DIFF
--- a/web/libs/editor/src/components/ImageGrid/ImageGrid.jsx
+++ b/web/libs/editor/src/components/ImageGrid/ImageGrid.jsx
@@ -34,7 +34,7 @@ export default observer(
       );
 
       return (
-        <Layer opacity={0.15} name="ruler">
+        <Layer opacity={0.15} name="ruler" listening={false}>
           {Object.values(grid).map((n, i) => (
             <Rect
               key={i}


### PR DESCRIPTION
closes #3378

<!--

Some pointers to think about when filling out your PR description:
 - Reason for change: 
 If grid is enabled, click and dragging or double clicking to draw an annotation does not work, as described in issue 3378.
 Added listening={false} to grid overlay, so the grid does not capture the mouse events.
 - Testing: Description of how this is being verified
 I don't have a unit test, but I verified the behavior that you can draw annotations again while the grid is enabled after this fix is applied.
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 No. It only affects one line of code, and that line is only used in one place, and there are no event listeners on the grid.
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.
 
 Reposted with correct title to fix formatting.
-->
