### PR TITLE
feat: FIT-1155: Improve the project state tooltip to account for personal workspace context

### DIFF
--- a/web/libs/app-common/src/components/state-chips/project-state-chip.tsx
+++ b/web/libs/app-common/src/components/state-chips/project-state-chip.tsx
@@ -22,13 +22,19 @@ export interface ProjectStateChipProps {
    * Whether the chip should be interactive (show history popover)
    */
   interactive?: boolean;
+
+  /**
+   * Optional custom description to override the default tooltip.
+   * Use this to provide context-specific tooltips.
+   */
+  description?: string;
 }
 
-export function ProjectStateChip({ state, projectId, interactive = true }: ProjectStateChipProps) {
+export function ProjectStateChip({ state, projectId, interactive = true, description }: ProjectStateChipProps) {
   const [open, setOpen] = useState(false);
 
   const label = formatStateName(state);
-  const description = getStateDescription(state, "project");
+  const defaultDescription = getStateDescription(state, "project");
   const colorClasses = getStateColorClass(state);
 
   const popoverContent = projectId ? (
@@ -43,7 +49,7 @@ export function ProjectStateChip({ state, projectId, interactive = true }: Proje
   return (
     <StateChip
       label={label}
-      description={description}
+      description={description ?? defaultDescription}
       className={colorClasses}
       interactive={interactive && !!projectId}
       popoverContent={popoverContent}


### PR DESCRIPTION
This pull request adds support for providing a custom tooltip description to the `ProjectStateChip` component, allowing more flexible and context-specific tooltips. If a custom `description` is not provided, the component will fall back to the default description based on the project state.

Enhancements to `ProjectStateChip`:

* Added an optional `description` prop to the `ProjectStateChipProps` interface, enabling consumers to override the default tooltip with a custom description.
* Updated the `ProjectStateChip` component to use the custom `description` if provided, or fall back to the default state-based description.