### PR TITLE
fix: FIT-1139: Copy region link option in Outliner (Regions tab) disappears on hover

### DIFF
--- a/web/libs/editor/src/components/ContextMenu/ContextMenu.module.scss
+++ b/web/libs/editor/src/components/ContextMenu/ContextMenu.module.scss
@@ -53,9 +53,6 @@
 
 .trigger {
   &.open {
-    background-color: var(--color-primary-emphasis);
-    color: var(--color-neutral-content);
-    border-radius: 4px;
     opacity: 1;
   }
 }

--- a/web/libs/editor/src/components/SidePanels/Components/RegionContextMenu.tsx
+++ b/web/libs/editor/src/components/SidePanels/Components/RegionContextMenu.tsx
@@ -46,17 +46,11 @@ export const RegionContextMenu: FC<{ item: any }> = observer(({ item }: { item: 
 
   return (
     <ContextMenuTrigger
-      className={cn("region-context-menu").toClassName()}
+      className={cn("region-context-menu").mod({ open }).toClassName()}
       content={<ContextMenu actions={actions} />}
       onToggle={(isOpen) => setOpen(isOpen)}
     >
-      <Button
-        variant="neutral"
-        look="string"
-        size="smaller"
-        style={{ ...(open ? { display: "flex !important" } : null) }}
-        aria-label="Region options"
-      >
+      <Button variant="neutral" look="string" size="smaller" aria-label="Region options">
         <IconEllipsis />
       </Button>
     </ContextMenuTrigger>

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/TreeView.scss
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/TreeView.scss
@@ -233,15 +233,25 @@
     }
 
     .region-context-menu button {
-      display: none;
+      transition: none;
+      opacity: 0;
+    }
+
+    .region-context-menu_open button {
+      opacity: 1;
     }
   }
 
-  &:hover &__controls {
+  &:hover &__controls,
+  &:has(.region-context-menu_open) &__controls {
     display: flex;
 
     .outliner-item__control_type_lock {
       display: flex;
+    }
+
+    .region-context-menu button {
+      opacity: 1;
     }
   }
 }


### PR DESCRIPTION
This pull request refines the behavior and styling of the region context menu in the Outliner panel. The main focus is on improving how the menu's open state is reflected visually and ensuring that controls are consistently visible when the menu is open, not just on hover.

**Context menu open state styling and visibility improvements:**

* Updated the `RegionContextMenu` component to add an `open` modifier class to the context menu trigger when the menu is open, making the open state explicit in the DOM.
* Modified the Outliner panel's SCSS to use opacity transitions for the region context menu button, ensuring it becomes visible when the menu is open or the parent is hovered, and remains hidden otherwise. This also introduces a `.region-context-menu_open` class for better state management.

**Cleanup of redundant styles:**

* Removed unnecessary background color, text color, and border-radius styles from the `.trigger.open` selector in the context menu SCSS, simplifying the styling.