### PR TITLE
fix: FIT-642: Text and number input fields are NOT aligned with other fields in the filter modal

### DIFF
--- a/web/libs/datamanager/src/components/Filters/FilterInput.jsx
+++ b/web/libs/datamanager/src/components/Filters/FilterInput.jsx
@@ -11,7 +11,7 @@ export const FilterInput = ({ value, type, onChange, placeholder, schema, style 
 
   return (
     <Input
-      rawClassName="h-full min-w-[100px]"
+      rawClassName="min-w-[100px]"
       size="small"
       type={type}
       value={value ?? ""}


### PR DESCRIPTION
This pull request makes a minor adjustment to the `FilterInput` component by removing the `h-full` class from the `rawClassName` prop. This change will affect the height styling of the input element, making it no longer take the full height of its container.