### PR TITLE
fix: FIT-1152: OOM issues with task state caclulation during storage sync

### DIFF
--- a/label_studio/fsm/functions.py
+++ b/label_studio/fsm/functions.py
@@ -4,11 +4,13 @@ FSM utility functions for backfilling and managing state transitions.
 This module contains reusable functions for FSM state management that are
 used across different parts of the codebase.
 """
+
 import logging
 
 from core.current_request import CurrentContext
+from core.utils.iterators import iterate_queryset
 from fsm.state_inference import get_or_infer_state
-from fsm.utils import get_or_initialize_state
+from fsm.utils import get_or_initialize_state, is_fsm_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -30,29 +32,38 @@ def backfill_fsm_states_for_tasks(storage_id, tasks_created, link_class):
         - CurrentContext must be available before calling this function
         - This function is safe to call in both LSO and LSE environments
         - Failures are logged but don't propagate to prevent breaking storage sync
+        - FSM feature flag is checked before processing
+        - Tasks are processed in chunks via iterate_queryset to avoid OOM issues
     """
     if tasks_created <= 0:
+        return
+
+    # Check FSM feature flag - early return if FSM is not enabled
+    if not is_fsm_enabled():
         return
 
     try:
         from tasks.models import Task
 
-        # Get tasks created in this sync
+        # Get task IDs created in this sync
         task_ids = list(
             link_class.objects.filter(storage=storage_id)
             .order_by('-created_at')[:tasks_created]
             .values_list('task_id', flat=True)
         )
 
-        tasks = Task.objects.filter(id__in=task_ids)
+        if not task_ids:
+            return
 
         logger.info(f'Storage sync: creating initial FSM states for {len(task_ids)} tasks')
 
-        # Backfill initial CREATED state for each task
-        for task in tasks:
+        # Use iterate_queryset to process tasks in chunks, avoiding OOM issues
+        user = CurrentContext.get_user()
+        tasks_qs = Task.objects.filter(id__in=task_ids)
 
+        for task in iterate_queryset(tasks_qs):
             inferred_state = get_or_infer_state(task)
-            get_or_initialize_state(task, user=CurrentContext.get_user(), inferred_state=inferred_state)
+            get_or_initialize_state(task, user=user, inferred_state=inferred_state)
 
         logger.info(f'Storage sync: FSM states created for {len(task_ids)} tasks')
     except Exception as e:


### PR DESCRIPTION
This pull request improves the FSM state backfilling logic for tasks by adding a feature flag check and optimizing memory usage. The main updates ensure that FSM processing only occurs when enabled and that large task sets are handled efficiently to prevent out-of-memory issues.

Key improvements:

**Feature flag integration:**
* Added a check for the FSM feature flag using `is_fsm_enabled()` to ensure FSM state backfilling only runs when the feature is enabled. [[1]](diffhunk://#diff-e083f435526a75a53b06e7cbe241dbb6991041f657fb812430ec27274fb673fbR7-R13) [[2]](diffhunk://#diff-e083f435526a75a53b06e7cbe241dbb6991041f657fb812430ec27274fb673fbR35-R66)

**Performance and memory optimization:**
* Updated the backfilling process to use `iterate_queryset` for chunked task processing, reducing the risk of out-of-memory errors when handling large numbers of tasks. [[1]](diffhunk://#diff-e083f435526a75a53b06e7cbe241dbb6991041f657fb812430ec27274fb673fbR7-R13) [[2]](diffhunk://#diff-e083f435526a75a53b06e7cbe241dbb6991041f657fb812430ec27274fb673fbR35-R66)

**General code improvements:**
* Ensured that user context is retrieved once and reused during state initialization for each task.
* Added early returns if no tasks need processing, further improving efficiency.