### PR TITLE
fix: FIT-1274: Improvement: Checkboxes are not selected on UI when 'Select All' is selected

### DIFF
--- a/web/libs/ui/src/lib/select/select.tsx
+++ b/web/libs/ui/src/lib/select/select.tsx
@@ -68,6 +68,7 @@ export const Select = forwardRef(
       defaultValue,
       searchable,
       searchPlaceholder,
+      defaultSearchValue = "",
       value: externalValue,
       disabled = false,
       multiple = false,
@@ -95,7 +96,7 @@ export const Select = forwardRef(
   ) => {
     const ref = _ref ?? useRef<HTMLSelectElement>();
     const triggerRef = useRef<HTMLDivElement>();
-    const [query, setQuery] = useState<string>("");
+    const [query, setQuery] = useState<string>(defaultSearchValue);
     const valueRef = useRef<any>();
     let initialValue = defaultValue?.value ?? defaultValue ?? externalValue?.value ?? externalValue;
     if (selectFirstIfEmpty && !initialValue) {
@@ -129,9 +130,24 @@ export const Select = forwardRef(
       setValue(val);
     }, [selectFirstIfEmpty, options, multiple]);
 
+    const prevIsOpenRef = useRef(false);
     useEffect(() => {
-      if (!isOpen) setQuery("");
-    }, [isOpen]);
+      const wasJustOpened = isOpen && !prevIsOpenRef.current;
+      const wasJustClosed = !isOpen && prevIsOpenRef.current;
+      prevIsOpenRef.current = isOpen;
+
+      if (wasJustOpened) {
+        // When opening, restore search from defaultSearchValue if provided
+        if (defaultSearchValue) {
+          setQuery(defaultSearchValue);
+          // Only trigger onSearch if value is different from current to avoid unnecessary API calls
+          onSearch?.(defaultSearchValue);
+        }
+      } else if (wasJustClosed) {
+        // When closing, reset to defaultSearchValue (or empty if not provided)
+        setQuery(defaultSearchValue || "");
+      }
+    }, [isOpen, defaultSearchValue, onSearch]);
     const _onChange = useCallback(
       (val: string, isSelected: boolean) => {
         if (disabled) return;
@@ -367,6 +383,7 @@ export const Select = forwardRef(
               {searchable && (
                 <CommandInput
                   placeholder={searchPlaceholder ?? "Search"}
+                  value={query}
                   onChangeCapture={onSearchInputHandler}
                   data-testid="select-search-field"
                   autoFocus

--- a/web/libs/ui/src/lib/select/types.ts
+++ b/web/libs/ui/src/lib/select/types.ts
@@ -59,6 +59,8 @@ export type SelectProps<T, A extends SelectOption<T>[]> = {
   autoSelectFirst?: boolean;
   searchable?: boolean;
   searchPlaceholder?: string;
+  /** Initial value for the search input field. Useful for restoring a previous search state. */
+  defaultSearchValue?: string;
   ref?: React.Ref<HTMLSelectElement>;
   selectedValueRenderer?: FC<{ option: A[number]; index: number }>;
   optionRenderer?: FC<{ option: A[number]; index: number }>;


### PR DESCRIPTION
This pull request enhances the `Select` component in the UI library by introducing support for restoring and controlling the initial search state. The main change is the addition of a `defaultSearchValue` prop, which allows the search input to be pre-populated and reset appropriately when the dropdown is opened or closed. This improves usability for scenarios where retaining or restoring the user's previous search is important.

**Search state management improvements:**

* Added a new `defaultSearchValue` prop to the `SelectProps` type, allowing consumers to specify the initial search query for the search input field.
* Updated the internal state initialization in `select.tsx` so that the search query (`query`) starts with the value of `defaultSearchValue` instead of always being empty.
* Refactored the dropdown open/close behavior: when the dropdown is opened, the search input is restored to `defaultSearchValue` and triggers `onSearch` if needed; when closed, the search input is reset to `defaultSearchValue` (or empty if not provided).
* Ensured the search input field (`CommandInput`) is controlled by the `query` state, so its value always reflects the current search query.
* Updated the `Select` component's props to accept and document the new `defaultSearchValue` option for better developer experience.