### PR TITLE
docs: FIT-1124: Async import returns HTTP 201 but fails silently when task data or predictions don’t match label_config

### DIFF
--- a/label_studio/data_import/api.py
+++ b/label_studio/data_import/api.py
@@ -54,35 +54,40 @@ ProjectImportPermission = load_func(settings.PROJECT_IMPORT_PERMISSION)
 
 task_create_response_scheme = {
     201: OpenApiResponse(
-        description='Tasks successfully imported',
+        description='Tasks successfully imported or import queued. **For non-Community editions**, the response will be `{"import": <import_id>}` which you can use to poll the import status. **For Community edition**, the response contains task counts and is processed synchronously.',
         response={
             'title': 'Task creation response',
-            'description': 'Task creation response',
+            'description': 'Response format varies by edition. Non-Community editions return `{"import": <import_id>}` for async processing. Community edition returns the detailed response below with task counts.',
             'type': 'object',
             'properties': {
+                'import': {
+                    'title': 'import',
+                    'description': 'Import ID for async operations (non-Community editions only). Use this ID to poll `/api/projects/{project_id}/imports/{import_id}` for status.',
+                    'type': 'integer',
+                },
                 'task_count': {
                     'title': 'task_count',
-                    'description': 'Number of tasks added',
+                    'description': 'Number of tasks added (Community edition sync import only)',
                     'type': 'integer',
                 },
                 'annotation_count': {
                     'title': 'annotation_count',
-                    'description': 'Number of annotations added',
+                    'description': 'Number of annotations added (Community edition sync import only)',
                     'type': 'integer',
                 },
                 'predictions_count': {
                     'title': 'predictions_count',
-                    'description': 'Number of predictions added',
+                    'description': 'Number of predictions added (Community edition sync import only)',
                     'type': 'integer',
                 },
                 'duration': {
                     'title': 'duration',
-                    'description': 'Time in seconds to create',
+                    'description': 'Time in seconds to create (Community edition sync import only)',
                     'type': 'number',
                 },
                 'file_upload_ids': {
                     'title': 'file_upload_ids',
-                    'description': 'Database IDs of uploaded files',
+                    'description': 'Database IDs of uploaded files (Community edition sync import only)',
                     'type': 'array',
                     'items': {
                         'title': 'File Upload IDs',
@@ -91,12 +96,12 @@ task_create_response_scheme = {
                 },
                 'could_be_tasks_list': {
                     'title': 'could_be_tasks_list',
-                    'description': 'Whether uploaded files can contain lists of tasks, like CSV/TSV files',
+                    'description': 'Whether uploaded files can contain lists of tasks, like CSV/TSV files (Community edition sync import only)',
                     'type': 'boolean',
                 },
                 'found_formats': {
                     'title': 'found_formats',
-                    'description': 'The list of found file formats',
+                    'description': 'The list of found file formats (Community edition sync import only)',
                     'type': 'array',
                     'items': {
                         'title': 'File format',
@@ -105,7 +110,7 @@ task_create_response_scheme = {
                 },
                 'data_columns': {
                     'title': 'data_columns',
-                    'description': 'The list of found data columns',
+                    'description': 'The list of found data columns (Community edition sync import only)',
                     'type': 'array',
                     'items': {
                         'title': 'Data column name',
@@ -175,6 +180,19 @@ task_create_response_scheme = {
             include all variables that were used in the *label_config*. For example,
             if the label configuration has a *$text* variable, then each item in a data object
             must include a "text" field.
+            <br>
+
+            ## Async Import Behavior
+            <hr style="opacity:0.3">
+
+            **For non-Community editions, this endpoint processes imports asynchronously.**
+            
+            - The POST request will **not** fail if something goes wrong during import.
+            - Instead, it immediately returns a response: `{{"import": <import_id>}}`
+            - Use the returned `import_id` to poll the GET `/api/projects/{{project_id}}/imports/{{import_id}}` endpoint to check the import status and see any errors.
+            - Errors and failures will only be visible in the GET request response.
+
+            For Community edition, imports are processed synchronously and return task counts immediately.
             <br>
 
             ## POST requests

--- a/label_studio/data_import/api.py
+++ b/label_studio/data_import/api.py
@@ -187,10 +187,11 @@ task_create_response_scheme = {
 
             **For non-Community editions, this endpoint processes imports asynchronously.**
             
-            - The POST request will **not** fail if something goes wrong during import.
-            - Instead, it immediately returns a response: `{{"import": <import_id>}}`
-            - Use the returned `import_id` to poll the GET `/api/projects/{{project_id}}/imports/{{import_id}}` endpoint to check the import status and see any errors.
-            - Errors and failures will only be visible in the GET request response.
+            - The POST request **can fail** for invalid parameters, malformed request body, or other request-level validation errors.
+            - However, **data validation errors** that occur during import processing are handled asynchronously and will not cause the POST request to fail.
+            - Upon successful request validation, a response is returned: `{{"import": <import_id>}}`
+            - Use the returned `import_id` to poll the GET `/api/projects/{{project_id}}/imports/{{import_id}}` endpoint to check the import status and see any data validation errors.
+            - Data-level errors and import failures will only be visible in the GET request response.
 
             For Community edition, imports are processed synchronously and return task counts immediately.
             <br>

--- a/label_studio/projects/api.py
+++ b/label_studio/projects/api.py
@@ -603,8 +603,18 @@ class ProjectSummaryResetAPI(GetParentObjectMixin, generics.CreateAPIView):
     name='get',
     decorator=extend_schema(
         tags=['Projects'],
-        summary='Get project import info',
-        description='Return data related to async project import operation',
+        summary='Get project import status',
+        description="""
+            Poll the status of an asynchronous project import operation.
+            
+            **Usage:**
+            1. When you POST to `/api/projects/{project_id}/import`, you'll receive a response like `{"import": <import_id>}`
+            2. Use that `import_id` with this GET endpoint to check the import status
+            3. Poll this endpoint to see if the import has completed, is still processing, or has failed
+            4. **Import errors and failures will only be visible in this GET response**, not in the original POST request
+            
+            This endpoint returns detailed information about the import including task counts, status, and any error messages.
+        """,
         parameters=[
             OpenApiParameter(
                 name='id',
@@ -633,8 +643,18 @@ class ProjectImportAPI(generics.RetrieveAPIView):
     name='get',
     decorator=extend_schema(
         tags=['Projects'],
-        summary='Get project reimport info',
-        description='Return data related to async project reimport operation',
+        summary='Get project reimport status',
+        description="""
+            Poll the status of an asynchronous project reimport operation.
+            
+            **Usage:**
+            1. When you POST to reimport tasks, you'll receive a response with a reimport ID
+            2. Use that `reimport_id` with this GET endpoint to check the reimport status
+            3. Poll this endpoint to see if the reimport has completed, is still processing, or has failed
+            4. **Reimport errors and failures will only be visible in this GET response**, not in the original POST request
+            
+            This endpoint returns detailed information about the reimport including task counts, status, and any error messages.
+        """,
         parameters=[
             OpenApiParameter(
                 name='id',


### PR DESCRIPTION
This pull request updates the API documentation and response schema for task import and project import endpoints to clarify the differences between Community and non-Community (Enterprise) editions, especially regarding asynchronous import behavior. The changes improve both the OpenAPI documentation and the response format descriptions, making it clear how clients should handle imports in each edition.

**API Documentation and Response Schema Improvements**

* Clarified the `task_create_response_scheme` object in `label_studio/data_import/api.py` to specify that non-Community editions process imports asynchronously, returning an `import_id` for polling, while Community edition processes synchronously and returns task counts. Added the `import` field and updated descriptions for all properties to indicate which edition they apply to. [[1]](diffhunk://#diff-0d189d758de143ca7197ad41a825d2285df6df57e018672bfe1451dc2785dd3bL57-R90) [[2]](diffhunk://#diff-0d189d758de143ca7197ad41a825d2285df6df57e018672bfe1451dc2785dd3bL94-R104) [[3]](diffhunk://#diff-0d189d758de143ca7197ad41a825d2285df6df57e018672bfe1451dc2785dd3bL108-R113)
* Added a new section to the import endpoint docstring describing async import behavior for non-Community editions, including instructions for polling import status and where to find error information.

**Project Import Status Endpoint Documentation**

* Updated the `GET /api/projects/{project_id}/imports/{import_id}` endpoint documentation to clarify its use for polling asynchronous import status, including usage steps, and specifying that errors are only visible in the GET response.
* Updated the `GET /api/projects/{project_id}/reimport/{reimport_id}` endpoint documentation similarly, clarifying polling usage and where to find error details.