### PR TITLE
fix: BROS-476: Fix span resizing in edge cases (#8979)

### DIFF
--- a/web/libs/editor/src/tags/object/RichText/view.jsx
+++ b/web/libs/editor/src/tags/object/RichText/view.jsx
@@ -14,6 +14,7 @@ import { htmlEscape, matchesSelector } from "../../../utils/html";
 import {
   applyTextGranularity,
   fixCodePointsInRange,
+  fixRange,
   rangeToGlobalOffset,
   trimSelection,
 } from "../../../utils/selection-tools";
@@ -194,7 +195,7 @@ class RichTextPieceView extends Component {
       if (selection.isCollapsed) return false;
       if (!area) return false;
 
-      let range = selection.getRangeAt(0);
+      let range = fixRange(selection.getRangeAt(0));
 
       // @todo would be more convenient to try to reduce the range to be within the root,
       // @todo so for example if we drag to the left and the range is outside of the root, we would

--- a/web/libs/editor/src/utils/selection-tools.js
+++ b/web/libs/editor/src/utils/selection-tools.js
@@ -303,7 +303,7 @@ const textNodeLookup = (commonContainer, node, offset, direction = "forward") =>
  * not root, not some previous element with `startOffset` on the last char.
  * @param {Range} range
  */
-const fixRange = (range) => {
+export const fixRange = (range) => {
   const { endOffset, commonAncestorContainer: commonContainer } = range;
   let { startOffset, startContainer, endContainer } = range;
 


### PR DESCRIPTION
When text span ends at the last character of the page or the line, it calculates its size wrong after resize, causing data corruption.

This fix applies missed `fixRange()` in these edge cases.

Cherry-pick from https://github.com/HumanSignal/label-studio/pull/8979