### PR TITLE
Documentation string correction

### DIFF
--- a/docs/source/guide/prompts_draft.md
+++ b/docs/source/guide/prompts_draft.md
@@ -24,8 +24,8 @@ With your [Prompt created](prompts_create), you can begin drafting your prompt c
     * You must include the text variables. These appear directly above the prompt field. (In the demo below, this is the `review` variable.) Click the text variable name to insert it into the prompt. 
     * Although not strictly required, you should provide definitions for each class to ensure prediction accuracy and to help [add context](#Add-context). 
 
-    !!! info "Tip"
-        You can generate an initial draft by simply adding the text variables and then [clicking **Enhance Prompt**](#Enhance-prompt). 
+!!! info "Tip"
+    You can generate an initial draft by simply adding the text variables and then [clicking **Enhance Prompt**](#Enhance-prompt). 
 
 3. Select your baseline:
    * **All Project Tasks** - Generate predictions for all tasks in the project. Depending on the size of your project, this might take some time to process. This does not generate an accuracy score for the prompt. 

--- a/docs/source/guide/prompts_draft.md
+++ b/docs/source/guide/prompts_draft.md
@@ -24,7 +24,7 @@ With your [Prompt created](prompts_create), you can begin drafting your prompt c
     * You must include the text variables. These appear directly above the prompt field. (In the demo below, this is the `review` variable.) Click the text variable name to insert it into the prompt. 
     * Although not strictly required, you should provide definitions for each class to ensure prediction accuracy and to help [add context](#Add-context). 
 
-    !!! info Tip
+    !!! info "Tip"
         You can generate an initial draft by simply adding the text variables and then [clicking **Enhance Prompt**](#Enhance-prompt). 
 
 3. Select your baseline:


### PR DESCRIPTION
<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
### Reason for change

The admonition `!!! info Tip` in `docs/source/guide/prompts_draft.md` was not rendering correctly, displaying raw markdown instead of a formatted info box with "Tip" as its title. This PR encloses "Tip" in quotes (`!!! info "Tip"`) to comply with MkDocs Material admonition syntax for custom titles.

### Screenshots

A screenshot of the rendered documentation showing the corrected admonition would be ideal.

### Rollout strategy

Standard documentation update. No special rollout strategy required.

### Testing

Verified against MkDocs Material admonition syntax. Local documentation build can confirm visual fix.

### Risks

Minimal. This is a minor documentation formatting correction.

### Reviewer notes

Please verify that the "Tip" admonition on the "Draft your prompt" page renders correctly in the documentation build.

### General notes

This change ensures the "Tip" admonition is displayed as intended, improving documentation readability.

---
[Slack Thread](https://humansignal.slack.com/archives/C01HGFXA7KR/p1766337309226189?thread_ts=1766337309.226189&cid=C01HGFXA7KR)

<a href="https://cursor.com/background-agent?bcId=bc-3898c7a2-a78d-41a6-b25e-8e2f61457e10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3898c7a2-a78d-41a6-b25e-8e2f61457e10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

