### PR TITLE
fix: FIT-1378: Incorrect project state colours for In Review and Setup in Progress

### DIFF
--- a/web/libs/app-common/src/components/state-chips/state-registry.ts
+++ b/web/libs/app-common/src/components/state-chips/state-registry.ts
@@ -29,6 +29,7 @@ export enum StateType {
   IN_PROGRESS = "in_progress",
   ATTENTION = "attention",
   TERMINAL = "terminal",
+  VERIFICATION = "verification",
 }
 
 /**
@@ -59,6 +60,7 @@ const STATE_TYPE_STYLES: Record<StateType, string> = {
   [StateType.INITIAL]: "bg-neutral-emphasis border-neutral-border text-neutral-content",
   [StateType.IN_PROGRESS]: "bg-primary-emphasis border-primary-border-subtlest text-primary-content",
   [StateType.ATTENTION]: "bg-warning-emphasis border-warning-border-subtlest text-warning-content",
+  [StateType.VERIFICATION]: "bg-accent-plum-subtle border-accent-plum-subtle text-accent-plum-bold",
   [StateType.TERMINAL]: "bg-positive-emphasis border-positive-border-subtlest text-positive-content",
 };
 


### PR DESCRIPTION
This pull request adds support for a new state type, `VERIFICATION`, to the state chips component, including its associated styling. This update allows the component to visually represent the verification state consistently.

Enhancement to state chips:

* Added `VERIFICATION` to the `StateType` enum in `state-registry.ts`, enabling the new state to be used throughout the component.
* Defined custom styles for `VERIFICATION` in the `STATE_TYPE_STYLES` mapping, ensuring it has a distinct appearance in the UI.