### PR TITLE
fix: BROS-684: Process export timeouts gracefully in LS community

### DIFF
--- a/docs/source/guide/export.md
+++ b/docs/source/guide/export.md
@@ -35,7 +35,7 @@ Use the following steps to export data and annotations from the Label Studio UI.
 !!! note
     1. The export will always include the annotated tasks, regardless of filters set on the tab. 
     2. Cancelled annotated tasks will be included in the exported result too.
-    3. If you want to apply tab filters to the export, try to use [export snapshots using the SDK](https://labelstud.io/sdk/project.html#label_studio_sdk.project.Project.export_snapshot_create) or [API](#Export-snapshots-using-the-Snapshot-API).
+    3. If you want to apply tab filters to the export, try creating [export snapshots using the SDK](https://api.labelstud.io/api-reference/api-reference/projects/exports/create).
 
 ### Export timeout in Community Edition
 
@@ -43,7 +43,7 @@ Exports from the Community Edition UI are generated **synchronously** as part of
 
 If you hit this limitation, you can still export your data using one of these options:
 
-- **Export snapshots using the SDK**: See how to [export snapshots using the SDK](https://labelstud.io/sdk/project.html#label_studio_sdk.project.Project.export_snapshot_create) or via the [Snapshot API](#Export-snapshots-using-the-Snapshot-API).
+- **Export snapshots using the SDK**: See how to [export snapshots using the SDK](https://api.labelstud.io/api-reference/api-reference/projects/exports/create).
 - **Export using the console command**: Use the [console command](#Export-using-console-command) to export your project directly from the machine running Label Studio.
 - **Export in the UI at scale**: Label Studio Enterprise includes **background snapshot exports** in the UI for large datasets (see [Export snapshots using the UI](#Export-snapshots-using-the-UI)).
 
@@ -88,30 +88,30 @@ In Label Studio Enterprise, create a snapshot of your data and annotations. Crea
 
 ### Export using the Easy Export API
 
-You can call the Label Studio API to export annotations. For a small labeling project, call the [export endpoint](/api#operation/api_projects_export_read) to export annotations.
+You can call the Label Studio API to export annotations. For a small labeling project, call the [export endpoint](https://api.labelstud.io/api-reference/api-reference/projects/exports/download-sync) to export annotations.
 
 
 #### Export all tasks including tasks without annotations
 
-Label Studio open source exports tasks with annotations only by default. If you want to easily export all tasks including tasks without annotations, you can call  the [Easy Export API](https://api.labelstud.io/#operation/api_projects_export_read) with query param `download_all_tasks=true`. For example:
+Label Studio open source exports tasks with annotations only by default. If you want to easily export all tasks including tasks without annotations, you can call  the [Easy Export API](https://api.labelstud.io/api-reference/api-reference/projects/exports/download-sync) with query param `download_all_tasks=true`. For example:
 ```
 curl -X GET https://localhost:8080/api/projects/{id}/export?exportType=JSON&download_all_tasks=true
 ``` 
 
-If your project is large, you can use a [snapshot export](https://api.labelstud.io/#operation/api_projects_exports_create) (or [snapshot SDK](https://labelstud.io/sdk/project.html#create-new-export-snapshot)) to avoid timeouts in most cases. Snapshots include all tasks without annotations by default.
+If your project is large, you can use a [snapshot export](https://api.labelstud.io/api-reference/api-reference/projects/exports/create) to avoid timeouts in most cases. Snapshots include all tasks without annotations by default.
 
 
 ### Export snapshots using the Snapshot API 
 
 For a large labeling project with hundreds of thousands of tasks, do the following:
-1. Make a POST request to [create a new export file or snapshot](/api#operation/api_projects_exports_create). The response includes an `id` for the created file.
-2. [Check the status of the export file created](/api#operation/api_projects_exports_read) using the `id` as the `export_pk`. 
-3. Using the `id` from the created snapshot as the export primary key, or `export_pk`, make a GET request to [download the export file](/api#operation/api_projects_exports_download_read).
+1. Make a POST request to [create a new export file or snapshot](https://api.labelstud.io/api-reference/api-reference/projects/exports/create). The response includes an `id` for the created file.
+2. [Check the status of the export file created](https://api.labelstud.io/api-reference/api-reference/projects/exports/get) using the `id` as the `export_pk`. 
+3. Using the `id` from the created snapshot as the export primary key, or `export_pk`, make a GET request to [download the export file](https://api.labelstud.io/api-reference/api-reference/projects/exports/download).
 
 
 ## Export formats supported by Label Studio
 
-Label Studio supports many common and standard formats for exporting completed labeling tasks. If you don't see a format that works for you, you can contribute one. For more information, see the [GitHub repository for the Label Studio Converter tool](https://github.com/HumanSignal/label-studio-converter).
+Label Studio supports many common and standard formats for exporting completed labeling tasks. If you don't see a format that works for you, you can contribute one. For more information, see the [Label Studio Converter tool in our SDK repo](https://github.com/HumanSignal/label-studio-sdk/tree/master/src/label_studio_sdk/converter).
 
 ### ASR_MANIFEST
 
@@ -342,7 +342,7 @@ Export object detection annotations in the YOLOv3 and YOLOv4 format. Supports ob
 {% insertmd includes/image_units.md %}
 
 ## Manually convert JSON annotations to another format
-You can run the [Label Studio converter tool](https://github.com/HumanSignal/label-studio-converter) on a directory or file of completed JSON annotations using the command line or Python to convert the completed annotations from Label Studio JSON format into another format. 
+You can run the [Label Studio converter tool](https://github.com/HumanSignal/label-studio-sdk/tree/master/src/label_studio_sdk/converter) on a directory or file of completed JSON annotations using the command line or Python to convert the completed annotations from Label Studio JSON format into another format. 
 
 !!! note
     If you use versions of Label Studio earlier than 1.0.0, then this is the only way to convert your Label Studio JSON format annotations into another labeling format. 
@@ -376,7 +376,7 @@ You can use `label_studio_tools.core.utils.io.get_local_path` method to get data
 
 You can get data with `label_studio_tools.core.utils.io.get_local_path` in case if you mount same disk to your machine. If you mount same disk to external box 
 
-Another way of accessing data is to use link from task and ACCESS_TOKEN ([see documentation for authentication](api.html#Authenticate-to-the-API)). Concatenate Label Studio hostname and link from task data. Then add access token to your request:
+Another way of accessing data is to use link from task and ACCESS_TOKEN ([see documentation for authentication](access_tokens)). Concatenate Label Studio hostname and link from task data. Then add access token to your request:
 
 ```json
 curl -X GET http://localhost:8080/api/projects/ -H 'Authorization: Token {YOUR_TOKEN}'

--- a/docs/source/guide/export.md
+++ b/docs/source/guide/export.md
@@ -39,7 +39,13 @@ Use the following steps to export data and annotations from the Label Studio UI.
 
 ### Export timeout in Community Edition
 
-If the export times out, see how to [export snapshots using the SDK](https://labelstud.io/sdk/project.html#label_studio_sdk.project.Project.export_snapshot_create) or [API](#Export-snapshots-using-the-Snapshot-API). You can also use a [console command](#Export-using-console-command) to export your project. For more information, see the following section.
+Exports from the Community Edition UI are generated **synchronously** as part of the request. Community Edition keeps deployment simple and does not run background export workers by default. Label Studio Enterprise supports background workers for asynchronous snapshot exports, which is better suited for large-scale projects. For large projects, the community's export can take longer than the timeout configured in your reverse proxy or ingress (often around **90 seconds**), which can result in 502/504 errors or an export timeout.
+
+If you hit this limitation, you can still export your data using one of these options:
+
+- **Export snapshots using the SDK**: See how to [export snapshots using the SDK](https://labelstud.io/sdk/project.html#label_studio_sdk.project.Project.export_snapshot_create) or via the [Snapshot API](#Export-snapshots-using-the-Snapshot-API).
+- **Export using the console command**: Use the [console command](#Export-using-console-command) to export your project directly from the machine running Label Studio.
+- **Export in the UI at scale**: Label Studio Enterprise includes **background snapshot exports** in the UI for large datasets (see [Export snapshots using the UI](#Export-snapshots-using-the-UI)).
 
 ### Export using console command
 

--- a/web/apps/labelstudio/src/pages/ExportPage/ExportPage.jsx
+++ b/web/apps/labelstudio/src/pages/ExportPage/ExportPage.jsx
@@ -20,7 +20,7 @@ import "./ExportPage.scss";
 
 // Community Edition exports run synchronously in a single HTTP request.
 // Large exports can exceed typical proxy timeouts, so we warn early and link to alternatives.
-const LARGE_EXPORT_TASK_THRESHOLD = 5000;
+const LARGE_EXPORT_TASK_THRESHOLD = 1000;
 const EXPORT_TIMEOUT_DOCS_URL = "https://labelstud.io/guide/export.html#Export-timeout-in-Community-Edition";
 const EXPORT_CONSOLE_DOCS_URL = "https://labelstud.io/guide/export.html#Export-using-console-command";
 const EXPORT_SNAPSHOT_SDK_URL = "https://api.labelstud.io/api-reference/api-reference/projects/exports/create";
@@ -281,7 +281,11 @@ const ExportLargeProjectWarning = ({ taskCount }) => {
         <a className="no-go" href={EXPORT_TIMEOUT_DOCS_URL} target="_blank" rel="noreferrer">
           CLI/SDK export options
         </a>{" "}
-        or consider Enterprise for background exports at scale.
+        or consider{" "}
+        <a className="no-go" href={ENTERPRISE_URL} target="_blank" rel="noreferrer">
+          Enterprise
+        </a>{" "}
+        for background exports at scale.
       </div>
     </div>
   );

--- a/web/apps/labelstudio/src/pages/ExportPage/ExportPage.jsx
+++ b/web/apps/labelstudio/src/pages/ExportPage/ExportPage.jsx
@@ -1,7 +1,14 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useHistory } from "react-router";
 import { Button } from "@humansignal/ui";
-import { IconWarningCircleFilled, IconTerminal, IconCode, IconBook, IconExternal, IconCopyOutline } from "@humansignal/icons";
+import {
+  IconWarningCircleFilled,
+  IconTerminal,
+  IconCode,
+  IconBook,
+  IconExternal,
+  IconCopyOutline,
+} from "@humansignal/icons";
 import { Form, Input } from "../../components/Form";
 import { Modal } from "../../components/Modal/Modal";
 import { Space } from "../../components/Space/Space";
@@ -16,8 +23,7 @@ import "./ExportPage.scss";
 const LARGE_EXPORT_TASK_THRESHOLD = 5000;
 const EXPORT_TIMEOUT_DOCS_URL = "https://labelstud.io/guide/export.html#Export-timeout-in-Community-Edition";
 const EXPORT_CONSOLE_DOCS_URL = "https://labelstud.io/guide/export.html#Export-using-console-command";
-const EXPORT_SNAPSHOT_SDK_URL =
-  "https://api.labelstud.io/api-reference/api-reference/projects/exports/create";
+const EXPORT_SNAPSHOT_SDK_URL = "https://api.labelstud.io/api-reference/api-reference/projects/exports/create";
 const ENTERPRISE_URL = "https://docs.humansignal.com/guide/label_studio_compare";
 
 // const formats = {
@@ -170,9 +176,7 @@ export const ExportPage = () => {
         />
 
         <ExportLargeProjectWarning taskCount={projectTaskNumber} />
-        {exportIssue === "timeout" && (
-          <ExportTimeoutGuidance projectId={pageParams.id} exportType={currentFormat} />
-        )}
+        {exportIssue === "timeout" && <ExportTimeoutGuidance projectId={pageParams.id} exportType={currentFormat} />}
 
         <Form ref={form}>
           <Input type="hidden" name="exportType" value={currentFormat} />
@@ -272,8 +276,8 @@ const ExportLargeProjectWarning = ({ taskCount }) => {
         Large project detected ({taskCount.toLocaleString()} tasks)
       </div>
       <div className={cn("export-page").elem("warning-body").toClassName()}>
-        The export in Community Edition runs in your browser request and might time out (502/504 errors) for large datasets. If you hit a
-        timeout, use the{" "}
+        The export in Community Edition runs in your browser request and might time out (502/504 errors) for large
+        datasets. If you hit a timeout, use the{" "}
         <a className="no-go" href={EXPORT_TIMEOUT_DOCS_URL} target="_blank" rel="noreferrer">
           CLI/SDK export options
         </a>{" "}
@@ -330,7 +334,9 @@ const ExportTimeoutGuidance = ({ projectId, exportType }) => {
                     title={copied ? "Copied!" : "Copy command"}
                   >
                     <IconCopyOutline className={cn("export-page").elem("timeout-copy-icon").toClassName()} />
-                    {copied && <span className={cn("export-page").elem("timeout-copy-text").toClassName()}>Copied</span>}
+                    {copied && (
+                      <span className={cn("export-page").elem("timeout-copy-text").toClassName()}>Copied</span>
+                    )}
                   </button>
                 </div>
               </div>

--- a/web/apps/labelstudio/src/pages/ExportPage/ExportPage.jsx
+++ b/web/apps/labelstudio/src/pages/ExportPage/ExportPage.jsx
@@ -1,14 +1,14 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { useHistory } from "react-router";
 import { Button } from "@humansignal/ui";
-import { IconWarningCircleFilled, IconTerminal, IconCode, IconBook, IconExternal } from "@humansignal/icons";
+import { IconWarningCircleFilled, IconTerminal, IconCode, IconBook, IconExternal, IconCopyOutline } from "@humansignal/icons";
 import { Form, Input } from "../../components/Form";
 import { Modal } from "../../components/Modal/Modal";
 import { Space } from "../../components/Space/Space";
 import { useAPI } from "../../providers/ApiProvider";
 import { useFixedLocation, useParams } from "../../providers/RoutesProvider";
 import { cn } from "../../utils/bem";
-import { isDefined } from "../../utils/helpers";
+import { isDefined, copyText } from "../../utils/helpers";
 import "./ExportPage.scss";
 
 // Community Edition exports run synchronously in a single HTTP request.
@@ -17,7 +17,7 @@ const LARGE_EXPORT_TASK_THRESHOLD = 5000;
 const EXPORT_TIMEOUT_DOCS_URL = "https://labelstud.io/guide/export.html#Export-timeout-in-Community-Edition";
 const EXPORT_CONSOLE_DOCS_URL = "https://labelstud.io/guide/export.html#Export-using-console-command";
 const EXPORT_SNAPSHOT_SDK_URL =
-  "https://labelstud.io/sdk/project.html#label_studio_sdk.project.Project.export_snapshot_create";
+  "https://api.labelstud.io/api-reference/api-reference/projects/exports/create";
 const ENTERPRISE_URL = "https://docs.humansignal.com/guide/label_studio_compare";
 
 // const formats = {
@@ -285,6 +285,13 @@ const ExportLargeProjectWarning = ({ taskCount }) => {
 
 const ExportTimeoutGuidance = ({ projectId, exportType }) => {
   const cliCommand = `label-studio export ${projectId} ${exportType} --export-path=<output-path>`;
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    copyText(cliCommand);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [cliCommand]);
 
   return (
     <div className={cn("export-page").elem("timeout").toClassName()}>
@@ -312,9 +319,20 @@ const ExportTimeoutGuidance = ({ projectId, exportType }) => {
                   </a>
                   :
                 </span>
-                <pre className={cn("export-page").elem("timeout-code").toClassName()}>
-                  <code>{cliCommand}</code>
-                </pre>
+                <div className={cn("export-page").elem("timeout-code-wrapper").toClassName()}>
+                  <pre className={cn("export-page").elem("timeout-code").toClassName()}>
+                    <code>{cliCommand}</code>
+                  </pre>
+                  <button
+                    className={cn("export-page").elem("timeout-copy-button").toClassName()}
+                    onClick={handleCopy}
+                    aria-label="Copy command"
+                    title={copied ? "Copied!" : "Copy command"}
+                  >
+                    <IconCopyOutline className={cn("export-page").elem("timeout-copy-icon").toClassName()} />
+                    {copied && <span className={cn("export-page").elem("timeout-copy-text").toClassName()}>Copied</span>}
+                  </button>
+                </div>
               </div>
             </div>
           </li>

--- a/web/apps/labelstudio/src/pages/ExportPage/ExportPage.jsx
+++ b/web/apps/labelstudio/src/pages/ExportPage/ExportPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useHistory } from "react-router";
 import { Button } from "@humansignal/ui";
+import { IconWarningCircleFilled, IconTerminal, IconCode, IconBook, IconExternal } from "@humansignal/icons";
 import { Form, Input } from "../../components/Form";
 import { Modal } from "../../components/Modal/Modal";
 import { Space } from "../../components/Space/Space";
@@ -9,6 +10,15 @@ import { useFixedLocation, useParams } from "../../providers/RoutesProvider";
 import { cn } from "../../utils/bem";
 import { isDefined } from "../../utils/helpers";
 import "./ExportPage.scss";
+
+// Community Edition exports run synchronously in a single HTTP request.
+// Large exports can exceed typical proxy timeouts, so we warn early and link to alternatives.
+const LARGE_EXPORT_TASK_THRESHOLD = 5000;
+const EXPORT_TIMEOUT_DOCS_URL = "https://labelstud.io/guide/export.html#Export-timeout-in-Community-Edition";
+const EXPORT_CONSOLE_DOCS_URL = "https://labelstud.io/guide/export.html#Export-using-console-command";
+const EXPORT_SNAPSHOT_SDK_URL =
+  "https://labelstud.io/sdk/project.html#label_studio_sdk.project.Project.export_snapshot_create";
+const ENTERPRISE_URL = "https://docs.humansignal.com/guide/label_studio_compare";
 
 // const formats = {
 //   json: 'JSON',
@@ -25,6 +35,8 @@ const downloadFile = (blob, filename) => {
 
 const wait = () => new Promise((resolve) => setTimeout(resolve, 5000));
 
+const isTimeoutLikeStatus = (status) => status === 408 || status === 502 || status === 504;
+
 export const ExportPage = () => {
   const history = useHistory();
   const location = useFixedLocation();
@@ -36,45 +48,65 @@ export const ExportPage = () => {
   const [downloadingMessage, setDownloadingMessage] = useState(false);
   const [availableFormats, setAvailableFormats] = useState([]);
   const [currentFormat, setCurrentFormat] = useState("JSON");
+  const [projectTaskNumber, setProjectTaskNumber] = useState(null);
+  const [exportIssue, setExportIssue] = useState(null);
 
   /** @type {import('react').RefObject<Form>} */
   const form = useRef();
 
   const proceedExport = async () => {
+    setExportIssue(null);
     setDownloading(true);
 
-    const message = setTimeout(() => {
+    const messageTimer = window.setTimeout(() => {
       setDownloadingMessage(true);
     }, 1000);
 
-    const params = form.current.assembleFormData({
-      asJSON: true,
-      full: true,
-      booleansAsNumbers: true,
-    });
+    try {
+      const params = form.current.assembleFormData({
+        asJSON: true,
+        full: true,
+        booleansAsNumbers: true,
+      });
 
-    const response = await api.callApi("exportRaw", {
-      params: {
-        pk: pageParams.id,
-        ...params,
-      },
-    });
+      const response = await api.callApi("exportRaw", {
+        params: {
+          pk: pageParams.id,
+          ...params,
+        },
+      });
 
-    if (response.ok) {
-      const blob = await response.blob();
+      // The API proxy can return `null` for certain network errors; treat it as timeout-like
+      // and show actionable guidance instead of a generic error.
+      if (!response) {
+        setExportIssue("timeout");
+        return;
+      }
 
-      downloadFile(blob, response.headers.get("filename"));
-    } else {
+      if (response.ok) {
+        const blob = await response.blob();
+
+        downloadFile(blob, response.headers.get("filename"));
+        return;
+      }
+
+      if (isTimeoutLikeStatus(response.status)) {
+        setExportIssue("timeout");
+        return;
+      }
+
       api.handleError(response);
+    } finally {
+      window.clearTimeout(messageTimer);
+      setDownloading(false);
+      setDownloadingMessage(false);
     }
-
-    setDownloading(false);
-    setDownloadingMessage(false);
-    clearTimeout(message);
   };
 
   useEffect(() => {
     if (isDefined(pageParams.id)) {
+      let cancelled = false;
+
       api
         .callApi("previousExports", {
           params: {
@@ -82,7 +114,7 @@ export const ExportPage = () => {
           },
         })
         .then(({ export_files }) => {
-          setPreviousExports(export_files.slice(0, 1));
+          if (!cancelled) setPreviousExports(export_files.slice(0, 1));
         });
 
       api
@@ -92,11 +124,28 @@ export const ExportPage = () => {
           },
         })
         .then((formats) => {
+          if (cancelled) return;
           setAvailableFormats(formats);
           setCurrentFormat(formats[0]?.name);
         });
+
+      // Fetch project metadata to show a proactive warning for large exports.
+      // This is best-effort and should not trigger global error UI if it fails.
+      api
+        .callApi("project", {
+          params: { pk: pageParams.id },
+          errorFilter: () => true,
+        })
+        .then((project) => {
+          if (cancelled) return;
+          setProjectTaskNumber(project?.task_number ?? null);
+        });
+
+      return () => {
+        cancelled = true;
+      };
     }
-  }, [pageParams]);
+  }, [pageParams.id]);
 
   return (
     <Modal
@@ -120,20 +169,31 @@ export const ExportPage = () => {
           onClick={(format) => setCurrentFormat(format.name)}
         />
 
+        <ExportLargeProjectWarning taskCount={projectTaskNumber} />
+        {exportIssue === "timeout" && (
+          <ExportTimeoutGuidance projectId={pageParams.id} exportType={currentFormat} />
+        )}
+
         <Form ref={form}>
           <Input type="hidden" name="exportType" value={currentFormat} />
         </Form>
 
         <div className={cn("export-page").elem("footer").toClassName()}>
+          {downloadingMessage && (
+            <div className={cn("export-page").elem("status-message").toClassName()}>
+              Files are being prepared. It might take long time.
+            </div>
+          )}
           <Space style={{ width: "100%" }} spread>
-            <div className={cn("export-page").elem("recent").toClassName()}>{/* {exportHistory} */}</div>
+            <div className={cn("export-page").elem("recent").toClassName()}>
+              <a className="no-go" href={EXPORT_TIMEOUT_DOCS_URL} target="_blank" rel="noreferrer">
+                Having a timeout or trouble exporting large projects?
+              </a>
+            </div>
             <div className={cn("export-page").elem("actions").toClassName()}>
-              <Space>
-                {downloadingMessage && "Files are being prepared. It might take some time."}
-                <Button className="w-[135px]" onClick={proceedExport} waiting={downloading} aria-label="Export data">
-                  Export
-                </Button>
-              </Space>
+              <Button className="w-[135px]" onClick={proceedExport} waiting={downloading} aria-label="Export data">
+                Export
+              </Button>
             </div>
           </Space>
         </div>
@@ -202,3 +262,100 @@ const FormatInfo = ({ availableFormats, selected, onClick }) => {
 
 ExportPage.path = "/export";
 ExportPage.modal = true;
+
+const ExportLargeProjectWarning = ({ taskCount }) => {
+  if (!Number.isFinite(taskCount) || taskCount < LARGE_EXPORT_TASK_THRESHOLD) return null;
+
+  return (
+    <div className={cn("export-page").elem("warning").toClassName()}>
+      <div className={cn("export-page").elem("warning-title").toClassName()}>
+        Large project detected ({taskCount.toLocaleString()} tasks)
+      </div>
+      <div className={cn("export-page").elem("warning-body").toClassName()}>
+        The export in Community Edition runs in your browser request and might time out (502/504 errors) for large datasets. If you hit a
+        timeout, use the{" "}
+        <a className="no-go" href={EXPORT_TIMEOUT_DOCS_URL} target="_blank" rel="noreferrer">
+          CLI/SDK export options
+        </a>{" "}
+        or consider Enterprise for background exports at scale.
+      </div>
+    </div>
+  );
+};
+
+const ExportTimeoutGuidance = ({ projectId, exportType }) => {
+  const cliCommand = `label-studio export ${projectId} ${exportType} --export-path=<output-path>`;
+
+  return (
+    <div className={cn("export-page").elem("timeout").toClassName()}>
+      <div className={cn("export-page").elem("timeout-header").toClassName()}>
+        <IconWarningCircleFilled className={cn("export-page").elem("timeout-icon").toClassName()} />
+        <div className={cn("export-page").elem("timeout-title").toClassName()}>Export timed out</div>
+      </div>
+      <div className={cn("export-page").elem("timeout-body").toClassName()}>
+        This export is processed synchronously in the Community Edition UI and can exceed typical reverse-proxy timeouts
+        (often around 90 seconds) for large datasets.
+      </div>
+
+      <div className={cn("export-page").elem("timeout-actions").toClassName()}>
+        <div className={cn("export-page").elem("timeout-actions-title").toClassName()}>Recommended options:</div>
+        <ul className={cn("export-page").elem("timeout-actions-list").toClassName()}>
+          <li>
+            <div className={cn("export-page").elem("timeout-action-item").toClassName()}>
+              <IconTerminal className={cn("export-page").elem("timeout-action-icon").toClassName()} />
+              <div className={cn("export-page").elem("timeout-action-content").toClassName()}>
+                <span>
+                  Export using the{" "}
+                  <a className="no-go" href={EXPORT_CONSOLE_DOCS_URL} target="_blank" rel="noreferrer">
+                    console command
+                    <IconExternal className={cn("export-page").elem("timeout-link-icon").toClassName()} />
+                  </a>
+                  :
+                </span>
+                <pre className={cn("export-page").elem("timeout-code").toClassName()}>
+                  <code>{cliCommand}</code>
+                </pre>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div className={cn("export-page").elem("timeout-action-item").toClassName()}>
+              <IconCode className={cn("export-page").elem("timeout-action-icon").toClassName()} />
+              <div className={cn("export-page").elem("timeout-action-content").toClassName()}>
+                Use{" "}
+                <a className="no-go" href={EXPORT_SNAPSHOT_SDK_URL} target="_blank" rel="noreferrer">
+                  export snapshots via the SDK
+                  <IconExternal className={cn("export-page").elem("timeout-link-icon").toClassName()} />
+                </a>{" "}
+                to create and download a snapshot without relying on a single UI request.
+              </div>
+            </div>
+          </li>
+          <li>
+            <div className={cn("export-page").elem("timeout-action-item").toClassName()}>
+              <IconWarningCircleFilled className={cn("export-page").elem("timeout-action-icon").toClassName()} />
+              <div className={cn("export-page").elem("timeout-action-content").toClassName()}>
+                For large-scale exports in the UI, consider{" "}
+                <a className="no-go" href={ENTERPRISE_URL} target="_blank" rel="noreferrer">
+                  Label Studio Enterprise
+                  <IconExternal className={cn("export-page").elem("timeout-link-icon").toClassName()} />
+                </a>{" "}
+                since it is designed for large-scale projects and asynchronous exports.
+              </div>
+            </div>
+          </li>
+        </ul>
+        <div className={cn("export-page").elem("timeout-footer").toClassName()}>
+          <IconBook className={cn("export-page").elem("timeout-footer-icon").toClassName()} />
+          <span>
+            More details in the documentation:{" "}
+            <a className="no-go" href={EXPORT_TIMEOUT_DOCS_URL} target="_blank" rel="noreferrer">
+              Export timeout in Community Edition
+              <IconExternal className={cn("export-page").elem("timeout-link-icon").toClassName()} />
+            </a>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/web/apps/labelstudio/src/pages/ExportPage/ExportPage.jsx
+++ b/web/apps/labelstudio/src/pages/ExportPage/ExportPage.jsx
@@ -328,6 +328,7 @@ const ExportTimeoutGuidance = ({ projectId, exportType }) => {
                     <code>{cliCommand}</code>
                   </pre>
                   <button
+                    type="button"
                     className={cn("export-page").elem("timeout-copy-button").toClassName()}
                     onClick={handleCopy}
                     aria-label="Copy command"

--- a/web/apps/labelstudio/src/pages/ExportPage/ExportPage.scss
+++ b/web/apps/labelstudio/src/pages/ExportPage/ExportPage.scss
@@ -86,7 +86,7 @@
   &__timeout {
     background: var(--color-neutral-surface);
     border-left: 2px solid var(--color-negative-border);
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+    box-shadow: 0 1px 3px rgb(0 0 0 / 4%);
   }
 
   &__timeout-header {
@@ -131,7 +131,7 @@
     color: var(--color-neutral-content-subtle);
 
     li {
-      margin: 0 0 14px 0;
+      margin: 0 0 14px;
       padding-left: 0;
 
       &:last-child {
@@ -261,7 +261,6 @@
       display: inline-flex;
       align-items: center;
       gap: 4px;
-      transition: opacity 0.2s;
       border-bottom: 1px solid transparent;
       transition: border-color 0.2s;
 

--- a/web/apps/labelstudio/src/pages/ExportPage/ExportPage.scss
+++ b/web/apps/labelstudio/src/pages/ExportPage/ExportPage.scss
@@ -169,9 +169,17 @@
     opacity: 0.6;
   }
 
-  &__timeout-code {
+  &__timeout-code-wrapper {
     margin: 10px 0 0;
+    position: relative;
+    display: flex;
+    align-items: stretch;
+  }
+
+  &__timeout-code {
+    flex: 1;
     padding: 10px 12px;
+    padding-right: 50px;
     border-radius: 4px;
     border: 1px solid var(--color-neutral-border-subtler);
     background-color: var(--color-neutral-surface-active);
@@ -196,6 +204,44 @@
       white-space: pre;
       display: block;
     }
+  }
+
+  &__timeout-copy-button {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 8px;
+    border: none;
+    background: transparent;
+    border-radius: 4px;
+    cursor: pointer;
+    color: var(--color-neutral-content-subtler);
+    transition: all 0.2s;
+    font-size: 11px;
+
+    &:hover {
+      background-color: var(--color-neutral-surface);
+      color: var(--color-neutral-content);
+    }
+
+    &:active {
+      transform: translateY(-50%) scale(0.95);
+    }
+  }
+
+  &__timeout-copy-icon {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+  }
+
+  &__timeout-copy-text {
+    font-weight: 500;
+    color: var(--color-primary-content);
   }
 
   &__timeout-footer {

--- a/web/apps/labelstudio/src/pages/ExportPage/ExportPage.scss
+++ b/web/apps/labelstudio/src/pages/ExportPage/ExportPage.scss
@@ -2,15 +2,236 @@
   &__recent {
     display: grid;
     grid-auto-flow: rows;
+
+    a {
+      color: var(--color-primary-content);
+      text-decoration: underline;
+      font-size: 14px;
+    }
   }
 
   &__footer {
-    margin: 0 -40px -32px;
-    padding: 24px 32px;
-    position: sticky;
-    bottom: -40px;
+    margin: 16px -40px -32px;
+    padding: 20px 32px;
+    position: static;
     background-color: var(--color-neutral-surface-active);
     border-top: 1px solid var(--color-neutral-border);
+
+    .ls-space {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--spacing-base);
+      align-items: center;
+      justify-content: space-between;
+      width: 100%;
+    }
+
+    .export-page__recent {
+      flex: 1;
+      min-width: 240px;
+    }
+
+    .export-page__actions {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-base);
+      flex-shrink: 0;
+    }
+  }
+
+  &__status-message {
+    margin-bottom: 12px;
+    font-size: 14px;
+    color: var(--color-neutral-content-subtle);
+    text-align: center;
+  }
+
+  &__warning,
+  &__timeout {
+    margin: 12px 0 16px;
+    padding: 16px 18px;
+    border-radius: 6px;
+    border: 1px solid var(--color-neutral-border-subtler);
+    color: var(--color-neutral-content);
+  }
+
+  &__warning {
+    background-color: var(--color-primary-emphasis-subtle);
+  }
+
+  &__warning-title,
+  &__timeout-title {
+    font-weight: 600;
+    margin-bottom: 4px;
+  }
+
+  &__warning-body,
+  &__timeout-body {
+    font-size: 14px;
+    color: var(--color-neutral-content-subtle);
+    line-height: 1.5;
+
+    a {
+      color: var(--color-primary-content);
+      text-decoration: none;
+      border-bottom: 1px solid transparent;
+      transition: border-color 0.2s;
+
+      &:hover {
+        border-bottom-color: var(--color-primary-content);
+      }
+    }
+  }
+
+  &__timeout {
+    background: var(--color-neutral-surface);
+    border-left: 2px solid var(--color-negative-border);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+  }
+
+  &__timeout-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 10px;
+  }
+
+  &__timeout-icon {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+    color: var(--color-neutral-content-subtle);
+    opacity: 0.7;
+  }
+
+  &__timeout-title {
+    font-weight: 500;
+    margin-bottom: 0;
+    font-size: 16px;
+    color: var(--color-neutral-content);
+    letter-spacing: -0.01em;
+  }
+
+  &__timeout-actions {
+    margin-top: 16px;
+    font-size: 14px;
+    color: var(--color-neutral-content);
+  }
+
+  &__timeout-actions-title {
+    font-weight: 500;
+    margin-bottom: 14px;
+    color: var(--color-neutral-content-subtle);
+  }
+
+  &__timeout-actions-list {
+    margin: 0;
+    padding-left: 0;
+    list-style: none;
+    color: var(--color-neutral-content-subtle);
+
+    li {
+      margin: 0 0 14px 0;
+      padding-left: 0;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
+
+  &__timeout-action-item {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+  }
+
+  &__timeout-action-icon {
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+    margin-top: 3px;
+    color: var(--color-neutral-content-subtler);
+    opacity: 0.6;
+  }
+
+  &__timeout-action-content {
+    flex: 1;
+    line-height: 1.6;
+  }
+
+  &__timeout-link-icon {
+    width: 11px;
+    height: 11px;
+    display: inline-block;
+    vertical-align: middle;
+    margin-left: 2px;
+    opacity: 0.6;
+  }
+
+  &__timeout-code {
+    margin: 10px 0 0;
+    padding: 10px 12px;
+    border-radius: 4px;
+    border: 1px solid var(--color-neutral-border-subtler);
+    background-color: var(--color-neutral-surface-active);
+    overflow-x: auto;
+    position: relative;
+
+    &::before {
+      content: "";
+      position: absolute;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      width: 2px;
+      background: var(--color-neutral-border-subtle);
+      border-radius: 4px 0 0 4px;
+    }
+
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      font-size: 12px;
+      color: var(--color-neutral-content-subtle);
+      white-space: pre;
+      display: block;
+    }
+  }
+
+  &__timeout-footer {
+    margin-top: 18px;
+    padding-top: 14px;
+    border-top: 1px solid var(--color-neutral-border-subtler);
+    font-size: 12px;
+    color: var(--color-neutral-content-subtler);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+
+    a {
+      color: var(--color-primary-content);
+      text-decoration: none;
+      font-weight: 400;
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      transition: opacity 0.2s;
+      border-bottom: 1px solid transparent;
+      transition: border-color 0.2s;
+
+      &:hover {
+        opacity: 0.8;
+        border-bottom-color: var(--color-primary-content);
+      }
+    }
+  }
+
+  &__timeout-footer-icon {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+    color: var(--color-neutral-content-subtler);
+    opacity: 0.5;
   }
 }
 


### PR DESCRIPTION
Improve timeout handling in exports for the LS community.

## ExportLargeProjectWarning
<img width="1740" height="806" alt="image" src="https://github.com/user-attachments/assets/39550234-b191-4161-8ae7-987548151c38" />



## ExportTimeoutGuidance
<img width="2161" height="2205" alt="image" src="https://github.com/user-attachments/assets/040df78a-1e83-4f61-bf9a-076e3a6030d5" />
