### PR TITLE
fix: FIT-1048: Ensure FSM queryset annotations work for background processes based on the correct FF

### DIFF
--- a/label_studio/fsm/queryset_mixins.py
+++ b/label_studio/fsm/queryset_mixins.py
@@ -13,11 +13,14 @@ Usage:
             return TaskQuerySet(self.model, using=self._db).annotate_fsm_state()
 
 Note:
-    All state annotation functionality is guarded by TWO feature flags:
-    1. 'fflag_feat_fit_568_finite_state_management' - Controls FSM background calculations
-    2. 'fflag_feat_fit_710_fsm_state_fields' - Controls state field display in APIs
+    State annotation is guarded by 'fflag_feat_fit_568_finite_state_management' only.
+    This allows background FSM processes to annotate current_state for internal use.
 
-    When disabled, no annotation is performed and there is zero performance impact.
+    UI/API consumption of state fields is separately controlled by serializers
+    that check BOTH 'fflag_feat_fit_568_finite_state_management' AND
+    'fflag_feat_fit_710_fsm_state_fields' before exposing state data.
+
+    When the flag is disabled, no annotation is performed and there is zero performance impact.
 """
 
 import logging
@@ -74,13 +77,12 @@ class FSMStateQuerySetMixin:
             - If no state exists for an entity, `current_state` will be None
             - The state is read-only and should not be modified directly
         """
-        # Check feature flag directly (works for both core and enterprise)
-        # Using flag_set directly instead of is_fsm_enabled to work in enterprise context
+        # Check only fflag_feat_fit_568_finite_state_management for background FSM processes.
+        # This allows background processes to annotate current_state for internal use.
+        # UI/API serializers separately check both fflag_feat_fit_568 AND fflag_feat_fit_710
+        # before exposing state data to consumers.
         user = CurrentContext.get_user()
-        if not (
-            flag_set('fflag_feat_fit_568_finite_state_management', user=user)
-            and flag_set('fflag_feat_fit_710_fsm_state_fields', user=user)
-        ):
+        if not flag_set('fflag_feat_fit_568_finite_state_management', user=user):
             logger.debug('FSM feature flag disabled, skipping state annotation')
             return self
 

--- a/label_studio/projects/api.py
+++ b/label_studio/projects/api.py
@@ -1,9 +1,10 @@
-"""This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
-"""
+"""This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license."""
+
 import logging
 import os
 import pathlib
 
+from core.feature_flags import flag_set
 from core.filters import ListFilter
 from core.label_config import config_essential_data_has_changed
 from core.mixins import GetParentObjectMixin
@@ -184,11 +185,15 @@ class ProjectListAPI(generics.ListCreateAPIView):
         )
         if filter in ['pinned_only', 'exclude_pinned']:
             projects = projects.filter(pinned_at__isnull=filter == 'exclude_pinned')
-        return (
-            ProjectManager.with_counts_annotate(projects, fields=fields)
-            .annotate_fsm_state()
-            .prefetch_related('members', 'created_by')
-        )
+        projects = ProjectManager.with_counts_annotate(projects, fields=fields)
+
+        # Only annotate FSM state for UI/API consumption when both feature flags are enabled
+        if flag_set('fflag_feat_fit_568_finite_state_management', user=self.request.user) and flag_set(
+            'fflag_feat_fit_710_fsm_state_fields', user=self.request.user
+        ):
+            projects = projects.annotate_fsm_state()
+
+        return projects.prefetch_related('members', 'created_by')
 
     def get_serializer_context(self):
         context = super(ProjectListAPI, self).get_serializer_context()
@@ -242,11 +247,17 @@ class ProjectCountsListAPI(generics.ListAPIView):
         serializer = GetFieldsSerializer(data=self.request.query_params)
         serializer.is_valid(raise_exception=True)
         fields = serializer.validated_data.get('include')
-        return (
-            Project.objects.with_counts(fields=fields)
-            .annotate_fsm_state()
-            .filter(organization=self.request.user.active_organization)
+        projects = Project.objects.with_counts(fields=fields).filter(
+            organization=self.request.user.active_organization
         )
+
+        # Only annotate FSM state for UI/API consumption when both feature flags are enabled
+        if flag_set('fflag_feat_fit_568_finite_state_management', user=self.request.user) and flag_set(
+            'fflag_feat_fit_710_fsm_state_fields', user=self.request.user
+        ):
+            projects = projects.annotate_fsm_state()
+
+        return projects
 
 
 @method_decorator(
@@ -353,7 +364,7 @@ class ProjectCountsListAPI(generics.ListAPIView):
 )
 class ProjectAPI(generics.RetrieveUpdateDestroyAPIView):
     parser_classes = (JSONParser, FormParser, MultiPartParser)
-    queryset = Project.objects.with_counts().annotate_fsm_state()
+    queryset = Project.objects.with_counts()
     permission_required = ViewClassPermission(
         GET=all_permissions.projects_view,
         DELETE=all_permissions.projects_delete,
@@ -370,11 +381,17 @@ class ProjectAPI(generics.RetrieveUpdateDestroyAPIView):
         serializer = GetFieldsSerializer(data=self.request.query_params)
         serializer.is_valid(raise_exception=True)
         fields = serializer.validated_data.get('include')
-        return (
-            Project.objects.with_counts(fields=fields)
-            .annotate_fsm_state()
-            .filter(organization=self.request.user.active_organization)
+        projects = Project.objects.with_counts(fields=fields).filter(
+            organization=self.request.user.active_organization
         )
+
+        # Only annotate FSM state for UI/API consumption when both feature flags are enabled
+        if flag_set('fflag_feat_fit_568_finite_state_management', user=self.request.user) and flag_set(
+            'fflag_feat_fit_710_fsm_state_fields', user=self.request.user
+        ):
+            projects = projects.annotate_fsm_state()
+
+        return projects
 
     def get(self, request, *args, **kwargs):
         return super(ProjectAPI, self).get(request, *args, **kwargs)


### PR DESCRIPTION
This pull request updates the logic for how finite state machine (FSM) state annotations are handled in querysets, clarifying and simplifying the use of feature flags. The main change is that state annotation for internal/background processes is now controlled by a single feature flag, while the exposure of state data to the UI/API remains gated by both flags at the serializer level.

Feature flag handling improvements:

* State annotation in `annotate_fsm_state` is now controlled only by the `'fflag_feat_fit_568_finite_state_management'` flag, allowing background processes to annotate `current_state` for internal use without considering the UI/API flag. (`label_studio/fsm/queryset_mixins.py`, [label_studio/fsm/queryset_mixins.pyL77-R85](diffhunk://#diff-94a93567c58417748a5a220038c784a3f8edf55b804a356c046787a81412b4caL77-R85))
* Documentation in `get_queryset` is updated to clarify that only the FSM background calculation flag is used for annotation, and that serializers are responsible for checking both flags before exposing state data to consumers. (`label_studio/fsm/queryset_mixins.py`, [label_studio/fsm/queryset_mixins.pyL16-R23](diffhunk://#diff-94a93567c58417748a5a220038c784a3f8edf55b804a356c046787a81412b4caL16-R23))