### PR TITLE
docs: Anchor link case sensitivity

### DIFF
--- a/docs/source/guide/prompts_overview.md
+++ b/docs/source/guide/prompts_overview.md
@@ -62,7 +62,7 @@ By utilizing AI to handle the bulk of the annotation work, you can significantly
     * [Sync data from external storage](storage)
 2. Annotate a subset of tasks, marking as many as possible as ground truth annotations. The more data you have for the prompt evaluation, the more confident you can be with the results.
 
-    If you want to skip this step, see the [bootstrapping use case](#bootstrapping-projects-with-prompts) outlined below. 
+    If you want to skip this step, see the [bootstrapping use case](#Bootstrapping-projects-with-Prompts) outlined below. 
 
     * [Labeling guide](labeling)
     * [Define ground truth annotations for a project](quality#Define-ground-truth-annotations-for-a-project)


### PR DESCRIPTION
<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
**Reason for change:**
The anchor link `#bootstrapping-projects-with-prompts` in `docs/source/guide/prompts_overview.md` was not working because it was case-sensitive and did not match the exact casing of its target heading `### Bootstrapping projects with Prompts`. This PR updates the anchor link to correctly match the heading's case.

**Screenshots:**
N/A - This is a documentation fix with no visible UI changes beyond the link now working.

**Rollout strategy:**
Standard documentation deployment.

**Testing:**
Verified by checking the diff and confirming the anchor link now matches the heading's case. The fix can be confirmed by navigating to the rendered documentation and clicking the "bootstrapping use case" link to ensure it scrolls to the correct section.

**Risks:**
Minimal to none. This is a minor documentation correction.

**Reviewer notes:**
Please confirm that the anchor link on line 65 now correctly points to the "Bootstrapping projects with Prompts" section.

**General notes:**
Anchor links in this documentation system are case-sensitive. The change from `#bootstrapping-projects-with-prompts` to `#Bootstrapping-projects-with-Prompts` ensures the link functions as intended.

---
[Slack Thread](https://humansignal.slack.com/archives/C01HGFXA7KR/p1766337984073109?thread_ts=1766337984.073109&cid=C01HGFXA7KR)

<a href="https://cursor.com/background-agent?bcId=bc-bc7b6208-0991-41c0-bd5e-45b42f36b25c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bc7b6208-0991-41c0-bd5e-45b42f36b25c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

