### PR TITLE
fix: BROS-664: Fix XSS via script injection in custom hotkeys

### DIFF
--- a/label_studio/core/templatetags/filters.py
+++ b/label_studio/core/templatetags/filters.py
@@ -127,3 +127,16 @@ def var_exists(context, name):
             if name in d:
                 return True
     return False
+
+@register.filter
+def replace(value, arg):
+    """
+    Replacing filter
+    Use `{{ "aaa"|replace:"a|b" }}`
+    """
+    if len(arg.split('|')) != 2:
+        return value
+
+    what, to = arg.split('|')
+    return value.replace(what, to)
+

--- a/label_studio/core/templatetags/filters.py
+++ b/label_studio/core/templatetags/filters.py
@@ -127,16 +127,3 @@ def var_exists(context, name):
             if name in d:
                 return True
     return False
-
-
-@register.filter
-def replace(value, arg):
-    """
-    Replacing filter
-    Use `{{ "aaa"|replace:"a|b" }}`
-    """
-    if len(arg.split('|')) != 2:
-        return value
-
-    what, to = arg.split('|')
-    return value.replace(what, to)

--- a/label_studio/core/templatetags/filters.py
+++ b/label_studio/core/templatetags/filters.py
@@ -128,6 +128,7 @@ def var_exists(context, name):
                 return True
     return False
 
+
 @register.filter
 def replace(value, arg):
     """
@@ -139,4 +140,3 @@ def replace(value, arg):
 
     what, to = arg.split('|')
     return value.replace(what, to)
-

--- a/label_studio/templates/base.html
+++ b/label_studio/templates/base.html
@@ -101,8 +101,7 @@
 </template>
 
 <script id="app-settings" nonce="{{request.csp_nonce}}">
-
-  var __customHotkeys = {{ user.custom_hotkeys|json_dumps_ensure_ascii|safe }};
+  var __customHotkeys = {{ user.custom_hotkeys|json_dumps_ensure_ascii|replace:"<|&lt;"|replace:">|&gt;"|safe }};
 
   // Filter custom hotkeys for editor-specific ones
   var editorCustomHotkeys = {};

--- a/label_studio/templates/base.html
+++ b/label_studio/templates/base.html
@@ -101,7 +101,7 @@
 </template>
 
 <script id="app-settings" nonce="{{request.csp_nonce}}">
-  var __customHotkeys = {{ user.custom_hotkeys|json_dumps_ensure_ascii|replace:"<|&lt;"|replace:">|&gt;"|safe }};
+  var __customHotkeys = {{ user.custom_hotkeys|json_dumps_ensure_ascii|escape_lt_gt|safe }};
 
   // Filter custom hotkeys for editor-specific ones
   var editorCustomHotkeys = {};


### PR DESCRIPTION
Addresses https://github.com/HumanSignal/label-studio/security/advisories/GHSA-2mq9-hm29-8qch

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hardens client boot script against XSS from `user.custom_hotkeys` and adds a small templating utility.
> 
> - New Django template filter `replace` for simple substring replacement
> - In `base.html`, escapes `<` and `>` in `user.custom_hotkeys` via `|json_dumps_ensure_ascii|replace:"<|&lt;"|replace:">|&gt;"|safe` before injecting into `__customHotkeys`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4839fcc2c76a02f63cebc468d134ff158de9d67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->