### PR TITLE
fix: FIT-1064: No close button on state history

### DIFF
--- a/web/libs/app-common/src/components/state-chips/annotation-state-chip.tsx
+++ b/web/libs/app-common/src/components/state-chips/annotation-state-chip.tsx
@@ -32,7 +32,12 @@ export function AnnotationStateChip({ state, annotationId, interactive = true }:
   const colorClasses = getStateColorClass(state);
 
   const popoverContent = annotationId ? (
-    <StateHistoryPopoverContent entityType="annotation" entityId={annotationId} isOpen={open} />
+    <StateHistoryPopoverContent
+      entityType="annotation"
+      entityId={annotationId}
+      isOpen={open}
+      onClose={() => setOpen(false)}
+    />
   ) : undefined;
 
   return (

--- a/web/libs/app-common/src/components/state-chips/project-state-chip.tsx
+++ b/web/libs/app-common/src/components/state-chips/project-state-chip.tsx
@@ -32,7 +32,12 @@ export function ProjectStateChip({ state, projectId, interactive = true }: Proje
   const colorClasses = getStateColorClass(state);
 
   const popoverContent = projectId ? (
-    <StateHistoryPopoverContent entityType="project" entityId={projectId} isOpen={open} />
+    <StateHistoryPopoverContent
+      entityType="project"
+      entityId={projectId}
+      isOpen={open}
+      onClose={() => setOpen(false)}
+    />
   ) : undefined;
 
   return (

--- a/web/libs/app-common/src/components/state-chips/state-history-popover-content.tsx
+++ b/web/libs/app-common/src/components/state-chips/state-history-popover-content.tsx
@@ -3,7 +3,7 @@
  */
 
 import { Badge, Button, Typography } from "@humansignal/ui";
-import { IconSync, IconError, IconHistoryRewind } from "@humansignal/icons";
+import { IconSync, IconError, IconHistoryRewind, IconCross } from "@humansignal/icons";
 import { useStateHistory, type StateHistoryItem } from "../../hooks/useStateHistory";
 import { getStateColorClass, formatStateName, formatTimestamp, formatUserName } from "./utils";
 
@@ -11,9 +11,10 @@ export interface StateHistoryPopoverContentProps {
   entityType: "task" | "annotation" | "project";
   entityId: number;
   isOpen: boolean;
+  onClose?: () => void;
 }
 
-export function StateHistoryPopoverContent({ entityType, entityId, isOpen }: StateHistoryPopoverContentProps) {
+export function StateHistoryPopoverContent({ entityType, entityId, isOpen, onClose }: StateHistoryPopoverContentProps) {
   const { data, isLoading, isError, error, refetch } = useStateHistory({
     entityType,
     entityId,
@@ -29,11 +30,25 @@ export function StateHistoryPopoverContent({ entityType, entityId, isOpen }: Sta
     >
       {/* Header */}
       <div className="px-4 py-3 border-b border-neutral-border">
-        <div className="flex items-center gap-2">
-          <IconHistoryRewind className="w-4 h-4 text-muted-foreground" />
-          <Typography variant="body" size="small" className="font-medium text-neutral-foreground">
-            State History
-          </Typography>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <IconHistoryRewind className="w-4 h-4 text-muted-foreground" />
+            <Typography variant="body" size="small" className="font-medium text-neutral-foreground">
+              State History
+            </Typography>
+          </div>
+          {onClose && (
+            <Button
+              onClick={(e) => {
+                e.stopPropagation();
+                onClose();
+              }}
+              leading={<IconCross />}
+              look="string"
+              size="small"
+              aria-label="Close"
+            />
+          )}
         </div>
       </div>
 

--- a/web/libs/app-common/src/components/state-chips/state-history-popover.tsx
+++ b/web/libs/app-common/src/components/state-chips/state-history-popover.tsx
@@ -5,7 +5,7 @@
 
 import type React from "react";
 import { Popover, Badge, Button, Typography } from "@humansignal/ui";
-import { IconSync, IconError, IconHistoryRewind } from "@humansignal/icons";
+import { IconSync, IconError, IconHistoryRewind, IconCross } from "@humansignal/icons";
 import { useStateHistory, type StateHistoryItem } from "../../hooks/useStateHistory";
 import { getStateColorClass, formatStateName, formatTimestamp, formatUserName } from "./utils";
 
@@ -42,11 +42,23 @@ export function StateHistoryPopover({
       >
         {/* Header */}
         <div className="px-4 py-3 border-b border-neutral-border">
-          <div className="flex items-center gap-2">
-            <IconHistoryRewind className="w-4 h-4 " />
-            <Typography variant="body" size="small" className="font-medium text-neutral-foreground">
-              State History
-            </Typography>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <IconHistoryRewind className="w-4 h-4 " />
+              <Typography variant="body" size="small" className="font-medium text-neutral-foreground">
+                State History
+              </Typography>
+            </div>
+            <Button
+              onClick={(e) => {
+                e.stopPropagation();
+                onOpenChange?.(false);
+              }}
+              leading={<IconCross />}
+              look="string"
+              size="small"
+              aria-label="Close"
+            />
           </div>
         </div>
 

--- a/web/libs/app-common/src/components/state-chips/state-history-popover.tsx
+++ b/web/libs/app-common/src/components/state-chips/state-history-popover.tsx
@@ -5,7 +5,7 @@
 
 import type React from "react";
 import { Popover, Badge, Button, Typography } from "@humansignal/ui";
-import { IconSync, IconError, IconHistoryRewind, IconCross } from "@humansignal/icons";
+import { IconSync, IconError, IconHistoryRewind } from "@humansignal/icons";
 import { useStateHistory, type StateHistoryItem } from "../../hooks/useStateHistory";
 import { getStateColorClass, formatStateName, formatTimestamp, formatUserName } from "./utils";
 
@@ -42,23 +42,11 @@ export function StateHistoryPopover({
       >
         {/* Header */}
         <div className="px-4 py-3 border-b border-neutral-border">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <IconHistoryRewind className="w-4 h-4 " />
-              <Typography variant="body" size="small" className="font-medium text-neutral-foreground">
-                State History
-              </Typography>
-            </div>
-            <Button
-              onClick={(e) => {
-                e.stopPropagation();
-                onOpenChange?.(false);
-              }}
-              leading={<IconCross />}
-              look="string"
-              size="small"
-              aria-label="Close"
-            />
+          <div className="flex items-center gap-2">
+            <IconHistoryRewind className="w-4 h-4 " />
+            <Typography variant="body" size="small" className="font-medium text-neutral-foreground">
+              State History
+            </Typography>
           </div>
         </div>
 

--- a/web/libs/app-common/src/components/state-chips/task-state-chip.tsx
+++ b/web/libs/app-common/src/components/state-chips/task-state-chip.tsx
@@ -32,7 +32,7 @@ export function TaskStateChip({ state, taskId, interactive = true }: TaskStateCh
   const colorClasses = getStateColorClass(state);
 
   const popoverContent = taskId ? (
-    <StateHistoryPopoverContent entityType="task" entityId={taskId} isOpen={open} />
+    <StateHistoryPopoverContent entityType="task" entityId={taskId} isOpen={open} onClose={() => setOpen(false)} />
   ) : undefined;
 
   return (


### PR DESCRIPTION
This pull request improves the usability of state history popovers in the state chip components by adding a close button to the popover headers and ensuring the popovers can be dismissed programmatically. The changes affect the annotation, project, and task state chips, as well as the underlying popover content components.

<img width="359" height="198" alt="image" src="https://github.com/user-attachments/assets/fce10706-a606-41bc-8d26-3c023113adf9" />


**Usability improvements to state history popovers:**

* Added an optional `onClose` prop to `StateHistoryPopoverContent` and updated the annotation, project, and task state chips (`annotation-state-chip.tsx`, `project-state-chip.tsx`, `task-state-chip.tsx`) to pass a handler that closes the popover when the close button is clicked. [[1]](diffhunk://#diff-15da57ebe849f7c2730cf1a2f355d4783d8b767e2857503134c40e2447b817a4L35-R40) [[2]](diffhunk://#diff-920e7521e12bdd853d20a10f93f3d35bddea39092de60b471b66618fad0890fbL35-R40) [[3]](diffhunk://#diff-9fecd82a907f9d546c01090f5c1829db4f2863d098f9b1e8035d4d0445b4af6bL35-R35) [[4]](diffhunk://#diff-0c11227a2cf4c370114aa5477064d3c1ff2bfe33455910e7659f4749c5ab5184L6-R17)
* Updated the popover header UI in both `StateHistoryPopoverContent` and `StateHistoryPopover` to include a close button (using `IconCross`), allowing users to dismiss the popover easily. [[1]](diffhunk://#diff-0c11227a2cf4c370114aa5477064d3c1ff2bfe33455910e7659f4749c5ab5184R33-R52) [[2]](diffhunk://#diff-ae63245c5110efe387dbd9049ded9c0d9e23888909db8e4e21ad363703cd26baR45-R62)
* Imported `IconCross` where needed to support the new close button. [[1]](diffhunk://#diff-0c11227a2cf4c370114aa5477064d3c1ff2bfe33455910e7659f4749c5ab5184L6-R17) [[2]](diffhunk://#diff-ae63245c5110efe387dbd9049ded9c0d9e23888909db8e4e21ad363703cd26baL8-R8)