### PR TITLE
fix: UTC-569: Toast 'Annotation saved successfully' does not auto-dismiss and persists across page navigation

### DIFF
--- a/web/libs/ui/src/lib/toast/toast.tsx
+++ b/web/libs/ui/src/lib/toast/toast.tsx
@@ -1,4 +1,4 @@
-import { createContext, type FC, type ReactNode, useCallback, useContext, useState, useRef } from "react";
+import { createContext, type FC, type ReactNode, useCallback, useContext, useState } from "react";
 import * as ToastPrimitive from "@radix-ui/react-toast";
 import styles from "./toast.module.scss";
 import clsx from "clsx";
@@ -119,7 +119,6 @@ export const useToast = () => {
 
 export const ToastProvider: FC<ToastProviderWithTypes> = ({ swipeDirection = "down", children, type, ...props }) => {
   const [toastMessage, setToastMessage] = useState<ToastShowArgs | null>();
-  const timerRef = useRef<NodeJS.Timeout>();
 
   const defaultDuration = 4000;
   const duration = toastMessage?.duration ?? defaultDuration;
@@ -130,20 +129,21 @@ export const ToastProvider: FC<ToastProviderWithTypes> = ({ swipeDirection = "do
       if (id && current.id !== id) return current;
       return null;
     });
-    if (timerRef.current) clearTimeout(timerRef.current);
   }, []);
 
-  const show = ({ message, type, duration = defaultDuration, id }: ToastShowArgs) => {
-    if (timerRef.current) clearTimeout(timerRef.current);
-
+  const show = useCallback(({ message, type, duration = defaultDuration, id }: ToastShowArgs) => {
     const toastId = id ?? nanoid();
     setToastMessage({ message, type, duration, id: toastId });
-
-    if (duration >= 0) {
-      timerRef.current = setTimeout(() => dismiss(toastId), duration);
-    }
     return toastId;
-  };
+  }, []);
+
+  // Handle Radix UI's onOpenChange to sync when toast closes
+  const handleOpenChange = useCallback((open: boolean) => {
+    if (!open) {
+      setToastMessage(null);
+    }
+  }, []);
+
   const toastType = toastMessage?.type ?? type ?? ToastType.info;
   return (
     <ToastContext.Provider value={{ show, dismiss }}>
@@ -155,6 +155,8 @@ export const ToastProvider: FC<ToastProviderWithTypes> = ({ swipeDirection = "do
             [styles.messageToast_alertError]: toastType === ToastType.alertError,
           })}
           open={!!toastMessage?.message}
+          onOpenChange={handleOpenChange}
+          duration={duration}
           action={
             <ToastAction onClose={() => setToastMessage(null)} altText="x">
               <IconCross />


### PR DESCRIPTION
Removed internal timeout to rely on Radix UI's timeout and removed the internal ref to avoid orphaned toasts which can't be closed if the user navigates away.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
