### PR TITLE
chore: GHSA-73rr-hh4g-fpgx: bump diff to 8.0.3 to fix jsdiff DoS vulnerability

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -238,7 +238,7 @@
     "@radix-ui/react-slot": "1.2.3",
     "d3-color": "3.1.0",
     "debug": ">=4.3.1",
-    "diff": ">=3.5.0",
+    "diff": ">=8.0.3",
     "esbuild": ">=0.25.5",
     "jpeg-js": "0.4.4",
     "js-yaml": "4.1.1",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -10404,10 +10404,10 @@ didyoumean@^1.2.2:
   resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.2.tgz#989346ffe9e839b4555ecf5666edea0d3e8ad037"
   integrity sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==
 
-diff@>=3.5.0, diff@^4.0.1, diff@^5.1.0, diff@^7.0.0:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.2.tgz#712156a6dd288e66ebb986864e190c2fc9eddfae"
-  integrity sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==
+diff@>=8.0.3, diff@^4.0.1, diff@^5.1.0, diff@^7.0.0:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.3.tgz#c7da3d9e0e8c283bb548681f8d7174653720c2d5"
+  integrity sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==
 
 dir-glob@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
## Problem

The `diff` (jsdiff) npm package has a **Denial-of-Service vulnerability** tracked as [GHSA-73rr-hh4g-fpgx](https://github.com/advisories/GHSA-73rr-hh4g-fpgx) (Dependabot alert #496).

### Vulnerability Details

- **Affected versions**: `< 8.0.3`
- **Patched version**: `8.0.3`
- **Impact**: Attempting to parse a patch whose filename headers contain line break characters (`\r`, `\u2028`, or `\u2029`) can cause the `parsePatch` method to enter an infinite loop, consuming memory without limit until the process crashes. The `applyPatch` method is similarly affected.
- **Severity**: Low (DoS vector)

### Why Dependabot Could Not Fix This

The vulnerable `diff@8.0.2` was introduced as a **transitive dependency** through multiple packages:
- `cypress-parallel@0.15.0` → `diff@8.0.2`
- `shadcn@2.1.8` → `diff@8.0.2`
- `sinon@17.0.1` → `diff@8.0.2`
- `ts-node@10.9.1` → `diff@8.0.2`

Dependabot cannot automatically update transitive dependencies when the parent packages have not yet released updates with the patched version.

---

## Solution

Updated the yarn resolutions in `web/package.json` to force all transitive dependencies to use `diff@>=8.0.3`:

```diff
- "diff": ">=3.5.0",
+ "diff": ">=8.0.3",
```

This approach:
1. **Immediately resolves the vulnerability** without waiting for upstream package updates
2. **Ensures future stability** by preventing any package from pulling in an older, vulnerable version
3. **Is the recommended pattern** for handling transitive dependency vulnerabilities in Yarn workspaces

---

## Verification

After running `yarn install`, verified the fix with `yarn why diff`:

```
info => Found "diff@8.0.3"
info Reasons this module exists
   - "ts-node" depends on it
   - Hoisted from "ts-node#diff"
   - Hoisted from "shadcn#diff"
   - Hoisted from "sinon#diff"
   - Hoisted from "cypress-parallel#mocha#diff"
```

All affected transitive dependency paths now resolve to the patched version `8.0.3`.

---

## Files Changed

| File | Change |
|------|--------|
| `web/package.json` | Updated `diff` resolution from `>=3.5.0` to `>=8.0.3` |
| `web/yarn.lock` | Regenerated with `diff@8.0.3` |

---

## Testing

- ✅ `yarn install` completes successfully
- ✅ `yarn why diff` confirms version `8.0.3`
- ✅ Linter (`make fmt-all`) passes

---

## References

- [GitHub Security Advisory GHSA-73rr-hh4g-fpgx](https://github.com/advisories/GHSA-73rr-hh4g-fpgx)
- [Dependabot Alert #496](https://github.com/HumanSignal/label-studio/security/dependabot/496)
- [PR that fixed the bug in jsdiff](https://github.com/kpdecker/jsdiff/pull/649)