### PR TITLE
fix: BROS-642: [oss regression] Redis is used by default if it's available

### DIFF
--- a/label_studio/core/redis.py
+++ b/label_studio/core/redis.py
@@ -79,7 +79,9 @@ def redis_healthcheck():
 
 
 def redis_connected():
-    return redis_healthcheck()
+    if settings.REDIS_ENABLED:
+        return redis_healthcheck()
+    return False
 
 
 def _is_serializable(value: Any) -> bool:

--- a/label_studio/core/settings/base.py
+++ b/label_studio/core/settings/base.py
@@ -346,6 +346,9 @@ TEMPLATES = [
     }
 ]
 
+# OSS version does not support Redis
+REDIS_ENABLED = False
+
 # RQ
 RQ_QUEUES = {
     'critical': {

--- a/label_studio/io_storages/base_models.py
+++ b/label_studio/io_storages/base_models.py
@@ -29,7 +29,6 @@ from django.db.models import JSONField
 from django.shortcuts import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
-from django_rq import job
 from io_storages.utils import StorageObject, get_uri_via_regex, parse_bucket_uri
 from rest_framework.exceptions import ValidationError
 from rq.job import Job

--- a/label_studio/io_storages/base_models.py
+++ b/label_studio/io_storages/base_models.py
@@ -723,7 +723,6 @@ class ProjectStorageMixin(models.Model):
         abstract = True
 
 
-@job('low')
 def import_sync_background(storage_class, storage_id, timeout=settings.RQ_LONG_JOB_TIMEOUT, **kwargs):
     storage = storage_class.objects.get(id=storage_id)
     try:
@@ -736,13 +735,11 @@ def import_sync_background(storage_class, storage_id, timeout=settings.RQ_LONG_J
         return
 
 
-@job('low', timeout=settings.RQ_LONG_JOB_TIMEOUT)
 def export_sync_background(storage_class, storage_id, **kwargs):
     storage = storage_class.objects.get(id=storage_id)
     storage.save_all_annotations()
 
 
-@job('low', timeout=settings.RQ_LONG_JOB_TIMEOUT)
 def export_sync_only_new_background(storage_class, storage_id, **kwargs):
     storage = storage_class.objects.get(id=storage_id)
     storage.save_only_new_annotations()

--- a/label_studio/users/functions/last_activity.py
+++ b/label_studio/users/functions/last_activity.py
@@ -14,7 +14,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.utils import timezone as django_timezone
-from django_rq import get_connection, job
+from django_rq import get_connection
 
 logger = logging.getLogger(__name__)
 

--- a/label_studio/users/functions/last_activity.py
+++ b/label_studio/users/functions/last_activity.py
@@ -302,7 +302,6 @@ def cleanup_redis_activity_data(user_ids: Set[int]) -> bool:
         return False
 
 
-@job('low', timeout=3600)
 def sync_user_activities_to_db(max_users: int = None) -> dict:
     """
     Synchronize user activities from Redis to database.


### PR DESCRIPTION
If you already have a running Redis instance, it will be used automatically in the open source LS. This leads to stuck jobs because OSS does not have RQ workers. It happened after we upgrade django-rq library to 2.10. 