### PR TITLE
chore: OPTIC-1337 Live Tooltips update for webinar

### DIFF
--- a/web/apps/labelstudio/src/components/HeidiTips/liveContent.json
+++ b/web/apps/labelstudio/src/components/HeidiTips/liveContent.json
@@ -201,7 +201,7 @@
   "authPage": [
     {
       "title": "Live Event Dec 10th",
-      "description": "Join the Label Studio product team for a fast-paced tour of this year's biggest releases,
+      "description": "Join the Label Studio product team for a fast-paced tour of this year's biggest releases",
       "link": {
         "label": "December 10, 2025 9am PST",
         "url": "https://humansignal.com/webinars/label-studio-wrapped-2025/",

--- a/web/apps/labelstudio/src/components/HeidiTips/liveContent.json
+++ b/web/apps/labelstudio/src/components/HeidiTips/liveContent.json
@@ -200,6 +200,18 @@
   ],
   "authPage": [
     {
+      "title": "Live Event Dec 10th",
+      "description": "Join the Label Studio product team for a fast-paced tour of this year's biggest releases,
+      "link": {
+        "label": "December 10, 2025 9am PST",
+        "url": "https://humansignal.com/webinars/label-studio-wrapped-2025/",
+        "params": {
+          "experiment": "login_revamp",
+          "treatment": "wrapped_webinar_2025_live"
+        }
+      }    
+    },      
+    {
       "title": "Auto-labeling with Prompts",
       "description": "Use LLMs to instantly pre-label thousands of tasks with accurate predictions.",
       "link": {

--- a/web/apps/labelstudio/src/components/HeidiTips/liveContent.json
+++ b/web/apps/labelstudio/src/components/HeidiTips/liveContent.json
@@ -209,8 +209,8 @@
           "experiment": "login_revamp",
           "treatment": "wrapped_webinar_2025_live"
         }
-      }    
-    },      
+      }
+    },
     {
       "title": "Auto-labeling with Prompts",
       "description": "Use LLMs to instantly pre-label thousands of tasks with accurate predictions.",


### PR DESCRIPTION
Live tooltips update: Added details for the live event on December 10th, 2025