### PR TITLE
feat: UTC-409: Additional Project Members UX Refinements

### DIFF
--- a/web/libs/ui/src/lib/data-table/data-table.stories.tsx
+++ b/web/libs/ui/src/lib/data-table/data-table.stories.tsx
@@ -171,17 +171,23 @@ export const WithSelection: Story = {
 export const WithRowClick: Story = {
   render: () => {
     const [clickedUser, setClickedUser] = useState<User | null>(null);
+    const [rowSelection, setRowSelection] = useState<Record<string, boolean>>({});
+    const selectedCount = Object.keys(rowSelection).length;
 
     return (
       <div className="flex flex-col gap-4">
-        <div className="p-4 bg-neutral-surface rounded-md">
+        <div className="p-4 bg-neutral-surface rounded-md flex justify-between items-center">
           <p className="text-sm text-neutral-content-subtle">
             {clickedUser ? `Last clicked: ${clickedUser.name}` : "Click on a row"}
           </p>
+          <p className="text-sm text-neutral-content-subtle">Selected: {selectedCount}</p>
         </div>
         <DataTable
           data={sampleData}
           columns={baseColumns}
+          selectable
+          rowSelection={rowSelection}
+          onRowSelectionChange={setRowSelection}
           onRowClick={(row) => setClickedUser(row ? row.original : null)}
         />
       </div>

--- a/web/libs/ui/src/lib/data-table/data-table.tsx
+++ b/web/libs/ui/src/lib/data-table/data-table.tsx
@@ -19,7 +19,7 @@ declare module "@tanstack/react-table" {
     sortParam?: string; // API field name for sorting (e.g., "user__first_name")
   }
 }
-import { memo, useState, useMemo, useCallback } from "react";
+import { memo, useState, useMemo, useCallback, useRef } from "react";
 import { cn } from "../../utils/utils";
 import { useColumnSizing, useDataColumns } from "../../hooks/data-table";
 import { Checkbox } from "../checkbox/checkbox";
@@ -71,6 +71,8 @@ export type DataTableProps<T extends DataShape> = {
   };
   /** Whether data is currently loading */
   isLoading?: boolean;
+  /** Whether data is currently being refetched (shows loading with preserved row count) */
+  isFetching?: boolean;
   /** Number of skeleton rows to show when loading (default: 5) */
   loadingRows?: number;
   /** Optional className to apply to the table container */
@@ -110,6 +112,9 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
   const [internalRowSelection, setInternalRowSelection] = useState<Record<string, boolean>>({});
   const [internalSorting, setInternalSorting] = useState<SortingState>([]);
   const [internalActiveRowId, setInternalActiveRowId] = useState<string | undefined>(undefined);
+
+  // Track previous row count for skeleton loading state
+  const prevRowCountRef = useRef<number>(loadingRows);
 
   // Use controlled activeRowId if onRowClick is provided (parent controls state via clicks)
   // OR if activeRowId is explicitly provided (not undefined)
@@ -312,6 +317,11 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
   const { columnSizing } = table.getState();
   const rows = table.getRowModel().rows;
 
+  // Update ref during render when we have stable data (no useEffect needed)
+  if (!props.isLoading && !props.isFetching && rows.length > 0) {
+    prevRowCountRef.current = rows.length;
+  }
+
   const handleRowClick = useCallback(
     (row?: Row<T[number]>) => {
       // Call parent's onRowClick handler if provided
@@ -327,8 +337,25 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
     [props.onRowClick, activeRowId, isActiveRowControlled],
   );
 
+  // Calculate skeleton row count based on loading state
+  const skeletonRowCount = useMemo(() => {
+    // If we have existing data and are refetching, use previous count
+    if (props.isFetching && rows.length > 0) {
+      return prevRowCountRef.current;
+    }
+    // Otherwise use default loadingRows
+    return loadingRows;
+  }, [props.isFetching, rows.length, loadingRows]);
+
   // Check if we should show loading skeleton
-  const showLoadingSkeleton = props.isLoading && rows.length === 0;
+  const showLoadingSkeleton = useMemo(() => {
+    // Show skeleton on initial load (no data yet)
+    if (props.isLoading && rows.length === 0) return true;
+    // Show skeleton when refetching with existing data
+    if (props.isFetching && rows.length > 0) return true;
+    return false;
+  }, [props.isLoading, props.isFetching, rows.length]);
+
   // Check if we should show empty state
   const showEmptyState = rows.length === 0 && !props.isLoading && props.emptyState;
 
@@ -338,7 +365,7 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
       {showLoadingSkeleton ? (
         <DataTableSkeletonBody
           table={table}
-          loadingRows={loadingRows}
+          loadingRows={skeletonRowCount}
           columnSizing={columnSizing}
           selectable={selectable}
         />

--- a/web/libs/ui/src/lib/data-table/data-table.tsx
+++ b/web/libs/ui/src/lib/data-table/data-table.tsx
@@ -71,8 +71,6 @@ export type DataTableProps<T extends DataShape> = {
   };
   /** Whether data is currently loading */
   isLoading?: boolean;
-  /** Whether data is currently being refetched (shows loading with preserved row count) */
-  isFetching?: boolean;
   /** Number of skeleton rows to show when loading (default: 5) */
   loadingRows?: number;
   /** Optional className to apply to the table container */
@@ -318,7 +316,7 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
   const rows = table.getRowModel().rows;
 
   // Update ref during render when we have stable data (no useEffect needed)
-  if (!props.isLoading && !props.isFetching && rows.length > 0) {
+  if (!props.isLoading && rows.length > 0) {
     prevRowCountRef.current = rows.length;
   }
 
@@ -337,35 +335,16 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
     [props.onRowClick, activeRowId, isActiveRowControlled],
   );
 
-  // Calculate skeleton row count based on loading state
-  const skeletonRowCount = useMemo(() => {
-    // If we have existing data and are refetching, use previous count
-    if (props.isFetching && rows.length > 0) {
-      return prevRowCountRef.current;
-    }
-    // Otherwise use default loadingRows
-    return loadingRows;
-  }, [props.isFetching, rows.length, loadingRows]);
-
-  // Check if we should show loading skeleton
-  const showLoadingSkeleton = useMemo(() => {
-    // Show skeleton on initial load (no data yet)
-    if (props.isLoading && rows.length === 0) return true;
-    // Show skeleton when refetching with existing data
-    if (props.isFetching && rows.length > 0) return true;
-    return false;
-  }, [props.isLoading, props.isFetching, rows.length]);
-
   // Check if we should show empty state
   const showEmptyState = rows.length === 0 && !props.isLoading && props.emptyState;
 
   return (
     <div className={cn(styles.container, className)} data-testid={dataTestId}>
       <DataTableHead table={table} />
-      {showLoadingSkeleton ? (
+      {props.isLoading ? (
         <DataTableSkeletonBody
           table={table}
-          loadingRows={skeletonRowCount}
+          loadingRows={loadingRows}
           columnSizing={columnSizing}
           selectable={selectable}
         />

--- a/web/libs/ui/src/lib/data-table/data-table.tsx
+++ b/web/libs/ui/src/lib/data-table/data-table.tsx
@@ -188,34 +188,36 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
         const isSomeSelected = invertedSelectionEnabled ? false : calculatedIsSomeSelected; // Don't show indeterminate in inverted mode
 
         return (
-          <Checkbox
-            checked={isAllSelected}
-            indeterminate={isSomeSelected}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              e.stopPropagation();
+          <label className="flex justify-center cursor-pointer size-[48px] -m-tight">
+            <Checkbox
+              checked={isAllSelected}
+              indeterminate={isSomeSelected}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                e.stopPropagation();
 
-              // Call custom handler if provided (allows parent to handle special cases)
-              if (onSelectAllChange) {
-                onSelectAllChange(e.target.checked, selectableRows.length);
-              }
+                // Call custom handler if provided (allows parent to handle special cases)
+                if (onSelectAllChange) {
+                  onSelectAllChange(e.target.checked, selectableRows.length);
+                }
 
-              // Build new selection state with only selectable rows
-              const newSelection: Record<string, boolean> = {};
+                // Build new selection state with only selectable rows
+                const newSelection: Record<string, boolean> = {};
 
-              if (e.target.checked) {
-                // Select all selectable rows
-                selectableRows.forEach((row) => {
-                  newSelection[row.id] = true;
-                });
-              }
-              // If unchecking, newSelection stays empty (deselect all)
+                if (e.target.checked) {
+                  // Select all selectable rows
+                  selectableRows.forEach((row) => {
+                    newSelection[row.id] = true;
+                  });
+                }
+                // If unchecking, newSelection stays empty (deselect all)
 
-              // Update selection state in one go
-              table.setRowSelection(newSelection);
-            }}
-            ariaLabel={isAllSelected ? "Unselect all rows" : "Select all rows"}
-            data-testid="data-table-select-all"
-          />
+                // Update selection state in one go
+                table.setRowSelection(newSelection);
+              }}
+              ariaLabel={isAllSelected ? "Unselect all rows" : "Select all rows"}
+              data-testid="data-table-select-all"
+            />
+          </label>
         );
       },
       cell: ({ row }) => {
@@ -227,15 +229,17 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
         }
 
         return (
-          <Checkbox
-            checked={row.getIsSelected()}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              e.stopPropagation();
-              row.toggleSelected(e.target.checked);
-            }}
-            ariaLabel={row.getIsSelected() ? "Unselect row" : "Select row"}
-            data-testid={`data-table-row-${row.id}-select`}
-          />
+          <label className="flex justify-center cursor-pointer size-[44px] -m-tight">
+            <Checkbox
+              checked={row.getIsSelected()}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                e.stopPropagation();
+                row.toggleSelected(e.target.checked);
+              }}
+              ariaLabel={row.getIsSelected() ? "Unselect row" : "Select row"}
+              data-testid={`data-table-row-${row.id}-select`}
+            />
+          </label>
         );
       },
       size: 20,

--- a/web/libs/ui/src/lib/data-table/data-table.tsx
+++ b/web/libs/ui/src/lib/data-table/data-table.tsx
@@ -188,7 +188,10 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
         const isSomeSelected = invertedSelectionEnabled ? false : calculatedIsSomeSelected; // Don't show indeterminate in inverted mode
 
         return (
-          <label className="flex justify-center cursor-pointer size-[48px] -m-tight">
+          <label
+            className="flex justify-center cursor-pointer size-[48px] -m-tight"
+            onClick={(e) => e.stopPropagation()}
+          >
             <Checkbox
               checked={isAllSelected}
               indeterminate={isSomeSelected}
@@ -229,7 +232,10 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
         }
 
         return (
-          <label className="flex justify-center cursor-pointer size-[48px] -m-tight">
+          <label
+            className="flex justify-center cursor-pointer size-[48px] -m-tight"
+            onClick={(e) => e.stopPropagation()}
+          >
             <Checkbox
               checked={row.getIsSelected()}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {

--- a/web/libs/ui/src/lib/data-table/data-table.tsx
+++ b/web/libs/ui/src/lib/data-table/data-table.tsx
@@ -676,7 +676,7 @@ export const Header = <T,>({
 
   if (!enableSorting) {
     return (
-      <Typography variant="body" size="small">
+      <Typography variant="label" size="small">
         {headerLabel}
       </Typography>
     );
@@ -687,7 +687,7 @@ export const Header = <T,>({
 
   return (
     <div className={styles.headerContent}>
-      <Typography variant="body" size="small" className={cn(isSorted && styles.headerTextSorted)}>
+      <Typography variant="label" size="small" className={cn(isSorted && styles.headerTextSorted)}>
         {headerLabel}
       </Typography>
       {/* Always render icon container for sortable columns - CSS handles visibility */}

--- a/web/libs/ui/src/lib/data-table/data-table.tsx
+++ b/web/libs/ui/src/lib/data-table/data-table.tsx
@@ -19,7 +19,7 @@ declare module "@tanstack/react-table" {
     sortParam?: string; // API field name for sorting (e.g., "user__first_name")
   }
 }
-import { memo, useState, useMemo, useCallback, useRef } from "react";
+import { memo, useState, useMemo, useCallback } from "react";
 import { cn } from "../../utils/utils";
 import { useColumnSizing, useDataColumns } from "../../hooks/data-table";
 import { Checkbox } from "../checkbox/checkbox";
@@ -110,9 +110,6 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
   const [internalRowSelection, setInternalRowSelection] = useState<Record<string, boolean>>({});
   const [internalSorting, setInternalSorting] = useState<SortingState>([]);
   const [internalActiveRowId, setInternalActiveRowId] = useState<string | undefined>(undefined);
-
-  // Track previous row count for skeleton loading state
-  const prevRowCountRef = useRef<number>(loadingRows);
 
   // Use controlled activeRowId if onRowClick is provided (parent controls state via clicks)
   // OR if activeRowId is explicitly provided (not undefined)
@@ -314,11 +311,6 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
 
   const { columnSizing } = table.getState();
   const rows = table.getRowModel().rows;
-
-  // Update ref during render when we have stable data (no useEffect needed)
-  if (!props.isLoading && rows.length > 0) {
-    prevRowCountRef.current = rows.length;
-  }
 
   const handleRowClick = useCallback(
     (row?: Row<T[number]>) => {

--- a/web/libs/ui/src/lib/data-table/data-table.tsx
+++ b/web/libs/ui/src/lib/data-table/data-table.tsx
@@ -229,7 +229,7 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
         }
 
         return (
-          <label className="flex justify-center cursor-pointer size-[44px] -m-tight">
+          <label className="flex justify-center cursor-pointer size-[48px] -m-tight">
             <Checkbox
               checked={row.getIsSelected()}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {

--- a/web/libs/ui/src/lib/toast/toast.tsx
+++ b/web/libs/ui/src/lib/toast/toast.tsx
@@ -116,7 +116,7 @@ export const useToast = () => {
 
 export const ToastProvider: FC<ToastProviderWithTypes> = ({ swipeDirection = "down", children, type, ...props }) => {
   const [toastMessage, setToastMessage] = useState<ToastShowArgs | null>();
-  const defaultDuration = 2000;
+  const defaultDuration = 4000;
   const duration = toastMessage?.duration ?? defaultDuration;
   const show = ({ message, type, duration = defaultDuration }: ToastShowArgs) => {
     setToastMessage({ message, type });


### PR DESCRIPTION
This pull request enhances the `DataTable` component in several ways, focusing on improving row selection usability, visual consistency, and the toast notification experience. The most significant updates include adding styled selection checkboxes, updating the header typography, and extending toast durations.

**DataTable selection and UI improvements:**

* Wrapped both the "select all" and individual row checkboxes in a styled `label` to improve click targets and cursor feedback, and prevent row click propagation when interacting with checkboxes (`data-table.tsx`). [[1]](diffhunk://#diff-12837e3d0134bd17183c0ba795639cc1449daef192e005241553d074de55c124R191-R194) [[2]](diffhunk://#diff-12837e3d0134bd17183c0ba795639cc1449daef192e005241553d074de55c124R223) [[3]](diffhunk://#diff-12837e3d0134bd17183c0ba795639cc1449daef192e005241553d074de55c124R235-R238) [[4]](diffhunk://#diff-12837e3d0134bd17183c0ba795639cc1449daef192e005241553d074de55c124R248)
* Updated the DataTable story to display the count of selected rows and improved layout for selection feedback (`data-table.stories.tsx`).

**Visual and loading state enhancements:**

* Changed header typography from `body` to `label` variant for improved visual hierarchy and consistency in both sortable and non-sortable columns (`data-table.tsx`). [[1]](diffhunk://#diff-12837e3d0134bd17183c0ba795639cc1449daef192e005241553d074de55c124L677-R685) [[2]](diffhunk://#diff-12837e3d0134bd17183c0ba795639cc1449daef192e005241553d074de55c124L688-R696)
* Modified the loading skeleton display logic to show the skeleton whenever the table is loading, regardless of row count, ensuring a more accurate loading state (`data-table.tsx`).

**Toast notification experience:**

* Increased the default toast notification duration from 2 seconds to 4 seconds for better visibility (`toast.tsx`).

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
