### PR TITLE
Feature flag cleanup

### DIFF
--- a/label_studio/feature_flags.json
+++ b/label_studio/feature_flags.json
@@ -784,33 +784,6 @@
       "version": 4,
       "deleted": false
     },
-    "fflag_all_feat_bros_421_review_random_and_limit_tasks": {
-      "key": "fflag_all_feat_bros_421_review_random_and_limit_tasks",
-      "on": true,
-      "prerequisites": [],
-      "targets": [],
-      "contextTargets": [],
-      "rules": [],
-      "fallthrough": {
-        "variation": 0
-      },
-      "offVariation": 1,
-      "variations": [
-        true,
-        false
-      ],
-      "clientSideAvailability": {
-        "usingMobileKey": false,
-        "usingEnvironmentId": false
-      },
-      "clientSide": false,
-      "salt": "db7b096d5f524fb591d122b4aaf9bc36",
-      "trackEvents": false,
-      "trackEventsFallthrough": false,
-      "debugEventsUntilDate": null,
-      "version": 4,
-      "deleted": false
-    },
     "fflag_all_feat_dia_1777_ls_homepage_short": {
       "key": "fflag_all_feat_dia_1777_ls_homepage_short",
       "on": true,


### PR DESCRIPTION
<!--
This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
**Reason for change:**
Removed the `fflag_all_feat_bros_421_review_random_and_limit_tasks` feature flag as requested. The flag was configured to always be `TRUE` and was not referenced by any runtime code, making its removal a cleanup.

**Screenshots:**
N/A - No visible changes.

**Rollout strategy:**
Direct merge. This is a configuration cleanup.

**Testing:**
*   `read_lints label_studio/feature_flags.json` was run and passed.
*   No automated tests were run as this is a configuration data change.
*   Consider a quick regression pass in any area that previously relied on review random/limit behavior if deemed necessary, though the flag was not actively used in code.

**Risks:**
Low risk, as the feature flag was not referenced in the application's runtime code, meaning its removal does not alter existing behavior.

**Reviewer notes:**
The flag `fflag_all_feat_bros_421_review_random_and_limit_tasks` was removed from `label_studio/feature_flags.json`. A search confirmed no code references this flag, so its removal is purely a cleanup.

**General notes:**
This change removes an unused feature flag entry from the `feature_flags.json` file.

---
[Slack Thread](https://humansignal.slack.com/archives/C08RF6EHN2W/p1767107025404009?thread_ts=1767107025.404009&cid=C08RF6EHN2W)

<a href="https://cursor.com/background-agent?bcId=bc-2cc5668c-3ecb-436f-a356-a0fb3d606813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2cc5668c-3ecb-436f-a356-a0fb3d606813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

