### PR TITLE
Dark mode report button

### DIFF
--- a/web/libs/ui/src/lib/button/button.module.scss
+++ b/web/libs/ui/src/lib/button/button.module.scss
@@ -324,6 +324,15 @@
       box-shadow: inset 0 1px 0 rgb(var(--black-raw) / 10%);
     }
   }
+
+  :global([data-color-scheme="dark"]) &:not(:disabled) {
+    --text-color: var(--text-outline, var(--color-neutral-content));
+    --border-color: color-mix(in srgb, var(--border-outline) 70%, rgb(var(--white-raw) / 35%));
+    --border-color-hover: color-mix(in srgb, var(--border-color-hover, var(--border-outline)) 70%, rgb(var(--white-raw) / 45%));
+    --background-color: color-mix(in srgb, var(--color-neutral-background) 80%, rgb(var(--white-raw) / 6%));
+    --background-color-hover: color-mix(in srgb, var(--color-neutral-background-hover, var(--color-neutral-background)) 70%, rgb(var(--white-raw) / 10%));
+    --background-color-active: color-mix(in srgb, var(--color-neutral-background-active, var(--color-neutral-background)) 60%, rgb(var(--white-raw) / 14%));
+  }
 }
 
 .look-string {


### PR DESCRIPTION
<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
**Reason for change:**
*   **Problem:** The "Download Report" button on the Support Reports page (BROS-689) was not visually adapting in Dark Mode, making it appear empty and unusable due to insufficient contrast.
*   **Solution:** Added dark-mode specific CSS overrides for outlined buttons (`.look-outlined`) to ensure their text, border, and background colors provide adequate contrast against a dark background.

**Screenshots:**
*   **Before (Dark Mode):** [Add screenshot showing the invisible/empty "Download Report" button]
*   **After (Dark Mode):** [Add screenshot showing the visible and correctly styled "Download Report" button]

**Rollout strategy:**
Standard deployment.

**Testing:**
Manual verification by:
1.  Enabling Dark Mode.
2.  Navigating to the Support Reports page.
3.  Confirming the "Download Report" button is clearly visible and styled correctly.

**Risks:**
Low. This is a CSS-only change targeting a specific visual issue.

**Reviewer notes:**
Please verify the appearance of the "Download Report" button on the Support Reports page in Dark Mode to ensure it has adequate contrast and is clearly visible.

**General notes:**
The changes are confined to `web/libs/ui/src/lib/button/button.module.scss` and specifically target the `.look-outlined` button style when `data-color-scheme="dark"` is active.

---
[Slack Thread](https://humansignal.slack.com/archives/D0A5U320CDR/p1767033948317449?thread_ts=1767033948.317449&cid=D0A5U320CDR)

<a href="https://cursor.com/background-agent?bcId=bc-cb1080e6-7b36-4206-9e84-235730b26791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cb1080e6-7b36-4206-9e84-235730b26791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

