### PR TITLE
chore: remove obsolete __future__ imports

### DIFF
--- a/label_studio/core/utils/common.py
+++ b/label_studio/core/utils/common.py
@@ -1,7 +1,5 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
-from __future__ import unicode_literals
-
 import calendar
 import contextlib
 import copy

--- a/label_studio/core/version.py
+++ b/label_studio/core/version.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
 """ Version Lib


### PR DESCRIPTION
Removed Python 2 compatibility imports (`print_function`, `unicode_literals`) that are no longer needed since the project requires Python 3.10+.