### PR TITLE
fix: FIT-1054: Ensure redis cache is used if available for all FSM operations which use cache

### DIFF
--- a/label_studio/fsm/state_manager.py
+++ b/label_studio/fsm/state_manager.py
@@ -12,13 +12,40 @@ from typing import Any, Dict, List, Optional, Type
 from core.current_request import CurrentContext
 from core.feature_flags import flag_set
 from django.conf import settings
-from django.core.cache import cache
+from django.core.cache import cache, caches
 from django.db.models import Model, QuerySet
 from fsm.registry import get_state_model_for_entity
 from fsm.state_models import BaseState
 from fsm.transition_executor import execute_transition_with_state_manager
 
 logger = logging.getLogger(__name__)
+
+
+_fsm_cache = None
+
+
+def get_fsm_cache():
+    """
+    Get the cache backend for FSM operations.
+
+    Uses REDIS_CACHE_ALIAS when available (LSE) to ensure FSM caching works
+    even when DUMMY_CACHE is enabled. Falls back to default cache for LSO.
+
+    The result is memoized so the cache lookup only happens once per process.
+
+    Returns:
+        Cache backend instance
+    """
+    global _fsm_cache
+    if _fsm_cache is not None:
+        return _fsm_cache
+
+    redis_cache_alias = getattr(settings, 'REDIS_CACHE_ALIAS', None)
+    if redis_cache_alias and redis_cache_alias in settings.CACHES:
+        _fsm_cache = caches[redis_cache_alias]
+    else:
+        _fsm_cache = cache
+    return _fsm_cache
 
 
 class StateManagerError(Exception):
@@ -90,9 +117,10 @@ class StateManager:
             return None  # Feature disabled, return no state
 
         cache_key = cls.get_cache_key(entity)
+        fsm_cache = get_fsm_cache()
 
         # Try cache first
-        cached_state = cache.get(cache_key)
+        cached_state = fsm_cache.get(cache_key)
         if cached_state is not None:
             logger.info(
                 'FSM: Cache hit',
@@ -116,7 +144,7 @@ class StateManager:
 
             # Cache result
             if current_state is not None:
-                cache.set(cache_key, current_state, cls.CACHE_TTL)
+                fsm_cache.set(cache_key, current_state, cls.CACHE_TTL)
                 logger.info(
                     'FSM: Cache miss',
                     extra={
@@ -237,6 +265,7 @@ class StateManager:
         # Optimistic concurrency control using cache-based locking
         cache_key = cls.get_cache_key(entity)
         lock_key = f'{cache_key}:lock'
+        fsm_cache = get_fsm_cache()
 
         if organization_id is None:
             organization_id = CurrentContext.get_organization_id()
@@ -244,7 +273,7 @@ class StateManager:
         try:
             # Try to acquire an optimistic lock using cache add (atomic operation)
             # add() only succeeds if the key doesn't exist
-            lock_acquired = cache.add(lock_key, 'locked', timeout=5)  # 5 second timeout
+            lock_acquired = fsm_cache.add(lock_key, 'locked', timeout=5)  # 5 second timeout
 
             if not lock_acquired:
                 # Another process is currently transitioning this entity
@@ -313,7 +342,7 @@ class StateManager:
 
                 # Write-through cache: Update immediately
                 # This ensures the cache is updated atomically with the database
-                cache.set(cache_key, new_state, cls.CACHE_TTL)
+                fsm_cache.set(cache_key, new_state, cls.CACHE_TTL)
 
                 logger.info(
                     'FSM: Cache updated for transition state',
@@ -347,12 +376,12 @@ class StateManager:
 
             finally:
                 # Always release the lock, regardless of success or failure
-                cache.delete(lock_key)
+                fsm_cache.delete(lock_key)
 
         except Exception as e:
             # On failure, clean up lock and invalidate potentially stale cache
-            cache.delete(lock_key)
-            cache.delete(cache_key)
+            fsm_cache.delete(lock_key)
+            fsm_cache.delete(cache_key)
 
             # Get organization_id for error logging if it wasn't set earlier
             organization_id = CurrentContext.get_organization_id()
@@ -421,7 +450,8 @@ class StateManager:
     def invalidate_cache(cls, entity: Model):
         """Invalidate cached state for an entity"""
         cache_key = cls.get_cache_key(entity)
-        cache.delete(cache_key)
+        fsm_cache = get_fsm_cache()
+        fsm_cache.delete(cache_key)
         organization_id = CurrentContext.get_organization_id()
         logger.info(
             'FSM: Cache invalidated',
@@ -450,7 +480,8 @@ class StateManager:
                 cache_updates[cache_key] = current_state
 
         if cache_updates:
-            cache.set_many(cache_updates, cls.CACHE_TTL)
+            fsm_cache = get_fsm_cache()
+            fsm_cache.set_many(cache_updates, cls.CACHE_TTL)
             logger.info(
                 'FSM: Cache warmed',
                 extra={

--- a/label_studio/fsm/state_manager.py
+++ b/label_studio/fsm/state_manager.py
@@ -82,6 +82,24 @@ class StateManager:
     CACHE_PREFIX = 'fsm:current'
 
     @classmethod
+    def clear_fsm_cache(cls):
+        """
+        Clear all FSM-related cache keys.
+
+        Uses delete_pattern if available (django-redis), otherwise logs a warning.
+        This is primarily used for test isolation.
+        """
+        fsm_cache = get_fsm_cache()
+        pattern = f'{cls.CACHE_PREFIX}:*'
+        if hasattr(fsm_cache, 'delete_pattern'):
+            fsm_cache.delete_pattern(pattern)
+        else:
+            logger.warning(
+                'FSM cache clear requested but cache backend does not support delete_pattern. '
+                'FSM cache keys may persist.'
+            )
+
+    @classmethod
     def _is_fsm_enabled(cls, user='auto') -> bool:
         if user == 'auto':
             user = CurrentContext.get_user()

--- a/label_studio/fsm/tests/conftest.py
+++ b/label_studio/fsm/tests/conftest.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 import pytest
 from django.core.cache import cache
 from fsm.registry import state_choices_registry, state_model_registry, transition_registry
+from fsm.state_manager import get_fsm_cache
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,7 @@ def fsm_test_isolation():
     # Clear context and cache after test
     CurrentContext.clear()
     cache.clear()
+    get_fsm_cache().clear()
     transition_registry.clear()
     state_choices_registry.clear()
     state_model_registry.clear()

--- a/label_studio/fsm/tests/conftest.py
+++ b/label_studio/fsm/tests/conftest.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 import pytest
 from django.core.cache import cache
 from fsm.registry import state_choices_registry, state_model_registry, transition_registry
-from fsm.state_manager import get_fsm_cache
+from fsm.state_manager import StateManager
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ def fsm_test_isolation():
     # Clear context and cache after test
     CurrentContext.clear()
     cache.clear()
-    get_fsm_cache().clear()
+    StateManager.clear_fsm_cache()
     transition_registry.clear()
     state_choices_registry.clear()
     state_model_registry.clear()


### PR DESCRIPTION
This pull request updates the caching mechanism used by the FSM (Finite State Machine) state management in `label_studio/fsm/state_manager.py`. The main goal is to ensure that FSM operations use the correct cache backend, especially in environments where the default cache may be a dummy cache (e.g., for testing or specific deployments), and to support using a dedicated Redis cache if configured. The changes also update tests to ensure cache isolation.

**Caching backend improvements:**

* Introduced the `get_fsm_cache()` function to select the appropriate cache backend for FSM operations, preferring a Redis cache if specified via `REDIS_CACHE_ALIAS` in settings, and falling back to the default cache otherwise. This ensures FSM caching works correctly even if the default cache is a dummy backend. The cache backend is memoized for efficiency.
* Replaced all direct uses of `cache` in FSM state management methods with `get_fsm_cache()`, ensuring consistent use of the selected cache backend for all FSM cache operations, including get, set, add, delete, and set_many. [[1]](diffhunk://#diff-757222088adfaa313e095fd7d461743038d7cf0963ca8ca443ba186cd0e6a9f4R120-R123) [[2]](diffhunk://#diff-757222088adfaa313e095fd7d461743038d7cf0963ca8ca443ba186cd0e6a9f4L119-R147) [[3]](diffhunk://#diff-757222088adfaa313e095fd7d461743038d7cf0963ca8ca443ba186cd0e6a9f4R268-R276) [[4]](diffhunk://#diff-757222088adfaa313e095fd7d461743038d7cf0963ca8ca443ba186cd0e6a9f4L316-R345) [[5]](diffhunk://#diff-757222088adfaa313e095fd7d461743038d7cf0963ca8ca443ba186cd0e6a9f4L350-R384) [[6]](diffhunk://#diff-757222088adfaa313e095fd7d461743038d7cf0963ca8ca443ba186cd0e6a9f4L424-R454) [[7]](diffhunk://#diff-757222088adfaa313e095fd7d461743038d7cf0963ca8ca443ba186cd0e6a9f4L453-R484)

**Testing improvements:**

* Updated the FSM test fixture to clear both the default cache and the FSM-specific cache after each test, ensuring proper test isolation regardless of which cache backend is in use. [[1]](diffhunk://#diff-6b91b3c1e0a4df7b85f33ed72794eaf1f37ee4ee85681cf45d44b0ef4abfc13eR13) [[2]](diffhunk://#diff-6b91b3c1e0a4df7b85f33ed72794eaf1f37ee4ee85681cf45d44b0ef4abfc13eR39)

**Imports and setup:**

* Updated imports to include `caches` from `django.core.cache` and import `get_fsm_cache` in tests. [[1]](diffhunk://#diff-757222088adfaa313e095fd7d461743038d7cf0963ca8ca443ba186cd0e6a9f4L15-R15) [[2]](diffhunk://#diff-6b91b3c1e0a4df7b85f33ed72794eaf1f37ee4ee85681cf45d44b0ef4abfc13eR13)