### PR TITLE
fix: Text in export timeout warning

### DIFF
--- a/web/apps/labelstudio/src/pages/ExportPage/ExportPage.jsx
+++ b/web/apps/labelstudio/src/pages/ExportPage/ExportPage.jsx
@@ -276,8 +276,7 @@ const ExportLargeProjectWarning = ({ taskCount }) => {
         Large project detected ({taskCount.toLocaleString()} tasks)
       </div>
       <div className={cn("export-page").elem("warning-body").toClassName()}>
-        The export in Community Edition runs in your browser request and might time out (502/504 errors) for large
-        datasets. If you hit a timeout, use the{" "}
+        To avoid potential timeouts during large dataset exports in the Community Edition, use the{" "}
         <a className="no-go" href={EXPORT_TIMEOUT_DOCS_URL} target="_blank" rel="noreferrer">
           CLI/SDK export options
         </a>{" "}


### PR DESCRIPTION
<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
**Reason for change**:
Updated the warning message copy for large project exports in `ExportPage.jsx` to be more concise and user-friendly, aligning with guidance from #600-product. The previous wording was slightly verbose.

**Screenshots**:
N/A (text change in UI).

**Rollout strategy**:
Direct code change.

**Testing**:
No automated tests. Please spot-check the export modal in the UI to verify the new warning message.

**Risks**:
Minimal; this is a purely cosmetic text change.

**Reviewer notes**:
Please verify the updated warning message displayed when attempting to export a large project in the Community Edition. The change is in `web/apps/labelstudio/src/pages/ExportPage/ExportPage.jsx`.

**General notes**:
The change specifically targets the warning displayed when a large project is detected during export, guiding users towards CLI/SDK options to prevent timeouts with improved clarity.

---
[Slack Thread](https://humansignal.slack.com/archives/C03DHS6RJRL/p1767029454363469?thread_ts=1767029454.363469&cid=C03DHS6RJRL)

<a href="https://cursor.com/background-agent?bcId=bc-223eb6fb-d6dd-4734-b2d4-b377275a8561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-223eb6fb-d6dd-4734-b2d4-b377275a8561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

