### PR TITLE
fix: FIT-1089: Projects prefetch would require too many fields and could cause OOM exceptions

### DIFF
--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -352,14 +352,23 @@ class Project(ProjectMixin, FsmHistoryStateModel):
 
     def __init__(self, *args, **kwargs):
         super(Project, self).__init__(*args, **kwargs)
-        self.__original_label_config = self.label_config
-        self.__maximum_annotations = self.maximum_annotations
-        self.__overlap_cohort_percentage = self.overlap_cohort_percentage
-        self.__skip_queue = self.skip_queue
+        # This check is required because deferred fields cause issues with evaluating lazy (deferred) fields if read directly, which means that any attempt to optimize a queryset involving projects
+        # will result in a performance regression as it will n+1 or in some cases cause an infinite loop.
+        deferred_fields = self.get_deferred_fields()
+        self.__original_label_config = self.label_config if 'label_config' not in deferred_fields else None
+        self.__maximum_annotations = self.maximum_annotations if 'maximum_annotations' not in deferred_fields else None
+        self.__overlap_cohort_percentage = (
+            self.overlap_cohort_percentage if 'overlap_cohort_percentage' not in deferred_fields else None
+        )
+        self.__skip_queue = self.skip_queue if 'skip_queue' not in deferred_fields else None
 
         # TODO: once bugfix with incorrect data types in List
         # logging.warning('! Please, remove code below after patching of all projects (extract_data_types)')
-        if self.label_config is not None:
+        if (
+            'label_config' not in deferred_fields
+            and self.label_config is not None
+            and 'data_types' not in deferred_fields
+        ):
             data_types = extract_data_types(self.label_config)
             if self.data_types != data_types:
                 self.data_types = data_types


### PR DESCRIPTION
This pull request improves how the `Project` model's initialization handles deferred fields in Django, preventing performance issues and potential infinite loops when working with optimized querysets. The main change ensures that certain attributes are only accessed if they are not deferred, which helps avoid unnecessary database queries and related bugs.

Initialization and deferred fields handling:

* Updated the `Project.__init__` method in `projects/models.py` to check for deferred fields before accessing `label_config`, `maximum_annotations`, `overlap_cohort_percentage`, and `skip_queue`, assigning `None` if the field is deferred. This prevents n+1 queries and possible infinite loops when using optimized querysets.
* Modified the data type extraction logic to only run if both `label_config` and `data_types` are not deferred, further reducing unnecessary database access.