### PR TITLE
fix: FIT-1294: Clear window.Htx in V17 destroy path

### DIFF
--- a/web/libs/editor/src/LabelStudio.tsx
+++ b/web/libs/editor/src/LabelStudio.tsx
@@ -179,6 +179,11 @@ export class LabelStudio {
       }
       destroy(this.store);
       Hotkey.unbindAll();
+
+      // Always clear window.Htx to allow garbage collection of the store
+      // This was previously only done in V18 path, causing memory leaks in V17
+      window.Htx = null;
+
       if (isFF(FF_LSDV_4620_3_ML)) {
         /*
             ...


### PR DESCRIPTION
## Problem

`window.Htx` is never cleared in the V17 destroy path, retaining the entire MST store in memory after navigation. This causes memory leaks as the store and all its references remain accessible via the global window object.

## Solution

Always set `window.Htx = null` in the `destroy()` method regardless of feature flags. This allows garbage collection of the store after destruction.

## Files Changed

- `web/libs/editor/src/LabelStudio.tsx`