### PR TITLE
fix: FIT-1332: Store and dispose onSnapshot subscriptions in beforeDestroy

### DIFF
--- a/web/libs/editor/src/stores/Annotation/Annotation.js
+++ b/web/libs/editor/src/stores/Annotation/Annotation.js
@@ -372,6 +372,8 @@ const _Annotation = types
     submissionStarted: 0,
     versions: {},
     resultSnapshot: "",
+    // Disposer function for onSnapshot subscription - must be called in beforeDestroy
+    _snapshotDisposer: null,
   }))
   .volatile(() =>
     isFF(FF_DEV_3391)
@@ -791,7 +793,9 @@ const _Annotation = types
         { leading: false },
       );
 
-      onSnapshot(self.areas, self.autosave);
+      // Store the disposer so we can clean up in beforeDestroy
+      // This prevents memory leaks from dangling MobX subscriptions
+      self._snapshotDisposer = onSnapshot(self.areas, self.autosave);
     }),
 
     async saveDraft(params) {
@@ -836,7 +840,15 @@ const _Annotation = types
     },
 
     beforeDestroy() {
+      // Cancel the throttled autosave function
       self.autosave?.cancel?.();
+
+      // Dispose the onSnapshot subscription to prevent memory leaks
+      // and avoid warnings when areas are destroyed
+      if (self._snapshotDisposer) {
+        self._snapshotDisposer();
+        self._snapshotDisposer = null;
+      }
     },
 
     setDraftId(id) {

--- a/web/libs/editor/src/stores/SettingsStore.js
+++ b/web/libs/editor/src/stores/SettingsStore.js
@@ -74,6 +74,10 @@ const SettingsModel = types
 
     invertedZoom: types.optional(types.boolean, false),
   })
+  .volatile(() => ({
+    // Disposer function for onSnapshot subscription - must be called in beforeDestroy
+    _snapshotDisposer: null,
+  }))
   .views((self) => ({
     get annotation() {
       return getRoot(self).annotationStore.selected;
@@ -88,6 +92,12 @@ const SettingsModel = types
   .actions((self) => ({
     beforeDestroy() {
       self.isDestroying = true;
+
+      // Dispose the onSnapshot subscription to prevent memory leaks
+      if (self._snapshotDisposer) {
+        self._snapshotDisposer();
+        self._snapshotDisposer = null;
+      }
     },
     afterCreate() {
       // sandboxed environment may break even on check of this property
@@ -125,7 +135,8 @@ const SettingsModel = types
       }
 
       // capture changes and save it
-      onSnapshot(self, (ss) => {
+      // Store the disposer so we can clean up in beforeDestroy
+      self._snapshotDisposer = onSnapshot(self, (ss) => {
         // it's necessary to wait 1 tick before check if self.isDestroying is true
         setTimeout(() => {
           if (!self.isDestroying) localStorage.setItem(lsKey, JSON.stringify(ss));


### PR DESCRIPTION
## Problem

`onSnapshot()` subscriptions in `Annotation.js` and `SettingsStore.js` are never disposed. This keeps references to destroyed stores alive and causes memory leaks when navigating between tasks.

## Solution

Store the disposer returned by `onSnapshot()` and call it in `beforeDestroy()`:
- Add `_snapshotDisposer` property to store the disposer function
- Call `_snapshotDisposer()` in `beforeDestroy()` hook
- Properly cleans up subscriptions before store destruction

## Files Changed

- `web/libs/editor/src/stores/Annotation/Annotation.js`
- `web/libs/editor/src/stores/SettingsStore.js`

## Jira

[FIT-1332](https://humansignal.atlassian.net/browse/FIT-1332)

Made with [Cursor](https://cursor.com)

[FIT-1332]: https://humansignal.atlassian.net/browse/FIT-1332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ