### PR TITLE
fix: FIT-720: Fix binary octet processing in image caching

### DIFF
--- a/.pre-commit-dev.yaml
+++ b/.pre-commit-dev.yaml
@@ -14,7 +14,7 @@ repos:
     rev: "v0.1.0"
     hooks:
       - id: biome-check
-        args: [ --config-path, ./web ]
+        args: [ --config-path, ./web, --diagnostic-level=error ]
         additional_dependencies: [ "@biomejs/biome@1.9.4" ]
         files: ^web/.*
   - repo: local

--- a/label_studio/data_manager/actions/experimental.py
+++ b/label_studio/data_manager/actions/experimental.py
@@ -165,6 +165,10 @@ def add_data_field(project, queryset, **kwargs):
     value = request.data.get('value')
     size = queryset.count()
 
+    # Save a task ID before the update, because queryset filters may no longer
+    # match after we modify the data field (e.g. changing the filtered column value).
+    first_task_id = queryset.values_list('id', flat=True).first()
+
     cast = {'String': str, 'Number': float, 'Expression': str}
     assert value_type in cast.keys()
     value = cast[value_type](value)
@@ -192,7 +196,13 @@ def add_data_field(project, queryset, **kwargs):
                 )
             )
 
-    project.summary.update_data_columns([queryset.first()])
+    # Fetch the task by saved ID since the original queryset filters
+    # may no longer match after the data field was modified.
+    if first_task_id is not None:
+        first_task = Task.objects.filter(id=first_task_id).first()
+        if first_task is not None:
+            project.summary.update_data_columns([first_task])
+
     return {'response_code': 200, 'detail': f'Updated {size} tasks'}
 
 

--- a/label_studio/io_storages/proxy_api.py
+++ b/label_studio/io_storages/proxy_api.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+import mimetypes
 import time
 from typing import Union
 from urllib.parse import unquote
@@ -245,6 +246,13 @@ class ResolveStorageUriAPIMixin:
                     {'error': 'Storage stream failed while proxying data', 'detail': 'Stream is None'},
                     status=status.HTTP_424_FAILED_DEPENDENCY,
                 )
+
+            # Detect content type from URI file extension as a safety net for all storage types
+            # when the storage returns a generic type like binary/octet-stream or application/octet-stream
+            if not content_type or 'octet-stream' in content_type:
+                guessed_type, _ = mimetypes.guess_type(uri)
+                if guessed_type:
+                    content_type = guessed_type
 
             # Create time-limited stream
             time_limited_stream = self.time_limited_chunker(stream)

--- a/label_studio/io_storages/s3/tests/test_resolve_s3_url.py
+++ b/label_studio/io_storages/s3/tests/test_resolve_s3_url.py
@@ -1,0 +1,104 @@
+"""Tests for resolve_s3_url content type handling.
+
+Verifies that presigned URLs include ResponseContentType based on file extension,
+so S3 returns the correct MIME type even if objects were uploaded without one.
+"""
+import unittest
+from unittest.mock import MagicMock
+
+from io_storages.s3.utils import resolve_s3_url
+
+
+class TestResolveS3UrlContentType(unittest.TestCase):
+    """Test that resolve_s3_url adds ResponseContentType to presigned URL params."""
+
+    def setUp(self):
+        self.mock_client = MagicMock()
+        self.mock_client.generate_presigned_url.return_value = 'https://bucket.s3.amazonaws.com/presigned'
+
+    def test_jpeg_gets_response_content_type(self):
+        """Presigned URL for .jpg should include ResponseContentType=image/jpeg"""
+        resolve_s3_url('s3://bucket/path/image.jpg', self.mock_client, presign=True)
+
+        call_args = self.mock_client.generate_presigned_url.call_args
+        params = call_args[1]['Params'] if 'Params' in call_args[1] else call_args[0][1] if len(call_args[0]) > 1 else call_args[1].get('Params')
+        assert params['ResponseContentType'] == 'image/jpeg'
+
+    def test_png_gets_response_content_type(self):
+        """Presigned URL for .png should include ResponseContentType=image/png"""
+        resolve_s3_url('s3://bucket/path/image.png', self.mock_client, presign=True)
+
+        call_args = self.mock_client.generate_presigned_url.call_args
+        params = call_args[1]['Params']
+        assert params['ResponseContentType'] == 'image/png'
+
+    def test_mp4_gets_response_content_type(self):
+        """Presigned URL for .mp4 should include ResponseContentType=video/mp4"""
+        resolve_s3_url('s3://bucket/videos/clip.mp4', self.mock_client, presign=True)
+
+        call_args = self.mock_client.generate_presigned_url.call_args
+        params = call_args[1]['Params']
+        assert params['ResponseContentType'] == 'video/mp4'
+
+    def test_unknown_extension_no_response_content_type(self):
+        """Presigned URL for unknown extension should NOT include ResponseContentType"""
+        resolve_s3_url('s3://bucket/data/file.xyz123', self.mock_client, presign=True)
+
+        call_args = self.mock_client.generate_presigned_url.call_args
+        params = call_args[1]['Params']
+        assert 'ResponseContentType' not in params
+
+    def test_no_extension_no_response_content_type(self):
+        """Presigned URL for file without extension should NOT include ResponseContentType"""
+        resolve_s3_url('s3://bucket/data/README', self.mock_client, presign=True)
+
+        call_args = self.mock_client.generate_presigned_url.call_args
+        params = call_args[1]['Params']
+        assert 'ResponseContentType' not in params
+
+    def test_json_gets_response_content_type(self):
+        """Presigned URL for .json should include ResponseContentType=application/json"""
+        resolve_s3_url('s3://bucket/data/tasks.json', self.mock_client, presign=True)
+
+        call_args = self.mock_client.generate_presigned_url.call_args
+        params = call_args[1]['Params']
+        assert params['ResponseContentType'] == 'application/json'
+
+    def test_tiff_gets_response_content_type(self):
+        """Presigned URL for .tiff should include ResponseContentType=image/tiff"""
+        resolve_s3_url('s3://bucket/scans/scan.tiff', self.mock_client, presign=True)
+
+        call_args = self.mock_client.generate_presigned_url.call_args
+        params = call_args[1]['Params']
+        assert params['ResponseContentType'] == 'image/tiff'
+
+    def test_presign_false_does_not_use_response_content_type(self):
+        """When presign=False, blob is returned directly - no presigned URL generated"""
+        mock_body = MagicMock()
+        mock_body.read.return_value = b'fake image data'
+        self.mock_client.get_object.return_value = {
+            'ResponseMetadata': {'HTTPHeaders': {'content-type': 'binary/octet-stream'}},
+            'Body': mock_body,
+        }
+
+        result = resolve_s3_url('s3://bucket/image.jpg', self.mock_client, presign=False)
+
+        # Should return base64 data, not call generate_presigned_url
+        self.mock_client.generate_presigned_url.assert_not_called()
+        assert result.startswith('data:binary/octet-stream;base64,')
+
+    def test_bucket_and_key_always_present(self):
+        """Bucket and Key should always be in params regardless of content type detection"""
+        resolve_s3_url('s3://my-bucket/path/to/file.jpg', self.mock_client, presign=True)
+
+        call_args = self.mock_client.generate_presigned_url.call_args
+        params = call_args[1]['Params']
+        assert params['Bucket'] == 'my-bucket'
+        assert params['Key'] == 'path/to/file.jpg'
+
+    def test_expires_in_passed_through(self):
+        """ExpiresIn parameter should be passed through to generate_presigned_url"""
+        resolve_s3_url('s3://bucket/file.jpg', self.mock_client, presign=True, expires_in=120)
+
+        call_args = self.mock_client.generate_presigned_url.call_args
+        assert call_args[1]['ExpiresIn'] == 120

--- a/label_studio/io_storages/s3/tests/test_resolve_s3_url.py
+++ b/label_studio/io_storages/s3/tests/test_resolve_s3_url.py
@@ -21,7 +21,13 @@ class TestResolveS3UrlContentType(unittest.TestCase):
         resolve_s3_url('s3://bucket/path/image.jpg', self.mock_client, presign=True)
 
         call_args = self.mock_client.generate_presigned_url.call_args
-        params = call_args[1]['Params'] if 'Params' in call_args[1] else call_args[0][1] if len(call_args[0]) > 1 else call_args[1].get('Params')
+        params = (
+            call_args[1]['Params']
+            if 'Params' in call_args[1]
+            else call_args[0][1]
+            if len(call_args[0]) > 1
+            else call_args[1].get('Params')
+        )
         assert params['ResponseContentType'] == 'image/jpeg'
 
     def test_png_gets_response_content_type(self):

--- a/label_studio/io_storages/s3/utils.py
+++ b/label_studio/io_storages/s3/utils.py
@@ -3,6 +3,7 @@
 import base64
 import fnmatch
 import logging
+import mimetypes
 import re
 from urllib.parse import urlparse
 
@@ -55,9 +56,17 @@ def resolve_s3_url(url, client, presign=True, expires_in=3600):
 
     # Otherwise try to generate presigned url
     try:
-        presigned_url = client.generate_presigned_url(
-            ClientMethod='get_object', Params={'Bucket': bucket_name, 'Key': key}, ExpiresIn=expires_in
-        )
+        params = {'Bucket': bucket_name, 'Key': key}
+
+        # Override response Content-Type based on file extension so that S3 returns
+        # the correct MIME type even if the object was uploaded without one.
+        # Without this, S3 may return binary/octet-stream which causes browsers
+        # to download files instead of displaying them inline (e.g. images, audio, video).
+        content_type, _ = mimetypes.guess_type(key)
+        if content_type:
+            params['ResponseContentType'] = content_type
+
+        presigned_url = client.generate_presigned_url(ClientMethod='get_object', Params=params, ExpiresIn=expires_in)
     except ClientError as exc:
         logger.warning(f"Can't generate presigned URL. Reason: {exc}")
         return url

--- a/label_studio/io_storages/tests/test_proxy_api.py
+++ b/label_studio/io_storages/tests/test_proxy_api.py
@@ -112,6 +112,117 @@ class TestResolveStorageUriAPIMixin(unittest.TestCase):
         result = self.mixin.redirect_to_presign_url('fileuri', self.task, 'Task')
         assert result.status_code == status.HTTP_404_NOT_FOUND
 
+    def test_proxy_data_from_storage_content_type_fallback_for_octet_stream(self):
+        """Test that proxy detects correct content type from URI when storage returns octet-stream.
+
+        S3 objects uploaded without explicit Content-Type often have binary/octet-stream.
+        The proxy should detect the correct type from the URI file extension.
+        """
+        mock_storage = MagicMock()
+        mock_stream = MagicMock()
+        mock_metadata = {
+            'StatusCode': 200,
+            'ContentLength': 1000,
+            'LastModified': datetime.now(),
+            'ETag': '"abcdef123456"',
+        }
+        # Storage returns binary/octet-stream (common S3 default for missing Content-Type)
+        mock_storage.get_bytes_stream.return_value = (mock_stream, 'binary/octet-stream', mock_metadata)
+        mock_project = MagicMock()
+
+        with patch('io_storages.proxy_api.StreamingHttpResponse') as mock_response_class, patch(
+            'io_storages.proxy_api.settings'
+        ) as mock_settings:
+            mock_settings.RESOLVER_PROXY_MAX_RANGE_SIZE = 1024 * 1024
+            mock_settings.RESOLVER_PROXY_BUFFER_SIZE = 8192
+            mock_settings.RESOLVER_PROXY_CACHE_TIMEOUT = 3600
+            mock_settings.RESOLVER_PROXY_TIMEOUT = 20
+            mock_settings.RESOLVER_PROXY_ENABLE_ETAG_CACHE = False
+
+            mock_response = MagicMock()
+            mock_response.headers = {}
+            mock_response_class.return_value = mock_response
+            self.request.headers = {}
+
+            # URI with .jpg extension - should be detected as image/jpeg
+            self.mixin.proxy_data_from_storage(self.request, 's3://bucket/photo.jpg', mock_project, mock_storage)
+
+            # Verify StreamingHttpResponse was called with image/jpeg, not binary/octet-stream
+            call_args, call_kwargs = mock_response_class.call_args
+            assert call_kwargs.get('content_type') == 'image/jpeg' or (
+                len(call_args) > 1 and call_args[1] == 'image/jpeg'
+            ), f'Expected content_type=image/jpeg, got: args={call_args}, kwargs={call_kwargs}'
+
+    def test_proxy_data_from_storage_content_type_fallback_for_application_octet_stream(self):
+        """Test fallback for application/octet-stream (another generic type)."""
+        mock_storage = MagicMock()
+        mock_stream = MagicMock()
+        mock_metadata = {
+            'StatusCode': 200,
+            'ContentLength': 5000,
+            'LastModified': datetime.now(),
+            'ETag': '"xyz789"',
+        }
+        mock_storage.get_bytes_stream.return_value = (mock_stream, 'application/octet-stream', mock_metadata)
+        mock_project = MagicMock()
+
+        with patch('io_storages.proxy_api.StreamingHttpResponse') as mock_response_class, patch(
+            'io_storages.proxy_api.settings'
+        ) as mock_settings:
+            mock_settings.RESOLVER_PROXY_MAX_RANGE_SIZE = 1024 * 1024
+            mock_settings.RESOLVER_PROXY_BUFFER_SIZE = 8192
+            mock_settings.RESOLVER_PROXY_CACHE_TIMEOUT = 3600
+            mock_settings.RESOLVER_PROXY_TIMEOUT = 20
+            mock_settings.RESOLVER_PROXY_ENABLE_ETAG_CACHE = False
+
+            mock_response = MagicMock()
+            mock_response.headers = {}
+            mock_response_class.return_value = mock_response
+            self.request.headers = {}
+
+            self.mixin.proxy_data_from_storage(self.request, 's3://bucket/video.mp4', mock_project, mock_storage)
+
+            call_args, call_kwargs = mock_response_class.call_args
+            assert call_kwargs.get('content_type') == 'video/mp4' or (
+                len(call_args) > 1 and call_args[1] == 'video/mp4'
+            ), f'Expected content_type=video/mp4, got: args={call_args}, kwargs={call_kwargs}'
+
+    def test_proxy_data_from_storage_preserves_correct_content_type(self):
+        """When storage returns a proper content type, it should not be overridden."""
+        mock_storage = MagicMock()
+        mock_stream = MagicMock()
+        mock_metadata = {
+            'StatusCode': 200,
+            'ContentLength': 1000,
+            'LastModified': datetime.now(),
+            'ETag': '"test"',
+        }
+        # Storage returns correct content type
+        mock_storage.get_bytes_stream.return_value = (mock_stream, 'image/webp', mock_metadata)
+        mock_project = MagicMock()
+
+        with patch('io_storages.proxy_api.StreamingHttpResponse') as mock_response_class, patch(
+            'io_storages.proxy_api.settings'
+        ) as mock_settings:
+            mock_settings.RESOLVER_PROXY_MAX_RANGE_SIZE = 1024 * 1024
+            mock_settings.RESOLVER_PROXY_BUFFER_SIZE = 8192
+            mock_settings.RESOLVER_PROXY_CACHE_TIMEOUT = 3600
+            mock_settings.RESOLVER_PROXY_TIMEOUT = 20
+            mock_settings.RESOLVER_PROXY_ENABLE_ETAG_CACHE = False
+
+            mock_response = MagicMock()
+            mock_response.headers = {}
+            mock_response_class.return_value = mock_response
+            self.request.headers = {}
+
+            self.mixin.proxy_data_from_storage(self.request, 's3://bucket/photo.jpg', mock_project, mock_storage)
+
+            # Should preserve the original image/webp, not override with image/jpeg
+            call_args, call_kwargs = mock_response_class.call_args
+            assert call_kwargs.get('content_type') == 'image/webp' or (
+                len(call_args) > 1 and call_args[1] == 'image/webp'
+            ), f'Expected content_type=image/webp, got: args={call_args}, kwargs={call_kwargs}'
+
     def test_proxy_data_from_storage_success(self):
         mock_storage = MagicMock()
         # Ensure get_bytes_stream returns a three-tuple, metadata can be empty initially

--- a/web/libs/core/src/lib/utils/ImageCache.test.ts
+++ b/web/libs/core/src/lib/utils/ImageCache.test.ts
@@ -32,8 +32,8 @@ function mockXHRWithContentType(contentType: string) {
       status: 200,
       response: blob,
       open: jest.fn(),
-      send: jest.fn(function () {
-        setTimeout(() => listeners["load"]?.(new Event("load")), 0);
+      send: jest.fn(() => {
+        setTimeout(() => listeners.load?.(new Event("load")), 0);
       }),
       addEventListener: jest.fn((event: string, handler: Function) => {
         listeners[event] = handler;
@@ -86,9 +86,7 @@ describe("ImageCache content type validation", () => {
   it("should reject text/html content type", async () => {
     const restore = mockXHRWithContentType("text/html");
     try {
-      await expect(imageCache.load("https://example.com/page.html")).rejects.toThrow(
-        "Invalid content type for image",
-      );
+      await expect(imageCache.load("https://example.com/page.html")).rejects.toThrow("Invalid content type for image");
     } finally {
       restore();
     }
@@ -100,9 +98,7 @@ describe("ImageCache content type validation", () => {
   it("should reject application/json content type", async () => {
     const restore = mockXHRWithContentType("application/json");
     try {
-      await expect(imageCache.load("https://example.com/data.json")).rejects.toThrow(
-        "Invalid content type for image",
-      );
+      await expect(imageCache.load("https://example.com/data.json")).rejects.toThrow("Invalid content type for image");
     } finally {
       restore();
     }

--- a/web/libs/core/src/lib/utils/ImageCache.test.ts
+++ b/web/libs/core/src/lib/utils/ImageCache.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for ImageCache content type validation.
+ *
+ * These tests verify that ImageCache correctly handles various Content-Type
+ * scenarios from cloud storages, particularly the common case where S3 objects
+ * are uploaded without explicit Content-Type and default to binary/octet-stream.
+ */
+
+import { imageCache } from "./ImageCache";
+
+// Mock URL.createObjectURL / revokeObjectURL (not available in jsdom)
+const mockBlobUrl = "blob:http://localhost/mock-blob-url";
+global.URL.createObjectURL = jest.fn(() => mockBlobUrl);
+global.URL.revokeObjectURL = jest.fn();
+
+// Minimal valid image data (> 100 bytes to pass minBlobSize check)
+const FAKE_IMAGE_DATA = new Uint8Array(200).fill(0xff);
+
+/**
+ * Helper: create a mock XHR that returns a blob with the given MIME type.
+ * Simulates what happens when S3 returns a file with a specific Content-Type.
+ */
+function mockXHRWithContentType(contentType: string) {
+  const blob = new Blob([FAKE_IMAGE_DATA], { type: contentType });
+
+  const originalXHR = global.XMLHttpRequest;
+  const mockXHRClass = jest.fn().mockImplementation(() => {
+    const listeners: Record<string, Function> = {};
+    return {
+      responseType: "",
+      readyState: 4,
+      status: 200,
+      response: blob,
+      open: jest.fn(),
+      send: jest.fn(function () {
+        setTimeout(() => listeners["load"]?.(new Event("load")), 0);
+      }),
+      addEventListener: jest.fn((event: string, handler: Function) => {
+        listeners[event] = handler;
+      }),
+    };
+  });
+
+  global.XMLHttpRequest = mockXHRClass as unknown as typeof XMLHttpRequest;
+  return () => {
+    global.XMLHttpRequest = originalXHR;
+  };
+}
+
+// Mock Image globally to simulate successful loading with valid dimensions
+beforeAll(() => {
+  Object.defineProperty(global, "Image", {
+    writable: true,
+    value: class MockImage {
+      crossOrigin = "";
+      naturalWidth = 100;
+      naturalHeight = 100;
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      private _src = "";
+
+      get src() {
+        return this._src;
+      }
+
+      set src(value: string) {
+        this._src = value;
+        if (value) {
+          setTimeout(() => this.onload?.(), 0);
+        }
+      }
+    },
+  });
+});
+
+describe("ImageCache content type validation", () => {
+  beforeEach(() => {
+    imageCache.forceClear();
+    jest.clearAllMocks();
+  });
+
+  /**
+   * Test that known non-image content types (e.g. text/html) are rejected.
+   * This prevents caching of non-image resources.
+   */
+  it("should reject text/html content type", async () => {
+    const restore = mockXHRWithContentType("text/html");
+    try {
+      await expect(imageCache.load("https://example.com/page.html")).rejects.toThrow(
+        "Invalid content type for image",
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  /**
+   * Test that application/json content type is rejected.
+   */
+  it("should reject application/json content type", async () => {
+    const restore = mockXHRWithContentType("application/json");
+    try {
+      await expect(imageCache.load("https://example.com/data.json")).rejects.toThrow(
+        "Invalid content type for image",
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  /**
+   * Test that binary/octet-stream (common S3 default) is NOT rejected.
+   * S3 objects uploaded without explicit Content-Type often have this type.
+   * The browser can render them as images by detecting format via magic bytes.
+   * This was the root cause of image display regression after FIT-720.
+   */
+  it("should not reject binary/octet-stream content type", async () => {
+    const restore = mockXHRWithContentType("binary/octet-stream");
+    try {
+      const result = await imageCache.load("https://s3.amazonaws.com/bucket/image.jpg");
+      expect(result.blobUrl).toBe(mockBlobUrl);
+      expect(result.naturalWidth).toBe(100);
+    } finally {
+      restore();
+    }
+  });
+
+  /**
+   * Test that application/octet-stream is NOT rejected.
+   * This is another common generic type from cloud storages.
+   */
+  it("should not reject application/octet-stream content type", async () => {
+    const restore = mockXHRWithContentType("application/octet-stream");
+    try {
+      const result = await imageCache.load("https://s3.amazonaws.com/bucket/photo.png");
+      expect(result.blobUrl).toBe(mockBlobUrl);
+    } finally {
+      restore();
+    }
+  });
+
+  /**
+   * Test that empty/missing blob type is NOT rejected.
+   * Some storages may return responses without Content-Type header.
+   */
+  it("should not reject empty blob type", async () => {
+    const restore = mockXHRWithContentType("");
+    try {
+      const result = await imageCache.load("https://storage.example.com/img.tiff");
+      expect(result.blobUrl).toBe(mockBlobUrl);
+    } finally {
+      restore();
+    }
+  });
+
+  /**
+   * Test that valid image content types are accepted as before.
+   */
+  it("should accept image/jpeg content type", async () => {
+    const restore = mockXHRWithContentType("image/jpeg");
+    try {
+      const result = await imageCache.load("https://example.com/photo.jpg");
+      expect(result.blobUrl).toBe(mockBlobUrl);
+      expect(result.naturalWidth).toBe(100);
+      expect(result.naturalHeight).toBe(100);
+    } finally {
+      restore();
+    }
+  });
+
+  /**
+   * Test that image/png content type is accepted.
+   */
+  it("should accept image/png content type", async () => {
+    const restore = mockXHRWithContentType("image/png");
+    try {
+      const result = await imageCache.load("https://example.com/screenshot.png");
+      expect(result.blobUrl).toBe(mockBlobUrl);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/web/libs/core/src/lib/utils/ImageCache.ts
+++ b/web/libs/core/src/lib/utils/ImageCache.ts
@@ -171,8 +171,12 @@ class ImageCacheManager {
             return;
           }
 
-          // Validate content type is an image
-          if (blob.type && !blob.type.startsWith("image/")) {
+          // When Content-Type is generic (e.g. binary/octet-stream, application/octet-stream)
+          // or missing, we still attempt to load the image since browsers detect format
+          // by magic bytes. S3 objects uploaded without explicit Content-Type often have
+          // binary/octet-stream but are valid images. Only reject known non-image types.
+          const isGenericType = !blob.type || blob.type.includes("octet-stream");
+          if (!isGenericType && !blob.type.startsWith("image/")) {
             reject(new ImageCacheError(`Invalid content type for image: ${blob.type} (url: ${url})`));
             return;
           }


### PR DESCRIPTION
## Image Display Broken for S3 IAM Storage — Root Cause Analysis

**Problem:** Images from S3 IAM storage stopped displaying this week. Browser offers to download them instead of rendering inline. Error in labeling UI: "There was an issue loading URL from $image value".

**Affected URL example:**
`s3://ffbgrad-dev-asianagri-inference/cropped_roi_for_annotation/PSP/20260207_192251_800.jpg`

### Root Cause

The commit **`FIT-720: Add global image cache for annotation switching`** (`62f264f9b` Jan 30 / `6c8d49d91` Feb 5) introduced `ImageCache` in `web/libs/core/src/lib/utils/ImageCache.ts`. This cache loads images via XHR into blobs and validates `blob.type`:

```typescript
// line 175 in ImageCache.ts
if (blob.type && !blob.type.startsWith("image/")) {
  reject(new ImageCacheError(`Invalid content type for image: ${blob.type} (url: ${url})`));
  return;
}
```

The user's S3 objects were uploaded without an explicit Content-Type, so S3 returns `Content-Type: binary/octet-stream`. This causes:

```
blob.type = "binary/octet-stream"
"binary/octet-stream".startsWith("image/") → false → REJECT
```

**Why it worked before:** Images were loaded directly via `<img src="presigned_url">`. Browsers detect image format by magic bytes (file header), not by Content-Type header. So `binary/octet-stream` was never a problem — the browser just rendered the image.

**Why it broke now:** The new image cache fetches images via XHR, creates a Blob, and explicitly validates `blob.type` against Content-Type. Objects with generic/missing MIME types are rejected before the browser ever gets a chance to detect the format.

### Fixes (4 files)

| File | Fix | Layer |
|---|---|---|
| `web/libs/core/src/lib/utils/ImageCache.ts` | Don't reject `octet-stream` types — let `new Image()` validate via magic bytes (lines 188-197 already do this) | **Frontend — direct fix** |
| `io_storages/proxy_api.py` | Content-type fallback for all storage types (GCS, Azure, S3) in the proxy streaming path | Backend — defense in depth |

### Client-side fix (ImageCache.ts)

The key logic change — skip the content-type rejection for generic types like `binary/octet-stream` or `application/octet-stream`, since the subsequent `new Image()` load (lines 188-197) already validates whether the data is actually a renderable image:

```typescript
// Before:
if (blob.type && !blob.type.startsWith("image/")) {
  reject(...);
}

// After:
const isGenericType = !blob.type || blob.type.includes("octet-stream");
if (!isGenericType && !blob.type.startsWith("image/")) {
  reject(...);
}
```

This still rejects known non-image types (e.g. `text/html`, `application/json`) but lets generic types through for browser-level validation.

### Workaround

```bash
aws s3 cp \
  s3://ffbgrad-dev-asianagri-inference/cropped_roi_for_annotation/ \
  s3://ffbgrad-dev-asianagri-inference/cropped_roi_for_annotation/ \
  --recursive --content-type "image/jpeg" --metadata-directive REPLACE \
  --exclude "*" --include "*.jpg" --include "*.jpeg"
```

This copies objects in-place, overwriting only metadata. Most likely the files were uploaded via a Python script using `boto3.upload_file()` without `ExtraArgs={'ContentType': 'image/jpeg'}`.