### PR TITLE
Add notes field to relationships

### DIFF
--- a/docs/source/includes/result_format.md
+++ b/docs/source/includes/result_format.md
@@ -182,6 +182,15 @@ You can draw relation arrow between two objects. For example, object detection c
   "type": "relation",
   "to_id": "RQbW3Sj_Zr",
   "from_id": "oid66",
-  "direction": "right"
+  "direction": "right",
+  "labels": ["similar"],
+  "notes": "Optional free text notes about this relationship"
 }]
 ```
+
+The relation object can include:
+- `from_id`: ID of the first region
+- `to_id`: ID of the second region
+- `direction`: Direction of the relation arrow (`"left"`, `"right"`, or `"bi"` for bidirectional)
+- `labels`: Optional array of relation labels (if using `<Relations>` tag with `<Relation>` values)
+- `notes`: Optional free text notes about the relationship

--- a/web/libs/editor/src/components/SidePanels/DetailsPanel/Relations.scss
+++ b/web/libs/editor/src/components/SidePanels/DetailsPanel/Relations.scss
@@ -85,9 +85,11 @@
 
 .relation-meta {
   display: flex;
+  flex-direction: column;
+  gap: 8px;
   padding-left: 64px;
   padding-bottom: 5px;
-  align-items: center;
+  align-items: stretch;
 
   &__title {
     flex: none;
@@ -96,5 +98,27 @@
 
   &__select {
     flex: 1;
+  }
+
+  &__notes {
+    width: 100%;
+    padding: 8px;
+    border: 1px solid var(--color-neutral-border);
+    border-radius: 4px;
+    background-color: var(--color-neutral-background);
+    color: var(--color-neutral-content);
+    font-family: inherit;
+    font-size: 14px;
+    resize: vertical;
+    min-height: 48px;
+    
+    &:focus {
+      outline: none;
+      border-color: var(--color-primary-border);
+    }
+    
+    &::placeholder {
+      color: var(--color-neutral-content-subtle);
+    }
   }
 }

--- a/web/libs/editor/src/components/SidePanels/DetailsPanel/Relations.tsx
+++ b/web/libs/editor/src/components/SidePanels/DetailsPanel/Relations.tsx
@@ -162,6 +162,14 @@ const RelationMeta: FC<any> = observer(({ relation }) => {
     },
     [relation],
   );
+
+  const onNotesChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      relation.setNotes(e.target.value);
+    },
+    [relation],
+  );
+
   const options = useMemo(
     () =>
       children.map((c: any) => ({
@@ -180,6 +188,13 @@ const RelationMeta: FC<any> = observer(({ relation }) => {
         value={selectedValues}
         onChange={onChange}
         options={options}
+      />
+      <textarea
+        className={cn("relation-meta").elem("notes").toClassName()}
+        placeholder="Add notes..."
+        value={relation.notes}
+        onChange={onNotesChange}
+        rows={2}
       />
     </div>
   );

--- a/web/libs/editor/src/stores/Annotation/Annotation.js
+++ b/web/libs/editor/src/stores/Annotation/Annotation.js
@@ -1256,6 +1256,7 @@ const _Annotation = types
               `${obj.to_id}#${self.id}`,
               obj.direction,
               obj.labels,
+              obj.notes,
             );
           }
         }

--- a/web/libs/editor/src/stores/RelationStore.js
+++ b/web/libs/editor/src/stores/RelationStore.js
@@ -23,6 +23,9 @@ const Relation = types
 
     // labels
     labels: types.maybeNull(types.array(types.string)),
+
+    // notes (free text)
+    notes: types.optional(types.string, ""),
   })
   .volatile(() => ({
     showMeta: false,
@@ -100,6 +103,10 @@ const Relation = types
 
     setRelations(values) {
       self.labels = values;
+    },
+
+    setNotes(notes) {
+      self.notes = notes;
     },
   }));
 
@@ -212,18 +219,20 @@ const RelationStore = types
         };
 
         if (r.selectedValues) s.labels = r.selectedValues;
+        if (r.notes) s.notes = r.notes;
 
         return s;
       });
     },
 
-    deserializeRelation(node1, node2, direction, labels) {
+    deserializeRelation(node1, node2, direction, labels, notes) {
       const rl = self.addRelation(node1, node2);
 
       if (!rl) return; // duplicated relation
 
       rl.direction = direction;
       rl.labels = labels;
+      if (notes) rl.notes = notes;
     },
 
     toggleConnections() {

--- a/web/libs/editor/tests/integration/e2e/relations/notes.cy.ts
+++ b/web/libs/editor/tests/integration/e2e/relations/notes.cy.ts
@@ -1,0 +1,143 @@
+import { ImageView, LabelStudio, Relations, Sidebar } from "@humansignal/frontend-test/helpers/LSF";
+
+const config = `
+  <View>
+    <Image name="img" value="$image"></Image>
+    <RectangleLabels name="tag" toName="img">
+      <Label value="Region1" background="red"></Label>
+      <Label value="Region2" background="blue"></Label>
+    </RectangleLabels>
+    <Relations>
+      <Relation value="similar"/>
+      <Relation value="different"/>
+    </Relations>
+  </View>
+`;
+
+const image =
+  "https://htx-pub.s3.us-east-1.amazonaws.com/examples/images/nick-owuor-astro-nic-visuals-wDifg5xc9Z4-unsplash.jpg";
+
+const task = {
+  id: 1,
+  annotations: [
+    {
+      id: 1001,
+      result: [
+        {
+          id: "region1",
+          source: "$image",
+          from_name: "tag",
+          to_name: "img",
+          type: "rectanglelabels",
+          origin: "manual",
+          value: {
+            height: 10,
+            rotation: 0,
+            width: 12,
+            x: 20,
+            y: 20,
+            rectanglelabels: ["Region1"],
+          },
+        },
+        {
+          id: "region2",
+          source: "$image",
+          from_name: "tag",
+          to_name: "img",
+          type: "rectanglelabels",
+          origin: "manual",
+          value: {
+            height: 10,
+            rotation: 0,
+            width: 12,
+            x: 50,
+            y: 50,
+            rectanglelabels: ["Region2"],
+          },
+        },
+      ],
+    },
+  ],
+  predictions: [],
+  data: { image },
+};
+
+describe("Relations: Notes", () => {
+  it("Should allow adding notes to relations", () => {
+    LabelStudio.init({
+      config,
+      task,
+    });
+
+    ImageView.waitForImage();
+    Relations.hasRelations(0);
+
+    // Select the first region
+    Sidebar.toggleRegionSelection(0);
+
+    // Create a relation
+    Relations.toggleCreation();
+
+    // Select the second region
+    Sidebar.toggleRegionSelection(1);
+
+    // Check that the relation is created
+    Relations.hasRelations(1);
+
+    // Open the relation metadata panel
+    cy.get(".lsf-relations__item")
+      .first()
+      .trigger("mouseover")
+      .find('button[aria-label="Show Relation Labels"]')
+      .click({ force: true });
+
+    // Find and type in the notes textarea
+    cy.get(".lsf-relation-meta__notes").should("be.visible").type("This is a test note for the relation");
+
+    // Verify the note is saved in the serialized output
+    LabelStudio.serialize().then((result) => {
+      expect(result[2]).to.have.property("type", "relation");
+      expect(result[2]).to.have.property("notes", "This is a test note for the relation");
+    });
+  });
+
+  it("Should persist notes when reloading annotation", () => {
+    const taskWithNotes = {
+      ...task,
+      annotations: [
+        {
+          ...task.annotations[0],
+          result: [
+            ...task.annotations[0].result,
+            {
+              from_id: "region1",
+              to_id: "region2",
+              type: "relation",
+              direction: "right",
+              labels: ["similar"],
+              notes: "Persisted note content",
+            },
+          ],
+        },
+      ],
+    };
+
+    LabelStudio.init({
+      config,
+      task: taskWithNotes,
+    });
+
+    ImageView.waitForImage();
+    Relations.hasRelations(1);
+
+    // Open the relation metadata panel
+    cy.get(".lsf-relations__item")
+      .first()
+      .trigger("mouseover")
+      .find('button[aria-label="Show Relation Labels"]')
+      .click({ force: true });
+
+    // Verify the note is displayed
+    cy.get(".lsf-relation-meta__notes").should("be.visible").should("have.value", "Persisted note content");
+  });
+});


### PR DESCRIPTION
## Description

Adds optional free-text `notes` field to relationships between labeled regions.

### Changes

**State Management**
- Added `notes` field to Relation model (optional string, defaults to empty)
- Added `setNotes` action
- Updated serialize/deserialize to handle notes

**UI**
- Added textarea in relation metadata panel (appears below label selector when expanded)
- Placeholder: "Add notes..."
- Styled with theme variables, vertically resizable

**Data Format**
```json
{
  "type": "relation",
  "from_id": "region1",
  "to_id": "region2",
  "direction": "right",
  "labels": ["similar"],
  "notes": "Optional free text"
}
```

## Rollout strategy

No feature flag needed. Field is optional and backward compatible. Existing relations work unchanged.

## Testing

- Integration tests cover note creation and persistence across reloads
- Tests located in `web/libs/editor/tests/integration/e2e/relations/notes.cy.ts`

## Risks

None. Optional field, no breaking changes. Empty notes omitted from serialization.

## Reviewer notes

- TypeScript event handler properly typed as `React.ChangeEvent<HTMLTextAreaElement>`
- CSS uses existing theme variables for consistency
- Follows existing patterns in RelationStore and Relations component

## General notes

Files modified:
- `web/libs/editor/src/stores/RelationStore.js` - Model and actions
- `web/libs/editor/src/stores/Annotation/Annotation.js` - Deserialization
- `web/libs/editor/src/components/SidePanels/DetailsPanel/Relations.tsx` - UI
- `web/libs/editor/src/components/SidePanels/DetailsPanel/Relations.scss` - Styling
- `docs/source/includes/result_format.md` - Documentation
- Closes #5495 