### PR TITLE
fix: FIT-1297: Guard async operations against destroyed store

### DIFF
--- a/web/libs/editor/src/stores/Annotation/store.js
+++ b/web/libs/editor/src/stores/Annotation/store.js
@@ -1,4 +1,4 @@
-import { destroy, getEnv, getParent, getRoot, types } from "mobx-state-tree";
+import { destroy, getEnv, getParent, getRoot, isAlive, types } from "mobx-state-tree";
 
 import { errorBuilder } from "../../core/DataValidator/ConfigValidator";
 import { DataValidator, ValidationError, VALIDATORS } from "../../core/DataValidator";
@@ -482,8 +482,13 @@ const AnnotationStoreModel = types
     function selectHistory(item) {
       self.selectedHistory = item;
       setTimeout(() => {
+        // Guard against accessing destroyed store after navigation
+        if (!isAlive(self)) return;
+
         // update classifications after render
         const updatedItem = item ?? self.selected;
+
+        if (!updatedItem) return;
 
         Array.from(updatedItem.names.values())
           .filter((t) => t.isClassificationTag)


### PR DESCRIPTION
## Problem

`setTimeout` in `selectHistory()` can fire after the store is destroyed (e.g., during navigation), causing it to access dead MST nodes and throw warnings.

## Solution

Add `isAlive(self)` guard at the start of the setTimeout callback to prevent accessing destroyed store state.

## Files Changed

- `web/libs/editor/src/stores/Annotation/store.js`