### PR TITLE
fix: FIT-1350: Playground image segmentation tags

### DIFF
--- a/web/libs/editor/src/mixins/Tool.js
+++ b/web/libs/editor/src/mixins/Tool.js
@@ -56,7 +56,7 @@ const ToolMixin = types
     },
 
     get getSelectedShape() {
-      return self.control.annotation.highlightedNode;
+      return self.control?.annotation?.highlightedNode;
     },
 
     get extraShortcuts() {
@@ -106,7 +106,7 @@ const ToolMixin = types
      */
     shouldSkipInteractions(e) {
       const isCtrlPressed = e.evt && (e.evt.metaKey || e.evt.ctrlKey);
-      const hasSelection = self.control.annotation.hasSelection;
+      const hasSelection = self.control?.annotation?.hasSelection;
 
       return !!isCtrlPressed && !hasSelection;
     },


### PR DESCRIPTION
<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
### Reason for change

This PR fixes a crash in the playground when using image segmentation tags (e.g., `BitmaskLabels`, `BrushLabels`, `Brush`). The error `Cannot read properties of null (reading 'highlightedNode')` occurred in `web/libs/editor/src/mixins/Tool.js` because `self.control.annotation` was accessed without null checks. In the playground context, `self.control` can be null or undefined during initialization, leading to a crash and preventing the image from rendering.

### Solution

Added optional chaining (`?.`) to safely access `self.control.annotation` in `web/libs/editor/src/mixins/Tool.js` at two locations:
- `getSelectedShape` getter (line 59)
- `shouldSkipInteractions` method (line 109)

This ensures that the application does not crash if `self.control` or `self.control.annotation` is not yet initialized.

### Screenshots

**Before (Crash):**
(Imagine a screenshot showing a blank or error state in the playground when using segmentation tools)

**After (Working):**
(Imagine a screenshot showing the playground with an image loaded and segmentation tools active without crashing)

### Rollout strategy

Standard deployment. No feature flags or special rollout required.

### Testing

1.  Open the playground.
2.  Load an image.
3.  Select an image segmentation tag (e.g., `BrushLabels`).
4.  Verify that the image renders correctly and the segmentation tools can be used without crashing.

### Risks

Low risk. The change involves adding null-safe accessors, which should not introduce new bugs but rather prevent existing crashes.

### Reviewer notes

Please pay attention to the two lines where optional chaining was added to ensure it correctly addresses the null reference issue without unintended side effects.

### General notes

This fix specifically targets the playground environment where the `control` object might not be fully initialized when `Tool.js` methods are first accessed.

---
[Slack Thread](https://humansignal.slack.com/archives/C03DQ8U76PP/p1770050416032449?thread_ts=1770050416.032449&cid=C03DQ8U76PP)

<a href="https://cursor.com/background-agent?bcId=bc-180c6152-b5d9-4dfb-867d-4889f427fa80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-180c6152-b5d9-4dfb-867d-4889f427fa80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

