### PR TITLE
fix: FIT-1037: FSM queryset mixin with_state was missing

### DIFF
--- a/label_studio/data_manager/managers.py
+++ b/label_studio/data_manager/managers.py
@@ -490,14 +490,7 @@ def apply_filters(queryset, filters, project, request):
 
 
 class TaskQuerySet(FSMStateQuerySetMixin, models.QuerySet):
-    """
-    QuerySet for Task model with FSM state annotation support.
-
-    Extends Django's QuerySet with:
-    - FSM state annotation (via FSMStateQuerySetMixin)
-    - Data Manager filters and ordering
-    - Selected items handling
-    """
+    """QuerySet for Task model with Data Manager filters and ordering support."""
 
     def prepared(self, prepare_params=None):
         """Apply filters, ordering and selected items to queryset

--- a/label_studio/data_manager/managers.py
+++ b/label_studio/data_manager/managers.py
@@ -707,16 +707,16 @@ def annotate_state(queryset):
     """
     Annotate queryset with FSM state as 'state' field.
 
-    Uses FSMStateQuerySetMixin.annotate_fsm_state() to efficiently annotate
+    Uses FSMStateQuerySetMixin.with_state() to efficiently annotate
     the current state without causing N+1 queries. Aliases 'current_state' to
     'state' to match the Data Manager column name.
 
     Note: Feature flag checks and user context validation are handled by
-    annotate_fsm_state() itself, so no additional checks are needed here.
+    with_state() itself, so no additional checks are needed here.
     """
-    # Use the mixin's annotate_fsm_state() method which creates 'current_state' annotation
+    # Use the mixin's with_state() method which creates 'current_state' annotation
     # (includes feature flag and user context checks)
-    queryset = queryset.annotate_fsm_state()
+    queryset = queryset.with_state()
 
     # Alias 'current_state' to 'state' for Data Manager column compatibility
     # Only add the alias if current_state was actually added (feature flags enabled)
@@ -851,4 +851,4 @@ class TaskManager(models.Manager):
 
     def with_state(self):
         """Return queryset with FSM state annotated."""
-        return self.get_queryset().annotate_fsm_state()
+        return self.get_queryset().with_state()

--- a/label_studio/fsm/queryset_mixins.py
+++ b/label_studio/fsm/queryset_mixins.py
@@ -37,8 +37,8 @@ class FSMStateQuerySetMixin:
     """
     Mixin for Django QuerySets to efficiently annotate FSM state.
 
-    Provides the `annotate_fsm_state()` method that adds a `current_state`
-    annotation to the queryset using an optimized subquery.
+    Provides both `annotate_fsm_state()` and `with_state()` methods that add a
+    `current_state` annotation to the queryset using an optimized subquery.
 
     This approach:
     - Prevents N+1 queries by using a single JOIN/subquery
@@ -55,11 +55,36 @@ class FSMStateQuerySetMixin:
             def with_state(self):
                 return self.get_queryset().annotate_fsm_state()
 
-        # Usage
+        # Usage - both approaches work identically
         tasks = Task.objects.with_state().filter(project=project)
+        # Or chain it after filters
+        tasks = Task.objects.filter(project=project).with_state()
+
         for task in tasks:
             print(f"Task {task.id}: {task.current_state}")  # No additional queries!
     """
+
+    def with_state(self):
+        """
+        Convenience method to annotate queryset with FSM state.
+
+        This is a more intuitive alias for `annotate_fsm_state()` that can be
+        chained with other queryset methods at any point in the query chain.
+
+        Returns:
+            QuerySet: The queryset with current_state annotation
+
+        Example:
+            # Chain after filters
+            tasks = Task.objects.filter(project=project).with_state()
+
+            # Or use from manager
+            tasks = Task.objects.with_state().filter(project=project)
+
+            # Multiple chaining
+            tasks = Task.objects.filter(is_labeled=True).with_state().order_by('-created_at')
+        """
+        return self.annotate_fsm_state()
 
     def annotate_fsm_state(self):
         """

--- a/label_studio/fsm/queryset_mixins.py
+++ b/label_studio/fsm/queryset_mixins.py
@@ -10,7 +10,7 @@ Usage:
 
     class TaskManager(models.Manager):
         def get_queryset(self):
-            return TaskQuerySet(self.model, using=self._db).annotate_fsm_state()
+            return TaskQuerySet(self.model, using=self._db)
 
 Note:
     State annotation is guarded by 'fflag_feat_fit_568_finite_state_management' only.
@@ -37,8 +37,8 @@ class FSMStateQuerySetMixin:
     """
     Mixin for Django QuerySets to efficiently annotate FSM state.
 
-    Provides both `annotate_fsm_state()` and `with_state()` methods that add a
-    `current_state` annotation to the queryset using an optimized subquery.
+    Provides the `with_state()` method that adds a `current_state`
+    annotation to the queryset using an optimized subquery.
 
     This approach:
     - Prevents N+1 queries by using a single JOIN/subquery
@@ -53,7 +53,7 @@ class FSMStateQuerySetMixin:
                 return TaskQuerySet(self.model, using=self._db)
 
             def with_state(self):
-                return self.get_queryset().annotate_fsm_state()
+                return self.get_queryset().with_state()
 
         # Usage - both approaches work identically
         tasks = Task.objects.with_state().filter(project=project)
@@ -66,13 +66,14 @@ class FSMStateQuerySetMixin:
 
     def with_state(self):
         """
-        Convenience method to annotate queryset with FSM state.
+        Annotate the queryset with the current FSM state.
 
-        This is a more intuitive alias for `annotate_fsm_state()` that can be
-        chained with other queryset methods at any point in the query chain.
+        Adds a `current_state` field to each object containing the current
+        state string value. This is done using an efficient subquery that
+        leverages UUID7 natural ordering to prevent N+1 queries.
 
         Returns:
-            QuerySet: The queryset with current_state annotation
+            QuerySet: The annotated queryset with `current_state` field
 
         Example:
             # Chain after filters
@@ -83,19 +84,6 @@ class FSMStateQuerySetMixin:
 
             # Multiple chaining
             tasks = Task.objects.filter(is_labeled=True).with_state().order_by('-created_at')
-        """
-        return self.annotate_fsm_state()
-
-    def annotate_fsm_state(self):
-        """
-        Annotate the queryset with the current FSM state.
-
-        Adds a `current_state` field to each object containing the current
-        state string value. This is done using an efficient subquery that
-        leverages UUID7 natural ordering.
-
-        Returns:
-            QuerySet: The annotated queryset with `current_state` field
 
         Note:
             - If FSM feature flag is disabled, returns queryset unchanged (zero impact)

--- a/label_studio/fsm/serializer_fields.py
+++ b/label_studio/fsm/serializer_fields.py
@@ -47,7 +47,7 @@ class FSMStateField(serializers.ReadOnlyField):
     Example with annotations (optimal):
         # In your viewset
         def get_queryset(self):
-            return Task.objects.all().annotate_fsm_state()
+            return Task.objects.all().with_state()
 
         # In your serializer
         class TaskSerializer(serializers.ModelSerializer):
@@ -98,7 +98,7 @@ class FSMStateField(serializers.ReadOnlyField):
             return None
 
         # Check if the instance has a state annotation
-        # This can come from Data Manager's annotate_state() or FSMStateQuerySetMixin.annotate_fsm_state()
+        # This can come from Data Manager's annotate_state() or FSMStateQuerySetMixin.with_state()
         if hasattr(instance, 'state'):
             # Use the annotated value (no additional query)
             return instance.state

--- a/label_studio/projects/api.py
+++ b/label_studio/projects/api.py
@@ -191,7 +191,7 @@ class ProjectListAPI(generics.ListCreateAPIView):
         if flag_set('fflag_feat_fit_568_finite_state_management', user=self.request.user) and flag_set(
             'fflag_feat_fit_710_fsm_state_fields', user=self.request.user
         ):
-            projects = projects.annotate_fsm_state()
+            projects = projects.with_state()
 
         return projects.prefetch_related('members', 'created_by')
 
@@ -255,7 +255,7 @@ class ProjectCountsListAPI(generics.ListAPIView):
         if flag_set('fflag_feat_fit_568_finite_state_management', user=self.request.user) and flag_set(
             'fflag_feat_fit_710_fsm_state_fields', user=self.request.user
         ):
-            projects = projects.annotate_fsm_state()
+            projects = projects.with_state()
 
         return projects
 
@@ -389,7 +389,7 @@ class ProjectAPI(generics.RetrieveUpdateDestroyAPIView):
         if flag_set('fflag_feat_fit_568_finite_state_management', user=self.request.user) and flag_set(
             'fflag_feat_fit_710_fsm_state_fields', user=self.request.user
         ):
-            projects = projects.annotate_fsm_state()
+            projects = projects.with_state()
 
         return projects
 

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -68,10 +68,6 @@ class ProjectQuerySet(models.QuerySet):
 
 
 class ProjectQuerySetWithFSM(FSMStateQuerySetMixin, ProjectQuerySet):
-    """
-    Custom QuerySet for Project model with FSM state annotation support.
-    """
-
     pass
 
 

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -119,7 +119,7 @@ class ProjectManager(models.Manager):
             for project in projects:
                 print(project.state)  # No N+1 queries!
         """
-        return self.get_queryset().annotate_fsm_state()
+        return self.get_queryset().with_state()
 
     def with_counts(self, fields=None):
         return self.with_counts_annotate(self.get_queryset(), fields=fields)

--- a/label_studio/tasks/models.py
+++ b/label_studio/tasks/models.py
@@ -571,10 +571,6 @@ class AnnotationQuerySet(models.QuerySet):
 
 
 class AnnotationQuerySetWithFSM(FSMStateQuerySetMixin, AnnotationQuerySet):
-    """
-    Custom QuerySet for Annotation model with FSM state annotation support.
-    """
-
     pass
 
 
@@ -846,15 +842,15 @@ class TaskLockQuerySet(models.QuerySet):
     pass
 
 
+class TaskLockQuerySetWithFSM(FSMStateQuerySetMixin, TaskLockQuerySet):
+    pass
+
+
 class TaskLockManager(models.Manager):
     """Manager for TaskLock with FSM state support"""
 
     def get_queryset(self):
         """Return QuerySet with FSM state annotation support"""
-        # Create a dynamic class that mixes FSM support into the queryset
-        class TaskLockQuerySetWithFSM(FSMStateQuerySetMixin, TaskLockQuerySet):
-            pass
-
         return TaskLockQuerySetWithFSM(self.model, using=self._db)
 
     def with_state(self):
@@ -890,15 +886,15 @@ class AnnotationDraftQuerySet(models.QuerySet):
     pass
 
 
+class AnnotationDraftQuerySetWithFSM(FSMStateQuerySetMixin, AnnotationDraftQuerySet):
+    pass
+
+
 class AnnotationDraftManager(models.Manager):
     """Manager for AnnotationDraft with FSM state support"""
 
     def get_queryset(self):
         """Return QuerySet with FSM state annotation support"""
-        # Create a dynamic class that mixes FSM support into the queryset
-        class AnnotationDraftQuerySetWithFSM(FSMStateQuerySetMixin, AnnotationDraftQuerySet):
-            pass
-
         return AnnotationDraftQuerySetWithFSM(self.model, using=self._db)
 
     def with_state(self):

--- a/label_studio/tasks/models.py
+++ b/label_studio/tasks/models.py
@@ -595,7 +595,7 @@ class AnnotationManager(models.Manager):
 
     def with_state(self):
         """Return queryset with FSM state annotated."""
-        return self.get_queryset().annotate_fsm_state()
+        return self.get_queryset().with_state()
 
     def bulk_create(self, objs, batch_size=None):
         pre_bulk_create.send(sender=self.model, objs=objs, batch_size=batch_size)
@@ -855,7 +855,7 @@ class TaskLockManager(models.Manager):
 
     def with_state(self):
         """Return queryset with FSM state annotated."""
-        return self.get_queryset().annotate_fsm_state()
+        return self.get_queryset().with_state()
 
 
 class TaskLock(FsmHistoryStateModel):
@@ -899,7 +899,7 @@ class AnnotationDraftManager(models.Manager):
 
     def with_state(self):
         """Return queryset with FSM state annotated."""
-        return self.get_queryset().annotate_fsm_state()
+        return self.get_queryset().with_state()
 
 
 class AnnotationDraft(FsmHistoryStateModel):


### PR DESCRIPTION
This pull request standardizes and simplifies how finite state machine (FSM) state annotations are applied to querysets across the codebase. The main change is the replacement of the method name `annotate_fsm_state()` with `with_state()`, making the API more intuitive and consistent. It also removes redundant custom QuerySet class docstrings and streamlines manager and queryset mixins for FSM state handling.

**✅ Works - calling on manager**
```python
projects = Project.objects.with_state()
```

**✅ Now works! - calling on queryset**
```python
projects = Project.objects.filter(...).with_state()
```

**⚠️ Removed annotate_fsm_state() - with_state() works everywhere.**
```python
❌ projects = Project.objects.filter(...).annotate_fsm_state()
✅ projects = Project.objects.filter(...).with_state()
```

**API and Method Renaming:**

* Replaces all usages of `annotate_fsm_state()` with `with_state()` in querysets, managers, and documentation, providing a clearer and more consistent interface for annotating FSM state. [[1]](diffhunk://#diff-94a93567c58417748a5a220038c784a3f8edf55b804a356c046787a81412b4caL56-R87) [[2]](diffhunk://#diff-27234509612462100a378bbf682f9f45558e59152afa111c0c9255c3bb7b0726L717-R719) [[3]](diffhunk://#diff-f35d9d87d993f654de65b582c637a08b5541453452a63fc66e96cd62c2531a76L50-R50) [[4]](diffhunk://#diff-de230f8c6422148eba24cf335d041aa51a20c329de9c1953ae201a5d1b2cc84fL194-R194) [[5]](diffhunk://#diff-de230f8c6422148eba24cf335d041aa51a20c329de9c1953ae201a5d1b2cc84fL258-R258) [[6]](diffhunk://#diff-de230f8c6422148eba24cf335d041aa51a20c329de9c1953ae201a5d1b2cc84fL392-R392) [[7]](diffhunk://#diff-6ff9748c9ae68f8cccd65f4ee20df06ed0a8b9c32b58da39db3001a7178b1dabL126-R122) [[8]](diffhunk://#diff-278a5eaed0e213875745abafc04f21d5564f53bbcf2160a6469d1ea0e3526e24L602-R598) [[9]](diffhunk://#diff-278a5eaed0e213875745abafc04f21d5564f53bbcf2160a6469d1ea0e3526e24R845-R858) [[10]](diffhunk://#diff-278a5eaed0e213875745abafc04f21d5564f53bbcf2160a6469d1ea0e3526e24R889-R902)

* Updates all related comments, docstrings, and usage examples to refer to `with_state()` instead of `annotate_fsm_state()`, ensuring documentation accuracy. [[1]](diffhunk://#diff-94a93567c58417748a5a220038c784a3f8edf55b804a356c046787a81412b4caL40-R40) [[2]](diffhunk://#diff-f35d9d87d993f654de65b582c637a08b5541453452a63fc66e96cd62c2531a76L101-R101) [[3]](diffhunk://#diff-27234509612462100a378bbf682f9f45558e59152afa111c0c9255c3bb7b0726L717-R719)

**Codebase Simplification and Cleanup:**

* Removes redundant or verbose docstrings from custom QuerySet classes that simply inherit FSM state support, reducing clutter. [[1]](diffhunk://#diff-27234509612462100a378bbf682f9f45558e59152afa111c0c9255c3bb7b0726L493-R493) [[2]](diffhunk://#diff-6ff9748c9ae68f8cccd65f4ee20df06ed0a8b9c32b58da39db3001a7178b1dabL71-L74) [[3]](diffhunk://#diff-278a5eaed0e213875745abafc04f21d5564f53bbcf2160a6469d1ea0e3526e24L574-L577)

* Refactors manager classes for models like `TaskLock` and `AnnotationDraft` to define their FSM-enabled QuerySet classes at the module level, improving readability and maintainability. [[1]](diffhunk://#diff-278a5eaed0e213875745abafc04f21d5564f53bbcf2160a6469d1ea0e3526e24R845-R858) [[2]](diffhunk://#diff-278a5eaed0e213875745abafc04f21d5564f53bbcf2160a6469d1ea0e3526e24R889-R902)

These changes make the codebase more consistent and easier to use when working with FSM state annotations.