### PR TITLE
fix: BROS-712: Double click behavior MST error fix

### DIFF
--- a/web/libs/editor/src/regions/VectorRegion.jsx
+++ b/web/libs/editor/src/regions/VectorRegion.jsx
@@ -447,6 +447,10 @@ const Model = types
         self._justSelected = false;
       },
 
+      setJustSelectedFlag(value) {
+        self._justSelected = value;
+      },
+
       /**
        * Override selectRegion to reset transform mode when selecting from sidebar
        * This ensures transform mode is reset whether selecting by clicking on the shape
@@ -696,7 +700,7 @@ const HtxVectorView = observer(({ item, suggestion }) => {
             // to prevent unselection if this is part of a double-click
             // The flag will be cleared by the double-click handler or after timeout
             if (item.selected) {
-              item._justSelected = true;
+              item.setJustSelectedFlag(true);
               setTimeout(() => {
                 // Only clear if still set (double-click handler might have cleared it)
                 if (item._justSelected) {


### PR DESCRIPTION
This PR fixes an MST error introduced by the recent double click behavior changes.

The error regarding inability to update state outside of MST action occurs in some cases when double clicking the shape.