### PR TITLE
fix: BROS-711: Decrease points hit radius to make it easier to drag vectors themselves

### DIFF
--- a/web/libs/editor/src/components/KonvaVector/constants.ts
+++ b/web/libs/editor/src/components/KonvaVector/constants.ts
@@ -52,7 +52,7 @@ export const KEYPOINT_POINT_RADIUS = {
 // Hit detection radii (in pixels)
 export const HIT_RADIUS = {
   CONTROL_POINT: 6,
-  SELECTION: 20, // Increased from 5 to 20 to make points easier to click
+  SELECTION: 10, // Hit radius for vector points
   SEGMENT: 8,
 } as const;
 


### PR DESCRIPTION
This PR addresses the issue when it's hard to position entire shape. Often instead of dragging the shape as a whole the user starts dragging individual nodes. This is caused by a large points' hit radius. This PR decreases the radius to 10px so the points are still easy to aim, but at the same time it's easier to drag entire shape when necessary.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
