### PR TITLE
fix: FIT-720: Avoid loading all annotations in LabelStream when the user is admin and goes to previous tasks

### DIFF
--- a/web/libs/editor/src/tags/object/Image/ImageEntity.js
+++ b/web/libs/editor/src/tags/object/Image/ImageEntity.js
@@ -234,9 +234,8 @@ export const ImageEntity = types
               self.markAsLoaded(result.blobUrl, { addCacheRef: true });
             })
             .catch(() => {
-              // Final failure - set error state
-              self.error = true;
-              self.setDownloading(false);
+              // Final failure - set error state (async-safe via action)
+              self.markAsFailed();
             });
           return;
         }


### PR DESCRIPTION
This pull request refactors the error handling logic in the `ImageEntity` model to improve state management when image loading fails.

Error handling improvements:

* Replaces direct state mutation (`self.error = true; self.setDownloading(false);`) with a single, async-safe method call to `self.markAsFailed()` in the image loading failure path of `ImageEntity.js`.