### PR TITLE
fix: BROS-793: Allow to hide reactcode regions from Outliner (#9376)

### DIFF
--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
@@ -487,7 +487,7 @@ const RegionControls: FC<RegionControlsProps> = injector(
     }, [entity, type, regions]);
 
     const onToggleHidden = useCallback(() => {
-      if (type?.includes("region") || type?.includes("range")) {
+      if (type?.includes("region") || type?.includes("range") || type?.includes("reactcode")) {
         entity.toggleHidden();
       } else if (!type || type.includes("label")) {
         regionStore.setHiddenByLabel(!hidden, entity);


### PR DESCRIPTION
Check for region's type didn't check for reactcode type.

Cherry-pick from #9376 