### PR TITLE
fix: FIT-1117: Project cards in LSO contain 'yy, HH:mm' literals (#8989)

### DIFF
--- a/web/apps/labelstudio/src/pages/Projects/ProjectsList.jsx
+++ b/web/apps/labelstudio/src/pages/Projects/ProjectsList.jsx
@@ -141,7 +141,7 @@ const ProjectCard = ({ project }) => {
         <div className={cn("project-card").elem("description").toClassName()}>{project.description}</div>
         <div className={cn("project-card").elem("info").toClassName()}>
           <div className={cn("project-card").elem("created-date").toClassName()}>
-            {format(new Date(project.created_at), "dd MMM 'yy, HH:mm")}
+            {format(new Date(project.created_at), "dd MMM yyyy, HH:mm")}
           </div>
           <div className={cn("project-card").elem("created-by").toClassName()}>
             <Userpic src="#" user={project.created_by} showUsernameTooltip />


### PR DESCRIPTION
This pull request makes a small formatting adjustment to the project creation date display in the `ProjectCard` component. The year is now shown in full (e.g., "2024" instead of "24") for improved clarity.

- Changed the date format in the `ProjectCard` component to display the full year (`yyyy`) instead of the two-digit year (`yy`). (`web/apps/labelstudio/src/pages/Projects/ProjectsList.jsx`)