### PR TITLE
perf: FIT-1299: Optimize autosave with debounce instead of throttle

### DIFF
--- a/web/libs/editor/src/stores/Annotation/Annotation.js
+++ b/web/libs/editor/src/stores/Annotation/Annotation.js
@@ -1,4 +1,4 @@
-import throttle from "lodash/throttle";
+import debounce from "lodash/debounce";
 import { destroy, detach, flow, getEnv, getParent, getRoot, isAlive, onSnapshot, types } from "mobx-state-tree";
 import { ff } from "@humansignal/core";
 import { errorBuilder } from "../../core/DataValidator/ConfigValidator";
@@ -779,8 +779,12 @@ const _Annotation = types
         return;
       }
 
-      // mobx will modify methods, so add it directly to have cancel() method
-      self.autosave = throttle(
+      // Use debounce instead of throttle to avoid saving during active drawing.
+      // Debounce waits until activity stops before saving, which:
+      // 1. Reduces unnecessary serialization during continuous operations
+      // 2. Saves once the user pauses, preserving work without interruption
+      // 3. Uses maxWait to ensure saves happen at least every 30 seconds during long operations
+      self.autosave = debounce(
         () => {
           // if autosave is paused, do nothing
           if (self.autosave.paused) return;
@@ -788,7 +792,7 @@ const _Annotation = types
           self.saveDraft();
         },
         self.autosaveDelay,
-        { leading: false },
+        { leading: false, maxWait: 30000 },
       );
 
       onSnapshot(self.areas, self.autosave);


### PR DESCRIPTION
## Problem

Throttle triggers saves periodically during continuous activity like brush strokes. This causes unnecessary serialization work during active drawing operations.

## Solution

Use `debounce` instead of `throttle` for autosave:
- Debounce waits until activity stops before saving
- Reduces CPU usage during brush strokes and polygon drawing
- Added `maxWait` of 30s to ensure saves happen during very long operations

## Files Changed

- `web/libs/editor/src/stores/Annotation/Annotation.js`

## Jira

[FIT-1299](https://humansignal.atlassian.net/browse/FIT-1299)

[FIT-1299]: https://humansignal.atlassian.net/browse/FIT-1299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ