### PR TITLE
fix: FIT-1117: Project cards in LSO contain 'yy, HH:mm' literals

### DIFF
--- a/web/apps/labelstudio/src/pages/Projects/ProjectsList.jsx
+++ b/web/apps/labelstudio/src/pages/Projects/ProjectsList.jsx
@@ -141,7 +141,7 @@ const ProjectCard = ({ project }) => {
         <div className={cn("project-card").elem("description").toClassName()}>{project.description}</div>
         <div className={cn("project-card").elem("info").toClassName()}>
           <div className={cn("project-card").elem("created-date").toClassName()}>
-            {format(new Date(project.created_at), "dd MMM 'yy, HH:mm")}
+            {format(new Date(project.created_at), "dd MMM yyyy, HH:mm")}
           </div>
           <div className={cn("project-card").elem("created-by").toClassName()}>
             <Userpic src="#" user={project.created_by} showUsernameTooltip />


### PR DESCRIPTION
This pull request makes a small change to the date formatting for project cards. The year in the displayed creation date now shows the full four digits instead of a two-digit abbreviation.

<img width="868" height="577" alt="image" src="https://github.com/user-attachments/assets/7bcdef51-bd63-48fc-8e0c-9c19c122fe96" />

- Updated the date format in the `ProjectCard` component to display the full year (e.g., "2024" instead of "24") for the project creation date.