### PR TITLE
fix: FIT-1327: Correct MultiChannel margin logic to align x-axis

### DIFF
--- a/web/libs/editor/src/tags/object/TimeSeries/MultiChannel.jsx
+++ b/web/libs/editor/src/tags/object/TimeSeries/MultiChannel.jsx
@@ -45,6 +45,9 @@ const Model = types
     },
 
     get margin() {
+      // If Y axis is hidden, we don't need to consider it for margin calculation
+      if (!self.showyaxis) return self.parent?.margin;
+
       const channelsWithYAxis = self.channels.filter((channel) => channel.showaxis && channel.showyaxis);
       if (channelsWithYAxis.length > 1) {
         return {

--- a/web/libs/editor/tests/integration/e2e/timeseries/multichannel.cy.ts
+++ b/web/libs/editor/tests/integration/e2e/timeseries/multichannel.cy.ts
@@ -133,15 +133,11 @@ describe("MultiChannel", () => {
     // Config with one outside channel for comparison and MultiChannel with showYAxis=false
     const config = multiChannwlCnfig.replace(
       "<MultiChannel>",
-      '<Channel column="velocity" legend="Standalone"/><MultiChannel showYAxis="false">'
+      '<Channel column="velocity" legend="Standalone"/><MultiChannel showYAxis="false">',
     );
 
     cy.log("Initialize MultiChannel TimeSeries for alignment reproduction");
-    LabelStudio.params()
-      .config(config)
-      .data(multiChannelSampleData)
-      .withResult([])
-      .init();
+    LabelStudio.params().config(config).data(multiChannelSampleData).withResult([]).init();
 
     LabelStudio.waitForObjectsReady();
     TimeSeries.waitForReady();
@@ -150,15 +146,19 @@ describe("MultiChannel", () => {
     TimeSeries.paths.should("have.length.greaterThan", 0);
 
     // Get the first plot (Sensor A / Standalone)
-    cy.get('.htx-timeseries-channel:not(.htx-timeseries-multichannel *) path').first().then($pathA => {
-        const d_A = $pathA.attr('d');
-        const firstPointA_X = parseFloat(d_A.substring(1).split(',')[0]);
-        
+    cy.get(".htx-timeseries-channel:not(.htx-timeseries-multichannel *) path")
+      .first()
+      .then(($pathA) => {
+        const d_A = $pathA.attr("d");
+        const firstPointA_X = Number.parseFloat(d_A.substring(1).split(",")[0]);
+
         // Get the path for channel inside MultiChannel
-        cy.get('.htx-timeseries-multichannel path').first().then($pathB => {
-            const d_B = $pathB.attr('d');
-            const firstPointB_X = parseFloat(d_B.substring(1).split(',')[0]);
-            
+        cy.get(".htx-timeseries-multichannel path")
+          .first()
+          .then(($pathB) => {
+            const d_B = $pathB.attr("d");
+            const firstPointB_X = Number.parseFloat(d_B.substring(1).split(",")[0]);
+
             cy.log(`Sensor A First Point X: ${firstPointA_X}`);
             cy.log(`Sensor B First Point X: ${firstPointB_X}`);
 
@@ -168,7 +168,7 @@ describe("MultiChannel", () => {
 
             // Tolerance of 1px
             expect(firstPointB_X, `Mismatch! A: ${firstPointA_X}, B: ${firstPointB_X}`).to.be.closeTo(firstPointA_X, 1);
-        });
-    });
+          });
+      });
   });
 });

--- a/web/libs/editor/tests/integration/e2e/timeseries/multichannel.cy.ts
+++ b/web/libs/editor/tests/integration/e2e/timeseries/multichannel.cy.ts
@@ -129,4 +129,46 @@ describe("MultiChannel", () => {
       cy.log("Channel visibility toggling works correctly");
     });
   });
+  it("should align MultiChannel x-axis with standard Channel", () => {
+    // Config with one outside channel for comparison and MultiChannel with showYAxis=false
+    const config = multiChannwlCnfig.replace(
+      "<MultiChannel>",
+      '<Channel column="velocity" legend="Standalone"/><MultiChannel showYAxis="false">'
+    );
+
+    cy.log("Initialize MultiChannel TimeSeries for alignment reproduction");
+    LabelStudio.params()
+      .config(config)
+      .data(multiChannelSampleData)
+      .withResult([])
+      .init();
+
+    LabelStudio.waitForObjectsReady();
+    TimeSeries.waitForReady();
+
+    // Verify paths are present
+    TimeSeries.paths.should("have.length.greaterThan", 0);
+
+    // Get the first plot (Sensor A / Standalone)
+    cy.get('.htx-timeseries-channel:not(.htx-timeseries-multichannel *) path').first().then($pathA => {
+        const d_A = $pathA.attr('d');
+        const firstPointA_X = parseFloat(d_A.substring(1).split(',')[0]);
+        
+        // Get the path for channel inside MultiChannel
+        cy.get('.htx-timeseries-multichannel path').first().then($pathB => {
+            const d_B = $pathB.attr('d');
+            const firstPointB_X = parseFloat(d_B.substring(1).split(',')[0]);
+            
+            cy.log(`Sensor A First Point X: ${firstPointA_X}`);
+            cy.log(`Sensor B First Point X: ${firstPointB_X}`);
+
+            if (Math.abs(firstPointB_X - firstPointA_X) > 1) {
+              console.error(`Mismatch! A: ${firstPointA_X}, B: ${firstPointB_X}`);
+            }
+
+            // Tolerance of 1px
+            expect(firstPointB_X, `Mismatch! A: ${firstPointA_X}, B: ${firstPointB_X}`).to.be.closeTo(firstPointA_X, 1);
+        });
+    });
+  });
 });


### PR DESCRIPTION
### Problem
MultiChannel visualization introduced an incorrect left margin even when showYAxis was false, causing misalignment with other channels.

### Solution
Updated margin calculation in MultiChannel.jsx to respect showYAxis setting.

### Verification
Added regression test in multichannel.cy.ts that verifies pixel-perfect alignment between MultiChannel and standard Channel.

**Misaligned (Before)**
<img width="2560" height="1440" alt="multichannel_misaligned" src="https://github.com/user-attachments/assets/071ff27c-0b7f-43df-9165-99b5647c0cdd" />

**Aligned (After)**
<img width="2560" height="1440" alt="multichannel_aligned" src="https://github.com/user-attachments/assets/19b2194f-17a4-4d92-b027-f24ea919dd5b" />

