### PR TITLE
fix: BROS-712: Double click behavior MST error fix

### DIFF
--- a/web/libs/editor/src/regions/VectorRegion.jsx
+++ b/web/libs/editor/src/regions/VectorRegion.jsx
@@ -447,6 +447,10 @@ const Model = types
         self._justSelected = false;
       },
 
+      setJustSelectedFlag(value) {
+        self._justSelected = value;
+      },
+
       /**
        * Override selectRegion to reset transform mode when selecting from sidebar
        * This ensures transform mode is reset whether selecting by clicking on the shape
@@ -696,7 +700,7 @@ const HtxVectorView = observer(({ item, suggestion }) => {
             // to prevent unselection if this is part of a double-click
             // The flag will be cleared by the double-click handler or after timeout
             if (item.selected) {
-              item._justSelected = true;
+              item.setJustSelectedFlag(true);
               setTimeout(() => {
                 // Only clear if still set (double-click handler might have cleared it)
                 if (item._justSelected) {


### PR DESCRIPTION
This PR fixes an MST error introduced by the recent double click behavior changes.

The error regarding inability to update state outside of MST action occurs in some cases when double clicking the shape.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
