### PR TITLE
fix: UTC-422: Some parts of Members button on workspace are not clickable

### DIFF
--- a/web/libs/ui/src/lib/Userpic/Userpic.module.scss
+++ b/web/libs/ui/src/lib/Userpic/Userpic.module.scss
@@ -11,6 +11,7 @@
   border: 1px solid rgba(var(--color-neutral-shadow-raw) / 10% );
   box-shadow: none;
   transition: all 150ms ease-out;
+  user-select: none;
 
   .avatar {
     opacity: 0;
@@ -34,6 +35,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    user-select: none;
   }
 
   .badge {

--- a/web/libs/ui/src/lib/Userpic/Userpic.tsx
+++ b/web/libs/ui/src/lib/Userpic/Userpic.tsx
@@ -148,7 +148,10 @@ export const Userpic = forwardRef(
                 ref={imgRef}
                 src={finalSrc}
                 alt={(displayName ?? "").toUpperCase()}
-                style={{ opacity: imgVisible ? (faded ? 0.3 : 1) : 0 }}
+                style={{
+                  opacity: imgVisible ? (faded ? 0.3 : 1) : 0,
+                  pointerEvents: imgVisible ? "auto" : "none",
+                }}
                 onLoad={onImageLoaded}
                 onError={() => setFinalSrc(FALLBACK_IMAGE)}
               />


### PR DESCRIPTION
When an Userpic component has no image still renders an img tag with opacity 0 which intercepts pointer events. Also removed user selection when displaying initials.

When on hovering the Members button label:

Before:
<img width="241" height="69" alt="Screenshot 2026-01-05 at 12 38 01" src="https://github.com/user-attachments/assets/24fc93bd-f298-469e-9d44-f5acaaf0d0bc" />


After:
<img width="203" height="61" alt="Screenshot 2026-01-05 at 12 38 27" src="https://github.com/user-attachments/assets/6e77f23e-4b9b-4c6e-ad08-19bd62040e05" />


<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
