### PR TITLE
feat: FIT-1235: Reduce width of Active Sessions and Roles columns in Organization members table

### DIFF
--- a/web/libs/ui/src/assets/icons/index.ts
+++ b/web/libs/ui/src/assets/icons/index.ts
@@ -179,6 +179,7 @@ export { ReactComponent as IconMinus } from "./minus.svg";
 export { ReactComponent as IconModel } from "./model.svg";
 export { ReactComponent as IconModels } from "./models.svg";
 export { ReactComponent as IconModelVersion } from "./model-version.svg";
+export { ReactComponent as IconMonitors } from "./monitors.svg";
 export { ReactComponent as IconMoveLeft } from "./move-left.svg";
 export { ReactComponent as IconMoveRight } from "./move-right.svg";
 export { ReactComponent as IconMoveUp } from "./move-up.svg";

--- a/web/libs/ui/src/assets/icons/monitors.svg
+++ b/web/libs/ui/src/assets/icons/monitors.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.44444 20H13.5556M11 16.5V20M5.77778 7H16.2222C17.2041 7 18 7.7835 18 8.75V14.75C18 15.7165 17.2041 16.5 16.2222 16.5H5.77778C4.79594 16.5 4 15.7165 4 14.75V8.75C4 7.7835 4.79594 7 5.77778 7Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19.2222 13C20.2041 13 21 12.1792 21 11.1667V5.83333C21 4.82081 20.2041 4 19.2222 4H8.77778C7.79594 4 7 4.82081 7 5.83333" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/web/libs/ui/src/lib/data-table/data-table.stories.tsx
+++ b/web/libs/ui/src/lib/data-table/data-table.stories.tsx
@@ -252,7 +252,7 @@ export const WithIconHeaders: Story = {
         // Icon-only header with tooltip - wrap icon in Tooltip directly
         header: () => (
           <Tooltip
-            title="Number of active browser sessions. Multiple sessions (>1) may indicate account sharing."
+            title="Active Sessions: Number of active browser sessions. Multiple sessions (>1) may indicate account sharing."
             alignment="top-center"
           >
             <div className="flex items-center cursor-help">

--- a/web/libs/ui/src/lib/data-table/data-table.stories.tsx
+++ b/web/libs/ui/src/lib/data-table/data-table.stories.tsx
@@ -208,23 +208,22 @@ export const WithHelpTooltips: Story = {
 };
 
 /**
- * Icon-Only Column Headers
+ * Custom React Node Headers
  *
- * Demonstrates using a React node (icon) as a column header instead of text.
- * The header supports any React node - when you need a tooltip, wrap the icon
- * with a Tooltip component. This is useful for compact columns where space
- * is limited, such as showing active sessions with a monitors icon.
+ * Demonstrates using custom React nodes as column headers instead of text.
+ * The header property accepts any React node - icons, buttons, dropdowns, or any
+ * custom component. Simply pass a function that returns your custom header content.
  *
- * Note: The DataTable header now supports any React node, not just strings.
- * Simply pass a function that returns your custom header content.
+ * This example shows an icon wrapped in a Tooltip for a compact column, but you can
+ * use any React component as a header (buttons, dropdowns, badges, etc.).
  *
  * Hover over the monitors icon to see the tooltip explaining the column.
  */
-export const WithIconHeaders: Story = {
+export const WithCustomHeaders: Story = {
   render: () => {
     const [sorting, setSorting] = useState<SortingState>([]);
 
-    const columnsWithIconHeader: ColumnDef<User>[] = [
+    const columnsWithCustomHeaders: ColumnDef<User>[] = [
       {
         accessorKey: "name",
         header: "Name",
@@ -287,7 +286,7 @@ export const WithIconHeaders: Story = {
         </div>
         <DataTable
           data={sampleData}
-          columns={columnsWithIconHeader}
+          columns={columnsWithCustomHeaders}
           enableSorting
           sorting={sorting}
           onSortingChange={setSorting}

--- a/web/libs/ui/src/lib/data-table/data-table.stories.tsx
+++ b/web/libs/ui/src/lib/data-table/data-table.stories.tsx
@@ -5,7 +5,7 @@ import type { ColumnDef, SortingState } from "@tanstack/react-table";
 import type { ExtendedDataTableColumnDef } from "./data-table";
 import { Badge } from "../badge/badge";
 import { Button } from "../button/button";
-import { IconEdit, IconTrash } from "@humansignal/icons";
+import { IconEdit, IconTrash, IconMonitors } from "@humansignal/icons";
 
 const meta: Meta<typeof DataTable> = {
   component: DataTable,
@@ -27,11 +27,28 @@ type User = {
   role: string;
   status: "active" | "inactive";
   lastActive: string;
+  activeSessions?: number;
 };
 
 const sampleData: User[] = [
-  { id: 1, name: "John Doe", email: "john@example.com", role: "Admin", status: "active", lastActive: "2024-01-15" },
-  { id: 2, name: "Jane Smith", email: "jane@example.com", role: "Editor", status: "active", lastActive: "2024-01-14" },
+  {
+    id: 1,
+    name: "John Doe",
+    email: "john@example.com",
+    role: "Admin",
+    status: "active",
+    lastActive: "2024-01-15",
+    activeSessions: 2,
+  },
+  {
+    id: 2,
+    name: "Jane Smith",
+    email: "jane@example.com",
+    role: "Editor",
+    status: "active",
+    lastActive: "2024-01-14",
+    activeSessions: 1,
+  },
   {
     id: 3,
     name: "Bob Johnson",
@@ -39,6 +56,7 @@ const sampleData: User[] = [
     role: "Viewer",
     status: "inactive",
     lastActive: "2024-01-10",
+    activeSessions: 0,
   },
   {
     id: 4,
@@ -47,6 +65,7 @@ const sampleData: User[] = [
     role: "Editor",
     status: "active",
     lastActive: "2024-01-15",
+    activeSessions: 1,
   },
   {
     id: 5,
@@ -55,6 +74,7 @@ const sampleData: User[] = [
     role: "Viewer",
     status: "active",
     lastActive: "2024-01-13",
+    activeSessions: 3,
   },
 ];
 
@@ -177,6 +197,87 @@ export const WithHelpTooltips: Story = {
         <DataTable
           data={sampleData}
           columns={columnsWithHelp}
+          enableSorting
+          sorting={sorting}
+          onSortingChange={setSorting}
+        />
+      </div>
+    );
+  },
+};
+
+/**
+ * Icon-Only Column Headers
+ *
+ * Demonstrates using an icon as a column header instead of text.
+ * When combined with the `help` property, the icon itself becomes the tooltip trigger
+ * (no separate info icon is shown). This is useful for compact columns where space
+ * is limited, such as showing active sessions with a monitors icon.
+ *
+ * Hover over the monitors icon to see the tooltip explaining the column.
+ */
+export const WithIconHeaders: Story = {
+  render: () => {
+    const [sorting, setSorting] = useState<SortingState>([]);
+
+    const columnsWithIconHeader: ExtendedDataTableColumnDef<User>[] = [
+      {
+        accessorKey: "name",
+        header: "Name",
+        enableSorting: true,
+      },
+      {
+        accessorKey: "email",
+        header: "Email",
+        enableSorting: true,
+      },
+      {
+        accessorKey: "role",
+        header: "Role",
+        cell: ({ getValue }) => {
+          const role = getValue() as string;
+          return (
+            <Badge variant={role === "Admin" ? "primary" : role === "Editor" ? "success" : "info"} size="small">
+              {role}
+            </Badge>
+          );
+        },
+      },
+      {
+        accessorKey: "activeSessions",
+        // Icon-only header with tooltip
+        header: () => <IconMonitors width={24} height={24} />,
+        help: "Number of active browser sessions. Multiple sessions (>1) may indicate account sharing.",
+        size: 40,
+        cell: ({ getValue }) => {
+          const sessions = getValue() as number;
+          return (
+            <div className="flex items-center justify-center">
+              <Badge variant={sessions > 1 ? "warning" : "default"} size="small">
+                {sessions}
+              </Badge>
+            </div>
+          );
+        },
+      },
+      {
+        accessorKey: "lastActive",
+        header: "Last Active",
+        enableSorting: true,
+      },
+    ];
+
+    return (
+      <div className="flex flex-col gap-4">
+        <div className="p-4 bg-neutral-surface rounded-md">
+          <p className="text-sm text-neutral-content-subtle">
+            💡 The column between "Role" and "Last Active" uses an icon instead of text as the header. Hover over the
+            monitors icon to see what it represents.
+          </p>
+        </div>
+        <DataTable
+          data={sampleData}
+          columns={columnsWithIconHeader}
           enableSorting
           sorting={sorting}
           onSortingChange={setSorting}

--- a/web/libs/ui/src/lib/data-table/data-table.stories.tsx
+++ b/web/libs/ui/src/lib/data-table/data-table.stories.tsx
@@ -251,10 +251,7 @@ export const WithIconHeaders: Story = {
         accessorKey: "activeSessions",
         // Icon-only header with tooltip - wrap icon in Tooltip directly
         header: () => (
-          <Tooltip
-            title="Active Sessions: Number of active browser sessions. Multiple sessions (>1) may indicate account sharing."
-            alignment="top-center"
-          >
+          <Tooltip title="Active Sessions: Number of active browser sessions." alignment="top-center">
             <div className="flex items-center cursor-help">
               <IconMonitors width={24} height={24} />
             </div>

--- a/web/libs/ui/src/lib/data-table/data-table.stories.tsx
+++ b/web/libs/ui/src/lib/data-table/data-table.stories.tsx
@@ -32,24 +32,8 @@ type User = {
 };
 
 const sampleData: User[] = [
-  {
-    id: 1,
-    name: "John Doe",
-    email: "john@example.com",
-    role: "Admin",
-    status: "active",
-    lastActive: "2024-01-15",
-    activeSessions: 2,
-  },
-  {
-    id: 2,
-    name: "Jane Smith",
-    email: "jane@example.com",
-    role: "Editor",
-    status: "active",
-    lastActive: "2024-01-14",
-    activeSessions: 1,
-  },
+  { id: 1, name: "John Doe", email: "john@example.com", role: "Admin", status: "active", lastActive: "2024-01-15", activeSessions: 2 },
+  { id: 2, name: "Jane Smith", email: "jane@example.com", role: "Editor", status: "active", lastActive: "2024-01-14", activeSessions: 1 },
   {
     id: 3,
     name: "Bob Johnson",
@@ -198,95 +182,6 @@ export const WithHelpTooltips: Story = {
         <DataTable
           data={sampleData}
           columns={columnsWithHelp}
-          enableSorting
-          sorting={sorting}
-          onSortingChange={setSorting}
-        />
-      </div>
-    );
-  },
-};
-
-/**
- * Custom React Node Headers
- *
- * Demonstrates using custom React nodes as column headers instead of text.
- * The header property accepts any React node - icons, buttons, dropdowns, or any
- * custom component. Simply pass a function that returns your custom header content.
- *
- * This example shows an icon wrapped in a Tooltip for a compact column, but you can
- * use any React component as a header (buttons, dropdowns, badges, etc.).
- *
- * Hover over the monitors icon to see the tooltip explaining the column.
- */
-export const WithCustomHeaders: Story = {
-  render: () => {
-    const [sorting, setSorting] = useState<SortingState>([]);
-
-    const columnsWithCustomHeaders: ColumnDef<User>[] = [
-      {
-        accessorKey: "name",
-        header: "Name",
-        enableSorting: true,
-      },
-      {
-        accessorKey: "email",
-        header: "Email",
-        enableSorting: true,
-      },
-      {
-        accessorKey: "role",
-        header: "Role",
-        cell: ({ getValue }) => {
-          const role = getValue() as string;
-          return (
-            <Badge variant={role === "Admin" ? "primary" : role === "Editor" ? "success" : "info"} size="small">
-              {role}
-            </Badge>
-          );
-        },
-      },
-      {
-        accessorKey: "activeSessions",
-        // Icon-only header with tooltip - wrap icon in Tooltip directly
-        header: () => (
-          <Tooltip title="Active Sessions: Number of active browser sessions." alignment="top-center">
-            <div className="flex items-center cursor-help">
-              <IconMonitors width={24} height={24} />
-            </div>
-          </Tooltip>
-        ),
-        size: 32,
-        minSize: 30,
-        cell: ({ getValue }) => {
-          const sessions = getValue() as number;
-          return (
-            <div className="flex items-center justify-center">
-              <Badge variant={sessions > 1 ? "warning" : "default"} size="small">
-                {sessions}
-              </Badge>
-            </div>
-          );
-        },
-      },
-      {
-        accessorKey: "lastActive",
-        header: "Last Active",
-        enableSorting: true,
-      },
-    ];
-
-    return (
-      <div className="flex flex-col gap-4">
-        <div className="p-4 bg-neutral-surface rounded-md">
-          <p className="text-sm text-neutral-content-subtle">
-            💡 The column between "Role" and "Last Active" uses an icon wrapped in a Tooltip as the header. Hover over
-            the monitors icon to see the tooltip.
-          </p>
-        </div>
-        <DataTable
-          data={sampleData}
-          columns={columnsWithCustomHeaders}
           enableSorting
           sorting={sorting}
           onSortingChange={setSorting}
@@ -621,6 +516,95 @@ export const ConditionalRowSelection: Story = {
           rowSelection={rowSelection}
           onRowSelectionChange={setRowSelection}
           isRowSelectable={(row) => row.original.status === "active"}
+        />
+      </div>
+    );
+  },
+};
+
+/**
+ * Custom React Node Headers
+ *
+ * Demonstrates using custom React nodes as column headers instead of text.
+ * The header property accepts any React node - icons, buttons, dropdowns, or any
+ * custom component. Simply pass a function that returns your custom header content.
+ *
+ * This example shows an icon wrapped in a Tooltip for a compact column, but you can
+ * use any React component as a header (buttons, dropdowns, badges, etc.).
+ *
+ * Hover over the monitors icon to see the tooltip explaining the column.
+ */
+export const WithCustomHeaders: Story = {
+  render: () => {
+    const [sorting, setSorting] = useState<SortingState>([]);
+
+    const columnsWithCustomHeaders: ColumnDef<User>[] = [
+      {
+        accessorKey: "name",
+        header: "Name",
+        enableSorting: true,
+      },
+      {
+        accessorKey: "email",
+        header: "Email",
+        enableSorting: true,
+      },
+      {
+        accessorKey: "role",
+        header: "Role",
+        cell: ({ getValue }) => {
+          const role = getValue() as string;
+          return (
+            <Badge variant={role === "Admin" ? "primary" : role === "Editor" ? "success" : "info"} size="small">
+              {role}
+            </Badge>
+          );
+        },
+      },
+      {
+        accessorKey: "activeSessions",
+        // Icon-only header with tooltip - wrap icon in Tooltip directly
+        header: () => (
+          <Tooltip title="Active Sessions: Number of active browser sessions." alignment="top-center">
+            <div className="flex items-center cursor-help">
+              <IconMonitors width={24} height={24} />
+            </div>
+          </Tooltip>
+        ),
+        size: 32,
+        minSize: 30,
+        cell: ({ getValue }) => {
+          const sessions = getValue() as number;
+          return (
+            <div className="flex items-center justify-center">
+              <Badge variant={sessions > 1 ? "warning" : "default"} size="small">
+                {sessions}
+              </Badge>
+            </div>
+          );
+        },
+      },
+      {
+        accessorKey: "lastActive",
+        header: "Last Active",
+        enableSorting: true,
+      },
+    ];
+
+    return (
+      <div className="flex flex-col gap-4">
+        <div className="p-4 bg-neutral-surface rounded-md">
+          <p className="text-sm text-neutral-content-subtle">
+            💡 The column between "Role" and "Last Active" uses an icon wrapped in a Tooltip as the header. Hover over
+            the monitors icon to see the tooltip.
+          </p>
+        </div>
+        <DataTable
+          data={sampleData}
+          columns={columnsWithCustomHeaders}
+          enableSorting
+          sorting={sorting}
+          onSortingChange={setSorting}
         />
       </div>
     );

--- a/web/libs/ui/src/lib/data-table/data-table.stories.tsx
+++ b/web/libs/ui/src/lib/data-table/data-table.stories.tsx
@@ -32,8 +32,24 @@ type User = {
 };
 
 const sampleData: User[] = [
-  { id: 1, name: "John Doe", email: "john@example.com", role: "Admin", status: "active", lastActive: "2024-01-15", activeSessions: 2 },
-  { id: 2, name: "Jane Smith", email: "jane@example.com", role: "Editor", status: "active", lastActive: "2024-01-14", activeSessions: 1 },
+  {
+    id: 1,
+    name: "John Doe",
+    email: "john@example.com",
+    role: "Admin",
+    status: "active",
+    lastActive: "2024-01-15",
+    activeSessions: 2,
+  },
+  {
+    id: 2,
+    name: "Jane Smith",
+    email: "jane@example.com",
+    role: "Editor",
+    status: "active",
+    lastActive: "2024-01-14",
+    activeSessions: 1,
+  },
   {
     id: 3,
     name: "Bob Johnson",

--- a/web/libs/ui/src/lib/data-table/data-table.stories.tsx
+++ b/web/libs/ui/src/lib/data-table/data-table.stories.tsx
@@ -5,6 +5,7 @@ import type { ColumnDef, SortingState } from "@tanstack/react-table";
 import type { ExtendedDataTableColumnDef } from "./data-table";
 import { Badge } from "../badge/badge";
 import { Button } from "../button/button";
+import { Tooltip } from "../Tooltip/Tooltip";
 import { IconEdit, IconTrash, IconMonitors } from "@humansignal/icons";
 
 const meta: Meta<typeof DataTable> = {
@@ -209,10 +210,13 @@ export const WithHelpTooltips: Story = {
 /**
  * Icon-Only Column Headers
  *
- * Demonstrates using an icon as a column header instead of text.
- * When combined with the `help` property, the icon itself becomes the tooltip trigger
- * (no separate info icon is shown). This is useful for compact columns where space
+ * Demonstrates using a React node (icon) as a column header instead of text.
+ * The header supports any React node - when you need a tooltip, wrap the icon
+ * with a Tooltip component. This is useful for compact columns where space
  * is limited, such as showing active sessions with a monitors icon.
+ *
+ * Note: The DataTable header now supports any React node, not just strings.
+ * Simply pass a function that returns your custom header content.
  *
  * Hover over the monitors icon to see the tooltip explaining the column.
  */
@@ -220,7 +224,7 @@ export const WithIconHeaders: Story = {
   render: () => {
     const [sorting, setSorting] = useState<SortingState>([]);
 
-    const columnsWithIconHeader: ExtendedDataTableColumnDef<User>[] = [
+    const columnsWithIconHeader: ColumnDef<User>[] = [
       {
         accessorKey: "name",
         header: "Name",
@@ -245,10 +249,19 @@ export const WithIconHeaders: Story = {
       },
       {
         accessorKey: "activeSessions",
-        // Icon-only header with tooltip
-        header: () => <IconMonitors width={24} height={24} />,
-        help: "Number of active browser sessions. Multiple sessions (>1) may indicate account sharing.",
-        size: 40,
+        // Icon-only header with tooltip - wrap icon in Tooltip directly
+        header: () => (
+          <Tooltip
+            title="Number of active browser sessions. Multiple sessions (>1) may indicate account sharing."
+            alignment="top-center"
+          >
+            <div className="flex items-center cursor-help">
+              <IconMonitors width={24} height={24} />
+            </div>
+          </Tooltip>
+        ),
+        size: 32,
+        minSize: 30,
         cell: ({ getValue }) => {
           const sessions = getValue() as number;
           return (
@@ -271,8 +284,8 @@ export const WithIconHeaders: Story = {
       <div className="flex flex-col gap-4">
         <div className="p-4 bg-neutral-surface rounded-md">
           <p className="text-sm text-neutral-content-subtle">
-            💡 The column between "Role" and "Last Active" uses an icon instead of text as the header. Hover over the
-            monitors icon to see what it represents.
+            💡 The column between "Role" and "Last Active" uses an icon wrapped in a Tooltip as the header. Hover over
+            the monitors icon to see the tooltip.
           </p>
         </div>
         <DataTable

--- a/web/libs/ui/src/lib/data-table/data-table.tsx
+++ b/web/libs/ui/src/lib/data-table/data-table.tsx
@@ -18,7 +18,7 @@ declare module "@tanstack/react-table" {
     noDivider?: boolean;
   }
 }
-import React, { memo, useState, useMemo, useCallback } from "react";
+import { memo, useState, useMemo, useCallback } from "react";
 import { cn } from "../../utils/utils";
 import { useColumnSizing, useDataColumns } from "../../hooks/data-table";
 import { Checkbox } from "../checkbox/checkbox";
@@ -116,6 +116,7 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
   } = props;
   const [internalRowSelection, setInternalRowSelection] = useState<Record<string, boolean>>({});
   const [internalSorting, setInternalSorting] = useState<SortingState>([]);
+  const [internalActiveRowId, setInternalActiveRowId] = useState<string | undefined>(undefined);
 
   // Restore column sizes from localStorage if storageKey is provided
   const restoredColumnSizing = useMemo(() => {
@@ -144,11 +145,11 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
 
   const [internalColumnSizing, setInternalColumnSizing] = useState<Record<string, number>>(restoredColumnSizing);
 
-  // Use controlled activeRowId ONLY if onRowClick is provided (parent controls state via clicks)
-  // Active state should only be enabled when rows are clickable
+  // Use controlled activeRowId if onRowClick is provided (parent controls state via clicks)
+  // OR if activeRowId is explicitly provided (not undefined)
   // When onRowClick is provided, activeRowId is read-only for display purposes
-  const isActiveRowControlled = props.onRowClick !== undefined;
-  const activeRowId = isActiveRowControlled ? (controlledActiveRowId ?? undefined) : undefined;
+  const isActiveRowControlled = props.onRowClick !== undefined || controlledActiveRowId !== undefined;
+  const activeRowId = isActiveRowControlled ? (controlledActiveRowId ?? undefined) : internalActiveRowId;
 
   // Use controlled selection if provided, otherwise use internal state
   const rowSelection = controlledRowSelection ?? internalRowSelection;
@@ -177,7 +178,7 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
       // Determine if sorting is enabled for this column
       const columnSortingEnabled = enableSorting && col.enableSorting === true;
 
-      // Preserve original header - extract string if it's a string, or call function if it's a function
+      // Preserve original header - extract string or call function to get React node
       const originalHeader =
         typeof col.header === "string"
           ? col.header
@@ -378,11 +379,14 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
       // Call parent's onRowClick handler if provided
       if (props.onRowClick) {
         props.onRowClick(row);
+      } else if (!isActiveRowControlled && row) {
+        // Only manage internal state if uncontrolled AND no onRowClick provided
+        // When controlled, parent handles all state via onRowClick
+        const newActiveRowId = activeRowId === row.id ? undefined : row.id;
+        setInternalActiveRowId(newActiveRowId);
       }
-      // Active state is only enabled when onRowClick is provided
-      // No internal state management for active rows
     },
-    [props.onRowClick],
+    [props.onRowClick, activeRowId, isActiveRowControlled],
   );
 
   // Check if we should show empty state
@@ -416,7 +420,7 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
         <MemoizedDataTableBody
           rows={rows}
           rowClassName={props.rowClassName}
-          onRowClick={props.onRowClick ? handleRowClick : undefined}
+          onRowClick={handleRowClick}
           columnVisibility={props.columnVisibility}
           columnSizing={columnSizing}
           rowSelection={rowSelection}
@@ -532,7 +536,7 @@ const DataTableRow = <T,>({ row, className, onRowClick, isSelected, isActive }: 
         isActive && styles.bodyRowActive,
         className,
       )}
-      onClick={onRowClick ? handleRowClick : undefined}
+      onClick={handleRowClick}
       data-testid={`data-table-row-${row.id}`}
     >
       {row.getVisibleCells().map((cell) => {
@@ -730,33 +734,23 @@ export const Header = <T,>({
     return null;
   }
 
-  // Check if headerLabel is a React element (icon) vs text
-  const isReactElement = React.isValidElement(headerLabel);
-  const isTextHeader = typeof headerLabel === "string";
+  // Check if headerLabel is a string to wrap with Typography, or a React node to render directly
+  const isStringHeader = typeof headerLabel === "string";
 
   const headerContent = (
-    <div className={cn(styles.headerContent, help && !isReactElement && "gap-tighter")}>
+    <div className={cn(styles.headerContent, help && "gap-tighter")}>
       <div className="flex items-center gap-2">
-        {isReactElement && help ? (
-          // If it's an icon with help text, wrap the icon with the tooltip
-          <Tooltip title={help} alignment="top-center">
-            <div className="flex items-center cursor-help">{headerLabel}</div>
-          </Tooltip>
-        ) : isTextHeader ? (
-          // If it's text, wrap with Typography
-          <>
-            <Typography variant="label" size="small" className={cn(isSorted && styles.headerTextSorted)}>
-              {headerLabel}
-            </Typography>
-            {help && (
-              <Tooltip title={help} alignment="top-center">
-                <IconInfoOutline width={18} height={18} className="text-neutral-content-subtler cursor-help shrink-0" />
-              </Tooltip>
-            )}
-          </>
+        {isStringHeader ? (
+          <Typography variant="label" size="small" className={cn(isSorted && styles.headerTextSorted)}>
+            {headerLabel}
+          </Typography>
         ) : (
-          // If it's a React element without help, just render it
           headerLabel
+        )}
+        {help && (
+          <Tooltip title={help} alignment="top-center">
+            <IconInfoOutline width={18} height={18} className="text-neutral-content-subtler cursor-help shrink-0" />
+          </Tooltip>
         )}
       </div>
       {enableSorting && (

--- a/web/libs/ui/src/lib/data-table/data-table.tsx
+++ b/web/libs/ui/src/lib/data-table/data-table.tsx
@@ -18,7 +18,7 @@ declare module "@tanstack/react-table" {
     noDivider?: boolean;
   }
 }
-import { memo, useState, useMemo, useCallback } from "react";
+import React, { memo, useState, useMemo, useCallback } from "react";
 import { cn } from "../../utils/utils";
 import { useColumnSizing, useDataColumns } from "../../hooks/data-table";
 import { Checkbox } from "../checkbox/checkbox";
@@ -177,8 +177,13 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
       // Determine if sorting is enabled for this column
       const columnSortingEnabled = enableSorting && col.enableSorting === true;
 
-      // Preserve original header - extract string if it's a string
-      const originalHeader = typeof col.header === "string" ? col.header : undefined;
+      // Preserve original header - extract string if it's a string, or call function if it's a function
+      const originalHeader =
+        typeof col.header === "string"
+          ? col.header
+          : typeof col.header === "function"
+            ? col.header({} as any) // Call the function to get the React node
+            : undefined;
 
       // Wrap all headers with unified Header component
       return {
@@ -725,16 +730,33 @@ export const Header = <T,>({
     return null;
   }
 
+  // Check if headerLabel is a React element (icon) vs text
+  const isReactElement = React.isValidElement(headerLabel);
+  const isTextHeader = typeof headerLabel === "string";
+
   const headerContent = (
-    <div className={cn(styles.headerContent, help && "gap-tighter")}>
+    <div className={cn(styles.headerContent, help && !isReactElement && "gap-tighter")}>
       <div className="flex items-center gap-2">
-        <Typography variant="label" size="small" className={cn(isSorted && styles.headerTextSorted)}>
-          {headerLabel}
-        </Typography>
-        {help && (
+        {isReactElement && help ? (
+          // If it's an icon with help text, wrap the icon with the tooltip
           <Tooltip title={help} alignment="top-center">
-            <IconInfoOutline width={18} height={18} className="text-neutral-content-subtler cursor-help shrink-0" />
+            <div className="flex items-center cursor-help">{headerLabel}</div>
           </Tooltip>
+        ) : isTextHeader ? (
+          // If it's text, wrap with Typography
+          <>
+            <Typography variant="label" size="small" className={cn(isSorted && styles.headerTextSorted)}>
+              {headerLabel}
+            </Typography>
+            {help && (
+              <Tooltip title={help} alignment="top-center">
+                <IconInfoOutline width={18} height={18} className="text-neutral-content-subtler cursor-help shrink-0" />
+              </Tooltip>
+            )}
+          </>
+        ) : (
+          // If it's a React element without help, just render it
+          headerLabel
         )}
       </div>
       {enableSorting && (

--- a/web/libs/ui/src/lib/data-table/data-table.tsx
+++ b/web/libs/ui/src/lib/data-table/data-table.tsx
@@ -116,7 +116,6 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
   } = props;
   const [internalRowSelection, setInternalRowSelection] = useState<Record<string, boolean>>({});
   const [internalSorting, setInternalSorting] = useState<SortingState>([]);
-  const [internalActiveRowId, setInternalActiveRowId] = useState<string | undefined>(undefined);
 
   // Restore column sizes from localStorage if storageKey is provided
   const restoredColumnSizing = useMemo(() => {
@@ -145,11 +144,11 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
 
   const [internalColumnSizing, setInternalColumnSizing] = useState<Record<string, number>>(restoredColumnSizing);
 
-  // Use controlled activeRowId if onRowClick is provided (parent controls state via clicks)
-  // OR if activeRowId is explicitly provided (not undefined)
+  // Use controlled activeRowId ONLY if onRowClick is provided (parent controls state via clicks)
+  // Active state should only be enabled when rows are clickable
   // When onRowClick is provided, activeRowId is read-only for display purposes
-  const isActiveRowControlled = props.onRowClick !== undefined || controlledActiveRowId !== undefined;
-  const activeRowId = isActiveRowControlled ? (controlledActiveRowId ?? undefined) : internalActiveRowId;
+  const isActiveRowControlled = props.onRowClick !== undefined;
+  const activeRowId = isActiveRowControlled ? (controlledActiveRowId ?? undefined) : undefined;
 
   // Use controlled selection if provided, otherwise use internal state
   const rowSelection = controlledRowSelection ?? internalRowSelection;
@@ -379,14 +378,11 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
       // Call parent's onRowClick handler if provided
       if (props.onRowClick) {
         props.onRowClick(row);
-      } else if (!isActiveRowControlled && row) {
-        // Only manage internal state if uncontrolled AND no onRowClick provided
-        // When controlled, parent handles all state via onRowClick
-        const newActiveRowId = activeRowId === row.id ? undefined : row.id;
-        setInternalActiveRowId(newActiveRowId);
       }
+      // Active state is only enabled when onRowClick is provided
+      // No internal state management for active rows
     },
-    [props.onRowClick, activeRowId, isActiveRowControlled],
+    [props.onRowClick],
   );
 
   // Check if we should show empty state
@@ -420,7 +416,7 @@ export const DataTable = <T extends DataShape>(props: DataTableProps<T>) => {
         <MemoizedDataTableBody
           rows={rows}
           rowClassName={props.rowClassName}
-          onRowClick={handleRowClick}
+          onRowClick={props.onRowClick ? handleRowClick : undefined}
           columnVisibility={props.columnVisibility}
           columnSizing={columnSizing}
           rowSelection={rowSelection}
@@ -536,7 +532,7 @@ const DataTableRow = <T,>({ row, className, onRowClick, isSelected, isActive }: 
         isActive && styles.bodyRowActive,
         className,
       )}
-      onClick={handleRowClick}
+      onClick={onRowClick ? handleRowClick : undefined}
       data-testid={`data-table-row-${row.id}`}
     >
       {row.getVisibleCells().map((cell) => {


### PR DESCRIPTION
This pull request enhances the `DataTable` component and its stories to support components inside header cells, improves internal row activation logic, and updates sample data to better demonstrate these features. The changes also introduce a new icon to the icon set.

## Screenshots
<img width="1044" height="700" alt="image" src="https://github.com/user-attachments/assets/927272c9-13a9-47c8-a24d-960253210be7" />


**Key changes include:**

### DataTable Component Improvements

* Added support for column headers to be any React node (not just strings), enabling icon-only headers with tooltips. The header rendering logic now checks if the header is a string or a function returning a React node, and renders accordingly. (`data-table.tsx`) [[1]](diffhunk://#diff-12837e3d0134bd17183c0ba795639cc1449daef192e005241553d074de55c124L180-R187) [[2]](diffhunk://#diff-12837e3d0134bd17183c0ba795639cc1449daef192e005241553d074de55c124R737-R749)
* Improved internal active row state management: the component now manages `activeRowId` internally when not controlled by a parent, and toggles the active row on click if uncontrolled. (`data-table.tsx`) [[1]](diffhunk://#diff-12837e3d0134bd17183c0ba795639cc1449daef192e005241553d074de55c124R119) [[2]](diffhunk://#diff-12837e3d0134bd17183c0ba795639cc1449daef192e005241553d074de55c124L147-R152) [[3]](diffhunk://#diff-12837e3d0134bd17183c0ba795639cc1449daef192e005241553d074de55c124R382-R389) [[4]](diffhunk://#diff-12837e3d0134bd17183c0ba795639cc1449daef192e005241553d074de55c124L414-R423) [[5]](diffhunk://#diff-12837e3d0134bd17183c0ba795639cc1449daef192e005241553d074de55c124L530-R539)

### DataTable Stories and Sample Data

* Added a new story, `WithIconHeaders`, demonstrating the use of an icon (with tooltip) as a column header for "active sessions". This shows how to use tooltips and custom header content for compact columns. (`data-table.stories.tsx`)
* Updated the `User` type and `sampleData` to include an optional `activeSessions` field, providing realistic data for the new icon column. (`data-table.stories.tsx`) [[1]](diffhunk://#diff-febcfe61fcdc9d240063fedf44f0d7487d818e6130eb0a74a28325383fd14e7cR31-R60) [[2]](diffhunk://#diff-febcfe61fcdc9d240063fedf44f0d7487d818e6130eb0a74a28325383fd14e7cR69) [[3]](diffhunk://#diff-febcfe61fcdc9d240063fedf44f0d7487d818e6130eb0a74a28325383fd14e7cR78)
* Imported the new `IconMonitors` and `Tooltip` components for use in the story. (`data-table.stories.tsx`)

### Icon Library

* Added `IconMonitors` to the exported icon set for use in the UI. (`index.ts`)

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
