### PR TITLE
fix: FIT-1333: Exempt assigned tasks from strict overlap enforcement

### DIFF
--- a/label_studio/projects/functions/next_task.py
+++ b/label_studio/projects/functions/next_task.py
@@ -230,7 +230,7 @@ def get_not_solved_tasks_qs(
     # Note: Only applies to annotators and reviewers - managers and admins can access all tasks
     # Note: Postponed tasks are NOT filtered here - they are served with overlap_reached flag
     # so users can see their work and understand why they can't submit
-    if flag_set('fflag_feat_all_fit_1304_strict_overlap', user=user):
+    if flag_set('fflag_feat_all_fit_1304_strict_overlap', user=user) and not assigned_flag:
         lse_project = getattr(project, 'lse_project', None)
         is_restricted_role = getattr(user, 'is_annotator', False) or getattr(user, 'is_reviewer', False)
         if lse_project and getattr(lse_project, 'strict_task_overlap', False) and is_restricted_role:


### PR DESCRIPTION
This pull request makes a targeted change to the logic that determines how tasks are filtered for users based on feature flags and assignment status. The update ensures that the strict overlap logic is only applied when the user does not already have an assigned task.

Task filtering logic update:

* Updated the condition in `get_not_solved_tasks_qs` (in `label_studio/projects/functions/next_task.py`) to check that `assigned_flag` is not set before applying the strict overlap feature flag logic. This prevents unnecessary restriction for users who already have an assigned task.