### PR TITLE
docs: Add LSE indicator  and notes to audio templates

### DIFF
--- a/docs/source/tags/audio.md
+++ b/docs/source/tags/audio.md
@@ -8,6 +8,11 @@ meta_description: Customize Label Studio with the Audio tag for advanced audio a
 
 The Audio tag plays audio and shows its waveform. Use for audio annotation tasks where you want to label regions of audio, see the waveform, and manipulate audio during annotation.
 
+!!! error Enterprise
+    If you're managing more complex or high-volume audio labeling projects, Label Studio Enterprise includes an advanced audio transcription interface built to support faster, more precise annotation at scale.
+
+    See our new [Multi-Channel Audio Transcription](/templates/react_audio) template and learn more in [Blog - A New Audio Transcription UI for Speed and Quality at Scale](https://humansignal.com/blog/building-a-better-ui-for-audio-transcription-at-scale/).
+
 Use with the following data types: audio
 
 {% insertmd includes/tags/audio.md %}

--- a/docs/source/tags/reactcode.md
+++ b/docs/source/tags/reactcode.md
@@ -14,7 +14,7 @@ You can use it to bring an external application that you have already created, o
 Importantly, this allows you to continue leveraging Label Studio's annotation management, review workflows, and data export capabilities.
 
 !!! error Enterprise
-    This tag is only available for Label Studio Enterprise users.
+    This tag is only available for Label Studio Enterprise users. For more information, see [Programmable & Embeddable Interfaces](https://humansignal.com/programmable-ui/).
 
 ## Parameters
 

--- a/docs/source/templates/audio_classification.md
+++ b/docs/source/templates/audio_classification.md
@@ -12,6 +12,11 @@ meta_description: Template for classifying audio and intent using Label Studio f
 
 If you want to perform audio classification tasks, such as intent or sentiment classification, you can use this template to listen to an audio file and classify the topic of the clip.
 
+!!! error Enterprise
+    If you're managing more complex or high-volume audio labeling projects, Label Studio Enterprise includes an advanced audio transcription interface built to support faster, more precise annotation at scale.
+
+    See our new [Multi-Channel Audio Transcription](react_audio) template and learn more in [A New Audio Transcription UI for Speed and Quality at Scale](https://humansignal.com/blog/building-a-better-ui-for-audio-transcription-at-scale/) (blog post).
+
 ## Interactive Template Preview
 
 <div id="main-preview"></div>

--- a/docs/source/templates/audio_regions.md
+++ b/docs/source/templates/audio_regions.md
@@ -12,6 +12,11 @@ meta_description: Template for classifying audio regions for segmentation tasks 
 
 If you want to perform audio classification tasks on specific segments of audio clips, you can use this template to listen to an audio file and classify the topic of the clip.
 
+!!! error Enterprise
+    If you're managing more complex or high-volume audio labeling projects, Label Studio Enterprise includes an advanced audio transcription interface built to support faster, more precise annotation at scale.
+
+    See our new [Multi-Channel Audio Transcription](react_audio) template and learn more in [A New Audio Transcription UI for Speed and Quality at Scale](https://humansignal.com/blog/building-a-better-ui-for-audio-transcription-at-scale/) (blog post).
+
 ## Interactive Template Preview
 
 <div id="main-preview"></div>

--- a/docs/source/templates/automatic_speech_recognition_segments.md
+++ b/docs/source/templates/automatic_speech_recognition_segments.md
@@ -12,6 +12,11 @@ meta_description: Template for audio transcription for automatic speech recognit
 
 Listen to an audio file and segment it, then transcribe the contents of each segment in natural language, performing speech recognition using segments.
 
+!!! error Enterprise
+    If you're managing more complex or high-volume audio labeling projects, Label Studio Enterprise includes an advanced audio transcription interface built to support faster, more precise annotation at scale.
+
+    See our new [Multi-Channel Audio Transcription](react_audio) template and learn more in [A New Audio Transcription UI for Speed and Quality at Scale](https://humansignal.com/blog/building-a-better-ui-for-audio-transcription-at-scale/) (blog post).
+
 ## Interactive Template Preview
 
 <div id="main-preview"></div>

--- a/docs/source/templates/chat_eval.md
+++ b/docs/source/templates/chat_eval.md
@@ -1,5 +1,5 @@
 ---
-title: Fine-tune an Agent without an LLM
+title: Fine-tune an Agent without an LLM 🔒
 type: templates
 category: Chat
 cat: Chat

--- a/docs/source/templates/chat_llm_eval.md
+++ b/docs/source/templates/chat_llm_eval.md
@@ -1,5 +1,5 @@
 ---
-title: Fine-Tune an Agent with an LLM
+title: Fine-Tune an Agent with an LLM 🔒
 type: templates
 category: LLM Fine-tuning
 cat: llm-fine-tuning

--- a/docs/source/templates/chat_red_team.md
+++ b/docs/source/templates/chat_red_team.md
@@ -1,5 +1,5 @@
 ---
-title: Red-Teaming in Chat
+title: Red-Teaming in Chat 🔒
 type: templates
 category: Chat
 cat: Chat

--- a/docs/source/templates/chat_rlhf.md
+++ b/docs/source/templates/chat_rlhf.md
@@ -1,5 +1,5 @@
 ---
-title: Evaluate Production Conversations for RLHF
+title: Evaluate Production Conversations for RLHF 🔒
 type: templates
 category: Chat
 cat: Chat

--- a/docs/source/templates/chatbot.md
+++ b/docs/source/templates/chatbot.md
@@ -1,5 +1,5 @@
 ---
-title: Chatbot Evaluation
+title: Chatbot Evaluation 🔒
 type: templates
 category: Chat
 cat: Chat

--- a/docs/source/templates/contextual_scrolling.md
+++ b/docs/source/templates/contextual_scrolling.md
@@ -12,6 +12,11 @@ meta_description: Template annotating transcriptions in their audio context.
 
 Playback synchronization between audio and corresponding paragraph segments provides you with enhanced context and control resulting in high-quality annotated datasets and increased productivity when performing conversational analysis.
 
+!!! error Enterprise
+    If you're managing more complex or high-volume audio labeling projects, Label Studio Enterprise includes an advanced audio transcription interface built to support faster, more precise annotation at scale.
+
+    See our new [Multi-Channel Audio Transcription](react_audio) template and learn more in [A New Audio Transcription UI for Speed and Quality at Scale](https://humansignal.com/blog/building-a-better-ui-for-audio-transcription-at-scale/) (blog post).
+
 ## Labeling Configuration
 
 ```html

--- a/docs/source/templates/get_started.md
+++ b/docs/source/templates/get_started.md
@@ -16,6 +16,10 @@ Need a hand with customizing our templates? Check out [our documentation on the 
 
 <a class="button" href="index.html">See all templates!</a>
 
+## Enterprise-only templates
+
+Templates with the lock emoji 🔒 next to their name are only available for Label Studio Enterprise users. 
+
 ## Template components
 
 Templates use tags to do the following:

--- a/docs/source/templates/pdf_ocr.md
+++ b/docs/source/templates/pdf_ocr.md
@@ -1,5 +1,5 @@
 ---
-title: OCR Labeling for PDFs
+title: OCR Labeling for PDFs 🔒
 type: templates
 category: Computer Vision
 cat: computer-vision
@@ -17,7 +17,7 @@ Each region stores normalized coordinates, rotation, and a page index, making ou
 Ideal for document intelligence, QA on OCR output, and structured data capture workflows. 
 
 !!! error Enterprise
-    This template can only be used with in Label Studio Enterprise.
+    This template requires the `OcrLabels` tag, which can only be used in Label Studio Enterprise.
 
 ![Screenshot](/images/templates-misc/pdf-opossum.png)
 

--- a/docs/source/templates/react_audio.md
+++ b/docs/source/templates/react_audio.md
@@ -22,7 +22,7 @@ The example labeling configuration creates a split-screen interface with:
 !!! error Enterprise
     This template and the `ReactCode` tag can only be used in Label Studio Enterprise.
 
-    For more information, including simplified code examples, see [ReactCode](/tags/reactcode).
+    For more information, see [Programmable & Embeddable Interfaces](https://humansignal.com/programmable-ui/). 
 
 ## Labeling configuration
 

--- a/docs/source/templates/react_audio.md
+++ b/docs/source/templates/react_audio.md
@@ -1,8 +1,8 @@
 ---
-title: Multi-Channel Audio Transcription
+title: Multi-Channel Audio Transcription 🔒
 type: templates
 category: Programmable Interfaces
-order: 753
+order: 353
 is_new: t
 meta_title: Template for multi-channel audio transcription
 meta_description: Template that uses a custom UI to visualize and transcribe multiple audio channels 

--- a/docs/source/templates/react_claims.md
+++ b/docs/source/templates/react_claims.md
@@ -1,8 +1,8 @@
 ---
-title: Agentic Tracing for Claims
+title: Agentic Tracing for Claims 🔒
 type: templates
 category: Programmable Interfaces
-order: 756
+order: 356
 is_new: t
 meta_title: Template for agentic tracing
 meta_description: Template that uses a custom UI to trace agentic responses to insurance claims  

--- a/docs/source/templates/react_claims.md
+++ b/docs/source/templates/react_claims.md
@@ -28,7 +28,7 @@ Users can then label each step using custom ontologies (single-select dropdowns 
 !!! error Enterprise
     This template and the `ReactCode` tag can only be used in Label Studio Enterprise.
 
-    For more information, including simplified code examples, see [ReactCode](/tags/reactcode).
+    For more information, see [Programmable & Embeddable Interfaces](https://humansignal.com/programmable-ui/).
 
 ## Labeling configuration
 

--- a/docs/source/templates/react_spreadsheet.md
+++ b/docs/source/templates/react_spreadsheet.md
@@ -24,7 +24,7 @@ The labeling interface provides a full-featured spreadsheet experience with capa
 !!! error Enterprise
     This template and the `ReactCode` tag can only be used in Label Studio Enterprise.
 
-    For more information, including simplified code examples, see [ReactCode](/tags/reactcode).
+    For more information, see [Programmable & Embeddable Interfaces](https://humansignal.com/programmable-ui/).
 
 ## Labeling configuration
 

--- a/docs/source/templates/react_spreadsheet.md
+++ b/docs/source/templates/react_spreadsheet.md
@@ -1,8 +1,8 @@
 ---
-title: Spreadsheet Editor
+title: Spreadsheet Editor 🔒
 type: templates
 category: Programmable Interfaces
-order: 750
+order: 350
 is_new: t
 meta_title: Template for spreadsheet editing
 meta_description: Template that uses a custom UI to edit a spreadsheet and then output any changes. 

--- a/docs/source/templates/speaker_segmentation.md
+++ b/docs/source/templates/speaker_segmentation.md
@@ -12,6 +12,11 @@ meta_description: Template for segmenting an audio clip based on speaker with La
 
 When preparing audio transcripts or training a machine learning model to differentiate between different speakers, use this template to perform speaker segmentation and label different regions of an audio clip with different speakers. 
 
+!!! error Enterprise
+    If you're managing more complex or high-volume audio labeling projects, Label Studio Enterprise includes an advanced audio transcription interface built to support faster, more precise annotation at scale.
+
+    See our new [Multi-Channel Audio Transcription](react_audio) template and learn more in [A New Audio Transcription UI for Speed and Quality at Scale](https://humansignal.com/blog/building-a-better-ui-for-audio-transcription-at-scale/) (blog post).
+
 ## Interactive Template Preview
 
 <div id="main-preview"></div>

--- a/docs/source/templates/transcribe_audio.md
+++ b/docs/source/templates/transcribe_audio.md
@@ -12,6 +12,11 @@ meta_description: Template for audio transcription for automatic speech recognit
 
 Listen to an audio file and transcribe its content in natural language, performing speech recognition.
 
+!!! error Enterprise
+    If you're managing more complex or high-volume audio labeling projects, Label Studio Enterprise includes an advanced audio transcription interface built to support faster, more precise annotation at scale.
+
+    See our new [Multi-Channel Audio Transcription](react_audio) template and learn more in [A New Audio Transcription UI for Speed and Quality at Scale](https://humansignal.com/blog/building-a-better-ui-for-audio-transcription-at-scale/) (blog post).
+
 ## Interactive Template Preview
 
 <div id="main-preview"></div>


### PR DESCRIPTION
- Added an emoji next to the TOC titles of LSE-only templates
- Moved ReactCode templates higher in the TOC
- Added a Enterprise callout to some select audio templates