### PR TITLE
fix: FIT-1108: Handle project states correctly when it is in a personal Sandbox

### DIFF
--- a/label_studio/core/settings/base.py
+++ b/label_studio/core/settings/base.py
@@ -932,7 +932,7 @@ DM_MAX_USERS_TO_DISPLAY = int(get_env('DM_MAX_USERS_TO_DISPLAY', 10))
 
 # Base FSM (Finite State Machine) Configuration for Label Studio
 FSM_CACHE_TTL = 300  # Cache TTL in seconds (5 minutes)
-FSM_SYNC_PROJECT_STATE = 'fsm.project_transitions.sync_project_state_lso'
+FSM_SYNC_PROJECT_STATE = 'fsm.project_transitions.sync_project_state'
 
 # Used for async migrations. In LSE this is set to a real queue name, including here so we
 # can use settings.SERVICE_QUEUE_NAME in async migrations in LSO

--- a/label_studio/core/settings/base.py
+++ b/label_studio/core/settings/base.py
@@ -932,7 +932,7 @@ DM_MAX_USERS_TO_DISPLAY = int(get_env('DM_MAX_USERS_TO_DISPLAY', 10))
 
 # Base FSM (Finite State Machine) Configuration for Label Studio
 FSM_CACHE_TTL = 300  # Cache TTL in seconds (5 minutes)
-FSM_UPDATE_PROJECT_STATE_AFTER_TASK_CHANGE = 'fsm.project_transitions._update_project_state_after_task_change_lso'
+FSM_SYNC_PROJECT_STATE = 'fsm.project_transitions.sync_project_state_lso'
 
 # Used for async migrations. In LSE this is set to a real queue name, including here so we
 # can use settings.SERVICE_QUEUE_NAME in async migrations in LSO

--- a/label_studio/fsm/project_transitions.py
+++ b/label_studio/fsm/project_transitions.py
@@ -133,7 +133,7 @@ class ProjectInProgressFromCompletedTransition(ModelChangeTransition):
         }
 
 
-def _update_project_state_after_task_change_lso(project, user=None):
+def sync_project_state(project, user=None, reason=None, context_data=None):
     current_state = StateManager.get_current_state_value(project)
     inferred_state = infer_entity_state_from_data(project)
 
@@ -155,5 +155,5 @@ def _update_project_state_after_task_change_lso(project, user=None):
 
 
 def update_project_state_after_task_change(project, user=None):
-    update_func = load_func(settings.FSM_UPDATE_PROJECT_STATE_AFTER_TASK_CHANGE)
+    update_func = load_func(settings.FSM_SYNC_PROJECT_STATE)
     return update_func(project, user)

--- a/label_studio/fsm/tests/test_transitions.py
+++ b/label_studio/fsm/tests/test_transitions.py
@@ -950,3 +950,246 @@ def test_skip_validation_flag():
     result_valid = transition_valid.prepare_and_validate(context_valid)
     assert result_valid['action'] == 'valid_action'
     assert result_valid['completed'] is True
+
+
+def test_transition_context_reason_field():
+    """
+    Test the reason field in TransitionContext.
+
+    This test validates step by step:
+    - Creating a TransitionContext with no reason (defaults to None)
+    - Creating a TransitionContext with a custom reason
+    - Verifying the reason is accessible on the context
+
+    Critical validation: The reason field allows callers to provide context-specific
+    reasons for transitions (e.g., "Bulk import completed") that override the
+    transition's default get_reason() method.
+    """
+    mock_entity = MockEntity()
+
+    # Test 1: Default reason is None
+    context_default = TransitionContext(
+        entity=mock_entity,
+        current_state=TestStateChoices.CREATED,
+        target_state=TestStateChoices.IN_PROGRESS,
+    )
+    assert context_default.reason is None
+
+    # Test 2: Custom reason can be set
+    custom_reason = 'Bulk import completed - 100 tasks added'
+    context_with_reason = TransitionContext(
+        entity=mock_entity,
+        current_state=TestStateChoices.CREATED,
+        target_state=TestStateChoices.IN_PROGRESS,
+        reason=custom_reason,
+    )
+    assert context_with_reason.reason == custom_reason
+
+
+def test_transition_context_context_data_field():
+    """
+    Test the context_data field in TransitionContext.
+
+    This test validates step by step:
+    - Creating a TransitionContext with no context_data (defaults to empty dict)
+    - Creating a TransitionContext with custom context_data
+    - Verifying the context_data is accessible and correct
+
+    Critical validation: The context_data field allows callers to add additional
+    data to be stored in the state record's JSONB context_data field for
+    historical tracking and auditing purposes.
+    """
+    mock_entity = MockEntity()
+
+    # Test 1: Default context_data is empty dict
+    context_default = TransitionContext(
+        entity=mock_entity,
+        current_state=TestStateChoices.CREATED,
+        target_state=TestStateChoices.IN_PROGRESS,
+    )
+    assert context_default.context_data == {}
+
+    # Test 2: Custom context_data can be set
+    custom_context_data = {
+        'import_source': 'cloud_storage',
+        'import_id': 123,
+        'task_count': 100,
+        'triggered_by': 'api',
+        'batch_id': 456,
+        'is_automatic': False,
+    }
+    context_with_data = TransitionContext(
+        entity=mock_entity,
+        current_state=TestStateChoices.CREATED,
+        target_state=TestStateChoices.IN_PROGRESS,
+        context_data=custom_context_data,
+    )
+    assert context_with_data.context_data == custom_context_data
+    assert context_with_data.context_data['import_id'] == 123
+    assert context_with_data.context_data['is_automatic'] is False
+
+
+def test_transition_reason_override():
+    """
+    Test that context.reason overrides transition.get_reason() in executor.
+
+    This test validates step by step:
+    - Creating a transition with a custom get_reason() implementation
+    - Executing with no context.reason (should use transition's get_reason)
+    - Executing with context.reason set (should override get_reason)
+
+    Critical validation: The reason override mechanism allows for context-specific
+    reasons without modifying transition classes.
+    """
+
+    class CustomReasonTransition(BaseTransition):
+        """Transition with custom get_reason"""
+
+        def get_target_state(self, context: Optional[TransitionContext] = None) -> str:
+            return TestStateChoices.IN_PROGRESS
+
+        def get_reason(self, context: TransitionContext) -> str:
+            return 'Default transition reason'
+
+        def transition(self, context: TransitionContext) -> Dict[str, Any]:
+            return {'executed': True}
+
+    mock_entity = MockEntity()
+    transition = CustomReasonTransition()
+
+    # Test 1: Without reason override - uses transition's get_reason
+    context_no_override = TransitionContext(
+        entity=mock_entity,
+        current_state=TestStateChoices.CREATED,
+        target_state=TestStateChoices.IN_PROGRESS,
+    )
+    default_reason = transition.get_reason(context_no_override)
+    assert default_reason == 'Default transition reason'
+
+    # Verify context.reason is None
+    assert context_no_override.reason is None
+
+    # The executor would use: context.reason if context.reason else transition.get_reason(context)
+    effective_reason = (
+        context_no_override.reason if context_no_override.reason else transition.get_reason(context_no_override)
+    )
+    assert effective_reason == 'Default transition reason'
+
+    # Test 2: With reason override - uses context.reason
+    custom_reason = 'Bulk import completed with 500 tasks'
+    context_with_override = TransitionContext(
+        entity=mock_entity,
+        current_state=TestStateChoices.CREATED,
+        target_state=TestStateChoices.IN_PROGRESS,
+        reason=custom_reason,
+    )
+
+    # The executor would use: context.reason if context.reason else transition.get_reason(context)
+    effective_reason = (
+        context_with_override.reason if context_with_override.reason else transition.get_reason(context_with_override)
+    )
+    assert effective_reason == custom_reason
+
+
+def test_transition_context_data_merge():
+    """
+    Test that context.context_data is merged with transition output.
+
+    This test validates step by step:
+    - Creating a transition that returns context data
+    - Adding additional context_data via TransitionContext
+    - Verifying both are merged correctly
+
+    Critical validation: Additional context_data from TransitionContext should
+    be merged with the data returned by transition.transition() method.
+    """
+
+    class DataProducingTransition(BaseTransition):
+        """Transition that produces context data"""
+
+        action: str = 'test_action'
+
+        def get_target_state(self, context: Optional[TransitionContext] = None) -> str:
+            return TestStateChoices.IN_PROGRESS
+
+        def transition(self, context: TransitionContext) -> Dict[str, Any]:
+            return {
+                'action': self.action,
+                'timestamp': context.timestamp.isoformat(),
+            }
+
+    mock_entity = MockEntity()
+    transition = DataProducingTransition(action='bulk_import')
+
+    # Create context with additional context_data
+    additional_context_data = {
+        'import_source_id': 123,
+        'task_count': 456,
+    }
+    context = TransitionContext(
+        entity=mock_entity,
+        current_state=TestStateChoices.CREATED,
+        target_state=TestStateChoices.IN_PROGRESS,
+        context_data=additional_context_data,
+    )
+
+    # Get transition output
+    transition_output = transition.transition(context)
+
+    # Simulate merge (as done in transition_executor.py)
+    merged_data = {**transition_output, **context.context_data}
+
+    # Verify both transition output and additional context_data are present
+    assert merged_data['action'] == 'bulk_import'
+    assert 'timestamp' in merged_data
+    assert merged_data['import_source_id'] == 123
+    assert merged_data['task_count'] == 456
+
+
+def test_transition_context_data_override():
+    """
+    Test that context.context_data can override transition output keys.
+
+    This test validates step by step:
+    - Creating a transition that returns a key
+    - Adding the same key in context_data with different value
+    - Verifying context_data wins (as it's merged second)
+
+    Critical validation: When the same key exists in both transition output
+    and context_data, the context_data value should win since it represents
+    caller-provided context that should take precedence.
+    """
+
+    class OverrideTestTransition(BaseTransition):
+        """Transition that produces a 'reason_code' key"""
+
+        def get_target_state(self, context: Optional[TransitionContext] = None) -> str:
+            return TestStateChoices.IN_PROGRESS
+
+        def transition(self, context: TransitionContext) -> Dict[str, Any]:
+            return {
+                'reason_code': 'default_reason',
+                'other_data': 'preserved',
+            }
+
+    mock_entity = MockEntity()
+    transition = OverrideTestTransition()
+
+    # Create context with context_data that overrides 'reason_code'
+    context = TransitionContext(
+        entity=mock_entity,
+        current_state=TestStateChoices.CREATED,
+        target_state=TestStateChoices.IN_PROGRESS,
+        context_data={'reason_code': 'custom_reason'},
+    )
+
+    # Get transition output
+    transition_output = transition.transition(context)
+
+    # Simulate merge (as done in transition_executor.py)
+    merged_data = {**transition_output, **context.context_data}
+
+    # Verify context_data wins for 'reason_code'
+    assert merged_data['reason_code'] == 'custom_reason'
+    # Other data should be preserved
+    assert merged_data['other_data'] == 'preserved'

--- a/label_studio/fsm/tests/test_utils.py
+++ b/label_studio/fsm/tests/test_utils.py
@@ -531,3 +531,183 @@ class TestGetCurrentStateSafeCoverage(TestCase):
         with patch('fsm.utils.is_fsm_enabled', return_value=False):
             result = get_current_state_safe(mock_entity)
             assert result is None
+
+
+class TestGetOrInitializeStateParameters(TestCase):
+    """Test coverage for get_or_initialize_state reason and context_data parameters.
+
+    These tests validate that the reason and context_data parameters are correctly
+    accepted and passed through to StateManager.execute_transition().
+    """
+
+    def setUp(self):
+        self.mock_entity = MockEntity()
+
+    def test_get_or_initialize_state_accepts_reason_parameter(self):
+        """Test that get_or_initialize_state accepts reason parameter.
+
+        This test validates step by step:
+        - Calling get_or_initialize_state with a reason parameter
+        - Verifying it's passed to StateManager.execute_transition
+
+        Critical validation: The reason parameter allows callers to provide
+        context-specific reasons for state initialization.
+        """
+        from fsm.utils import get_or_initialize_state
+
+        custom_reason = 'Bulk import completed - initializing state'
+
+        with patch('fsm.utils.is_fsm_enabled', return_value=True):
+            with patch('fsm.utils.CurrentContext') as mock_context:
+                mock_context.is_fsm_disabled.return_value = False
+
+                # Mock StateManager to capture call arguments
+                with patch('fsm.utils.get_state_manager') as mock_get_sm:
+                    mock_sm = Mock()
+                    mock_sm.get_current_state_value.return_value = None  # No existing state
+                    mock_get_sm.return_value = mock_sm
+
+                    # Mock state inference
+                    with patch('fsm.utils.infer_entity_state_from_data', return_value='IN_PROGRESS'):
+                        with patch('fsm.utils._get_initialization_transition_name', return_value='init_transition'):
+                            # Call with reason
+                            get_or_initialize_state(
+                                self.mock_entity,
+                                user=None,
+                                inferred_state='IN_PROGRESS',
+                                reason=custom_reason,
+                            )
+
+                            # Verify execute_transition was called with reason
+                            mock_sm.execute_transition.assert_called_once()
+                            call_kwargs = mock_sm.execute_transition.call_args[1]
+                            assert call_kwargs.get('reason') == custom_reason
+
+    def test_get_or_initialize_state_accepts_context_data_parameter(self):
+        """Test that get_or_initialize_state accepts context_data parameter.
+
+        This test validates step by step:
+        - Calling get_or_initialize_state with a context_data parameter
+        - Verifying it's passed to StateManager.execute_transition
+
+        Critical validation: The context_data parameter allows callers to add
+        additional data to be stored in the state record's JSONB context_data.
+        """
+        from fsm.utils import get_or_initialize_state
+
+        custom_context_data = {
+            'import_source_id': 123,
+            'task_count': 456,
+            'triggered_by_api': False,
+        }
+
+        with patch('fsm.utils.is_fsm_enabled', return_value=True):
+            with patch('fsm.utils.CurrentContext') as mock_context:
+                mock_context.is_fsm_disabled.return_value = False
+
+                # Mock StateManager to capture call arguments
+                with patch('fsm.utils.get_state_manager') as mock_get_sm:
+                    mock_sm = Mock()
+                    mock_sm.get_current_state_value.return_value = None  # No existing state
+                    mock_get_sm.return_value = mock_sm
+
+                    # Mock state inference
+                    with patch('fsm.utils.infer_entity_state_from_data', return_value='IN_PROGRESS'):
+                        with patch('fsm.utils._get_initialization_transition_name', return_value='init_transition'):
+                            # Call with context_data
+                            get_or_initialize_state(
+                                self.mock_entity,
+                                user=None,
+                                inferred_state='IN_PROGRESS',
+                                context_data=custom_context_data,
+                            )
+
+                            # Verify execute_transition was called with context_data
+                            mock_sm.execute_transition.assert_called_once()
+                            call_kwargs = mock_sm.execute_transition.call_args[1]
+                            assert call_kwargs.get('context_data') == custom_context_data
+
+    def test_get_or_initialize_state_with_both_reason_and_context_data(self):
+        """Test get_or_initialize_state with both reason and context_data.
+
+        This test validates step by step:
+        - Calling get_or_initialize_state with both reason and context_data
+        - Verifying both are passed to StateManager.execute_transition
+
+        Critical validation: Both parameters should be passed independently
+        without interference.
+        """
+        from fsm.utils import get_or_initialize_state
+
+        custom_reason = 'Bulk import completed with configuration changes'
+        custom_context_data = {
+            'import_source_id': 123,
+            'previous_task_count': 100,
+            'new_task_count': 456,
+            'triggered_by_api': False,
+        }
+
+        with patch('fsm.utils.is_fsm_enabled', return_value=True):
+            with patch('fsm.utils.CurrentContext') as mock_context:
+                mock_context.is_fsm_disabled.return_value = False
+
+                # Mock StateManager to capture call arguments
+                with patch('fsm.utils.get_state_manager') as mock_get_sm:
+                    mock_sm = Mock()
+                    mock_sm.get_current_state_value.return_value = None  # No existing state
+                    mock_get_sm.return_value = mock_sm
+
+                    # Mock state inference
+                    with patch('fsm.utils.infer_entity_state_from_data', return_value='IN_PROGRESS'):
+                        with patch('fsm.utils._get_initialization_transition_name', return_value='init_transition'):
+                            # Call with both reason and context_data
+                            get_or_initialize_state(
+                                self.mock_entity,
+                                user=None,
+                                inferred_state='IN_PROGRESS',
+                                reason=custom_reason,
+                                context_data=custom_context_data,
+                            )
+
+                            # Verify execute_transition was called with both parameters
+                            mock_sm.execute_transition.assert_called_once()
+                            call_kwargs = mock_sm.execute_transition.call_args[1]
+                            assert call_kwargs.get('reason') == custom_reason
+                            assert call_kwargs.get('context_data') == custom_context_data
+
+    def test_get_or_initialize_state_defaults_context_data_to_empty_dict(self):
+        """Test that get_or_initialize_state defaults context_data to empty dict.
+
+        This test validates step by step:
+        - Calling get_or_initialize_state without context_data
+        - Verifying empty dict is passed to StateManager.execute_transition
+
+        Critical validation: When context_data is not provided, it should
+        default to an empty dict (not None) to ensure proper merging behavior.
+        """
+        from fsm.utils import get_or_initialize_state
+
+        with patch('fsm.utils.is_fsm_enabled', return_value=True):
+            with patch('fsm.utils.CurrentContext') as mock_context:
+                mock_context.is_fsm_disabled.return_value = False
+
+                # Mock StateManager to capture call arguments
+                with patch('fsm.utils.get_state_manager') as mock_get_sm:
+                    mock_sm = Mock()
+                    mock_sm.get_current_state_value.return_value = None  # No existing state
+                    mock_get_sm.return_value = mock_sm
+
+                    # Mock state inference
+                    with patch('fsm.utils.infer_entity_state_from_data', return_value='IN_PROGRESS'):
+                        with patch('fsm.utils._get_initialization_transition_name', return_value='init_transition'):
+                            # Call without context_data
+                            get_or_initialize_state(
+                                self.mock_entity,
+                                user=None,
+                                inferred_state='IN_PROGRESS',
+                            )
+
+                            # Verify execute_transition was called with empty dict for context_data
+                            mock_sm.execute_transition.assert_called_once()
+                            call_kwargs = mock_sm.execute_transition.call_args[1]
+                            assert call_kwargs.get('context_data') == {}

--- a/label_studio/fsm/tests/test_utils.py
+++ b/label_studio/fsm/tests/test_utils.py
@@ -561,8 +561,8 @@ class TestGetOrInitializeStateParameters(TestCase):
             with patch('fsm.utils.CurrentContext') as mock_context:
                 mock_context.is_fsm_disabled.return_value = False
 
-                # Mock StateManager to capture call arguments
-                with patch('fsm.utils.get_state_manager') as mock_get_sm:
+                # Mock StateManager - patch where it's imported (fsm.state_manager)
+                with patch('fsm.state_manager.get_state_manager') as mock_get_sm:
                     mock_sm = Mock()
                     mock_sm.get_current_state_value.return_value = None  # No existing state
                     mock_get_sm.return_value = mock_sm
@@ -605,8 +605,8 @@ class TestGetOrInitializeStateParameters(TestCase):
             with patch('fsm.utils.CurrentContext') as mock_context:
                 mock_context.is_fsm_disabled.return_value = False
 
-                # Mock StateManager to capture call arguments
-                with patch('fsm.utils.get_state_manager') as mock_get_sm:
+                # Mock StateManager - patch where it's imported (fsm.state_manager)
+                with patch('fsm.state_manager.get_state_manager') as mock_get_sm:
                     mock_sm = Mock()
                     mock_sm.get_current_state_value.return_value = None  # No existing state
                     mock_get_sm.return_value = mock_sm
@@ -651,8 +651,8 @@ class TestGetOrInitializeStateParameters(TestCase):
             with patch('fsm.utils.CurrentContext') as mock_context:
                 mock_context.is_fsm_disabled.return_value = False
 
-                # Mock StateManager to capture call arguments
-                with patch('fsm.utils.get_state_manager') as mock_get_sm:
+                # Mock StateManager - patch where it's imported (fsm.state_manager)
+                with patch('fsm.state_manager.get_state_manager') as mock_get_sm:
                     mock_sm = Mock()
                     mock_sm.get_current_state_value.return_value = None  # No existing state
                     mock_get_sm.return_value = mock_sm
@@ -691,8 +691,8 @@ class TestGetOrInitializeStateParameters(TestCase):
             with patch('fsm.utils.CurrentContext') as mock_context:
                 mock_context.is_fsm_disabled.return_value = False
 
-                # Mock StateManager to capture call arguments
-                with patch('fsm.utils.get_state_manager') as mock_get_sm:
+                # Mock StateManager - patch where it's imported (fsm.state_manager)
+                with patch('fsm.state_manager.get_state_manager') as mock_get_sm:
                     mock_sm = Mock()
                     mock_sm.get_current_state_value.return_value = None  # No existing state
                     mock_get_sm.return_value = mock_sm

--- a/label_studio/fsm/transition_executor.py
+++ b/label_studio/fsm/transition_executor.py
@@ -117,6 +117,11 @@ def execute_transition_with_state_manager(
     # Phase 1: Prepare and validate the transition
     transition_context_data = transition.prepare_and_validate(context)
 
+    # Merge any additional context_data from TransitionContext
+    # This allows callers to add extra data (e.g., workspace_from_id) to the state record
+    if context.context_data:
+        transition_context_data = {**transition_context_data, **context.context_data}
+
     # Phase 2: Create the state record via StateManager methods (skip for side-effect only transitions)
     if is_side_effect_only:
         # For side-effect only transitions, execute hooks without creating state records
@@ -135,13 +140,16 @@ def execute_transition_with_state_manager(
     # Check if this transition forces state record creation (for audit trails)
     force_state_record = getattr(transition, '_force_state_record', False)
 
+    # Use context.reason if provided (caller override), otherwise use transition's default
+    reason = context.reason if context.reason else transition.get_reason(context)
+
     success = state_manager_class.transition_state(
         entity=entity,
         new_state=target_state,
         transition_name=transition.transition_name,
         user=user,
         context=transition_context_data,
-        reason=transition.get_reason(context),
+        reason=reason,
         force_state_record=force_state_record,
     )
 

--- a/label_studio/fsm/transitions.py
+++ b/label_studio/fsm/transitions.py
@@ -57,6 +57,20 @@ class TransitionContext(BaseModel, Generic[EntityType, StateModelType]):
     # Validation context, for cases where we want to skip validation for the transition
     skip_validation: Optional[bool] = Field(default=False, description='Whether to skip validation for the transition')
 
+    # Reason override - if provided, takes precedence over Transition.get_reason()
+    # This allows callers to provide context-specific reasons for transitions
+    # (e.g., "Project moved from Sandbox to FSM Testing workspace")
+    reason: Optional[str] = Field(
+        None, description='Override reason for this transition (takes precedence over get_reason)'
+    )
+
+    # Additional context data to be merged with transition's context_data
+    # This allows callers to add extra data to be stored in the state record's JSONB context_data
+    # (e.g., workspace_from_id, workspace_to_id for workspace change transitions)
+    context_data: Dict[str, Any] = Field(
+        default_factory=dict, description='Additional context data to store with state record'
+    )
+
     @property
     def has_current_state(self) -> bool:
         """Check if entity has a current state"""
@@ -250,6 +264,10 @@ class BaseTransition(BaseModel, ABC, Generic[EntityType, StateModelType]):
         Get a human-readable reason for this transition.
 
         Override in subclasses to provide more specific reasons.
+
+        Note: If `context.reason` is set, it takes precedence over this method.
+        This allows callers to provide context-specific reasons when executing
+        transitions (e.g., "Project moved from Sandbox to shared workspace").
 
         Args:
             context: The transition context

--- a/label_studio/fsm/utils.py
+++ b/label_studio/fsm/utils.py
@@ -374,7 +374,7 @@ def infer_entity_state_from_data(entity) -> Optional[str]:
         return None
 
 
-def get_or_initialize_state(entity, user=None, inferred_state=None) -> Optional[str]:
+def get_or_initialize_state(entity, user=None, inferred_state=None, reason=None, context_data=None) -> Optional[str]:
     """
     Get current state, or initialize it if it doesn't exist.
 
@@ -389,6 +389,8 @@ def get_or_initialize_state(entity, user=None, inferred_state=None) -> Optional[
         entity: The entity to get or initialize state for
         user: User for FSM context (optional)
         inferred_state: Pre-computed inferred state (optional, will compute if not provided)
+        reason: Custom reason for the state initialization (optional, overrides default)
+        context_data: Additional context data to store with state record (optional)
 
     Returns:
         Current or newly initialized state value, or None if FSM disabled or failed
@@ -448,7 +450,14 @@ def get_or_initialize_state(entity, user=None, inferred_state=None) -> Optional[
                     'transition_name': transition_name,
                 },
             )
-            StateManager.execute_transition(entity=entity, transition_name=transition_name, user=user)
+            # Pass reason and context_data if provided (flow through to TransitionContext)
+            StateManager.execute_transition(
+                entity=entity,
+                transition_name=transition_name,
+                user=user,
+                reason=reason,
+                context_data=context_data or {},
+            )
             return inferred_state
         else:
             logger.warning(


### PR DESCRIPTION
This pull request introduces support for custom transition reasons and additional context data in the FSM (Finite State Machine) transition workflow. These enhancements allow callers to override default transition reasons and attach extra metadata to state records for better auditing and historical tracking. The changes include updates to the core transition context, transition executor, and the utility function for state initialization, as well as comprehensive test coverage for the new functionality.

### FSM Transition Context and Executor Enhancements

**Custom Reason and Context Data Support**
* Added `reason` and `context_data` fields to the `TransitionContext` class, enabling callers to override transition reasons and attach extra metadata to transitions.
* Updated the transition executor (`execute_transition_with_state_manager`) to merge `context_data` from the context into the transition output and to use `context.reason` as an override for the transition's default reason. [[1]](diffhunk://#diff-545da87bbc65a43e0dc6222f1f389a0f6f8414466e5512b300b5f57b61e37ef0R120-R124) [[2]](diffhunk://#diff-545da87bbc65a43e0dc6222f1f389a0f6f8414466e5512b300b5f57b61e37ef0R143-R152)

**Transition Reason Handling**
* Documented and enforced that if `context.reason` is set, it takes precedence over the transition's `get_reason()` method, allowing for context-specific explanations without modifying transition logic.

### State Initialization Utility Improvements

**API Extension and Flow-Through**
* Extended the `get_or_initialize_state` utility function to accept `reason` and `context_data` parameters, passing them through to the state manager and ensuring they are properly handled during state initialization. [[1]](diffhunk://#diff-a6c21669adfe5cf170539ede50336480b76585d262595099482f6388569174d1L377-R377) [[2]](diffhunk://#diff-a6c21669adfe5cf170539ede50336480b76585d262595099482f6388569174d1R392-R393) [[3]](diffhunk://#diff-a6c21669adfe5cf170539ede50336480b76585d262595099482f6388569174d1L451-R460)

### Test Coverage

**Comprehensive Testing of New Features**
* Added new tests to verify that `TransitionContext` correctly handles `reason` and `context_data`, that these fields override and merge as expected, and that the `get_or_initialize_state` function passes these parameters through to the state manager. [[1]](diffhunk://#diff-18a7e9cbe30643a61d520ce8ad2996ea13e3ed2e6840807aac3e378f02f43f43R953-R1195) [[2]](diffhunk://#diff-0f93b6b13316be70ddfe266da387dc1ac46c505260e3099224216db286de818fR534-R713)