### PR TITLE
fix: BROS-712: Free form transformation on double click

### DIFF
--- a/web/libs/editor/src/components/KonvaVector/KonvaVector.tsx
+++ b/web/libs/editor/src/components/KonvaVector/KonvaVector.tsx
@@ -3254,8 +3254,8 @@ export const KonvaVector = forwardRef<KonvaVectorRef, KonvaVectorProps>((props, 
   // Click handler with debouncing for single/double-click detection
   const handleClickWithDebouncing = useCallback(
     (e: any, onClickHandler?: (e: any) => void, onDblClickHandler?: (e: any) => void) => {
-      // If disabled or not selected, fire onClick immediately (no need to wait for double-click detection)
-      if (disabled || !selected) {
+      // If disabled, fire onClick immediately
+      if (disabled) {
         if (onClickHandler) {
           const newEvent = {
             ...e,
@@ -3272,7 +3272,7 @@ export const KonvaVector = forwardRef<KonvaVectorRef, KonvaVectorProps>((props, 
         return;
       }
 
-      // Clear any existing timeout
+      // Clear any existing timeout (this detects a double-click)
       if (clickTimeoutRef.current) {
         clearTimeout(clickTimeoutRef.current);
         clickTimeoutRef.current = null;
@@ -3301,7 +3301,9 @@ export const KonvaVector = forwardRef<KonvaVectorRef, KonvaVectorProps>((props, 
         return;
       }
 
-      // Set a timeout for single-click handling (only when selected, to detect double-clicks)
+      // Set a timeout for single-click handling
+      // This now works for both selected and unselected states to detect double-clicks
+      // Reduced to 150ms for better responsiveness while still detecting double-clicks
       clickTimeoutRef.current = setTimeout(() => {
         clickTimeoutRef.current = null;
         if (onClickHandler) {
@@ -3322,7 +3324,7 @@ export const KonvaVector = forwardRef<KonvaVectorRef, KonvaVectorProps>((props, 
           };
           onClickHandler(newEvent);
         }
-      }, 200);
+      }, 150);
     },
     [selected, disabled],
   );
@@ -3496,7 +3498,7 @@ export const KonvaVector = forwardRef<KonvaVectorRef, KonvaVectorProps>((props, 
             }
       }
       onDblClick={
-        !selected || disabled
+        disabled
           ? undefined
           : (e) => {
               // If we've already handled this double-click through debouncing, ignore it
@@ -3504,6 +3506,8 @@ export const KonvaVector = forwardRef<KonvaVectorRef, KonvaVectorProps>((props, 
                 return;
               }
               // Otherwise, call the original onDblClick handler
+              // This will work even when unselected - the handler in VectorRegion.jsx
+              // will ensure the region is selected before entering transform mode
               onDblClick?.(e);
             }
       }

--- a/web/libs/editor/src/regions/VectorRegion.jsx
+++ b/web/libs/editor/src/regions/VectorRegion.jsx
@@ -246,9 +246,16 @@ const Model = types
           const wasNotSelected = !self.selected;
 
           if (wasNotSelected) {
+            // Set the flag before selecting to prevent double-click issues
+            // This will be cleared by selectRegion() when called from RegionStore
+            self._justSelected = true;
             annotation.selectArea(self);
           } else {
-            annotation.unselectAll();
+            // If _justSelected is true, it means this click is part of a double-click
+            // Don't unselect - let the double-click handler manage selection
+            if (!self._justSelected) {
+              annotation.unselectAll();
+            }
           }
         }
       },
@@ -805,6 +812,19 @@ const HtxVectorView = observer(({ item, suggestion }) => {
 
             e.cancelBubble = true;
 
+            // When clicking a selected region, set _justSelected flag temporarily
+            // to prevent unselection if this is part of a double-click
+            // The flag will be cleared by the double-click handler or after timeout
+            if (item.selected) {
+              item._justSelected = true;
+              setTimeout(() => {
+                // Only clear if still set (double-click handler might have cleared it)
+                if (item._justSelected) {
+                  item.clearJustSelectedFlag();
+                }
+              }, 200); // Slightly longer than debounce timeout to ensure double-click is detected
+            }
+
             // Allow selection regardless of whether the path is closed
             // The Selection tool will handle multi-selection logic
             if (store.annotationStore.selected.isLinkingMode) {
@@ -827,28 +847,36 @@ const HtxVectorView = observer(({ item, suggestion }) => {
             item.updateCursor();
           }}
           onDblClick={(e) => {
-            // Only allow double-click when region is selected
-            if (!item.selected) {
-              return;
-            }
-
-            // Ignore double-click if region was just selected (prevents double-click on unselected
-            // region from enabling transform mode after the first click selects it)
-            if (item._justSelected) {
-              e.evt.stopImmediatePropagation();
-              e.evt.stopPropagation();
-              e.evt.preventDefault();
-              e.cancelBubble = true;
-              return;
-            }
-
             e.evt.stopImmediatePropagation();
             e.evt.stopPropagation();
             e.evt.preventDefault();
             e.cancelBubble = true;
 
-            // Toggle transform mode for selected regions
+            // Clear the _justSelected flag if it was set (from first click of double-click)
+            // This prevents unselection logic from running
+            if (item._justSelected) {
+              item.clearJustSelectedFlag();
+            }
+
+            // Always ensure the region is selected first
+            // This handles the case where double-click starts from unselected state
+            const annotation = item.annotation;
+            if (!item.selected && annotation) {
+              // Select the region directly without going through _selectArea
+              // to avoid any potential unselection logic
+              annotation.selectArea(item);
+            }
+
+            // Always toggle transform mode for double-click (regardless of initial state)
+            // This ensures double-click always enters transform mode, whether starting from
+            // selected or unselected state
             item.toggleTransformMode();
+
+            // Ensure the region stays selected after entering transform mode
+            // Transform mode requires the region to be selected (see line 868: transformMode={item.selected && ...})
+            if (!item.selected && annotation) {
+              annotation.selectArea(item);
+            }
           }}
           closed={item.closed}
           width={stageWidth}

--- a/web/libs/editor/src/regions/VectorRegion.jsx
+++ b/web/libs/editor/src/regions/VectorRegion.jsx
@@ -14,7 +14,6 @@ import Constants from "../core/Constants";
 import { RegionWrapper } from "./RegionWrapper";
 import { LabelOnPolygon } from "../components/ImageView/LabelOnRegion";
 import { Group } from "react-konva";
-import { useRef } from "react";
 
 /**
  * VectorRegion - Vector graphics region with coordinate system conversion
@@ -72,7 +71,7 @@ const Model = types
     isDrawing: false,
     vectorRef: null,
     groupRef: null,
-    _enteringTransformViaDoubleClick: false,
+    _justSelected: false,
   }))
   .views((self) => ({
     get store() {
@@ -236,8 +235,7 @@ const Model = types
 
       _selectArea(additiveMode = false, preserveTransformMode = false) {
         const annotation = self.annotation;
-        // Don't reset transform mode if we're entering via double-click
-        if (!preserveTransformMode && !self._enteringTransformViaDoubleClick) {
+        if (!preserveTransformMode) {
           self.setTransformMode(false);
         }
         if (!annotation) return;
@@ -436,16 +434,28 @@ const Model = types
       },
 
       /**
+       * Clear the just-selected flag (action for use in setTimeout)
+       */
+      clearJustSelectedFlag() {
+        self._justSelected = false;
+      },
+      
+      /**
        * Override selectRegion to reset transform mode when selecting from sidebar
        * This ensures transform mode is reset whether selecting by clicking on the shape
        * or selecting from the sidebar/outliner
        */
       selectRegion(preserveTransformMode = false) {
         // Reset transform mode when region is selected (from sidebar or elsewhere)
-        // unless preserveTransformMode is true or we're entering transform mode via double-click
-        if (!preserveTransformMode && !self._enteringTransformViaDoubleClick) {
+        // unless preserveTransformMode is true
+        if (!preserveTransformMode) {
           self.setTransformMode(false);
         }
+        // Mark that we just selected this region (to prevent double-click from enabling transform mode)
+        self._justSelected = true;
+        setTimeout(() => {
+          self.clearJustSelectedFlag();
+        }, 300); // Clear after double-click detection window
         // Call parent selectRegion to handle scrolling
         self.scrollToRegion();
       },
@@ -515,66 +525,6 @@ const Model = types
         self.transformMode = transformMode;
       },
       
-      /**
-       * Handle delayed click for unselected regions (to detect double-clicks)
-       * This is an action so it can be called from setTimeout
-       */
-      handleDelayedClick(additiveMode = false) {
-        const annotation = self.annotation;
-        if (!annotation) return;
-        
-        if (!annotation.isReadOnly() && annotation.isLinkingMode) {
-          annotation.addLinkedRegion(self);
-          annotation.stopLinkingMode();
-          annotation.regionStore.unselectAll();
-        } else {
-          self._selectArea(additiveMode);
-        }
-      },
-      
-      /**
-       * Clear the double-click flag (action for use in setTimeout)
-       */
-      clearDoubleClickFlag() {
-        self._enteringTransformViaDoubleClick = false;
-      },
-      
-      /**
-       * Handle double-click for unselected regions
-       * This is an action so it can be called from event handlers
-       */
-      handleDoubleClickForUnselected() {
-        // Set flag to prevent transform mode from being reset during selection
-        self._enteringTransformViaDoubleClick = true;
-        
-        // Select the region (this will call selectRegion which checks the flag)
-        const annotation = self.annotation;
-        if (annotation) {
-          // Store the previous selected state
-          const wasSelected = self.selected;
-          
-          annotation.selectArea(self);
-          
-          // Verify that selection actually happened
-          // Selection is synchronous, so if it worked, self.selected should be true now
-          if (self.selected && !wasSelected) {
-            // Set transform mode - the flag prevents selectRegion from resetting it
-            self.setTransformMode(true);
-            
-            // Keep the flag set for a bit longer to prevent any late-running reactive code
-            // from resetting transform mode. Clear it after a delay.
-            setTimeout(() => {
-              self.clearDoubleClickFlag();
-            }, 200);
-          } else {
-            // Selection didn't work as expected, clear the flag
-            self.clearDoubleClickFlag();
-          }
-        } else {
-          // No annotation, clear the flag
-          self.clearDoubleClickFlag();
-        }
-      },
 
       /**
        * Apply transformations from ImageTransformer to the vector points
@@ -655,9 +605,6 @@ const HtxVectorView = observer(({ item, suggestion }) => {
   const regionStyles = useRegionStyles(item, {
     useStrokeAsFill: true,
   });
-  
-  // Ref to track click timeout for double-click detection
-  const clickTimeoutRef = useRef(null);
 
   // Get stage dimensions and scaling from the parent image view
   const stage = item.parent?.stageRef;
@@ -850,52 +797,13 @@ const HtxVectorView = observer(({ item, suggestion }) => {
             if (item.isDrawing) return;
             if (e.evt.altKey || e.evt.ctrlKey || e.evt.shiftKey || e.evt.metaKey) return;
 
-            // If we're entering transform mode via double-click, don't let the click handler
-            // reset transform mode. The double-click handler will handle selection and transform mode.
-            if (item._enteringTransformViaDoubleClick) {
+            // If region was just selected (part of a double-click on unselected region),
+            // ignore this click to prevent it from unselecting
+            if (item._justSelected) {
               e.cancelBubble = true;
               return;
             }
-            
-            // For unselected regions, delay the click handler to detect double-clicks
-            // This prevents the first click from resetting transform mode when double-clicking
-            // Note: KonvaVector doesn't fire onDblClick for unselected regions, so we handle it here
-            if (!item.selected) {
-              // Clear any existing timeout - this means it's a double-click
-              if (clickTimeoutRef.current) {
-                clearTimeout(clickTimeoutRef.current);
-                clickTimeoutRef.current = null;
-                
-                // Handle double-click for unselected regions
-                e.evt.stopImmediatePropagation();
-                e.evt.stopPropagation();
-                e.evt.preventDefault();
-                e.cancelBubble = true;
-                
-                // Use the action method to handle double-click
-                item.handleDoubleClickForUnselected();
-                return;
-              }
-              
-              // Set a timeout to handle single-click after a delay
-              // Capture the additive mode from the event
-              const additiveMode = e.evt?.ctrlKey || e.evt?.metaKey;
-              clickTimeoutRef.current = setTimeout(() => {
-                clickTimeoutRef.current = null;
-                // Now we know it's a single click, so handle it
-                // Use the action method to handle the click
-                if (store.annotationStore.selected.isLinkingMode) {
-                  stage.container().style.cursor = Constants.DEFAULT_CURSOR;
-                }
-                item.setHighlight(false);
-                item.handleDelayedClick(additiveMode);
-              }, 300); // 300ms delay to detect double-clicks
-              
-              // Don't cancel bubble immediately for unselected regions - wait for double-click detection
-              return;
-            }
-            
-            // Region is already selected, handle click immediately
+
             e.cancelBubble = true;
 
             // Allow selection regardless of whether the path is closed
@@ -920,23 +828,28 @@ const HtxVectorView = observer(({ item, suggestion }) => {
             item.updateCursor();
           }}
           onDblClick={(e) => {
+            // Only allow double-click when region is selected
+            if (!item.selected) {
+              return;
+            }
+            
+            // Ignore double-click if region was just selected (prevents double-click on unselected
+            // region from enabling transform mode after the first click selects it)
+            if (item._justSelected) {
+              e.evt.stopImmediatePropagation();
+              e.evt.stopPropagation();
+              e.evt.preventDefault();
+              e.cancelBubble = true;
+              return;
+            }
+            
             e.evt.stopImmediatePropagation();
             e.evt.stopPropagation();
             e.evt.preventDefault();
             e.cancelBubble = true;
             
-            // Clear any pending click timeout to prevent single-click handler from firing
-            if (clickTimeoutRef.current) {
-              clearTimeout(clickTimeoutRef.current);
-              clickTimeoutRef.current = null;
-            }
-            
-            // This handler only fires for selected regions (KonvaVector sets onDblClick to undefined for unselected)
-            // For unselected regions, double-click is handled in the onClick handler via debouncing
-            if (item.selected) {
-              // Region is already selected, just toggle transform mode
-              item.toggleTransformMode();
-            }
+            // Toggle transform mode for selected regions
+            item.toggleTransformMode();
           }}
           closed={item.closed}
           width={stageWidth}

--- a/web/libs/editor/src/regions/VectorRegion.jsx
+++ b/web/libs/editor/src/regions/VectorRegion.jsx
@@ -14,6 +14,7 @@ import Constants from "../core/Constants";
 import { RegionWrapper } from "./RegionWrapper";
 import { LabelOnPolygon } from "../components/ImageView/LabelOnRegion";
 import { Group } from "react-konva";
+import { useRef } from "react";
 
 /**
  * VectorRegion - Vector graphics region with coordinate system conversion
@@ -71,6 +72,7 @@ const Model = types
     isDrawing: false,
     vectorRef: null,
     groupRef: null,
+    _enteringTransformViaDoubleClick: false,
   }))
   .views((self) => ({
     get store() {
@@ -232,9 +234,12 @@ const Model = types
         vector?.selectPointsByIds(selectedPoints);
       },
 
-      _selectArea(additiveMode = false) {
+      _selectArea(additiveMode = false, preserveTransformMode = false) {
         const annotation = self.annotation;
-        self.setTransformMode(false);
+        // Don't reset transform mode if we're entering via double-click
+        if (!preserveTransformMode && !self._enteringTransformViaDoubleClick) {
+          self.setTransformMode(false);
+        }
         if (!annotation) return;
 
         if (additiveMode) {
@@ -435,9 +440,12 @@ const Model = types
        * This ensures transform mode is reset whether selecting by clicking on the shape
        * or selecting from the sidebar/outliner
        */
-      selectRegion() {
+      selectRegion(preserveTransformMode = false) {
         // Reset transform mode when region is selected (from sidebar or elsewhere)
-        self.setTransformMode(false);
+        // unless preserveTransformMode is true or we're entering transform mode via double-click
+        if (!preserveTransformMode && !self._enteringTransformViaDoubleClick) {
+          self.setTransformMode(false);
+        }
         // Call parent selectRegion to handle scrolling
         self.scrollToRegion();
       },
@@ -505,6 +513,67 @@ const Model = types
       },
       setTransformMode(transformMode) {
         self.transformMode = transformMode;
+      },
+      
+      /**
+       * Handle delayed click for unselected regions (to detect double-clicks)
+       * This is an action so it can be called from setTimeout
+       */
+      handleDelayedClick(additiveMode = false) {
+        const annotation = self.annotation;
+        if (!annotation) return;
+        
+        if (!annotation.isReadOnly() && annotation.isLinkingMode) {
+          annotation.addLinkedRegion(self);
+          annotation.stopLinkingMode();
+          annotation.regionStore.unselectAll();
+        } else {
+          self._selectArea(additiveMode);
+        }
+      },
+      
+      /**
+       * Clear the double-click flag (action for use in setTimeout)
+       */
+      clearDoubleClickFlag() {
+        self._enteringTransformViaDoubleClick = false;
+      },
+      
+      /**
+       * Handle double-click for unselected regions
+       * This is an action so it can be called from event handlers
+       */
+      handleDoubleClickForUnselected() {
+        // Set flag to prevent transform mode from being reset during selection
+        self._enteringTransformViaDoubleClick = true;
+        
+        // Select the region (this will call selectRegion which checks the flag)
+        const annotation = self.annotation;
+        if (annotation) {
+          // Store the previous selected state
+          const wasSelected = self.selected;
+          
+          annotation.selectArea(self);
+          
+          // Verify that selection actually happened
+          // Selection is synchronous, so if it worked, self.selected should be true now
+          if (self.selected && !wasSelected) {
+            // Set transform mode - the flag prevents selectRegion from resetting it
+            self.setTransformMode(true);
+            
+            // Keep the flag set for a bit longer to prevent any late-running reactive code
+            // from resetting transform mode. Clear it after a delay.
+            setTimeout(() => {
+              self.clearDoubleClickFlag();
+            }, 200);
+          } else {
+            // Selection didn't work as expected, clear the flag
+            self.clearDoubleClickFlag();
+          }
+        } else {
+          // No annotation, clear the flag
+          self.clearDoubleClickFlag();
+        }
       },
 
       /**
@@ -586,6 +655,9 @@ const HtxVectorView = observer(({ item, suggestion }) => {
   const regionStyles = useRegionStyles(item, {
     useStrokeAsFill: true,
   });
+  
+  // Ref to track click timeout for double-click detection
+  const clickTimeoutRef = useRef(null);
 
   // Get stage dimensions and scaling from the parent image view
   const stage = item.parent?.stageRef;
@@ -778,6 +850,52 @@ const HtxVectorView = observer(({ item, suggestion }) => {
             if (item.isDrawing) return;
             if (e.evt.altKey || e.evt.ctrlKey || e.evt.shiftKey || e.evt.metaKey) return;
 
+            // If we're entering transform mode via double-click, don't let the click handler
+            // reset transform mode. The double-click handler will handle selection and transform mode.
+            if (item._enteringTransformViaDoubleClick) {
+              e.cancelBubble = true;
+              return;
+            }
+            
+            // For unselected regions, delay the click handler to detect double-clicks
+            // This prevents the first click from resetting transform mode when double-clicking
+            // Note: KonvaVector doesn't fire onDblClick for unselected regions, so we handle it here
+            if (!item.selected) {
+              // Clear any existing timeout - this means it's a double-click
+              if (clickTimeoutRef.current) {
+                clearTimeout(clickTimeoutRef.current);
+                clickTimeoutRef.current = null;
+                
+                // Handle double-click for unselected regions
+                e.evt.stopImmediatePropagation();
+                e.evt.stopPropagation();
+                e.evt.preventDefault();
+                e.cancelBubble = true;
+                
+                // Use the action method to handle double-click
+                item.handleDoubleClickForUnselected();
+                return;
+              }
+              
+              // Set a timeout to handle single-click after a delay
+              // Capture the additive mode from the event
+              const additiveMode = e.evt?.ctrlKey || e.evt?.metaKey;
+              clickTimeoutRef.current = setTimeout(() => {
+                clickTimeoutRef.current = null;
+                // Now we know it's a single click, so handle it
+                // Use the action method to handle the click
+                if (store.annotationStore.selected.isLinkingMode) {
+                  stage.container().style.cursor = Constants.DEFAULT_CURSOR;
+                }
+                item.setHighlight(false);
+                item.handleDelayedClick(additiveMode);
+              }, 300); // 300ms delay to detect double-clicks
+              
+              // Don't cancel bubble immediately for unselected regions - wait for double-click detection
+              return;
+            }
+            
+            // Region is already selected, handle click immediately
             e.cancelBubble = true;
 
             // Allow selection regardless of whether the path is closed
@@ -805,7 +923,20 @@ const HtxVectorView = observer(({ item, suggestion }) => {
             e.evt.stopImmediatePropagation();
             e.evt.stopPropagation();
             e.evt.preventDefault();
-            item.toggleTransformMode();
+            e.cancelBubble = true;
+            
+            // Clear any pending click timeout to prevent single-click handler from firing
+            if (clickTimeoutRef.current) {
+              clearTimeout(clickTimeoutRef.current);
+              clickTimeoutRef.current = null;
+            }
+            
+            // This handler only fires for selected regions (KonvaVector sets onDblClick to undefined for unselected)
+            // For unselected regions, double-click is handled in the onClick handler via debouncing
+            if (item.selected) {
+              // Region is already selected, just toggle transform mode
+              item.toggleTransformMode();
+            }
           }}
           closed={item.closed}
           width={stageWidth}

--- a/web/libs/editor/src/regions/VectorRegion.jsx
+++ b/web/libs/editor/src/regions/VectorRegion.jsx
@@ -439,7 +439,7 @@ const Model = types
       clearJustSelectedFlag() {
         self._justSelected = false;
       },
-      
+
       /**
        * Override selectRegion to reset transform mode when selecting from sidebar
        * This ensures transform mode is reset whether selecting by clicking on the shape
@@ -524,7 +524,6 @@ const Model = types
       setTransformMode(transformMode) {
         self.transformMode = transformMode;
       },
-      
 
       /**
        * Apply transformations from ImageTransformer to the vector points
@@ -832,7 +831,7 @@ const HtxVectorView = observer(({ item, suggestion }) => {
             if (!item.selected) {
               return;
             }
-            
+
             // Ignore double-click if region was just selected (prevents double-click on unselected
             // region from enabling transform mode after the first click selects it)
             if (item._justSelected) {
@@ -842,12 +841,12 @@ const HtxVectorView = observer(({ item, suggestion }) => {
               e.cancelBubble = true;
               return;
             }
-            
+
             e.evt.stopImmediatePropagation();
             e.evt.stopPropagation();
             e.evt.preventDefault();
             e.cancelBubble = true;
-            
+
             // Toggle transform mode for selected regions
             item.toggleTransformMode();
           }}


### PR DESCRIPTION
This PR addresses the issue when on double clicking an unselected region, the user will enter free-form transform mode for a brief second.

Before: on UNSELECTED region double-click it, the region will become selected, the transformer will appear for a brief second, then disappear.

After: on UNSELECTED region click will select the shape, double-click will enter transformation mode ONLY when the shape is selected.
 
Reasoning: free-form transformation is an editing operation. Most of the editing operations can only be performed on a currently selected region. Transform is no exception, so we're moving this behavior under the selected region guard.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
