### PR TITLE
feat: FIT-1193: Remove Beta badge from Theme Toggle

### DIFF
--- a/web/libs/ui/src/lib/ThemeToggle/ThemeToggle.module.scss
+++ b/web/libs/ui/src/lib/ThemeToggle/ThemeToggle.module.scss
@@ -84,7 +84,3 @@
   left: 0;
   top: 30px;
 }
-
-.betaBadge {
-  margin-left: var(--spacing-tight);
-}

--- a/web/libs/ui/src/lib/ThemeToggle/ThemeToggle.tsx
+++ b/web/libs/ui/src/lib/ThemeToggle/ThemeToggle.tsx
@@ -3,7 +3,6 @@ import styles from "./ThemeToggle.module.scss";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ReactComponent as Sun } from "./icons/sun.svg";
 import { ReactComponent as Moon } from "./icons/moon.svg";
-import { Badge } from "@humansignal/ui";
 import { atom, useSetAtom } from "jotai";
 
 interface ThemeToggleProps {
@@ -70,9 +69,6 @@ export const ThemeToggle: React.FC<ThemeToggleProps> = ({ className }) => {
         </div>
       </div>
       <span className={clsx(styles.themeToggle__label)}>{themeLabel}</span>
-      <Badge variant="beta" className={styles.betaBadge}>
-        Beta
-      </Badge>
     </button>
   );
 };


### PR DESCRIPTION
This pull request simplifies the `ThemeToggle` component by removing the "Beta" badge from both the UI and the related code. The changes are focused on cleaning up unused imports, styles, and JSX elements associated with the badge.

## Screenshots
<img width="329" height="93" alt="image" src="https://github.com/user-attachments/assets/08d20679-f27d-4778-bb44-ac0ded9a683b" />


**ThemeToggle component cleanup:**

* Removed the `Badge` import and the JSX rendering of the "Beta" badge from `ThemeToggle.tsx`. [[1]](diffhunk://#diff-96ce748a5f6ef73be500376468873169f95361d10a3fa4652b77075fa249169aL6) [[2]](diffhunk://#diff-96ce748a5f6ef73be500376468873169f95361d10a3fa4652b77075fa249169aL73-L75)
* Deleted the `.betaBadge` CSS class from `ThemeToggle.module.scss` since it is no longer used.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
