### PR TITLE
fix: FIT-642: Text and number input fields are NOT aligned with other fields in the filter modal

### DIFF
--- a/web/libs/datamanager/src/components/Filters/FilterInput.jsx
+++ b/web/libs/datamanager/src/components/Filters/FilterInput.jsx
@@ -11,7 +11,7 @@ export const FilterInput = ({ value, type, onChange, placeholder, schema, style 
 
   return (
     <Input
-      rawClassName="h-full min-w-[100px]"
+      rawClassName="min-w-[100px]"
       size="small"
       type={type}
       value={value ?? ""}


### PR DESCRIPTION
This pull request makes a minor adjustment to the `FilterInput` component by removing the `h-full` class from the input's class list. This change likely affects the input's height styling to better fit its intended design.

before:
<img width="519" height="213" alt="image" src="https://github.com/user-attachments/assets/9326fe07-5c03-4382-bce9-b2b1bfb8f128" />


after:
<img width="547" height="237" alt="image" src="https://github.com/user-attachments/assets/e9a32870-5645-4526-a0ac-ae3b1abf5d6c" />
