### PR TITLE
fix: FIT-87: AutoComplete option modal is wider than before

### DIFF
--- a/web/libs/ui/src/lib/code-editor/code-editor.module.scss
+++ b/web/libs/ui/src/lib/code-editor/code-editor.module.scss
@@ -129,6 +129,7 @@
 
   // Create Project modal has z-index: 10000, so we have to overrule it
   z-index: 11000;
+  max-width: 600px;
 }
 
 :global(.CodeMirror-hints .CodeMirror-hint) {


### PR DESCRIPTION
This pull request makes a minor style adjustment to the code editor component to improve its layout. The change sets a maximum width for the editor's container to ensure it does not expand beyond 600px.

* Added `max-width: 600px;` to the `.code-editor-container` class in `code-editor.module.scss` to limit the editor's width.

## Screenshots
### Before
<img width="1677" height="698" alt="image" src="https://github.com/user-attachments/assets/64e64368-2715-426e-9c54-fcea1e926b0b" />

### After
<img width="795" height="749" alt="image" src="https://github.com/user-attachments/assets/7d07022b-3deb-4c46-8690-8d2665958201" />


<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
