### PR TITLE
chore: FIT-1068: setting flakey tests to retry 3 times

### DIFF
--- a/web/libs/editor/tests/e2e/tests/image.transformer.test.js
+++ b/web/libs/editor/tests/e2e/tests/image.transformer.test.js
@@ -127,89 +127,91 @@ for (const shapeName of Object.keys(shapes)) {
   shapesTable.add([shapeName]);
 }
 
-Data(shapesTable).Scenario(
-  "Check transformer existing for different shapes, their amount and modes.",
-  async ({ I, LabelStudio, AtImageView, AtOutliner, AtPanels, current }) => {
-    const { shapeName } = current;
-    const Shape = shapes[shapeName];
+Data(shapesTable)
+  .Scenario(
+    "Check transformer existing for different shapes, their amount and modes.",
+    async ({ I, LabelStudio, AtImageView, AtOutliner, AtPanels, current }) => {
+      const { shapeName } = current;
+      const Shape = shapes[shapeName];
 
-    I.amOnPage("/");
-    const bbox1 = {
-      x: 100,
-      y: 100,
-      width: 200,
-      height: 200,
-    };
-    const bbox2 = {
-      x: 400,
-      y: 100,
-      width: 200,
-      height: 200,
-    };
-    const getCenter = (bbox) => [bbox.x + bbox.width / 2, bbox.y + bbox.height / 2];
-    let isTransformerExist;
-    const AtDetailsPanel = AtPanels.usePanel(AtPanels.PANEL.DETAILS);
+      I.amOnPage("/");
+      const bbox1 = {
+        x: 100,
+        y: 100,
+        width: 200,
+        height: 200,
+      };
+      const bbox2 = {
+        x: 400,
+        y: 100,
+        width: 200,
+        height: 200,
+      };
+      const getCenter = (bbox) => [bbox.x + bbox.width / 2, bbox.y + bbox.height / 2];
+      let isTransformerExist;
+      const AtDetailsPanel = AtPanels.usePanel(AtPanels.PANEL.DETAILS);
 
-    LabelStudio.init(getParamsWithLabels(shapeName));
-    AtDetailsPanel.collapsePanel();
+      LabelStudio.init(getParamsWithLabels(shapeName));
+      AtDetailsPanel.collapsePanel();
 
-    LabelStudio.waitForObjectsReady();
-    AtOutliner.seeRegions(0);
-    await AtImageView.lookForStage();
+      LabelStudio.waitForObjectsReady();
+      AtOutliner.seeRegions(0);
+      await AtImageView.lookForStage();
 
-    // Draw two regions
-    I.pressKey("1");
-    drawShapeByBbox(Shape, bbox1.x, bbox1.y, bbox1.width, bbox1.height, AtImageView);
-    AtOutliner.seeRegions(1);
-    I.pressKey("1");
-    drawShapeByBbox(Shape, bbox2.x, bbox2.y, bbox2.width, bbox2.height, AtImageView);
-    AtOutliner.seeRegions(2);
+      // Draw two regions
+      I.pressKey("1");
+      drawShapeByBbox(Shape, bbox1.x, bbox1.y, bbox1.width, bbox1.height, AtImageView);
+      AtOutliner.seeRegions(1);
+      I.pressKey("1");
+      drawShapeByBbox(Shape, bbox2.x, bbox2.y, bbox2.width, bbox2.height, AtImageView);
+      AtOutliner.seeRegions(2);
 
-    // Check that it wasn't a cause to show a transformer
-    isTransformerExist = await AtImageView.isTransformerExist();
-    assert.strictEqual(isTransformerExist, false);
+      // Check that it wasn't a cause to show a transformer
+      isTransformerExist = await AtImageView.isTransformerExist();
+      assert.strictEqual(isTransformerExist, false);
 
-    // Select the first region
-    AtImageView.clickAt(...getCenter(bbox1));
-    AtOutliner.seeSelectedRegion();
+      // Select the first region
+      AtImageView.clickAt(...getCenter(bbox1));
+      AtOutliner.seeSelectedRegion();
 
-    // Match if transformer exist with expectations in single selected mode
-    isTransformerExist = await AtImageView.isTransformerExist();
-    assert.strictEqual(isTransformerExist, Shape.hasTransformer);
+      // Match if transformer exist with expectations in single selected mode
+      isTransformerExist = await AtImageView.isTransformerExist();
+      assert.strictEqual(isTransformerExist, Shape.hasTransformer);
 
-    // Match if rotator at transformer exist with expectations in single selected mode
-    isTransformerExist = await AtImageView.isRotaterExist();
-    assert.strictEqual(isTransformerExist, Shape.hasRotator);
+      // Match if rotator at transformer exist with expectations in single selected mode
+      isTransformerExist = await AtImageView.isRotaterExist();
+      assert.strictEqual(isTransformerExist, Shape.hasRotator);
 
-    // Switch to move tool
-    I.pressKey("v");
+      // Switch to move tool
+      I.pressKey("v");
 
-    // Match if rotator at transformer exist with expectations in single selected mode with move tool chosen
-    isTransformerExist = await AtImageView.isTransformerExist();
-    assert.strictEqual(isTransformerExist, Shape.hasMoveToolTransformer);
+      // Match if rotator at transformer exist with expectations in single selected mode with move tool chosen
+      isTransformerExist = await AtImageView.isTransformerExist();
+      assert.strictEqual(isTransformerExist, Shape.hasMoveToolTransformer);
 
-    // Deselect the previous selected region
-    I.pressKey(["u"]);
+      // Deselect the previous selected region
+      I.pressKey(["u"]);
 
-    // Select 2 regions
-    AtImageView.drawThroughPoints(
-      [
-        [bbox1.x - 5, bbox1.y - 5],
-        [bbox2.x + bbox2.width + 5, bbox2.y + bbox2.height + 5],
-      ],
-      "steps",
-      10,
-    );
+      // Select 2 regions
+      AtImageView.drawThroughPoints(
+        [
+          [bbox1.x - 5, bbox1.y - 5],
+          [bbox2.x + bbox2.width + 5, bbox2.y + bbox2.height + 5],
+        ],
+        "steps",
+        10,
+      );
 
-    // Match if transformer exist with expectations in multiple selected mode
-    isTransformerExist = await AtImageView.isTransformerExist();
-    assert.strictEqual(isTransformerExist, Shape.hasMultiSelectionTransformer);
+      // Match if transformer exist with expectations in multiple selected mode
+      isTransformerExist = await AtImageView.isTransformerExist();
+      assert.strictEqual(isTransformerExist, Shape.hasMultiSelectionTransformer);
 
-    // Match if rotator exist with expectations in multiple selected mode
-    isTransformerExist = await AtImageView.isRotaterExist();
-    assert.strictEqual(isTransformerExist, Shape.hasMultiSelectionRotator);
-  },
-);
+      // Match if rotator exist with expectations in multiple selected mode
+      isTransformerExist = await AtImageView.isRotaterExist();
+      assert.strictEqual(isTransformerExist, Shape.hasMultiSelectionRotator);
+    },
+  )
+  .retry(3);
 
 Data(shapesTable.filter(({ shapeName }) => shapes[shapeName].hasMoveToolTransformer)).Scenario(
   "Resizing a single region",

--- a/web/libs/editor/tests/e2e/tests/outliner.test.js
+++ b/web/libs/editor/tests/e2e/tests/outliner.test.js
@@ -219,7 +219,7 @@ Scenario("Basic details", async ({ I, LabelStudio, AtOutliner, AtDetails }) => {
   const resultWithoutMeta = await LabelStudio.serialize();
 
   assert.deepStrictEqual(resultWithoutMeta[2].meta, undefined);
-});
+}).retry(3);
 
 Scenario("Panels manipulations", async ({ I, LabelStudio, AtPanels }) => {
   I.amOnPage("/");

--- a/web/libs/editor/tests/e2e/tests/taxonomy.test.js
+++ b/web/libs/editor/tests/e2e/tests/taxonomy.test.js
@@ -12,8 +12,23 @@ Before(({ LabelStudio }) => {
 
 Scenario("Lines overlap", async ({ I, LabelStudio, AtTaxonomy }) => {
   async function checkOverlapAndGap(text1, text2) {
-    const bbox1 = await I.grabElementBoundingRect(AtTaxonomy.locate(AtTaxonomy.item).find("label").withText(text1));
-    const bbox2 = await I.grabElementBoundingRect(AtTaxonomy.locate(AtTaxonomy.item).find("label").withText(text2));
+    // Wait for elements to be present in the DOM before grabbing their bounding rects
+    const locator1 = AtTaxonomy.locate(AtTaxonomy.item).find("label").withText(text1);
+    const locator2 = AtTaxonomy.locate(AtTaxonomy.item).find("label").withText(text2);
+
+    await I.waitForElement(locator1, 5);
+    await I.waitForElement(locator2, 5);
+
+    const bbox1 = await I.grabElementBoundingRect(locator1);
+    const bbox2 = await I.grabElementBoundingRect(locator2);
+
+    // Add null checks with better error messages
+    if (!bbox1) {
+      assert.fail(`Element with text "${text1}" not found or has no bounding rect`);
+    }
+    if (!bbox2) {
+      assert.fail(`Element with text "${text2}" not found or has no bounding rect`);
+    }
 
     bbox1.y2 = bbox1.y + bbox1.height;
     bbox2.y2 = bbox2.y + bbox2.height;
@@ -98,7 +113,7 @@ Scenario("Lines overlap", async ({ I, LabelStudio, AtTaxonomy }) => {
   AtTaxonomy.fillSearch("long");
   await checkOverlapAndGap("super long line", "enough long line");
   await checkOverlapAndGap("enough long line", "not long line");
-});
+}).retry(3);
 
 Scenario("Add custom items", async ({ I, LabelStudio, AtTaxonomy }) => {
   const params = {


### PR DESCRIPTION
This pull request focuses on improving the reliability and robustness of E2E tests in the `web/libs/editor/tests/e2e/tests` suite. The main enhancements include adding retries to flaky test scenarios and strengthening element handling in the taxonomy overlap test to prevent false negatives due to timing issues.

**Test reliability improvements:**

* Added `.retry(3)` to several test scenarios in `image.transformer.test.js`, `outliner.test.js`, and `taxonomy.test.js` to automatically retry tests up to three times if they fail, reducing flakiness from intermittent issues. [[1]](diffhunk://#diff-928147e170d70c28ba8dd7729340c7d07c6034bf5584017cc0eaff412eadf775L212-R214) [[2]](diffhunk://#diff-cf3f5e577c14533a6a7fcc79d82ff477766c79350cc140109b6fca728fb48511L222-R222) [[3]](diffhunk://#diff-aca2d8e7393d42abf21c1f11326354296b9bf517a1380f0402e4566a1e4e3294L101-R116)

**Test robustness enhancements:**

* Improved the `Lines overlap` scenario in `taxonomy.test.js` by waiting for elements to appear in the DOM before attempting to grab their bounding rectangles, and by adding explicit null checks with informative error messages. This helps prevent test failures caused by elements not being immediately available.

**Test code formatting:**

* Minor formatting change to the chaining of `.Scenario()` in `image.transformer.test.js` for better readability.