### PR TITLE
fix: BROS-780: Fix custom tab detection after merge conflict

### DIFF
--- a/web/libs/editor/src/components/App/App.jsx
+++ b/web/libs/editor/src/components/App/App.jsx
@@ -303,6 +303,7 @@ class App extends Component {
                       currentEntity={as.selectedHistory ?? as.selected}
                       regions={as.selected.regionStore}
                       showComments={store.hasInterface("annotations:comments")}
+                      showCustomTab={hasTagInSidebar(as.selected)}
                       focusTab={store.commentStore.tooltipMessage ? "comments" : null}
                     >
                       {mainContent}


### PR DESCRIPTION
`showCustomTab()` detection was moved to a wrong branch in [merge commit](https://github.com/HumanSignal/label-studio/pull/9350/changes/863fd922aedaa9cb29cabfa2add9f7f37fc89858) for #9350 PR
This fix adds it back.