### PR TITLE
fix: UTC-431: After returning from the activity logs page, the role dropdown and member count don’t display correctly on Members page

### DIFF
--- a/web/libs/ui/src/lib/drawer/drawer.tsx
+++ b/web/libs/ui/src/lib/drawer/drawer.tsx
@@ -80,6 +80,11 @@ export interface DrawerProps {
    * @default "drawer"
    */
   dataTestId?: string;
+  /**
+   * Callback fired when the drawer opens to handle auto-focus behavior
+   * Set to `(e) => e.preventDefault()` to prevent auto-focus on the first focusable element
+   */
+  onOpenAutoFocus?: (event: Event) => void;
 }
 
 /**
@@ -116,6 +121,7 @@ export const Drawer = ({
   closeOnClickOutside = true,
   contentClassName,
   dataTestId = "drawer",
+  onOpenAutoFocus,
 }: DrawerProps) => {
   const defaultWidth = side === "left" || side === "right" ? "w-1/4" : undefined;
   const computedContentClassName = cnm(
@@ -134,6 +140,7 @@ export const Drawer = ({
         closeOnClickOutside={closeOnClickOutside}
         data-slot="drawer-content"
         data-testid={dataTestId}
+        onOpenAutoFocus={onOpenAutoFocus}
       >
         <SheetHeader
           className={cn(

--- a/web/libs/ui/src/shad/components/ui/sheet.tsx
+++ b/web/libs/ui/src/shad/components/ui/sheet.tsx
@@ -44,7 +44,7 @@ const SheetContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Co
         <DialogPrimitive.Content
           ref={ref}
           className={cn(
-            "fixed z-50 flex flex-col bg-neutral-surface shadow-lg border-neutral-border transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+            "fixed z-50 flex flex-col bg-neutral-surface shadow-lg border-neutral-border transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500 focus:outline-none",
             side === "top" &&
               "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
             side === "bottom" &&
@@ -56,6 +56,7 @@ const SheetContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Co
             className,
           )}
           onInteractOutside={closeOnClickOutside ? undefined : (e) => e.preventDefault()}
+          tabIndex={-1}
           {...props}
         >
           {children}


### PR DESCRIPTION
Exposing auto focus prop for the drawer

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
