### PR TITLE
fix: FIT-1292: Fix DM Tabs overflowing the screen

### DIFF
--- a/web/libs/datamanager/src/components/Common/Tabs/Tabs.scss
+++ b/web/libs/datamanager/src/components/Common/Tabs/Tabs.scss
@@ -19,7 +19,7 @@
 
   &__droppable {
     display: flex;
-    overflow: visible;
+    overflow: hidden;
     gap: 2px;
   }
 


### PR DESCRIPTION
This pull request makes a small change to the `Tabs.scss` file, updating the styling of the `__droppable` class to use `overflow: hidden` instead of `overflow: visible`. This will help contain overflowing content within the droppable area.

## Screenshots
### Before
<img width="1390" height="87" alt="image" src="https://github.com/user-attachments/assets/da55be57-7b15-4682-8c38-347826e7bfc2" />

### After
<img width="1384" height="142" alt="image" src="https://github.com/user-attachments/assets/a9f2b382-d705-45db-99ee-3bda9472294c" />


<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
