### PR TITLE
fix: UTC-453: Root dynamic columns definition

### DIFF
--- a/web/libs/datamanager/src/sdk/app-create.jsx
+++ b/web/libs/datamanager/src/sdk/app-create.jsx
@@ -60,7 +60,7 @@ export const createApp = async (rootNode, datamanager) => {
   // in incorrect dynamic columns and mapping mismatch
   const FinalStore = types.compose(
     AppStore,
-    types.model("Base", {
+    types.model("DataStore", {
       taskStore: types.optional(
         types.late(() => DynamicModel.get("tasksStore")),
         {},

--- a/web/libs/datamanager/src/sdk/app-create.jsx
+++ b/web/libs/datamanager/src/sdk/app-create.jsx
@@ -2,7 +2,7 @@ import ReactDOM from "react-dom";
 import { App } from "../components/App/App";
 import { AppStore } from "../stores/AppStore";
 import * as DataStores from "../stores/DataStores";
-import { DynamicModel, registerModel, registryReset } from "../stores/DynamicModel";
+import { DynamicModel, registerModel } from "../stores/DynamicModel";
 import { types } from "mobx-state-tree";
 
 const createDynamicModels = (columns) => {
@@ -33,7 +33,6 @@ const createDynamicModels = (columns) => {
  * @returns {Promise<AppStore>}
  */
 export const createApp = async (rootNode, datamanager) => {
-  registryReset();
   const isLabelStream = datamanager.mode === "labelstream";
 
   const response = await datamanager.api.columns();

--- a/web/libs/datamanager/src/sdk/app-create.jsx
+++ b/web/libs/datamanager/src/sdk/app-create.jsx
@@ -2,7 +2,8 @@ import ReactDOM from "react-dom";
 import { App } from "../components/App/App";
 import { AppStore } from "../stores/AppStore";
 import * as DataStores from "../stores/DataStores";
-import { registerModel } from "../stores/DynamicModel";
+import { DynamicModel, registerModel, registryReset } from "../stores/DynamicModel";
+import { types } from "mobx-state-tree";
 
 const createDynamicModels = (columns) => {
   const grouppedColumns = columns.reduce((res, column) => {
@@ -32,6 +33,7 @@ const createDynamicModels = (columns) => {
  * @returns {Promise<AppStore>}
  */
 export const createApp = async (rootNode, datamanager) => {
+  registryReset();
   const isLabelStream = datamanager.mode === "labelstream";
 
   const response = await datamanager.api.columns();
@@ -50,7 +52,28 @@ export const createApp = async (rootNode, datamanager) => {
 
   createDynamicModels(columns);
 
-  const appStore = AppStore.create({
+  // types.late is resolved once in MST, although,
+  // we need it to be resolved each time DM is initialized
+  // so both taskStore and annotationStore moved here to dynamically
+  // initialized
+  //
+  // without it the columns set will be cached during navigation resulting
+  // in incorrect dynamic columns and mapping mismatch
+  const FinalStore = types.compose(
+    AppStore,
+    types.model("Base", {
+      taskStore: types.optional(
+        types.late(() => DynamicModel.get("tasksStore")),
+        {},
+      ),
+      annotationStore: types.optional(
+        types.late(() => DynamicModel.get("annotationsStore")),
+        {},
+      ),
+    }),
+  );
+
+  const appStore = FinalStore.create({
     viewsStore: {
       views: [],
       columnsRaw: columns,

--- a/web/libs/datamanager/src/stores/AppStore.js
+++ b/web/libs/datamanager/src/stores/AppStore.js
@@ -34,19 +34,6 @@ export const AppStore = types
 
     users: types.optional(types.array(User), []),
 
-    taskStore: types.optional(
-      types.late(() => {
-        return DynamicModel.get("tasksStore");
-      }),
-      {},
-    ),
-
-    annotationStore: types.optional(
-      types.late(() => {
-        return DynamicModel.get("annotationsStore");
-      }),
-      {},
-    ),
 
     availableActions: types.optional(types.array(Action), []),
 

--- a/web/libs/datamanager/src/stores/AppStore.js
+++ b/web/libs/datamanager/src/stores/AppStore.js
@@ -5,7 +5,7 @@ import { History } from "../utils/history";
 import { isDefined } from "../utils/utils";
 import { Action } from "./Action";
 import * as DataStores from "./DataStores";
-import { DynamicModel, registerModel } from "./DynamicModel";
+import { registerModel } from "./DynamicModel";
 import { TabStore } from "./Tabs";
 import { CustomJSON } from "./types";
 import { User } from "./Users";
@@ -33,7 +33,6 @@ export const AppStore = types
     loadingData: false,
 
     users: types.optional(types.array(User), []),
-
 
     availableActions: types.optional(types.array(Action), []),
 


### PR DESCRIPTION
The problem:

With consensus agreement enabled, when navigating between projects without refreshing the page the agreement columns will be empty in every project except for the first one loaded.

Root cause:

The way AppStore's `taskStore` and `annotationStore` are initialized caused columns definitions to stuck so that only the first loaded set of columns will be applied. This is due to how MST's `types.late` works that resolves the model only once.

The fix:

Both definitions for task and annotation stores were moved to the app creation step where we can dynamically initialize them bypassing the `types.late` behavior. This unlocks dynamic columns definition.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures dynamic columns are re-resolved on each app initialization to avoid stale/cached mappings across project navigation.
> 
> - In `app-create.jsx`, add `createDynamicModels(columns)` to register per-target stores via `DynamicModel` based on API `columns`, with fallbacks for empty columns and annotations
> - Compose a `FinalStore` (`AppStore` + dynamic `taskStore`/`annotationStore` via `types.late(() => DynamicModel.get(...))`) and create the app store from it with `columnsRaw`
> - Remove `taskStore`/`annotationStore` late definitions and `DynamicModel` import from `AppStore.js` (now injected at bootstrap)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8bfb2ee3e8302bbe8cea985428c9f6b0d8a5eb5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->