### PR TITLE
fix: FIT-1139: Copy region link option in Outliner (Regions tab) disappears on hover

### DIFF
--- a/web/libs/editor/src/components/ContextMenu/ContextMenu.module.scss
+++ b/web/libs/editor/src/components/ContextMenu/ContextMenu.module.scss
@@ -53,9 +53,6 @@
 
 .trigger {
   &.open {
-    background-color: var(--color-primary-emphasis);
-    color: var(--color-neutral-content);
-    border-radius: 4px;
     opacity: 1;
   }
 }

--- a/web/libs/editor/src/components/SidePanels/Components/RegionContextMenu.tsx
+++ b/web/libs/editor/src/components/SidePanels/Components/RegionContextMenu.tsx
@@ -46,17 +46,11 @@ export const RegionContextMenu: FC<{ item: any }> = observer(({ item }: { item: 
 
   return (
     <ContextMenuTrigger
-      className={cn("region-context-menu").toClassName()}
+      className={cn("region-context-menu").mod({ open }).toClassName()}
       content={<ContextMenu actions={actions} />}
       onToggle={(isOpen) => setOpen(isOpen)}
     >
-      <Button
-        variant="neutral"
-        look="string"
-        size="smaller"
-        style={{ ...(open ? { display: "flex !important" } : null) }}
-        aria-label="Region options"
-      >
+      <Button variant="neutral" look="string" size="smaller" aria-label="Region options">
         <IconEllipsis />
       </Button>
     </ContextMenuTrigger>

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/TreeView.scss
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/TreeView.scss
@@ -233,15 +233,25 @@
     }
 
     .region-context-menu button {
-      display: none;
+      transition: none;
+      opacity: 0;
+    }
+
+    .region-context-menu_open button {
+      opacity: 1;
     }
   }
 
-  &:hover &__controls {
+  &:hover &__controls,
+  &:has(.region-context-menu_open) &__controls {
     display: flex;
 
     .outliner-item__control_type_lock {
       display: flex;
+    }
+
+    .region-context-menu button {
+      opacity: 1;
     }
   }
 }


### PR DESCRIPTION
This pull request refines the appearance and behavior of the region context menu in the outliner panel. The changes primarily focus on improving how the context menu button is displayed and styled, especially when the menu is open or hovered.

[screen-recorder-tue-dec-16-2025-12-57-29.webm](https://github.com/user-attachments/assets/9dfc67a6-79d1-4892-b8be-1de1f8898bfd)

**Region context menu visibility and styling:**

* The context menu button in `.region-context-menu` now uses opacity to control its visibility instead of toggling display, making transitions smoother and more flexible. The button is fully visible when the menu is open or the parent is hovered, and otherwise transparent. (`web/libs/editor/src/components/SidePanels/OutlinerPanel/TreeView.scss` [web/libs/editor/src/components/SidePanels/OutlinerPanel/TreeView.scssL236-R255](diffhunk://#diff-b088514e9a8e8f1eaa65655520df7a3d197d0974369413cacbd5efce089f5253L236-R255))
* The trigger for the context menu now applies an `.open` modifier class when the menu is open, enabling more precise CSS targeting for open-state styles. (`web/libs/editor/src/components/SidePanels/Components/RegionContextMenu.tsx` [web/libs/editor/src/components/SidePanels/Components/RegionContextMenu.tsxL49-R53](diffhunk://#diff-20992b80215c09348898530efb725ef915345d30c0f4eaeb8e958d6dbabb919aL49-R53))

**Code and style cleanup:**

* Unused or redundant styles for the `.trigger.open` state were removed from the context menu SCSS, reducing unnecessary CSS. (`web/libs/editor/src/components/ContextMenu/ContextMenu.module.scss` [web/libs/editor/src/components/ContextMenu/ContextMenu.module.scssL56-L58](diffhunk://#diff-84fe75f4c849b68527bff8eb663ebb79bfa9f922dac3d9df0cc7afe3c8879534L56-L58))
* Inline style hacks and unnecessary `display` property manipulations were removed from the button, simplifying the component code. (`web/libs/editor/src/components/SidePanels/Components/RegionContextMenu.tsx` [web/libs/editor/src/components/SidePanels/Components/RegionContextMenu.tsxL49-R53](diffhunk://#diff-20992b80215c09348898530efb725ef915345d30c0f4eaeb8e958d6dbabb919aL49-R53))