### PR TITLE
fix: TRIAG-1864: Export snapshot filenames should use the custom snap…

### DIFF
--- a/label_studio/data_export/api.py
+++ b/label_studio/data_export/api.py
@@ -591,16 +591,20 @@ class ExportDownloadAPI(generics.RetrieveAPIView):
                 # below header tells NGINX to catch it and serve, see docker-config/nginx-app.conf
                 redirect = '/file_download/' + protocol + '/' + url.replace(protocol + '://', '')
                 response['X-Accel-Redirect'] = redirect
-                response['Content-Disposition'] = 'attachment; filename="{}"'.format(file.name)
-                response['filename'] = os.path.basename(file.name)
+                # Use basename to get just the filename, not the full path
+                filename = os.path.basename(file.name)
+                response['Content-Disposition'] = 'attachment; filename="{}"'.format(filename)
+                response['filename'] = filename
                 return response
 
             # No NGINX: standard way for export downloads in the community edition
             else:
                 ext = file.name.split('.')[-1]
                 response = RangedFileResponse(request, file, content_type=f'application/{ext}')
-                response['Content-Disposition'] = f'attachment; filename="{file.name}"'
-                response['filename'] = os.path.basename(file.name)
+                # Use basename to get just the filename, not the full path
+                filename = os.path.basename(file.name)
+                response['Content-Disposition'] = f'attachment; filename="{filename}"'
+                response['filename'] = filename
                 return response
         else:
             if export_type is None:
@@ -614,8 +618,10 @@ class ExportDownloadAPI(generics.RetrieveAPIView):
             ext = file_.name.split('.')[-1]
 
             response = RangedFileResponse(request, file_, content_type=f'application/{ext}')
-            response['Content-Disposition'] = f'attachment; filename="{file_.name}"'
-            response['filename'] = file_.name
+            # Use basename to get just the filename, not the full path
+            filename = os.path.basename(file_.name)
+            response['Content-Disposition'] = f'attachment; filename="{filename}"'
+            response['filename'] = filename
             return response
 
 
@@ -640,7 +646,15 @@ def async_convert(converted_format_id, export_type, project, hostname, download_
     ext = converted_file.name.split('.')[-1]
 
     now = datetime.now()
-    file_name = f'project-{project.id}-at-{now.strftime("%Y-%m-%d-%H-%M")}-{md5[0:8]}.{ext}'
+    
+    # Use custom title if available, otherwise fall back to default pattern
+    from data_export.mixins import sanitize_filename
+    sanitized_title = sanitize_filename(snapshot.title)
+    if sanitized_title:
+        file_name = f'{sanitized_title}-{md5[0:8]}.{ext}'
+    else:
+        file_name = f'project-{project.id}-at-{now.strftime("%Y-%m-%d-%H-%M")}-{md5[0:8]}.{ext}'
+    
     file_path = f'{project.id}/{file_name}'  # finally file will be in settings.DELAYED_EXPORT_DIR/project.id/file_name
     file_ = File(converted_file, name=file_path)
     converted_format.file.save(file_path, file_)

--- a/label_studio/data_export/mixins.py
+++ b/label_studio/data_export/mixins.py
@@ -3,6 +3,7 @@ import io
 import json
 import logging
 import pathlib
+import re
 import shutil
 from datetime import datetime
 from functools import reduce
@@ -32,6 +33,40 @@ EXCLUDE = 'exclude'
 
 
 logger = logging.getLogger(__name__)
+
+
+def sanitize_filename(title):
+    """
+    Sanitize a title string for use in filenames.
+    Replaces spaces and special characters with hyphens, removes invalid characters.
+    
+    Args:
+        title: The title string to sanitize
+        
+    Returns:
+        A sanitized string safe for use in filenames, or None if title is empty/invalid
+    """
+    if not title or not isinstance(title, str):
+        return None
+    
+    # Remove leading/trailing whitespace
+    title = title.strip()
+    
+    if not title:
+        return None
+    
+    # Replace spaces and common special characters with hyphens
+    title = re.sub(r'[^\w\s-]', '', title)  # Remove invalid filename characters
+    title = re.sub(r'[-\s]+', '-', title)   # Replace spaces and multiple hyphens with single hyphen
+    
+    # Remove leading/trailing hyphens
+    title = title.strip('-')
+    
+    # Limit length to avoid filesystem issues (keep reasonable length)
+    if len(title) > 200:
+        title = title[:200]
+    
+    return title if title else None
 
 
 class ExportMixin:
@@ -271,7 +306,14 @@ class ExportMixin:
 
     def save_file(self, file, md5):
         now = datetime.now()
-        file_name = f'project-{self.project.id}-at-{now.strftime("%Y-%m-%d-%H-%M")}-{md5[0:8]}.json'
+        
+        # Use custom title if available, otherwise fall back to default pattern
+        sanitized_title = sanitize_filename(self.title)
+        if sanitized_title:
+            file_name = f'{sanitized_title}-{md5[0:8]}.json'
+        else:
+            file_name = f'project-{self.project.id}-at-{now.strftime("%Y-%m-%d-%H-%M")}-{md5[0:8]}.json'
+        
         file_path = f'{self.project.id}/{file_name}'  # finally file will be in settings.DELAYED_EXPORT_DIR/self.project.id/file_name
         file_ = File(file, name=file_path)
         self.file.save(file_path, file_)


### PR DESCRIPTION
For now this is me and **Alec** playing around, don't suffer for this yet

# Use Custom Titles in Export Snapshot Filenames

## Summary

This PR enables export snapshots to use custom titles in their filenames instead of the default `project-{id}-at-{timestamp}-{md5}` pattern. When a user provides a custom snapshot name, it will be sanitized and used as the filename prefix, making exported files more identifiable and user-friendly.

## Changes

### Backend Changes

1. **Added `sanitize_filename()` helper function** (`data_export/mixins.py`)
   - Sanitizes custom titles for safe use in filenames
   - Removes invalid filename characters
   - Replaces spaces with hyphens
   - Limits length to 200 characters
   - Returns `None` if title is empty/invalid (triggers fallback to default pattern)

2. **Updated `save_file()` method** (`data_export/mixins.py`)
   - Uses sanitized custom title if available
   - Falls back to default pattern if no title or sanitization fails
   - Format: `{sanitized-title}-{md5[0:8]}.json` or `project-{id}-at-{timestamp}-{md5[0:8]}.json`

3. **Updated `async_convert()` function** (`data_export/api.py`)
   - Uses sanitized title for converted format files (CSV, TSV, COCO, etc.)
   - Same fallback behavior as main export files

4. **Fixed download endpoint filename extraction** (`data_export/api.py`)
   - Uses `os.path.basename()` to extract just the filename from the full storage path
   - Prevents full path (`export/{project_id}/{filename}`) from appearing in download headers
   - Fixes issue where filenames included path components like `export_198575_...`

## Example

**Before:**
- Filename: `project-198575-at-2026-01-23-16-16-48a6bac9.json`
- Download header: `export_198575_project-198575-at-2026-01-23-16-16-48a6bac9`

**After (with custom title "Alec is cool"):**
- Filename: `Alec-is-cool-48a6bac9.json`
- Download header: `Alec-is-cool-48a6bac9.json`

**After (without custom title):**
- Filename: `project-198575-at-2026-01-23-16-16-48a6bac9.json` (unchanged)
- Download header: `project-198575-at-2026-01-23-16-16-48a6bac9.json` (fixed)

## Impact Analysis

### ✅ Safe Areas (No Breaking Changes)

- **Backward Compatibility**: Exports without custom titles continue to use the default pattern
- **File Storage**: Directory structure unchanged (`export/{project_id}/{filename}`)
- **Database**: No schema changes (title field already existed)
- **Frontend**: No changes needed (already sends title in API requests)
- **Deprecated Sync Export**: Separate code path, unaffected

### ⚠️ Areas Requiring Attention

- **Deprecated Endpoints**: 
  - `ProjectExportFilesAuthCheck` and `ProjectExportFiles` parse filenames using `split('-')[0]` to extract project ID
  - These endpoints are deprecated (`exclude=True` in OpenAPI) and likely not used in production
  - May not work correctly with custom titles, but this is acceptable given their deprecated status

## Testing

### Manual Testing Checklist

- [x] Create export with custom title → Filename uses custom title
- [x] Create export without title → Filename uses default pattern
- [x] Create export with special characters → Characters sanitized correctly
- [x] Create export with very long title → Title truncated appropriately
- [x] Convert export to CSV/TSV → Converted files use custom title
- [x] Download export → Headers contain only filename (not full path)
- [x] Download old exports → Still works correctly
- [x] Export list displays correctly → Both old and new exports shown

### Test Plan

See [EXPORT_FILENAME_CUSTOM_TITLE_TEST_PLAN.md](./EXPORT_FILENAME_CUSTOM_TITLE_TEST_PLAN.md) for comprehensive test cases.

## Filename Sanitization Rules

The `sanitize_filename()` function:
- Removes invalid filename characters (`/`, `\`, `:`, `*`, `?`, `"`, `<`, `>`, `|`)
- Replaces spaces and multiple hyphens with single hyphens
- Removes leading/trailing hyphens
- Limits length to 200 characters
- Returns `None` if result is empty (triggers default pattern)

**Examples:**
- `"My Export"` → `"My-Export"`
- `"Test/File:Name?"` → `"TestFileName"`
- `"  Multiple   Spaces  "` → `"Multiple-Spaces"`
- `"---Test---"` → `"Test"`
- `"!!!@@@###"` → `None` (falls back to default)

## Files Changed

```
label_studio/data_export/mixins.py
  - Added sanitize_filename() function
  - Updated save_file() method to use custom titles

label_studio/data_export/api.py
  - Updated async_convert() to use custom titles
  - Fixed download endpoint to use basename() for filename extraction
```

## Migration Notes

- **No migration required**: Changes are backward compatible
- **Existing exports**: Continue to work with old filename pattern
- **New exports**: Automatically use custom titles when provided
- **Rollback**: Safe to revert; existing exports unaffected

## Related Issues

- Fixes issue where custom snapshot titles were not reflected in downloaded filenames
- Fixes issue where download filenames included full storage path

## Screenshots

### Before
```
Downloaded filename: export_198575_project-198575-at-2026-01-23-16-16-48a6bac9.json
```

### After (with custom title "Alec is cool")
```
Downloaded filename: Alec-is-cool-48a6bac9.json
```

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are backward compatible
- [x] No database migrations required
- [x] No breaking API changes
- [x] Test plan documented
- [x] Edge cases handled (empty titles, special characters, etc.)
- [x] Fallback to default pattern when title unavailable
- [x] Download headers fixed to use basename only

## Future Improvements

- Consider updating deprecated endpoints to handle custom titles
- Add validation for title length in frontend
- Consider allowing users to see sanitized filename before export creation
- Update documentation to mention custom title support
