### PR TITLE
feat: add strict task overlap filtering for main queue

### DIFF
--- a/label_studio/projects/functions/next_task.py
+++ b/label_studio/projects/functions/next_task.py
@@ -231,18 +231,26 @@ def get_not_solved_tasks_qs(
     # so users can see their work and understand why they can't submit
     lse_project = getattr(project, 'lse_project', None)
     if lse_project and getattr(lse_project, 'strict_task_overlap', False):
-        # Exclude tasks where distinct annotator count >= overlap
-        tasks_at_overlap = Task.objects.filter(
-            project=project
-        ).annotate(
-            distinct_annotators=Count(
-                'annotations__completed_by',
-                filter=Q(annotations__was_cancelled=False),
-                distinct=True,
+        # Calculate effective overlap limit
+        # When agreement_threshold is set, allow additional annotators up to max_additional_annotators_assignable
+        max_additional = 0
+        if lse_project.agreement_threshold is not None:
+            max_additional = lse_project.max_additional_annotators_assignable or 0
+
+        # Exclude tasks where distinct annotator count >= effective overlap
+        # Ground truth annotations don't count toward overlap
+        tasks_at_overlap = (
+            Task.objects.filter(project=project)
+            .annotate(
+                distinct_annotators=Count(
+                    'annotations__completed_by',
+                    filter=Q(annotations__was_cancelled=False, annotations__ground_truth=False),
+                    distinct=True,
+                )
             )
-        ).filter(
-            distinct_annotators__gte=F('overlap')
-        ).values_list('pk', flat=True)
+            .filter(distinct_annotators__gte=F('overlap') + max_additional)
+            .values_list('pk', flat=True)
+        )
 
         not_solved_tasks = not_solved_tasks.exclude(pk__in=tasks_at_overlap)
 

--- a/label_studio/projects/functions/next_task.py
+++ b/label_studio/projects/functions/next_task.py
@@ -225,6 +225,27 @@ def get_not_solved_tasks_qs(
             _, not_solved_tasks = _try_tasks_with_overlap(not_solved_tasks)
             queue_info += (' & ' if queue_info else '') + 'Show overlap first'
 
+    # Strict task overlap enforcement: filter out tasks where overlap is already reached
+    # This prevents NEW users from getting tasks that are already at their annotation limit
+    # Note: Postponed tasks are NOT filtered here - they are served with overlap_reached flag
+    # so users can see their work and understand why they can't submit
+    lse_project = getattr(project, 'lse_project', None)
+    if lse_project and getattr(lse_project, 'strict_task_overlap', False):
+        # Exclude tasks where distinct annotator count >= overlap
+        tasks_at_overlap = Task.objects.filter(
+            project=project
+        ).annotate(
+            distinct_annotators=Count(
+                'annotations__completed_by',
+                filter=Q(annotations__was_cancelled=False),
+                distinct=True,
+            )
+        ).filter(
+            distinct_annotators__gte=F('overlap')
+        ).values_list('pk', flat=True)
+
+        not_solved_tasks = not_solved_tasks.exclude(pk__in=tasks_at_overlap)
+
     return not_solved_tasks, user_solved_tasks_array, queue_info, prioritized_on_agreement
 
 

--- a/label_studio/projects/functions/next_task.py
+++ b/label_studio/projects/functions/next_task.py
@@ -232,17 +232,18 @@ def get_not_solved_tasks_qs(
     lse_project = getattr(project, 'lse_project', None)
     if lse_project and getattr(lse_project, 'strict_task_overlap', False):
         # Exclude tasks where distinct annotator count >= overlap
-        tasks_at_overlap = Task.objects.filter(
-            project=project
-        ).annotate(
-            distinct_annotators=Count(
-                'annotations__completed_by',
-                filter=Q(annotations__was_cancelled=False),
-                distinct=True,
+        tasks_at_overlap = (
+            Task.objects.filter(project=project)
+            .annotate(
+                distinct_annotators=Count(
+                    'annotations__completed_by',
+                    filter=Q(annotations__was_cancelled=False),
+                    distinct=True,
+                )
             )
-        ).filter(
-            distinct_annotators__gte=F('overlap')
-        ).values_list('pk', flat=True)
+            .filter(distinct_annotators__gte=F('overlap'))
+            .values_list('pk', flat=True)
+        )
 
         not_solved_tasks = not_solved_tasks.exclude(pk__in=tasks_at_overlap)
 

--- a/web/libs/datamanager/src/sdk/lsf-sdk.js
+++ b/web/libs/datamanager/src/sdk/lsf-sdk.js
@@ -387,9 +387,10 @@ export class LSFWrapper {
     // Handle strict task overlap - disable submission controls when overlap is reached
     const overlapReached = this.task.overlap_reached === true;
     this.overlapReached = overlapReached;
-    this.overlapReachedMessage = this.task.overlap_reached_message || 
+    this.overlapReachedMessage =
+      this.task.overlap_reached_message ||
       "Annotation overlap has been reached for this task. Your draft is preserved but cannot be submitted.";
-    
+
     if (overlapReached) {
       // Disable submission-related interfaces
       this.lsf.toggleInterface("submit", false);

--- a/web/libs/datamanager/src/sdk/lsf-sdk.js
+++ b/web/libs/datamanager/src/sdk/lsf-sdk.js
@@ -383,10 +383,44 @@ export class LSFWrapper {
     // undefined or true for backward compatibility
     this.lsf.toggleInterface("postpone", this.task.allow_postpone !== false);
     this.lsf.toggleInterface("topbar:task-counter", true);
+
+    // Handle strict task overlap - disable submission controls when overlap is reached
+    const overlapReached = this.task.overlap_reached === true;
+    this.overlapReached = overlapReached;
+    this.overlapReachedMessage = this.task.overlap_reached_message || 
+      "Annotation overlap has been reached for this task. Your draft is preserved but cannot be submitted.";
+    
+    if (overlapReached) {
+      // Disable submission-related interfaces
+      this.lsf.toggleInterface("submit", false);
+      this.lsf.toggleInterface("update", false);
+      this.lsf.toggleInterface("skip", false);
+      // Keep navigation enabled - users must be able to move to next task
+      // The Next/Prev buttons should remain functional
+    }
+
     this.lsf.assignTask(task);
     this.lsf.initializeStore(lsfTask);
     this.setAnnotation(annotationID, fromHistory || isRejectedQueue, selectPrediction);
     this.setLoading(false);
+
+    // Show informational message if overlap is reached
+    if (overlapReached) {
+      this.showOverlapReachedMessage();
+    }
+  }
+
+  /**
+   * Show informational message when overlap is reached
+   * @private
+   */
+  showOverlapReachedMessage() {
+    // Use info toast to communicate the overlap status
+    // This is informational, not an error, so we use a neutral tone
+    this.datamanager.invoke("toast", {
+      message: `${this.overlapReachedMessage} Click the Next arrow (→) to continue.`,
+      type: "info",
+    });
   }
 
   /** @private */
@@ -623,6 +657,12 @@ export class LSFWrapper {
 
   /** @private */
   onSubmitAnnotation = async () => {
+    // Prevent submission if overlap is reached
+    if (this.overlapReached) {
+      this.showOverlapReachedMessage();
+      return;
+    }
+
     const exitStream = this.shouldExitStream();
     const loadNext = exitStream ? false : this.shouldLoadNext();
     const result = await this.submitCurrentAnnotation(
@@ -804,6 +844,12 @@ export class LSFWrapper {
   };
 
   onSkipTask = async (_, { comment } = {}) => {
+    // Prevent skipping if overlap is reached
+    if (this.overlapReached) {
+      this.showOverlapReachedMessage();
+      return;
+    }
+
     // Manager roles that can force-skip unskippable tasks (OW=Owner, AD=Admin, MA=Manager)
     const MANAGER_ROLES = ["OW", "AD", "MA"];
     const task = this.task;


### PR DESCRIPTION
## Summary
- Add filtering to `get_not_solved_tasks_qs()` to exclude tasks that have already reached their annotation overlap limit
- Add frontend handling in `lsf-sdk.js` for `overlap_reached` flag - disables submit/update/skip buttons and shows informational toast
- Postponed queue is intentionally NOT filtered - users see their postponed tasks in read-only mode with clear messaging

## Test plan
- [ ] Verify main queue filtering excludes tasks at overlap for new users
- [ ] Verify users who already have annotations can still access their tasks
- [ ] Verify frontend shows informational message when overlap is reached
- [ ] Verify navigation (prev/next) remains functional when overlap is reached

## Related
- Requires label-studio-enterprise PR for full functionality (project setting and API validation)