### PR TITLE
docs: Fix incomplete description in release notes

### DIFF
--- a/docs/source/guide/release_notes/onprem/2.31.0.md
+++ b/docs/source/guide/release_notes/onprem/2.31.0.md
@@ -204,7 +204,7 @@ You can now use personal access tokens as well.
 
 - Added user session IDs to activity logs.
 
-- Added a `none` option for the `decoder` param for Audio tags, which will allos
+- Added a `none` option for the `decoder` param for Audio tags, which will allow you to skip audio decoding for use cases which require labeling on the timeline but the file size is far too large to decode at one time. 
 
 
 #### Performance improvements

--- a/docs/source/guide/release_notes/onprem/2.31.0.md
+++ b/docs/source/guide/release_notes/onprem/2.31.0.md
@@ -204,7 +204,7 @@ You can now use personal access tokens as well.
 
 - Added user session IDs to activity logs.
 
-- Added a `none` option for the `decoder` param for Audio tags, which will allow you to skip audio decoding for use cases which require labeling on the timeline but the file size is far too large to decode at one time. 
+- Added a `none` option for the `decoder` param for Audio tags, which will allow you to skip audio decoding for use cases that require labeling on the timeline but the file size is far too large to decode at one time. 
 
 
 #### Performance improvements


### PR DESCRIPTION
2.31 release notes had an incomplete bullet point