### PR TITLE
fix: FIT-1180: Label Studio will not reliably load in airgapped environments

### DIFF
--- a/web/libs/core/src/lib/utils/query-client.ts
+++ b/web/libs/core/src/lib/utils/query-client.ts
@@ -16,6 +16,10 @@ export const queryClient = new QC({
     queries: {
       refetchOnWindowFocus: false,
       cacheTime: shouldBypassCache ? TEST_CACHE_TIME : DEFAULT_CACHE_TIME,
+      // Always attempt to fetch regardless of browser's network status detection.
+      // This is critical for air-gapped environments where navigator.onLine may
+      // return false even though the local Label Studio server is reachable.
+      networkMode: "always",
     },
   },
 });


### PR DESCRIPTION
This pull request makes an important update to the query client configuration to improve reliability in air-gapped environments. The main change ensures that queries always attempt to fetch data, regardless of the browser's network status detection.

Query client configuration:

* Added `networkMode: "always"` to the query client options in `web/libs/core/src/lib/utils/query-client.ts`, ensuring fetches occur even when `navigator.onLine` reports offline, which is essential for air-gapped setups.