### PR TITLE
fix: FIT-1153: StateChip does not contrast with various backgrounds

### DIFF
--- a/web/libs/ui/src/shad/components/ui/badge.tsx
+++ b/web/libs/ui/src/shad/components/ui/badge.tsx
@@ -1,7 +1,7 @@
 import type * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@humansignal/shad/utils";
+import { cnm } from "@humansignal/shad/utils";
 
 const badgeVariants = cva(
   "inline-flex items-center border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
@@ -33,7 +33,7 @@ const badgeVariants = cva(
 export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, shape, ...props }: BadgeProps) {
-  return <div className={cn(badgeVariants({ variant, shape }), className)} {...props} />;
+  return <div className={cnm(badgeVariants({ variant, shape }), className)} {...props} />;
 }
 
 export { Badge, badgeVariants };


### PR DESCRIPTION
The utility for Badge component wasn't using the proper tailwind merge version of the classnames utility, and ended up incorrectly with duplicated tailwind classes in the same group, ie. `border-transparent` in this case would never be able to be supplied an override and include a border of any color as both classes would be present on the element, and border-transparent took precedence. This made Badges have very low or no contrast on same or similar backgrounds in Headers, Cards etc.

<img width="2742" height="439" alt="Screenshot 2026-01-07 at 9 18 41 AM" src="https://github.com/user-attachments/assets/e6b2d3ed-cd86-436b-82ad-31ec1d5edd42" />
<img width="615" height="60" alt="Screenshot 2026-01-07 at 9 20 09 AM" src="https://github.com/user-attachments/assets/303c7db1-5bfa-4c98-85d0-fffea04d510f" />
<img width="615" height="60" alt="Screenshot 2026-01-07 at 9 20 01 AM" src="https://github.com/user-attachments/assets/df47390c-01f8-4b96-bc68-39f2dab16dfe" />
<img width="615" height="464" alt="Screenshot 2026-01-07 at 9 19 36 AM" src="https://github.com/user-attachments/assets/391ebcb8-708d-49ea-8352-a98cc4776e89" />
<img width="615" height="464" alt="Screenshot 2026-01-07 at 9 19 26 AM" src="https://github.com/user-attachments/assets/4e92a75b-81b3-4d34-aa2e-8958947e6255" />
<img width="2742" height="439" alt="Screenshot 2026-01-07 at 9 19 03 AM" src="https://github.com/user-attachments/assets/15b117c4-ec12-472f-b7b8-c90ef6649f5b" />
<img width="2742" height="439" alt="Screenshot 2026-01-07 at 9 18 49 AM" src="https://github.com/user-attachments/assets/6dc15d18-136b-4b38-ac84-dd282bc62cca" />

