### PR TITLE
fix: FIT-1247: Selected task state broken on Quick View

### DIFF
--- a/web/libs/datamanager/src/components/Common/Table/Table.scss
+++ b/web/libs/datamanager/src/components/Common/Table/Table.scss
@@ -55,6 +55,7 @@
       }
 
       & .table-head {
+        width: calc(100% + var(--spacing-base));
         border-top: 1px solid var(--color-neutral-border);
       }
     }

--- a/web/libs/datamanager/src/components/Common/Table/Table.scss
+++ b/web/libs/datamanager/src/components/Common/Table/Table.scss
@@ -57,10 +57,6 @@
       & .table-head {
         border-top: 1px solid var(--color-neutral-border);
       }
-
-      & .table__row-wrapper::after {
-        display: none;
-      }
     }
   }
 
@@ -142,18 +138,6 @@
 
     &:not(.table__row_wrapper_selected):hover {
       background-color: var(--color-primary-emphasis-subtle);
-    }
-
-    &_highlighted:not(.table__row_wrapper_selected)::after {
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      content: "";
-      z-index: 50;
-      position: absolute;
-      pointer-events: none;
-      box-shadow: 0 0 0 1px rgb(var(--accent_color-raw) / 80%) inset;
     }
   }
 

--- a/web/libs/datamanager/src/components/Common/Table/Table.scss
+++ b/web/libs/datamanager/src/components/Common/Table/Table.scss
@@ -57,6 +57,10 @@
       & .table-head {
         border-top: 1px solid var(--color-neutral-border);
       }
+
+      & .table__row-wrapper::after {
+        display: none;
+      }
     }
   }
 


### PR DESCRIPTION
This pull request makes minor adjustments to the table styling in `Table.scss`, focusing on layout and hover effects.

## Screenshots
### Before
<img width="482" height="981" alt="image" src="https://github.com/user-attachments/assets/c6528adf-3d50-46fa-b3be-4400cd6158b6" />

### After
<img width="275" height="736" alt="image" src="https://github.com/user-attachments/assets/733de8c9-99a7-4749-87e3-f9087e564a81" />


- Table layout adjustment:
  * The `.table-head` element now has its width set to `calc(100% + var(--spacing-base))` to better align with spacing requirements.

- Hover and highlight effect update:
  * The `_highlighted` row style, which previously added an inset box-shadow on highlighted rows, has been removed to simplify row highlighting behavior.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
