### PR TITLE
fix: FIT-1316: don't leak CurrentContext across RQ jobs

### DIFF
--- a/label_studio/core/redis.py
+++ b/label_studio/core/redis.py
@@ -189,11 +189,10 @@ def start_job_async_or_sync(job, *args, in_seconds=0, **kwargs):
         try:
             context_data = _capture_context()
 
-            if context_data:
-                meta = kwargs.get('meta', {})
-                # Store context data in job meta for worker access
-                meta.update(context_data)
-                kwargs['meta'] = meta
+            meta = kwargs.get('meta', {})
+            # Store context data in job meta for worker access
+            meta.update(context_data)
+            kwargs['meta'] = meta
         except Exception:
             logger.info(f'Failed to capture context for job {job.__name__} on queue {queue_name}')
 


### PR DESCRIPTION
Was seeing in develop that FSM history was not showing after this backfill because it was filtered out by organization, because the backfill was completed with the wrong organization_id being set! This affects all FSM functions that run on RQ and have empty context, since it doesn't get reset properly when the context is empty.
<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
