### PR TITLE
chore: Ensure that all analytical capture is behind the COLLECT_ANALYTICS env var

### DIFF
--- a/label_studio/users/templates/users/new-ui/user_base.html
+++ b/label_studio/users/templates/users/new-ui/user_base.html
@@ -8,6 +8,7 @@
 <link rel="stylesheet" href="{{ settings.HOSTNAME }}{% static 'css/fonts.hellix.css' %}"/>
 <link rel="stylesheet" href="{{ settings.HOSTNAME }}{% static 'css/login.css' %}"/>
 
+{% if settings.COLLECT_ANALYTICS %}
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-129877673-1" nonce="{{request.csp_nonce}}"></script>
 <script nonce="{{request.csp_nonce}}">
 window.dataLayer = window.dataLayer || [];
@@ -15,6 +16,7 @@ function gtag(){dataLayer.push(arguments);}
 gtag('js', new Date());
 gtag('config', 'UA-129877673-1');
 </script>
+{% endif %}
 {% endblock %}
 
 {% block content %}

--- a/label_studio/users/templates/users/user_base.html
+++ b/label_studio/users/templates/users/user_base.html
@@ -6,6 +6,7 @@
 {% block head %}
 <link rel="stylesheet" href="{{ settings.HOSTNAME }}{% static 'css/login.css' %}"/>
 
+{% if settings.COLLECT_ANALYTICS %}
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-129877673-1"></script>
 <script nonce="{{request.csp_nonce}}">
 window.dataLayer = window.dataLayer || [];
@@ -13,6 +14,7 @@ function gtag(){dataLayer.push(arguments);}
 gtag('js', new Date());
 gtag('config', 'UA-129877673-1');
 </script>
+{% endif %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Ensure that COLLECT_ANALYTICS covers all analytical capture, GA was incidentally not correctly adhering to this at the template level.