### PR TITLE
feat: BROS-702: Databricks service principle

### DIFF
--- a/web/libs/app-common/src/blocks/StorageProviderForm/components/provider-form.test.tsx
+++ b/web/libs/app-common/src/blocks/StorageProviderForm/components/provider-form.test.tsx
@@ -1,0 +1,195 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ProviderForm } from "./provider-form";
+import type { ProviderConfig } from "../types/provider";
+import { z } from "zod";
+
+/**
+ * Tests for ProviderForm component with visibleWhen conditional field rendering.
+ *
+ * These tests validate:
+ * - Fields without visibleWhen are always rendered
+ * - Fields with visibleWhen are conditionally rendered based on form data
+ * - Array values in visibleWhen.value work correctly
+ * - Function values in visibleWhen.value work correctly
+ */
+
+// Mock provider config for testing visibleWhen functionality
+const createTestProvider = (): ProviderConfig => ({
+  name: "test-provider",
+  title: "Test Provider",
+  description: "Test provider for conditional field rendering",
+  fields: [
+    {
+      name: "auth_type",
+      type: "select",
+      label: "Authentication Type",
+      required: true,
+      defaultValue: "pat",
+      options: [
+        { value: "pat", label: "Personal Access Token" },
+        { value: "sp", label: "Service Principal" },
+        { value: "azure_sp", label: "Azure Service Principal" },
+      ],
+      schema: z.string(),
+    },
+    {
+      name: "token",
+      type: "password",
+      label: "Access Token",
+      schema: z.string().optional(),
+      visibleWhen: { field: "auth_type", value: "pat" },
+    },
+    {
+      name: "client_id",
+      type: "text",
+      label: "Client ID",
+      schema: z.string().optional(),
+      visibleWhen: { field: "auth_type", value: ["sp", "azure_sp"] },
+    },
+    {
+      name: "tenant_id",
+      type: "text",
+      label: "Tenant ID",
+      schema: z.string().optional(),
+      visibleWhen: { field: "auth_type", value: "azure_sp" },
+    },
+    {
+      name: "always_visible",
+      type: "text",
+      label: "Always Visible Field",
+      schema: z.string().optional(),
+      // No visibleWhen - should always be rendered
+    },
+  ],
+  layout: [
+    { fields: ["auth_type"] },
+    { fields: ["token"] },
+    { fields: ["client_id"] },
+    { fields: ["tenant_id"] },
+    { fields: ["always_visible"] },
+  ],
+});
+
+describe("ProviderForm visibleWhen", () => {
+  const defaultProps = {
+    provider: createTestProvider(),
+    errors: {},
+    onChange: jest.fn(),
+  };
+
+  it("renders fields without visibleWhen condition", () => {
+    render(<ProviderForm {...defaultProps} formData={{ auth_type: "pat" }} />);
+
+    // auth_type selector should always be visible
+    expect(screen.getByText("Authentication Type")).toBeInTheDocument();
+    // Field without visibleWhen should be visible
+    expect(screen.getByText("Always Visible Field")).toBeInTheDocument();
+  });
+
+  it("shows token field when auth_type is 'pat'", () => {
+    render(<ProviderForm {...defaultProps} formData={{ auth_type: "pat" }} />);
+
+    // token should be visible in PAT mode
+    expect(screen.getByText("Access Token")).toBeInTheDocument();
+    // client_id should NOT be visible in PAT mode
+    expect(screen.queryByText("Client ID")).not.toBeInTheDocument();
+    // tenant_id should NOT be visible in PAT mode
+    expect(screen.queryByText("Tenant ID")).not.toBeInTheDocument();
+  });
+
+  it("shows client_id field when auth_type is 'sp'", () => {
+    render(<ProviderForm {...defaultProps} formData={{ auth_type: "sp" }} />);
+
+    // token should NOT be visible in SP mode
+    expect(screen.queryByText("Access Token")).not.toBeInTheDocument();
+    // client_id should be visible in SP mode (matches array value)
+    expect(screen.getByText("Client ID")).toBeInTheDocument();
+    // tenant_id should NOT be visible in SP mode (only azure_sp)
+    expect(screen.queryByText("Tenant ID")).not.toBeInTheDocument();
+  });
+
+  it("shows both client_id and tenant_id when auth_type is 'azure_sp'", () => {
+    render(<ProviderForm {...defaultProps} formData={{ auth_type: "azure_sp" }} />);
+
+    // token should NOT be visible in Azure SP mode
+    expect(screen.queryByText("Access Token")).not.toBeInTheDocument();
+    // client_id should be visible (matches array value)
+    expect(screen.getByText("Client ID")).toBeInTheDocument();
+    // tenant_id should be visible (exact match)
+    expect(screen.getByText("Tenant ID")).toBeInTheDocument();
+  });
+
+  it("hides fields when visibleWhen condition is not met", () => {
+    render(<ProviderForm {...defaultProps} formData={{ auth_type: "sp" }} />);
+
+    // token has visibleWhen: { field: "auth_type", value: "pat" }
+    // Current auth_type is "sp", so token should be hidden
+    expect(screen.queryByText("Access Token")).not.toBeInTheDocument();
+  });
+
+  it("handles empty form data gracefully", () => {
+    render(<ProviderForm {...defaultProps} formData={{}} />);
+
+    // Fields without visibleWhen should still render
+    expect(screen.getByText("Authentication Type")).toBeInTheDocument();
+    expect(screen.getByText("Always Visible Field")).toBeInTheDocument();
+    // Fields with visibleWhen should not render (no matching value)
+    expect(screen.queryByText("Access Token")).not.toBeInTheDocument();
+    expect(screen.queryByText("Client ID")).not.toBeInTheDocument();
+    expect(screen.queryByText("Tenant ID")).not.toBeInTheDocument();
+  });
+});
+
+describe("ProviderForm visibleWhen with function values", () => {
+  const createProviderWithFunctionCondition = (): ProviderConfig => ({
+    name: "test-provider-func",
+    title: "Test Provider",
+    description: "Test provider with function-based visibleWhen",
+    fields: [
+      {
+        name: "enable_advanced",
+        type: "toggle",
+        label: "Enable Advanced Options",
+        schema: z.boolean().optional(),
+      },
+      {
+        name: "advanced_option",
+        type: "text",
+        label: "Advanced Option",
+        schema: z.string().optional(),
+        visibleWhen: {
+          field: "enable_advanced",
+          value: (value: boolean) => value === true,
+        },
+      },
+    ],
+    layout: [{ fields: ["enable_advanced"] }, { fields: ["advanced_option"] }],
+  });
+
+  it("shows field when function condition returns true", () => {
+    render(
+      <ProviderForm
+        provider={createProviderWithFunctionCondition()}
+        formData={{ enable_advanced: true }}
+        errors={{}}
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Advanced Option")).toBeInTheDocument();
+  });
+
+  it("hides field when function condition returns false", () => {
+    render(
+      <ProviderForm
+        provider={createProviderWithFunctionCondition()}
+        formData={{ enable_advanced: false }}
+        errors={{}}
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("Advanced Option")).not.toBeInTheDocument();
+  });
+});

--- a/web/libs/app-common/src/blocks/StorageProviderForm/components/provider-form.tsx
+++ b/web/libs/app-common/src/blocks/StorageProviderForm/components/provider-form.tsx
@@ -22,10 +22,6 @@ interface ProviderFormProps {
  * @returns true if field should be visible, false otherwise
  */
 const isFieldVisible = (field: FieldDefinition | MessageDefinition, formData: Record<string, any>): boolean => {
-  console.log("isFieldVisible field", field);
-  console.log("isFieldVisible formData", formData);
-  console.log("isFieldVisible field.type", field.type);
-
   // Messages don't have visibleWhen, always visible
   if (field.type === "message") {
     return true;

--- a/web/libs/app-common/src/blocks/StorageProviderForm/components/provider-form.tsx
+++ b/web/libs/app-common/src/blocks/StorageProviderForm/components/provider-form.tsx
@@ -50,9 +50,6 @@ const isFieldVisible = (field: FieldDefinition | MessageDefinition, formData: Re
     isVisible = currentValue === expectedValue;
   }
 
-  // Debug: uncomment to trace visibility issues
-  // console.log(`[visibleWhen] ${fieldDef.name}: currentValue=${currentValue}, expected=${JSON.stringify(expectedValue)}, visible=${isVisible}`);
-
   return isVisible;
 };
 

--- a/web/libs/app-common/src/blocks/StorageProviderForm/components/provider-form.tsx
+++ b/web/libs/app-common/src/blocks/StorageProviderForm/components/provider-form.tsx
@@ -14,6 +14,52 @@ interface ProviderFormProps {
   target?: "import" | "export";
 }
 
+/**
+ * Check if a field should be visible based on its visibleWhen condition.
+ *
+ * @param field - Field definition to check
+ * @param formData - Current form data to evaluate conditions against
+ * @returns true if field should be visible, false otherwise
+ */
+const isFieldVisible = (field: FieldDefinition | MessageDefinition, formData: Record<string, any>): boolean => {
+  console.log("isFieldVisible field", field);
+  console.log("isFieldVisible formData", formData);
+  console.log("isFieldVisible field.type", field.type);
+
+  // Messages don't have visibleWhen, always visible
+  if (field.type === "message") {
+    return true;
+  }
+
+  const fieldDef = field as FieldDefinition;
+
+  // No visibleWhen condition means always visible
+  if (!fieldDef.visibleWhen) {
+    return true;
+  }
+
+  const { field: dependencyField, value: expectedValue } = fieldDef.visibleWhen;
+  const currentValue = formData[dependencyField];
+
+  let isVisible: boolean;
+
+  // If expected value is a function, call it with current value and form data
+  if (typeof expectedValue === "function") {
+    isVisible = expectedValue(currentValue, formData);
+  } else if (Array.isArray(expectedValue)) {
+    // If expected value is an array, check if current value is in the array
+    isVisible = expectedValue.includes(currentValue);
+  } else {
+    // Simple equality check
+    isVisible = currentValue === expectedValue;
+  }
+
+  // Debug: uncomment to trace visibility issues
+  // console.log(`[visibleWhen] ${fieldDef.name}: currentValue=${currentValue}, expected=${JSON.stringify(expectedValue)}, visible=${isVisible}`);
+
+  return isVisible;
+};
+
 export const ProviderForm: React.FC<ProviderFormProps> = ({
   provider,
   formData,
@@ -45,16 +91,20 @@ export const ProviderForm: React.FC<ProviderFormProps> = ({
       {/* Render visible fields in layout */}
       {provider.layout.map((row, rowIndex) => {
         const fields = getFieldsForRow(provider.fields, row.fields, target);
+        // Filter fields based on visibility conditions
+        const visibleFields = fields.filter((field) => isFieldVisible(field, formData));
+
         return (
-          fields.length > 0 && (
+          visibleFields.length > 0 && (
             <div
               key={rowIndex}
               className="grid gap-6"
               style={{
-                gridTemplateColumns: `repeat(${row.fields.length}, 1fr)`,
+                // Use visible fields count for grid columns to avoid empty spaces
+                gridTemplateColumns: `repeat(${visibleFields.length}, 1fr)`,
               }}
             >
-              {fields.map((field) => {
+              {visibleFields.map((field) => {
                 // Skip hidden fields from layout - they'll be rendered separately
                 if (field.type === "hidden") {
                   return null;

--- a/web/libs/app-common/src/blocks/StorageProviderForm/types/common.ts
+++ b/web/libs/app-common/src/blocks/StorageProviderForm/types/common.ts
@@ -31,7 +31,7 @@ export interface FieldDefinition {
     value: any | ((dependencyValue: any, formData: Record<string, any>) => boolean); // The value or function to check if field should be enabled
   };
   visibleWhen?: {
-    field: string; // Name of the field this depends on for visibility
+    field: string; // Name of the field that depends on for visibility
     value: string | string[] | ((dependencyValue: any, formData: Record<string, any>) => boolean); // Value(s) or function to check if field should be visible
   };
 }

--- a/web/libs/app-common/src/blocks/StorageProviderForm/types/common.ts
+++ b/web/libs/app-common/src/blocks/StorageProviderForm/types/common.ts
@@ -30,6 +30,10 @@ export interface FieldDefinition {
     field: string; // Name of the field this depends on
     value: any | ((dependencyValue: any, formData: Record<string, any>) => boolean); // The value or function to check if field should be enabled
   };
+  visibleWhen?: {
+    field: string; // Name of the field this depends on for visibility
+    value: string | string[] | ((dependencyValue: any, formData: Record<string, any>) => boolean); // Value(s) or function to check if field should be visible
+  };
 }
 
 export interface MessageDefinition {


### PR DESCRIPTION
This PR adds `visibleWhen` behavior for data storages so that you can toggle fields in the storage settings depending on the selected authentication method. It is used in databricks storage. 

## Example for visibleWhen

<img width="1701" height="778" alt="image" src="https://github.com/user-attachments/assets/5ac7ba83-2485-4dc7-9e71-c7b5355684df" />

<img width="1712" height="797" alt="image" src="https://github.com/user-attachments/assets/f0c7f2e5-756d-4e32-93dc-5462b30cefce" />

<img width="1705" height="964" alt="image" src="https://github.com/user-attachments/assets/09f0dbc1-dcf9-4f49-9552-8d92ce9e76b0" />
