### PR TITLE
fix: FIT-1375: Prevent FSM leakage in update_task_states

### DIFF
--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -543,8 +543,9 @@ class Project(ProjectMixin, FsmHistoryStateModel):
 
         if tasks_number_changed:
             # FSM: Recalculate project state after task deletion or import
-            user = CurrentContext.get_user()
-            update_project_state_after_task_change(self, user=user)
+            if CurrentContext.is_fsm_enabled():
+                user = CurrentContext.get_user()
+                update_project_state_after_task_change(self, user=user)
 
     def _batch_update_with_retry(self, queryset, batch_size=500, max_retries=3, **update_fields):
         batch_update_with_retry(queryset, batch_size, max_retries, **update_fields)


### PR DESCRIPTION
### Problem
\`update_tasks_states\` was unconditionally calling FSM-related state updates (\`update_project_state_after_task_change\`), even when executed in a context where FSM is explicitly disabled (e.g., specific rqworker jobs). This caused \`FieldError\` ("Cannot resolve keyword 'current_state' into field") because the necessary fields/context were not available.

### Solution
Added a guard clause \`if CurrentContext.is_fsm_enabled():\` in \`label_studio/projects/models.py\`.

### Verification
- Verified that the call is now guarded.