### PR TITLE
perf: FIT-1295: Add React memoization to hot rendering paths

### DIFF
--- a/web/libs/editor/src/components/SidePanels/DetailsPanel/RegionLabels.tsx
+++ b/web/libs/editor/src/components/SidePanels/DetailsPanel/RegionLabels.tsx
@@ -1,26 +1,37 @@
-import type { FC } from "react";
+import { memo, useMemo, type FC } from "react";
 import { observer } from "mobx-react";
 
 import { cn } from "../../../utils/bem";
 
+// Memoized label item component to prevent unnecessary re-renders
+const LabelItem = memo(({ label, showComma }: { label: any; showComma: boolean }) => {
+  const color = label.background || "#000000";
+
+  return (
+    <>
+      {showComma ? ", " : null}
+      <span style={{ color }}>{label.value}</span>
+    </>
+  );
+});
+
+LabelItem.displayName = "LabelItem";
+
 export const RegionLabels: FC<{ region: LSFRegion }> = observer(({ region }) => {
-  const labelsInResults = region.labelings.map((result: any) => result.selectedLabels || []);
-  const labels: any[] = [].concat(...labelsInResults);
+  // Memoize label extraction to prevent recalculation on every render
+  const labels = useMemo(() => {
+    const labelsInResults = region.labelings.map((result: any) => result.selectedLabels || []);
+
+    return ([] as any[]).concat(...labelsInResults);
+  }, [region.labelings]);
 
   if (!labels.length) return <div className={cn("labels-list").toClassName()}>{region.noLabelView || "No label"}</div>;
 
   return (
     <div className={cn("labels-list").toClassName()}>
-      {labels.map((label, index) => {
-        const color = label.background || "#000000";
-
-        return [
-          index ? ", " : null,
-          <span key={label.id} style={{ color }}>
-            {label.value}
-          </span>,
-        ];
-      })}
+      {labels.map((label, index) => (
+        <LabelItem key={label.id} label={label} showComma={index > 0} />
+      ))}
     </div>
   );
 });

--- a/web/libs/editor/src/regions/PolygonRegion.jsx
+++ b/web/libs/editor/src/regions/PolygonRegion.jsx
@@ -1,5 +1,5 @@
 import Konva from "konva";
-import { memo, useContext, useEffect, useMemo } from "react";
+import { memo, useCallback, useContext, useEffect, useMemo } from "react";
 import { Group, Line } from "react-konva";
 import { destroy, detach, getRoot, isAlive, types } from "mobx-state-tree";
 
@@ -420,32 +420,43 @@ const Poly = memo(
  */
 const Edge = observer(({ name, item, idx, p1, p2, closed, regionStyles }) => {
   const insertIdx = idx + 1; // idx1 + 1 or idx2
-  const flattenedPoints = [p1.canvasX, p1.canvasY, p2.canvasX, p2.canvasY];
+  const flattenedPoints = useMemo(() => [p1.canvasX, p1.canvasY, p2.canvasX, p2.canvasY], [p1.canvasX, p1.canvasY, p2.canvasX, p2.canvasY]);
 
-  const lineProps = closed
-    ? {
-        stroke: "transparent",
-        strokeWidth: regionStyles.strokeWidth,
-        strokeScaleEnabled: false,
-      }
-    : {
-        stroke: regionStyles.strokeColor,
-        strokeWidth: regionStyles.strokeWidth,
-        strokeScaleEnabled: false,
-      };
+  const lineProps = useMemo(
+    () =>
+      closed
+        ? {
+            stroke: "transparent",
+            strokeWidth: regionStyles.strokeWidth,
+            strokeScaleEnabled: false,
+          }
+        : {
+            stroke: regionStyles.strokeColor,
+            strokeWidth: regionStyles.strokeWidth,
+            strokeScaleEnabled: false,
+          },
+    [closed, regionStyles.strokeWidth, regionStyles.strokeColor],
+  );
+
+  // Extract handlers with useCallback to prevent recreation on each render
+  const handleClick = useCallback(
+    (e) => item.handleLineClick({ e, flattenedPoints, insertIdx }),
+    [item, flattenedPoints, insertIdx],
+  );
+
+  const handleMouseMove = useCallback(
+    (e) => {
+      if (!item.closed || !item.selected || item.isReadOnly()) return;
+
+      item.handleMouseMove({ e, flattenedPoints });
+    },
+    [item, flattenedPoints],
+  );
+
+  const handleMouseLeave = useCallback((e) => item.handleMouseLeave({ e }), [item]);
 
   return (
-    <Group
-      key={name}
-      name={name}
-      onClick={(e) => item.handleLineClick({ e, flattenedPoints, insertIdx })}
-      onMouseMove={(e) => {
-        if (!item.closed || !item.selected || item.isReadOnly()) return;
-
-        item.handleMouseMove({ e, flattenedPoints });
-      }}
-      onMouseLeave={(e) => item.handleMouseLeave({ e })}
-    >
+    <Group key={name} name={name} onClick={handleClick} onMouseMove={handleMouseMove} onMouseLeave={handleMouseLeave}>
       <Line
         lineJoin="round"
         opacity={1}

--- a/web/libs/editor/src/tags/control/Choices.jsx
+++ b/web/libs/editor/src/tags/control/Choices.jsx
@@ -23,7 +23,7 @@ import SelectedChoiceMixin from "../../mixins/SelectedChoiceMixin";
 import ClassificationBase from "./ClassificationBase";
 import PerItemMixin from "../../mixins/PerItem";
 import Infomodal from "../../components/Infomodal/Infomodal";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { Select, Tooltip } from "@humansignal/ui";
 
 /**
@@ -266,25 +266,32 @@ const ChoicesSelectLayout = observer(({ item }) => {
       })),
     [item.tiedChildren],
   );
+
+  // Extract onChange handler with useCallback to prevent recreation on each render
+  const handleChange = useCallback(
+    (val) => {
+      if (Array.isArray(val)) {
+        item.resetSelected();
+        val.forEach((v) => item.findLabel(v).setSelected(true));
+        item.updateResult();
+      } else {
+        const c = item.findLabel(val);
+
+        if (c) {
+          c.toggleSelected();
+        }
+      }
+    },
+    [item],
+  );
+
   return (
     <Select
       style={{ width: "100%" }}
       value={item.selectedLabels.map((l) => l._value)}
       multiple={item.choice === "multiple"}
       disabled={item.isReadOnly()}
-      onChange={(val) => {
-        if (Array.isArray(val)) {
-          item.resetSelected();
-          val.forEach((v) => item.findLabel(v).setSelected(true));
-          item.updateResult();
-        } else {
-          const c = item.findLabel(val);
-
-          if (c) {
-            c.toggleSelected();
-          }
-        }
-      }}
+      onChange={handleChange}
       options={options}
     />
   );

--- a/web/libs/editor/src/tags/object/Video/VideoRegions.jsx
+++ b/web/libs/editor/src/tags/object/Video/VideoRegions.jsx
@@ -37,9 +37,14 @@ const VideoRegionsPure = ({
   const [newRegion, setNewRegion] = useState();
   const [isDrawing, setDrawingMode] = useState(false);
 
-  const selected = regions.filter((reg) => {
-    return (reg.selected || reg.inSelection) && !reg.hidden && !reg.isReadOnly() && reg.isInLifespan(item.frame);
-  });
+  // Memoize selected regions to prevent recalculation on every render
+  const selected = useMemo(
+    () =>
+      regions.filter((reg) => {
+        return (reg.selected || reg.inSelection) && !reg.hidden && !reg.isReadOnly() && reg.isInLifespan(item.frame);
+      }),
+    [regions, item.frame],
+  );
   const listenToEvents = !locked;
 
   // if region is not in lifespan, it's not rendered,
@@ -273,27 +278,24 @@ const Shape = observer(({ id, reg, item, stageRef, currentFrame, ...props }) => 
   const frame = currentFrame ?? item.frame;
   const box = reg.getShape(frame);
 
+  // Extract onClick handler with useCallback to prevent recreation on each render
+  const handleClick = useCallback(
+    (e) => {
+      const annotation = getParentOfType(reg, Annotation);
+
+      if (annotation && annotation.isLinkingMode) {
+        stageRef.current.container().style.cursor = Constants.DEFAULT_CURSOR;
+      }
+
+      reg.setHighlight(false);
+      reg.onClickRegion(e);
+    },
+    [reg, stageRef],
+  );
+
   return (
     reg.isInLifespan(frame) &&
-    box && (
-      <Rectangle
-        id={id}
-        reg={reg}
-        box={box}
-        frame={frame}
-        onClick={(e) => {
-          const annotation = getParentOfType(reg, Annotation);
-
-          if (annotation && annotation.isLinkingMode) {
-            stageRef.current.container().style.cursor = Constants.DEFAULT_CURSOR;
-          }
-
-          reg.setHighlight(false);
-          reg.onClickRegion(e);
-        }}
-        {...props}
-      />
-    )
+    box && <Rectangle id={id} reg={reg} box={box} frame={frame} onClick={handleClick} {...props} />
   );
 });
 


### PR DESCRIPTION
## Problem

Inline function handlers are recreated on every render, causing child components to receive new prop references and re-render unnecessarily. This is particularly impactful in hot paths like VideoRegions, Choices, and PolygonRegion.

## Solution

Add `useCallback` for event handlers and `useMemo` for computed values to prevent unnecessary re-renders.

## Files Changed

- `web/libs/editor/src/tags/object/Video/VideoRegions.jsx`
- `web/libs/editor/src/tags/control/Choices.jsx`
- `web/libs/editor/src/regions/PolygonRegion.jsx`
- `web/libs/editor/src/components/SidePanels/DetailsPanel/RegionLabels.tsx`