### PR TITLE
Fb echo 423/modal context

### DIFF
--- a/web/libs/ui/src/lib/modal/ModalBody.tsx
+++ b/web/libs/ui/src/lib/modal/ModalBody.tsx
@@ -1,10 +1,6 @@
 import type { PropsWithChildren } from "react";
-import { Elem } from "./ModalContext";
+import { cnb as cn } from "@humansignal/core/lib/utils/bem";
 
 export const ModalBody = ({ bare, children }: PropsWithChildren<{ bare?: boolean }>) => {
-  return (
-    <Elem name="body" mod={{ bare }}>
-      {children}
-    </Elem>
-  );
+  return <div className={cn("modal-ls").elem("body").mod({ bare }).toClassName()}>{children}</div>;
 };

--- a/web/libs/ui/src/lib/modal/ModalContext.tsx
+++ b/web/libs/ui/src/lib/modal/ModalContext.tsx
@@ -1,3 +1,0 @@
-import { BemWithSpecificContext } from "@humansignal/core";
-
-export const { Block, Elem } = BemWithSpecificContext();

--- a/web/libs/ui/src/lib/modal/ModalFooter.tsx
+++ b/web/libs/ui/src/lib/modal/ModalFooter.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties, PropsWithChildren } from "react";
-import { Elem } from "./ModalContext";
+import { cnb as cn } from "@humansignal/core/lib/utils/bem";
 
 type ModalFooterProps = PropsWithChildren<{
   bare?: boolean;
@@ -8,7 +8,7 @@ type ModalFooterProps = PropsWithChildren<{
 }>;
 
 export const ModalFooter = ({ children, bare, style, className }: ModalFooterProps) => (
-  <Elem name="footer" mod={{ bare }} mix={className} style={style}>
+  <div className={cn("modal-ls").elem("footer").mod({ bare }).mix(className).toClassName()} style={style}>
     {children}
-  </Elem>
+  </div>
 );

--- a/web/libs/ui/src/lib/modal/ModalHeader.tsx
+++ b/web/libs/ui/src/lib/modal/ModalHeader.tsx
@@ -1,5 +1,5 @@
 import type { PropsWithChildren } from "react";
-import { Elem } from "./ModalContext";
+import { cnb as cn } from "@humansignal/core/lib/utils/bem";
 
 type ModalHeaderProps = PropsWithChildren<{
   /**
@@ -9,9 +9,5 @@ type ModalHeaderProps = PropsWithChildren<{
 }>;
 
 export const ModalHeader = ({ children, divided }: ModalHeaderProps) => {
-  return (
-    <Elem name="header" mod={{ divided }}>
-      {children}
-    </Elem>
-  );
+  return <div className={cn("modal-ls").elem("header").mod({ divided }).toClassName()}>{children}</div>;
 };

--- a/web/libs/ui/src/lib/modal/ModalPopup.tsx
+++ b/web/libs/ui/src/lib/modal/ModalPopup.tsx
@@ -4,7 +4,6 @@ import { cnb as cn } from "@humansignal/core/lib/utils/bem";
 import { isDefined } from "@humansignal/core/lib/utils/helpers";
 import { aroundTransition } from "@humansignal/core/lib/utils/transition";
 import { setRef } from "@humansignal/core/lib/utils/unwrapRef";
-import { Block, Elem } from "./ModalContext";
 import { ModalBody } from "./ModalBody";
 import { ModalCloseButton } from "./ModalCloseButton";
 import { ModalFooter } from "./ModalFooter";
@@ -56,7 +55,7 @@ export class Modal<BP = unknown> extends Component<ModalProps<BP>, ModalState> {
   static Body = ModalBody;
   static CloseButton = ModalCloseButton;
 
-  modalRef = createRef<HTMLElement>();
+  modalRef = createRef<HTMLDivElement>();
   mouseDownTarget: HTMLElement | null = null;
 
   constructor(props: ModalProps<BP>) {
@@ -130,8 +129,6 @@ export class Modal<BP = unknown> extends Component<ModalProps<BP>, ModalState> {
     };
     const styles: Record<string, string | number> = {};
 
-    const mixes = [this.transitionClass, this.props.className];
-
     const modalSizeStyle: React.CSSProperties = {};
 
     if (this.props.width) modalSizeStyle.width = this.props.width;
@@ -149,33 +146,42 @@ export class Modal<BP = unknown> extends Component<ModalProps<BP>, ModalState> {
       }
     }
 
+    const blockClassName = [
+      cn("modal-ls").mod(mods).mix(this.transitionClass, this.props.className).toClassName(),
+      this.props.rawClassName,
+    ]
+      .filter(Boolean)
+      .join(" ");
+
     const modalContent = (
       <ModalContext.Provider value={this}>
-        <Block
-          name="modal-ls"
+        <div
           ref={(el) => setRef(this.modalRef, el)}
-          mod={mods}
-          mix={mixes}
+          className={blockClassName}
           onMouseDown={this.onMouseDown}
           onClick={this.onClickOutside}
           data-testid={this.props["data-testid"]}
           style={styles}
-          rawClassName={this.props.rawClassName}
         >
-          <Elem name="wrapper">
-            <Elem name="content" style={Object.assign({}, this.props.style, modalSizeStyle)}>
+          <div className={cn("modal-ls").elem("wrapper").toClassName()}>
+            <div
+              className={cn("modal-ls").elem("content").toClassName()}
+              style={Object.assign({}, this.props.style, modalSizeStyle)}
+            >
               {!bare && (
                 <ModalHeader>
                   <ModalTitle>{this.props.title}</ModalTitle>
-                  {this.props.header && <Elem name="header-content">{this.props.header}</Elem>}
+                  {this.props.header && (
+                    <div className={cn("modal-ls").elem("header-content").toClassName()}>{this.props.header}</div>
+                  )}
                   {this.props.allowClose !== false && <ModalCloseButton />}
                 </ModalHeader>
               )}
               <ModalBody bare={bare}>{this.body}</ModalBody>
               {this.props.footer && <ModalFooter bare={this.props.bareFooter}>{this.footer}</ModalFooter>}
-            </Elem>
-          </Elem>
-        </Block>
+            </div>
+          </div>
+        </div>
       </ModalContext.Provider>
     );
 

--- a/web/libs/ui/src/lib/modal/ModalTitle.tsx
+++ b/web/libs/ui/src/lib/modal/ModalTitle.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren } from "react";
-import { Elem } from "./ModalContext";
+import { cnb as cn } from "@humansignal/core/lib/utils/bem";
 
 export const ModalTitle = ({ children }: PropsWithChildren) => {
-  return <Elem name="title">{children}</Elem>;
+  return <div className={cn("modal-ls").elem("title").toClassName()}>{children}</div>;
 };


### PR DESCRIPTION
# BEM Migration: Modal and Form Components

## Summary
Completes the BEM migration by replacing the last `Block` and `Elem` components with the `cn()` helper function. This PR removes the `ModalContext` files from both repos as they are no longer needed.

## Changes

### Open-source (`label-studio/web`)
| File | Change |
|------|--------|
| `libs/ui/src/lib/modal/ModalPopup.tsx` | Replace `<Block name="modal-ls">` and `<Elem>` with `div` + `cn()` |
| `libs/ui/src/lib/modal/ModalBody.tsx` | Replace `<Elem name="body">` with `div` + `cn()` |
| `libs/ui/src/lib/modal/ModalHeader.tsx` | Replace `<Elem name="header">` with `div` + `cn()` |
| `libs/ui/src/lib/modal/ModalFooter.tsx` | Replace `<Elem name="footer">` with `div` + `cn()` |
| `libs/ui/src/lib/modal/ModalTitle.tsx` | Replace `<Elem name="title">` with `div` + `cn()` |
| `libs/ui/src/lib/modal/ModalContext.tsx` | **Deleted** - no longer needed |

### Enterprise (`label-studio-enterprise/web`)
| File | Change |
|------|--------|
| `components/Form/FormField.tsx` | Replace `<Elem block="form">` with `div` + `cn()` |
| `components/Form/FormBuilder.tsx` | Replace `<Elem block="form">` with `div` + `cn()` |
| `components/Form/Elements/TextArea/TextArea.tsx` | Replace `<Block>` with native `<textarea>` + `cn()` |
| `components/Modal/ModalContext.ts` | **Deleted** - no longer needed |

## Before/After Example

```tsx
// Before
import { Block, Elem } from "./ModalContext";

<Block name="modal-ls" mod={mods}>
  <Elem name="wrapper">
    <Elem name="content">{children}</Elem>
  </Elem>
</Block>

// After
import { cn } from "@humansignal/core/lib/utils/bem";

<div className={cn("modal-ls").mod(mods).toClassName()}>
  <div className={cn("modal-ls").elem("wrapper").toClassName()}>
    <div className={cn("modal-ls").elem("content").toClassName()}>{children}</div>
  </div>
</div>
```

## Testing
- [x] Build passes (both repos)
- [x] Unit tests pass (117/117 in enterprise)
- [x] No linter errors
- [x] Generated HTML/CSS class names unchanged

## Visual Verification
All Modals should render identically:
- [ ] Settings modals
- [ ] Confirmation dialogs
- [ ] Form validation errors
- [ ] TextArea components

## Notes
- This completes the BEM migration for both repos
- No functional changes - only the method of generating class names
- Future cleanup: Remove unused `BemWithSpecificContext`, `Block`, `Elem` exports from `@humansignal/core`
