### PR TITLE
ci: Allow selective test running based on actual files changed in Follow Merge

### DIFF
--- a/.github/workflows/follow-merge-dispatch.yml
+++ b/.github/workflows/follow-merge-dispatch.yml
@@ -111,5 +111,4 @@ jobs:
         with:
           github_token: ${{ secrets.GIT_PAT }}
           downstream_repository: "label-studio-enterprise"
-          frontend_changed: ${{ steps.detect-changes.outputs.frontend_changed }}
-          backend_changed: ${{ steps.detect-changes.outputs.backend_changed }}
+          extra_inputs: '{"frontend_changed": "${{ steps.detect-changes.outputs.frontend_changed }}", "backend_changed": "${{ steps.detect-changes.outputs.backend_changed }}"}'

--- a/.github/workflows/follow-merge-dispatch.yml
+++ b/.github/workflows/follow-merge-dispatch.yml
@@ -62,6 +62,43 @@ jobs:
             });
             throw `${{ github.actor }} don't have membership in ${owner} organization`
 
+      - name: Detect changed files
+        uses: actions/github-script@v8
+        id: detect-changes
+        with:
+          github-token: ${{ secrets.GIT_PAT }}
+          script: |
+            const { repo, owner } = context.repo;
+            const base_sha = '${{ github.event.pull_request.base.sha }}';
+            const head_sha = '${{ github.event.pull_request.head.sha }}';
+            
+            const {data: compare} = await github.rest.repos.compareCommits({
+              owner,
+              repo,
+              base: base_sha,
+              head: head_sha,
+            });
+            
+            const changed_files = compare.files.map(file => file.filename);
+            console.log(`Comparing commits between ${base_sha} and ${head_sha}`);
+            console.log(`Changed files: ${changed_files.join(', ')}`);
+            
+            // Detect frontend changes (web/ directory)
+            const frontend_changed = changed_files.some(file => file.startsWith('web/'));
+            console.log(`Frontend changed: ${frontend_changed}`);
+            
+            // Detect backend changes (Python files, pyproject.toml, poetry.lock, or label_studio/ excluding frontend)
+            const backend_changed = changed_files.some(file => 
+              file.endsWith('.py') || 
+              file === 'pyproject.toml' || 
+              file === 'poetry.lock' ||
+              (file.startsWith('label_studio/') && !file.startsWith('label_studio/frontend/'))
+            );
+            console.log(`Backend changed: ${backend_changed}`);
+            
+            core.setOutput('frontend_changed', frontend_changed);
+            core.setOutput('backend_changed', backend_changed);
+
       - name: Checkout Actions Hub
         uses: actions/checkout@v6
         with:
@@ -74,3 +111,5 @@ jobs:
         with:
           github_token: ${{ secrets.GIT_PAT }}
           downstream_repository: "label-studio-enterprise"
+          frontend_changed: ${{ steps.detect-changes.outputs.frontend_changed }}
+          backend_changed: ${{ steps.detect-changes.outputs.backend_changed }}


### PR DESCRIPTION
**Problem:** Follow Merge PRs that only contain frontend changes can fail on unrelated backend flaky tests (and vice versa). This happens because the sync process updates both lockfiles unconditionally, causing LSE's CI to run all tests regardless of what actually changed.

This creates two major pain points:
1. **Blocked authors** — A frontend-only change gets blocked by a flaky backend test the author never touched
2. **Flaky test confusion** — When tracking down flaky tests, failures appear on PRs with no relevant changes, making root cause analysis nearly impossible

**Solution**: Only sync the lockfiles for code that actually changed, so tests only run for the affected scope. A frontend-only PR will only fail on frontend test issues.
