### PR TITLE
chore: FIT-1140: Cleanup fflag_feat_front_optic_1553_url_based_region_visibility_short

### DIFF
--- a/label_studio/feature_flags.json
+++ b/label_studio/feature_flags.json
@@ -3120,6 +3120,33 @@
       "version": 3,
       "deleted": false
     },
+    "fflag_feat_front_optic_1553_url_based_region_visibility_short": {
+      "key": "fflag_feat_front_optic_1553_url_based_region_visibility_short",
+      "on": true,
+      "prerequisites": [],
+      "targets": [],
+      "contextTargets": [],
+      "rules": [],
+      "fallthrough": {
+        "variation": 0
+      },
+      "offVariation": 1,
+      "variations": [
+        true,
+        false
+      ],
+      "clientSideAvailability": {
+        "usingMobileKey": false,
+        "usingEnvironmentId": false
+      },
+      "clientSide": false,
+      "salt": "b4340048580d4eb3b2bc524d748ded76",
+      "trackEvents": false,
+      "trackEventsFallthrough": false,
+      "debugEventsUntilDate": null,
+      "version": 3,
+      "deleted": false
+    },
     "fflag_feat_front_optic_1746_improve_global_error_messages_short": {
       "key": "fflag_feat_front_optic_1746_improve_global_error_messages_short",
       "on": true,

--- a/label_studio/feature_flags.json
+++ b/label_studio/feature_flags.json
@@ -3120,33 +3120,6 @@
       "version": 3,
       "deleted": false
     },
-    "fflag_feat_front_optic_1553_url_based_region_visibility_short": {
-      "key": "fflag_feat_front_optic_1553_url_based_region_visibility_short",
-      "on": true,
-      "prerequisites": [],
-      "targets": [],
-      "contextTargets": [],
-      "rules": [],
-      "fallthrough": {
-        "variation": 0
-      },
-      "offVariation": 1,
-      "variations": [
-        true,
-        false
-      ],
-      "clientSideAvailability": {
-        "usingMobileKey": false,
-        "usingEnvironmentId": false
-      },
-      "clientSide": false,
-      "salt": "b4340048580d4eb3b2bc524d748ded76",
-      "trackEvents": false,
-      "trackEventsFallthrough": false,
-      "debugEventsUntilDate": null,
-      "version": 3,
-      "deleted": false
-    },
     "fflag_feat_front_optic_1746_improve_global_error_messages_short": {
       "key": "fflag_feat_front_optic_1746_improve_global_error_messages_short",
       "on": true,

--- a/web/libs/datamanager/src/sdk/lsf-sdk.js
+++ b/web/libs/datamanager/src/sdk/lsf-sdk.js
@@ -1,12 +1,4 @@
-import {
-  FF_DEV_1752,
-  FF_DEV_2186,
-  FF_DEV_2887,
-  FF_DEV_3034,
-  FF_LSDV_4620_3_ML,
-  FF_REGION_VISIBILITY_FROM_URL,
-  isFF,
-} from "../utils/feature-flags";
+import { FF_DEV_1752, FF_DEV_2186, FF_DEV_2887, FF_DEV_3034, FF_LSDV_4620_3_ML, isFF } from "../utils/feature-flags";
 import { isDefined } from "../utils/utils";
 import { Modal } from "../components/Common/Modal/Modal";
 import { CommentsSdk } from "./comments-sdk";
@@ -141,10 +133,8 @@ export class LSFWrapper {
         "annotations:delete",
         "annotations:tabs",
         "predictions:tabs",
+        "annotations:copy-link",
       );
-      if (isFF(FF_REGION_VISIBILITY_FROM_URL)) {
-        interfaces.push("annotations:copy-link");
-      }
     }
 
     if (this.datamanager.hasInterface("instruction")) {

--- a/web/libs/datamanager/src/stores/AppStore.js
+++ b/web/libs/datamanager/src/stores/AppStore.js
@@ -1,12 +1,6 @@
 import { destroy, flow, types } from "mobx-state-tree";
 import { Modal } from "../components/Common/Modal/Modal";
-import {
-  FF_DEV_2887,
-  FF_DISABLE_GLOBAL_USER_FETCHING,
-  FF_LOPS_E_3,
-  FF_REGION_VISIBILITY_FROM_URL,
-  isFF,
-} from "../utils/feature-flags";
+import { FF_DEV_2887, FF_DISABLE_GLOBAL_USER_FETCHING, FF_LOPS_E_3, isFF } from "../utils/feature-flags";
 import { History } from "../utils/history";
 import { isDefined } from "../utils/utils";
 import { Action } from "./Action";
@@ -215,7 +209,7 @@ export const AppStore = types
           interaction: null,
           region: null,
         });
-      } else if (isFF(FF_REGION_VISIBILITY_FROM_URL)) {
+      } else {
         const { task, region, annotation } = History.getParams();
         History.navigate(
           {
@@ -262,27 +256,25 @@ export const AppStore = types
 
           self.LSF?.setLSFTask(self.taskStore.selected, id);
 
-          if (isFF(FF_REGION_VISIBILITY_FROM_URL)) {
-            const { annotation: annIDFromUrl, region: regionIDFromUrl } = History.getParams();
-            const annotationStore = self.LSF?.lsf?.annotationStore;
+          const { annotation: annIDFromUrl, region: regionIDFromUrl } = History.getParams();
+          const annotationStore = self.LSF?.lsf?.annotationStore;
 
-            if (annIDFromUrl && annotationStore) {
-              const lsfAnnotation = [...annotationStore.annotations, ...annotationStore.predictions].find((a) => {
-                return a.pk === annIDFromUrl || a.id === annIDFromUrl;
-              });
+          if (annIDFromUrl && annotationStore) {
+            const lsfAnnotation = [...annotationStore.annotations, ...annotationStore.predictions].find((a) => {
+              return a.pk === annIDFromUrl || a.id === annIDFromUrl;
+            });
 
-              if (lsfAnnotation) {
-                const annID = lsfAnnotation.pk ?? lsfAnnotation.id;
-                self.LSF?.setLSFTask(self.taskStore.selected, annID, undefined, lsfAnnotation.type === "prediction");
-              }
+            if (lsfAnnotation) {
+              const annID = lsfAnnotation.pk ?? lsfAnnotation.id;
+              self.LSF?.setLSFTask(self.taskStore.selected, annID, undefined, lsfAnnotation.type === "prediction");
             }
-            if (regionIDFromUrl) {
-              const currentAnn = self.LSF?.currentAnnotation;
-              // Focus on the region by hiding all other regions
-              currentAnn?.regionStore?.setRegionVisible(regionIDFromUrl);
-              // Select the region so outliner details are visible
-              currentAnn?.regionStore?.selectRegionByID(regionIDFromUrl);
-            }
+          }
+          if (regionIDFromUrl) {
+            const currentAnn = self.LSF?.currentAnnotation;
+            // Focus on the region by hiding all other regions
+            currentAnn?.regionStore?.setRegionVisible(regionIDFromUrl);
+            // Select the region so outliner details are visible
+            currentAnn?.regionStore?.selectRegionByID(regionIDFromUrl);
           }
         } else {
           console.error("LSF not initialized properly");

--- a/web/libs/datamanager/src/utils/feature-flags.js
+++ b/web/libs/datamanager/src/utils/feature-flags.js
@@ -38,11 +38,6 @@ export const FF_SELF_SERVE = "fflag_feat_front_leap_482_self_serve_short";
 export const FF_GRID_PREVIEW = "fflag_feat_front_leap_1424_grid_preview_short";
 
 /**
- * Add ability to show specific region from URL params (by hiding all other regions).
- */
-export const FF_REGION_VISIBILITY_FROM_URL = "fflag_feat_front_optic_1553_url_based_region_visibility_short";
-
-/**
  * Add ability to show average agreement score popover in Agreement cell.
  */
 export const FF_AVERAGE_AGREEMENT_SCORE_POPOVER = "fflag_feat_all_leap_2042_average_agreement_score_popover";


### PR DESCRIPTION
This pull request removes the feature flag and related code for "region visibility from URL," which previously allowed the application to show a specific region based on URL parameters. The change simplifies the codebase by always enabling this functionality, rather than gating it behind a feature flag.

Feature flag removal:

* Removed the `fflag_feat_front_optic_1553_url_based_region_visibility_short` feature flag from `label_studio/feature_flags.json`, and deleted the corresponding constant `FF_REGION_VISIBILITY_FROM_URL` from `web/libs/datamanager/src/utils/feature-flags.js`. [[1]](diffhunk://#diff-48ae7bd1c9581f8f15356cea4538a387b12f99b7c97cb9d269a218bc675ab650L3123-L3149) [[2]](diffhunk://#diff-904085fb45b5c0bcc8dfac543ede200ca334876f946ca98b6ca9bc9e12381b0fL40-L44)

Code cleanup and simplification:

* Removed all conditional checks and imports related to `FF_REGION_VISIBILITY_FROM_URL` in `lsf-sdk.js` and `AppStore.js`, making the region visibility from URL feature always enabled. [[1]](diffhunk://#diff-679489a404ba3dd06905287db35ee48bccafc5cc6a61567ef7531cb785012595L1-R1) [[2]](diffhunk://#diff-679489a404ba3dd06905287db35ee48bccafc5cc6a61567ef7531cb785012595R136-L147) [[3]](diffhunk://#diff-d1e11a839827428aa6aada8e027a22b057a463ccb73c693e464c6e0784a9825fL3-R3) [[4]](diffhunk://#diff-d1e11a839827428aa6aada8e027a22b057a463ccb73c693e464c6e0784a9825fL218-R212) [[5]](diffhunk://#diff-d1e11a839827428aa6aada8e027a22b057a463ccb73c693e464c6e0784a9825fL265) [[6]](diffhunk://#diff-d1e11a839827428aa6aada8e027a22b057a463ccb73c693e464c6e0784a9825fL286)