### PR TITLE
perf: FIT-1302: Fix non-deterministic React keys causing unnecessary remounts

### DIFF
--- a/web/libs/editor/src/components/App/App.jsx
+++ b/web/libs/editor/src/components/App/App.jsx
@@ -185,7 +185,7 @@ class App extends Component {
 
     return (
       <RelationsOverlay
-        key={guidGenerator()}
+        key="relations-overlay"
         store={store}
         ref={this.relationsRef}
         tags={selectedStore.names}

--- a/web/libs/editor/src/components/App/Grid.jsx
+++ b/web/libs/editor/src/components/App/Grid.jsx
@@ -213,7 +213,7 @@ export default class Grid extends Component {
                 bordered={false}
                 style={{ height: 44 }}
               />
-              <Item root={this.props.root} onFinish={this.onFinish} key={i} annotation={selected} />
+              <Item root={this.props.root} onFinish={this.onFinish} key={selected.id} annotation={selected} />
             </div>
           )}
         </div>

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
@@ -635,7 +635,7 @@ const RegionItemDesc: FC<RegionItemOCSProps> = observer(({ item, collapsed, setC
 
           return View ? (
             <View
-              key={idx}
+              key={tag.name || `${tag.type}-${idx}`}
               item={tag}
               area={item}
               collapsed={collapsed}

--- a/web/libs/editor/src/components/SidePanels/SidePanels.tsx
+++ b/web/libs/editor/src/components/SidePanels/SidePanels.tsx
@@ -510,7 +510,9 @@ const SidePanelsComponent: FC<SidePanelsProps> = ({ currentEntity, panelsHidden,
             {panelsHidden !== true && (
               <>
                 {Object.entries(panels).map(([key, panel]) => {
-                  const content = panel.map(({ props, Component }, i) => <Component key={i} {...props} />);
+                  const content = panel.map(({ props, Component }) => (
+                    <Component key={Component.displayName || Component.name || "panel"} {...props} />
+                  ));
 
                   if (key === "detached") {
                     return <Fragment key={key}>{content}</Fragment>;

--- a/web/libs/editor/src/regions/PolygonRegion.jsx
+++ b/web/libs/editor/src/regions/PolygonRegion.jsx
@@ -579,7 +579,7 @@ const HtxPolygonView = ({ item, setShapeRef }) => {
 
   return (
     <Group
-      key={item.id ? item.id : guidGenerator(5)}
+      key={item.id}
       name={item.id}
       ref={(el) => setShapeRef(el)}
       onMouseOver={() => {

--- a/web/libs/editor/src/tags/control/TextArea/TextAreaRegionView.jsx
+++ b/web/libs/editor/src/tags/control/TextArea/TextAreaRegionView.jsx
@@ -119,7 +119,7 @@ const HtxTextAreaResult = observer(({ item, control, firstResultInputRef, onFocu
   return value.map((line, idx) => {
     return (
       <HtxTextAreaResultLine
-        key={idx}
+        key={`${item.id}-line-${idx}`}
         idx={idx}
         value={line}
         readOnly={!editable}


### PR DESCRIPTION
## Problem

Two critical anti-patterns in React key usage:

1. **`guidGenerator()` as key** - Creates a new key on every render, forcing React to completely unmount and remount the component. Found in `App.jsx` for `RelationsOverlay`.

2. **Array index as key** - Causes incorrect diffing when items are added, removed, or reordered. Found in multiple components.

## Solution

Replace non-deterministic keys with stable identifiers:

| File | Before | After |
|------|--------|-------|
| `App.jsx` | `key={guidGenerator()}` | `key="relations-overlay"` |
| `Grid.jsx` | `key={i}` | `key={selected.id}` |
| `SidePanels.tsx` | `key={i}` | `key={Component.displayName}` |
| `OutlinerTree.tsx` | `key={idx}` | `key={tag.name}` |
| `PolygonRegion.jsx` | `key={item.id \|\| guidGenerator()}` | `key={item.id}` |
| `TextAreaRegionView.jsx` | `key={idx}` | `key={\`${item.id}-line-${idx}\`}` |

## Files Changed

- `web/libs/editor/src/components/App/App.jsx`
- `web/libs/editor/src/components/App/Grid.jsx`
- `web/libs/editor/src/components/SidePanels/SidePanels.tsx`
- `web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx`
- `web/libs/editor/src/regions/PolygonRegion.jsx`
- `web/libs/editor/src/tags/control/TextArea/TextAreaRegionView.jsx`