### PR TITLE
chore: echo-425: migrate to biome 2 to have the possibility to add plugings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,15 +10,14 @@ repos:
     hooks:
       - id: blue
         args: [ --check, --diff, --color ]
-  - repo: https://github.com/biomejs/pre-commit
-    rev: "v0.1.0"
-    hooks:
-      - id: biome-check
-        args: [ --config-path, ./web ]
-        additional_dependencies: [ "@biomejs/biome@2.0.6" ]
-        files: ^web/.*
   - repo: local
     hooks:
+      - id: biome-check
+        name: biome-check
+        entry: bash -c 'cd web && yarn biome check . --diagnostic-level=error'
+        language: system
+        pass_filenames: false
+        files: ^web/.*
       - id: stylelint
         name: stylelint
         entry: bash -c 'cd web && npx stylelint **/*.scss --fix'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: biome-check
         args: [ --config-path, ./web ]
-        additional_dependencies: [ "@biomejs/biome@1.9.4" ]
+        additional_dependencies: [ "@biomejs/biome@2.0.6" ]
         files: ^web/.*
   - repo: local
     hooks:

--- a/.pre-commit-dev.yaml
+++ b/.pre-commit-dev.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: biome-check
         args: [ --config-path, ./web, --diagnostic-level=error ]
-        additional_dependencies: [ "@biomejs/biome@1.9.4" ]
+        additional_dependencies: [ "@biomejs/biome@2.0.6" ]
         files: ^web/.*
   - repo: local
     hooks:

--- a/.pre-commit-dev.yaml
+++ b/.pre-commit-dev.yaml
@@ -19,6 +19,12 @@ repos:
         files: ^web/.*
   - repo: local
     hooks:
+      - id: biome-check
+        name: biome-check
+        entry: bash -c 'cd web && yarn biome check . --diagnostic-level=error'
+        language: system
+        pass_filenames: false
+        files: ^web/.*
       - id: stylelint
         name: stylelint
         entry: bash -c 'cd web && npx stylelint **/*.scss --fix'

--- a/web/apps/labelstudio/src/pages/CreateProject/Config/UnsavedChanges.tsx
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/UnsavedChanges.tsx
@@ -44,7 +44,7 @@ export const unsavedChangesModal = ({
   body = "Would you like to save them before leaving?",
   ...props
 }: UnsavedChangesModalProps) => {
-  let modalInstance: any = undefined;
+  let modalInstance: any;
   const saveAndLeave = async () => {
     await onSave?.();
     modalInstance?.close();

--- a/web/apps/labelstudio/src/pages/Home/HomePage.tsx
+++ b/web/apps/labelstudio/src/pages/Home/HomePage.tsx
@@ -242,11 +242,7 @@ HomePage.title = "Home";
 HomePage.path = "/";
 HomePage.exact = true;
 
-function ProjectSimpleCard({
-  project,
-}: {
-  project: APIProject;
-}) {
+function ProjectSimpleCard({ project }: { project: APIProject }) {
   const finished = project.finished_task_number ?? 0;
   const total = project.task_number ?? 0;
   const progress = (total > 0 ? finished / total : 0) * 100;

--- a/web/apps/playground/src/utils/generateSampleTask.ts
+++ b/web/apps/playground/src/utils/generateSampleTask.ts
@@ -134,8 +134,8 @@ export async function generateSampleTaskFromConfig(config: string): Promise<{
   }
 
   // Try to find a root-level comment with a JSON object
-  let userData: Record<string, any> | undefined = undefined;
-  let userAnnotation: any = undefined;
+  let userData: Record<string, any> | undefined;
+  let userAnnotation: any;
   const root = xml.documentElement;
   if (root) {
     for (let i = 0; i < root.childNodes.length; i++) {

--- a/web/biome.json
+++ b/web/biome.json
@@ -1,16 +1,15 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-  "organizeImports": {
-    "enabled": false
-  },
+  "$schema": "https://biomejs.dev/schemas/2.0.6/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "off" } } },
   "files": {
-    "ignore": [
-      "node_modules/**",
-      "dist/**",
-      "**/tsconfig*",
-      "libs/editor/examples/**/*.json",
-      "libs/editor/src/examples/**/annotations/1.json",
-      "apps/labelstudio-e2e/**"
+    "includes": [
+      "**",
+      "!**/node_modules/**",
+      "!**/dist/**",
+      "!**/tsconfig*",
+      "!**/libs/editor/examples/**/*.json",
+      "!**/libs/editor/src/examples/**/annotations/1.json",
+      "!**/apps/labelstudio-e2e/**"
     ],
     "maxSize": 3670016
   },
@@ -40,7 +39,11 @@
       "a11y": {
         "noAutofocus": "off",
         "useKeyWithClickEvents": "off",
-        "noLabelWithoutControl": "off"
+        "noLabelWithoutControl": "off",
+        "noStaticElementInteractions": "off",
+        "useAriaPropsSupportedByRole": "off",
+        "useAriaPropsForRole": "off",
+        "useSemanticElements": "off"
       },
       "suspicious": {
         "noExplicitAny": "off",
@@ -64,6 +67,7 @@
         "useExhaustiveDependencies": "off",
         "noChildrenProp": "off",
         "useJsxKeyInIterable": "off",
+        "useHookAtTopLevel": "off",
         "noUnusedImports": {
           "level": "warn"
         },
@@ -79,7 +83,15 @@
         "noNonNullAssertion": "off",
         "useDefaultParameterLast": "off",
         "useNodejsImportProtocol": "off",
-        "noParameterAssign": "off"
+        "noParameterAssign": "off",
+        "useAsConstAssertion": "error",
+        "useEnumInitializers": "error",
+        "useSelfClosingElements": "error",
+        "useSingleVarDeclarator": "error",
+        "noUnusedTemplateLiteral": "error",
+        "useNumberNamespace": "error",
+        "noInferrableTypes": "error",
+        "noUselessElse": "error"
       },
       "nursery": {},
       "security": {

--- a/web/libs/app-common/package.json
+++ b/web/libs/app-common/package.json
@@ -5,5 +5,8 @@
   "private": true,
   "dependencies": {},
   "main": "src/index.ts",
-  "files": ["src/lib", "src/pages"]
+  "files": [
+    "src/lib",
+    "src/pages"
+  ]
 }

--- a/web/libs/app-common/src/blocks/StorageProviderForm/types/provider.ts
+++ b/web/libs/app-common/src/blocks/StorageProviderForm/types/provider.ts
@@ -107,7 +107,7 @@ export function extractDefaultValues(fields: (FieldDefinition | MessageDefinitio
     if (field.type === "message") return;
 
     // Check if the field has a default value
-    if (Object.prototype.hasOwnProperty.call(field, "defaultValue") && field.defaultValue !== undefined) {
+    if (Object.hasOwn(field, "defaultValue") && field.defaultValue !== undefined) {
       const customDefault = typeof field.defaultValue === "function" ? field.defaultValue() : field.defaultValue;
       defaultValues[field.name] = customDefault;
       return;
@@ -117,7 +117,7 @@ export function extractDefaultValues(fields: (FieldDefinition | MessageDefinitio
     try {
       // Try to get the default value from the schema by accessing the internal structure
       const schemaAny = field.schema as any;
-      let defaultValue = undefined;
+      let defaultValue;
 
       // Check different possible locations for default values in Zod schemas
       if (schemaAny._def?.defaultValue !== undefined) {

--- a/web/libs/app-common/src/blocks/TokenSettingsModal/index.tsx
+++ b/web/libs/app-common/src/blocks/TokenSettingsModal/index.tsx
@@ -6,13 +6,7 @@ import { useAtomValue } from "jotai";
 import { queryClientAtom } from "jotai-tanstack-query";
 import { type ChangeEvent, useState } from "react";
 
-export const TokenSettingsModal = ({
-  showTTL,
-  onSaved,
-}: {
-  showTTL?: boolean;
-  onSaved?: () => void;
-}) => {
+export const TokenSettingsModal = ({ showTTL, onSaved }: { showTTL?: boolean; onSaved?: () => void }) => {
   const settings = useAtomValue(settingsAtom);
   if (!settings.isSuccess || settings.isError || "error" in settings.data) {
     return <div>Error loading settings.</div>;

--- a/web/libs/app-common/src/pages/AccountSettings/sections/Hotkeys/Key.tsx
+++ b/web/libs/app-common/src/pages/AccountSettings/sections/Hotkeys/Key.tsx
@@ -24,7 +24,7 @@ export const KeyboardKey = ({ children }: KeyboardKeyProps) => {
 
   // Split the key combination by common separators
   const keys = keyString
-    .split(/[\+\s]+/) // Split by + or spaces
+    .split(/[+\s]+/) // Split by + or spaces
     .filter((key) => key.trim().length > 0) // Remove empty strings
     .map((key) => key.trim()); // Trim whitespace
 

--- a/web/libs/core/package.json
+++ b/web/libs/core/package.json
@@ -5,5 +5,8 @@
   "private": true,
   "dependencies": {},
   "main": "src/index.ts",
-  "files": ["src/lib", "src/pages"]
+  "files": [
+    "src/lib",
+    "src/pages"
+  ]
 }

--- a/web/libs/core/src/lib/Tour/Tour.tsx
+++ b/web/libs/core/src/lib/Tour/Tour.tsx
@@ -82,12 +82,7 @@ export const Tour: React.FC<TourProps> = ({ name, autoStart = false, delay = 0, 
    * - Dynamic step content based on application state
    */
   const handleTourCallback = useCallback(
-    (data: {
-      action: string;
-      index: number;
-      type: string;
-      status: string;
-    }) => {
+    (data: { action: string; index: number; type: string; status: string }) => {
       const { action, index, type, status } = data;
 
       // tour ends when

--- a/web/libs/core/src/lib/api-proxy/index.ts
+++ b/web/libs/core/src/lib/api-proxy/index.ts
@@ -477,7 +477,7 @@ export class APIProxy<T extends {}> {
     settings: Exclude<EndpointConfig, string>,
   ) {
     return new Promise<Response>(async (resolve) => {
-      let response: Record<string, any> | undefined = undefined;
+      let response: Record<string, any> | undefined;
       let ok = true;
 
       try {

--- a/web/libs/datamanager/src/components/Common/SkeletonLoader/SkeletonLine.tsx
+++ b/web/libs/datamanager/src/components/Common/SkeletonLoader/SkeletonLine.tsx
@@ -4,7 +4,11 @@ export const SkeletonLine = ({
   lineCount = 1,
   width = "60%",
   height = "16px",
-}: { lineCount?: number; width?: string; height?: string }) => {
+}: {
+  lineCount?: number;
+  width?: string;
+  height?: string;
+}) => {
   const rows = [];
 
   for (let i = 0; i < lineCount; i++) {

--- a/web/libs/datamanager/src/components/MainView/GridView/__tests__/GridView.test.tsx
+++ b/web/libs/datamanager/src/components/MainView/GridView/__tests__/GridView.test.tsx
@@ -42,11 +42,8 @@ jest.mock("mobx-state-tree", () => ({
 // Mock the required dependencies
 jest.mock("react-virtualized-auto-sizer", () => ({
   __esModule: true,
-  default: ({
-    children,
-  }: {
-    children: (size: { width: number; height: number }) => React.ReactNode;
-  }) => children({ width: 1000, height: 800 }),
+  default: ({ children }: { children: (size: { width: number; height: number }) => React.ReactNode }) =>
+    children({ width: 1000, height: 800 }),
 }));
 
 jest.mock("react-window", () => {
@@ -68,11 +65,7 @@ jest.mock("react-window", () => {
           style,
           ...props
         }: {
-          children: (props: {
-            rowIndex: number;
-            columnIndex: number;
-            style: React.CSSProperties;
-          }) => React.ReactNode;
+          children: (props: { rowIndex: number; columnIndex: number; style: React.CSSProperties }) => React.ReactNode;
           width?: number;
           height?: number;
           rowHeight?: number;
@@ -108,10 +101,7 @@ jest.mock("react-window-infinite-loader", () => ({
   default: ({
     children,
   }: {
-    children: (props: {
-      onItemsRendered: () => void;
-      ref: React.RefObject<unknown>;
-    }) => React.ReactNode;
+    children: (props: { onItemsRendered: () => void; ref: React.RefObject<unknown> }) => React.ReactNode;
   }) => children({ onItemsRendered: jest.fn(), ref: jest.fn() }),
 }));
 

--- a/web/libs/datamanager/src/utils/helpers.ts
+++ b/web/libs/datamanager/src/utils/helpers.ts
@@ -110,10 +110,10 @@ export const hasProperties = (obj: AnyObject, properties: string[], all?: boolea
 
   return all
     ? properties.reduce((res, prop) => {
-        return res && Object.prototype.hasOwnProperty.call(obj, prop);
+        return res && Object.hasOwn(obj, prop);
       }, true)
     : properties.findIndex((prop) => {
-        return Object.prototype.hasOwnProperty.call(obj, prop);
+        return Object.hasOwn(obj, prop);
       }) >= 0;
 };
 

--- a/web/libs/editor/scripts/create-docs.js
+++ b/web/libs/editor/scripts/create-docs.js
@@ -131,7 +131,7 @@ function processTemplate(t) {
       })(),
     )
     // force adding new lines before footnote definitions
-    .replace(/(?<![\r\n])([\r\n])(\[\^[^\[]+\]:)/gm, "$1$1$2");
+    .replace(/(?<![\r\n])([\r\n])(\[\^[^[]+\]:)/gm, "$1$1$2");
 
   return str;
 }

--- a/web/libs/editor/src/components/BottomBar/Controls.tsx
+++ b/web/libs/editor/src/components/BottomBar/Controls.tsx
@@ -201,13 +201,7 @@ export const Controls = controlsInjector<{ annotation: MSTAnnotation }>(
 
       const useExitOption = !isDisabled && isNotQuickView;
 
-      const SubmitOption = ({
-        isUpdate,
-        onClickMethod,
-      }: {
-        isUpdate: boolean;
-        onClickMethod: () => any;
-      }) => {
+      const SubmitOption = ({ isUpdate, onClickMethod }: { isUpdate: boolean; onClickMethod: () => any }) => {
         return (
           <div className="p-tighter rounded">
             <Button

--- a/web/libs/editor/src/components/Comments/Comment/CommentFormButtons.tsx
+++ b/web/libs/editor/src/components/Comments/Comment/CommentFormButtons.tsx
@@ -9,7 +9,11 @@ export const CommentFormButtons = ({
   region,
   linking,
   onLinkTo,
-}: { region: any; linking: boolean; onLinkTo?: MouseEventHandler<HTMLElement> }) => (
+}: {
+  region: any;
+  linking: boolean;
+  onLinkTo?: MouseEventHandler<HTMLElement>;
+}) => (
   <div className={cn("comment-form-buttons").toClassName()}>
     <div className={cn("comment-form-buttons").elem("buttons").toClassName()}>
       {onLinkTo && !region && (

--- a/web/libs/editor/src/components/Comments/Comment/CommentItem.tsx
+++ b/web/libs/editor/src/components/Comments/Comment/CommentItem.tsx
@@ -42,11 +42,7 @@ interface CommentItemProps {
     setHighlighted: (value: boolean) => {};
     _commentRef: React.Ref<HTMLElement>;
   };
-  listComments: ({
-    suppressClearComments,
-  }: {
-    suppressClearComments: boolean;
-  }) => void;
+  listComments: ({ suppressClearComments }: { suppressClearComments: boolean }) => void;
   classificationsItems: any;
 }
 

--- a/web/libs/editor/src/components/KonvaVector/utils.ts
+++ b/web/libs/editor/src/components/KonvaVector/utils.ts
@@ -100,7 +100,7 @@ export const isBezierPoint = (point: PointInput): point is BezierPoint => {
  * @throws Error if point format is invalid
  */
 export const normalizePoints = (points: PointInput[]): BezierPoint[] => {
-  let lastPointId: string | undefined = undefined;
+  let lastPointId: string | undefined;
 
   return points.map((point, index) => {
     if (isSimplePoint(point)) {

--- a/web/libs/editor/src/components/SidePanels/TabPanels/SideTabsPanels.tsx
+++ b/web/libs/editor/src/components/SidePanels/TabPanels/SideTabsPanels.tsx
@@ -198,7 +198,7 @@ const SideTabsPanelsComponent: FC<SidePanelsProps> = ({
       const panelLeftHit = left <= targetLeftWidth;
       const topHit = top <= snapThreshold;
       const bottomHit = bottom >= parentHeight - snapThreshold;
-      let snap: DropSide | undefined = undefined;
+      let snap: DropSide | undefined;
 
       if (!collapsedSideRef.current?.[Side.left] && panelLeftHit) {
         if (left <= snapThreshold) snap = DropSide.left;

--- a/web/libs/editor/src/components/TaskSummary/Aggregation.tsx
+++ b/web/libs/editor/src/components/TaskSummary/Aggregation.tsx
@@ -46,7 +46,11 @@ export const AggregationCell = ({
   control,
   annotations,
   isExpanded,
-}: { control: ControlTag; annotations: AnnotationSummary[]; isExpanded: boolean }) => {
+}: {
+  control: ControlTag;
+  annotations: AnnotationSummary[];
+  isExpanded: boolean;
+}) => {
   const allResults = annotations.flatMap((ann) => ann.results.filter((r) => r.from_name === control.name));
   // Exclude predictions for percentage denominator to match backend TaskAgreementAPI
   const totalAnnotations = annotations.filter((a) => a.type === "annotation").length;

--- a/web/libs/editor/src/components/VideoCanvas/VideoCanvas.tsx
+++ b/web/libs/editor/src/components/VideoCanvas/VideoCanvas.tsx
@@ -554,8 +554,8 @@ export const VideoCanvas = memo(
 
     useEffect(() => {
       let isLoaded = false;
-      let loadTimeout: ReturnType<typeof setTimeout> | undefined = undefined;
-      let timeout: ReturnType<typeof setTimeout> | undefined = undefined;
+      let loadTimeout: ReturnType<typeof setTimeout> | undefined;
+      let timeout: ReturnType<typeof setTimeout> | undefined;
 
       const checkVideoLoaded = () => {
         if (isLoaded) return;

--- a/web/libs/editor/src/core/DataValidator/ConfigValidator.js
+++ b/web/libs/editor/src/core/DataValidator/ConfigValidator.js
@@ -252,7 +252,7 @@ const validateAttributes = (child, model, fieldsToSkip) => {
   const properties = Object.keys(model.properties);
 
   for (const key of properties) {
-    if (!{}.hasOwnProperty.call(child, key)) continue;
+    if (!Object.hasOwn(child, key)) continue;
     if (fieldsToSkip.includes(key)) continue;
     const value = child[key];
     const modelProperty = model.properties[key.toLowerCase()];

--- a/web/libs/editor/src/core/Hotkey.ts
+++ b/web/libs/editor/src/core/Hotkey.ts
@@ -406,7 +406,7 @@ export const Hotkey = (namespace = "global", description = "Hotkeys") => {
         if (prefix) comb = `${prefix}+${combs[i]}`;
         else comb = combs[i];
 
-        if (!{}.hasOwnProperty.call(_hotkeys_map, comb)) return comb;
+        if (!Object.hasOwn(_hotkeys_map, comb)) return comb;
       }
 
       return null;

--- a/web/libs/editor/src/lib/AudioUltra/Media/AudioDecoder.ts
+++ b/web/libs/editor/src/lib/AudioUltra/Media/AudioDecoder.ts
@@ -72,7 +72,7 @@ export class AudioDecoder extends BaseAudioDecoder {
     // This is a shared promise which will be observed by all instances of the same source
     this.decodingPromise = new Promise((resolve) => (this.decodingResolve = resolve as any));
 
-    let splitChannels: SplitChannel | undefined = undefined;
+    let splitChannels: SplitChannel | undefined;
 
     try {
       // Set the worker instance and resolve the decoder promise

--- a/web/libs/editor/src/lib/AudioUltra/Media/SplitChannelWorker.ts
+++ b/web/libs/editor/src/lib/AudioUltra/Media/SplitChannelWorker.ts
@@ -1,12 +1,6 @@
 import { ComputeWorker } from "../Common/Worker";
 
-export function splitChannels({
-  value,
-  channelCount,
-}: {
-  value: Float32Array;
-  channelCount: number;
-}): Float32Array[] {
+export function splitChannels({ value, channelCount }: { value: Float32Array; channelCount: number }): Float32Array[] {
   const channels: Float32Array[] = [];
 
   // Create new Float32Array for each channel

--- a/web/libs/editor/src/mixins/ProcessAttrs.js
+++ b/web/libs/editor/src/mixins/ProcessAttrs.js
@@ -47,7 +47,7 @@ const ProcessAttrsMixin = types
 
       const { type, options } = parseTypeAndOption(self.resolver);
 
-      if (!Object.prototype.hasOwnProperty.call(resolvers, type)) {
+      if (!Object.hasOwn(resolvers, type)) {
         console.error(`Resolver "${type ?? self.resolver}" looks unfamiliar`);
         return value;
       }

--- a/web/libs/editor/src/regions/BitmaskRegion/utils.ts
+++ b/web/libs/editor/src/regions/BitmaskRegion/utils.ts
@@ -8,7 +8,14 @@ export const BitmaskDrawing = {
     y,
     brushSize = 10,
     eraserMode = false,
-  }: { ctx: CanvasRenderingContext2D; x: number; y: number; brushSize: number; color: string; eraserMode: boolean }): {
+  }: {
+    ctx: CanvasRenderingContext2D;
+    x: number;
+    y: number;
+    brushSize: number;
+    color: string;
+    eraserMode: boolean;
+  }): {
     x: number;
     y: number;
   } {

--- a/web/libs/editor/src/utils/colors.js
+++ b/web/libs/editor/src/utils/colors.js
@@ -275,7 +275,7 @@ export function stringToColor(str) {
  * @param {number} alpha from 0 to 1
  */
 export function rgbaChangeAlpha(rgba, alpha) {
-  return rgba.replace(/[\d\.]+\)$/g, `${alpha})`); // eslint-disable-line no-useless-escape
+  return rgba.replace(/[\d.]+\)$/g, `${alpha})`); // eslint-disable-line no-useless-escape
 }
 
 // given number from 0.00 to 1.00 return a color from red to green

--- a/web/libs/editor/src/utils/reactCleaner.js
+++ b/web/libs/editor/src/utils/reactCleaner.js
@@ -16,7 +16,7 @@ export function cutFibers(object) {
       const isWritable = descriptors[key].writable;
 
       if (prop && isWritable) {
-        if (key !== "_debugOwner" && typeof prop === "object" && {}.hasOwnProperty.call(prop, "stateNode")) {
+        if (key !== "_debugOwner" && typeof prop === "object" && Object.hasOwn(prop, "stateNode")) {
           objects.push(obj[key]);
         }
         if (typeof prop === "object" || typeof prop === "function") {

--- a/web/libs/editor/src/utils/utilities.ts
+++ b/web/libs/editor/src/utils/utilities.ts
@@ -51,7 +51,7 @@ export const isStringJSON = (value: string) => {
  */
 export function getUrl(i: number, text: string) {
   const stringToTest = text.slice(i);
-  const myRegexp = /^(https?:\/\/(?:www\.|(?!www))[^\s\.]+\.[^\s]{2,}|www\.[^\s]+\.[^\s]{2,})/g; // eslint-disable-line no-useless-escape
+  const myRegexp = /^(https?:\/\/(?:www\.|(?!www))[^\s.]+\.[^\s]{2,}|www\.[^\s]+\.[^\s]{2,})/g; // eslint-disable-line no-useless-escape
   const match = myRegexp.exec(stringToTest);
 
   return match && match.length ? match[1] : "";

--- a/web/libs/frontend-test/package.json
+++ b/web/libs/frontend-test/package.json
@@ -3,5 +3,7 @@
   "version": "1.0.0",
   "dependencies": {},
   "devDependencies": {},
-  "files": ["./src/**/*"]
+  "files": [
+    "./src/**/*"
+  ]
 }

--- a/web/libs/frontend-test/src/helpers/LSF/AudioView.ts
+++ b/web/libs/frontend-test/src/helpers/LSF/AudioView.ts
@@ -16,7 +16,7 @@ class AudioViewHelper extends withMedia(
     _rootSelector: string;
 
     constructor(rootSelector: string) {
-      this._rootSelector = rootSelector.replace(/^\&/, this._baseRootSelector);
+      this._rootSelector = rootSelector.replace(/^&/, this._baseRootSelector);
     }
 
     get root() {

--- a/web/libs/frontend-test/src/helpers/LSF/Choices.ts
+++ b/web/libs/frontend-test/src/helpers/LSF/Choices.ts
@@ -12,7 +12,7 @@ class ChoicesHelper {
 
   private _rootSelector: string;
   constructor(rootSelector) {
-    this._rootSelector = rootSelector.replace(/^\&/, this._baseRootSelector);
+    this._rootSelector = rootSelector.replace(/^&/, this._baseRootSelector);
   }
 
   get root() {

--- a/web/libs/frontend-test/src/helpers/LSF/Collapse.ts
+++ b/web/libs/frontend-test/src/helpers/LSF/Collapse.ts
@@ -6,7 +6,7 @@ class CollapseHelper {
   private _rootSelector: string;
 
   constructor(rootSelector) {
-    this._rootSelector = rootSelector.replace(/^\&/, this._baseRootSelector);
+    this._rootSelector = rootSelector.replace(/^&/, this._baseRootSelector);
   }
 
   get root() {

--- a/web/libs/frontend-test/src/helpers/LSF/DateTime.ts
+++ b/web/libs/frontend-test/src/helpers/LSF/DateTime.ts
@@ -6,7 +6,7 @@ class DateTimeHelper {
   private _rootSelector: string;
 
   constructor(rootSelector) {
-    this._rootSelector = rootSelector.replace(/^\&/, this._baseRootSelector);
+    this._rootSelector = rootSelector.replace(/^&/, this._baseRootSelector);
   }
 
   get root() {

--- a/web/libs/frontend-test/src/helpers/LSF/Number.ts
+++ b/web/libs/frontend-test/src/helpers/LSF/Number.ts
@@ -6,7 +6,7 @@ class NumberHelper {
   private _rootSelector: string;
 
   constructor(rootSelector) {
-    this._rootSelector = rootSelector.replace(/^\&/, this._baseRootSelector);
+    this._rootSelector = rootSelector.replace(/^&/, this._baseRootSelector);
   }
 
   get root() {

--- a/web/libs/frontend-test/src/helpers/LSF/Paragraphs.ts
+++ b/web/libs/frontend-test/src/helpers/LSF/Paragraphs.ts
@@ -10,7 +10,7 @@ class ParagraphsHelper extends withMedia(
     _rootSelector: string;
 
     constructor(rootSelector: string) {
-      this._rootSelector = rootSelector.replace(/^\&/, this._baseRootSelector);
+      this._rootSelector = rootSelector.replace(/^&/, this._baseRootSelector);
     }
 
     get root() {

--- a/web/libs/frontend-test/src/helpers/LSF/Ranker.ts
+++ b/web/libs/frontend-test/src/helpers/LSF/Ranker.ts
@@ -6,7 +6,7 @@ class RankerHelper {
   private _rootSelector: string;
 
   constructor(rootSelector) {
-    this._rootSelector = rootSelector.replace(/^\&/, this._baseRootSelector);
+    this._rootSelector = rootSelector.replace(/^&/, this._baseRootSelector);
   }
 
   get root() {

--- a/web/libs/frontend-test/src/helpers/LSF/Rating.ts
+++ b/web/libs/frontend-test/src/helpers/LSF/Rating.ts
@@ -6,7 +6,7 @@ class RatingHelper {
   private _rootSelector: string;
 
   constructor(rootSelector) {
-    this._rootSelector = rootSelector.replace(/^\&/, this._baseRootSelector);
+    this._rootSelector = rootSelector.replace(/^&/, this._baseRootSelector);
   }
 
   get root() {

--- a/web/libs/frontend-test/src/helpers/LSF/RichText.ts
+++ b/web/libs/frontend-test/src/helpers/LSF/RichText.ts
@@ -6,7 +6,7 @@ class RichTextHelper {
   private _rootSelector: string;
 
   constructor(rootSelector) {
-    this._rootSelector = rootSelector.replace(/^\&/, this._baseRootSelector);
+    this._rootSelector = rootSelector.replace(/^&/, this._baseRootSelector);
   }
 
   get root() {

--- a/web/libs/frontend-test/src/helpers/LSF/Table.ts
+++ b/web/libs/frontend-test/src/helpers/LSF/Table.ts
@@ -6,7 +6,7 @@ class TableHelper {
   private _rootSelector: string;
 
   constructor(rootSelector) {
-    this._rootSelector = rootSelector.replace(/^\&/, this._baseRootSelector);
+    this._rootSelector = rootSelector.replace(/^&/, this._baseRootSelector);
   }
 
   get root() {

--- a/web/libs/frontend-test/src/helpers/LSF/Taxonomy.ts
+++ b/web/libs/frontend-test/src/helpers/LSF/Taxonomy.ts
@@ -27,7 +27,7 @@ class TaxonomyHelper {
 
   constructor(rootSelector, isNew = false) {
     if (isNew) this.selectors = this._new_selectors;
-    this.selectors.root = rootSelector.replace(/^\&/, this._baseRootSelector);
+    this.selectors.root = rootSelector.replace(/^&/, this._baseRootSelector);
     this.isNew = isNew;
   }
 

--- a/web/libs/frontend-test/src/helpers/LSF/Textarea.ts
+++ b/web/libs/frontend-test/src/helpers/LSF/Textarea.ts
@@ -6,7 +6,7 @@ class TextareaHelper {
   private _rootSelector: string;
 
   constructor(rootSelector) {
-    this._rootSelector = rootSelector.replace(/^\&/, this._baseRootSelector);
+    this._rootSelector = rootSelector.replace(/^&/, this._baseRootSelector);
   }
 
   get root() {

--- a/web/libs/frontend-test/src/helpers/LSF/TimeSeries.ts
+++ b/web/libs/frontend-test/src/helpers/LSF/TimeSeries.ts
@@ -11,7 +11,7 @@ class TimeSeriesHelper {
   private _rootSelector: string;
 
   constructor(rootSelector) {
-    this._rootSelector = rootSelector.replace(/^\&/, this._baseRootSelector);
+    this._rootSelector = rootSelector.replace(/^&/, this._baseRootSelector);
   }
 
   get root() {

--- a/web/libs/frontend-test/src/helpers/LSF/VideoView.ts
+++ b/web/libs/frontend-test/src/helpers/LSF/VideoView.ts
@@ -21,7 +21,7 @@ class VideoViewHelper extends withMedia(
     _rootSelector: string;
 
     constructor(rootSelector: string) {
-      this._rootSelector = rootSelector.replace(/^\&/, this._baseRootSelector);
+      this._rootSelector = rootSelector.replace(/^&/, this._baseRootSelector);
     }
     get root() {
       cy.log("Get VideoView's root");

--- a/web/libs/ui/package.json
+++ b/web/libs/ui/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "private": true,
   "main": "src/index.ts",
-  "files": ["src/tailwind.css", "src/shad/components", "src/ui/assets"],
+  "files": [
+    "src/tailwind.css",
+    "src/shad/components",
+    "src/ui/assets"
+  ],
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/web/libs/ui/src/lib/auto-sizer-table/auto-sizer-table.tsx
+++ b/web/libs/ui/src/lib/auto-sizer-table/auto-sizer-table.tsx
@@ -49,7 +49,10 @@ export const AutoSizerTable = forwardRef<VariableSizeList, AutoSizerTableProps>(
               {({
                 onItemsRendered,
                 ref: infiniteLoaderRef,
-              }: { onItemsRendered: (params: { startIndex: number; stopIndex: number }) => void; ref: any }) => {
+              }: {
+                onItemsRendered: (params: { startIndex: number; stopIndex: number }) => void;
+                ref: any;
+              }) => {
                 return (
                   <VariableSizeList
                     ref={infiniteLoaderRef}

--- a/web/libs/ui/src/lib/code-editor/config-hint.ts
+++ b/web/libs/ui/src/lib/code-editor/config-hint.ts
@@ -179,7 +179,7 @@ function getHints(cm: any, options: CMHintOptions) {
       const atName = before.match(/([^\s\u00a0=<>"']+)=$/);
       const atValues = atName?.[1] ? attrs[atName[1]]?.type : undefined;
 
-      if (!atName || !Object.prototype.hasOwnProperty.call(attrs, atName[1])) return;
+      if (!atName || !Object.hasOwn(attrs, atName[1])) return;
       if (!atValues || !Array.isArray(atValues)) return;
       if (token.type === "string") {
         prefix = token.string;

--- a/web/libs/ui/src/lib/data-table/data-table.tsx
+++ b/web/libs/ui/src/lib/data-table/data-table.tsx
@@ -719,7 +719,7 @@ export const Header = <T,>({
   help,
 }: HeaderProps<T>) => {
   // Get header label - use originalHeader if provided, otherwise try to extract from columnDef
-  let headerLabel: string | React.ReactNode = undefined;
+  let headerLabel: string | React.ReactNode;
   if (originalHeader !== undefined) {
     headerLabel = originalHeader;
   } else {

--- a/web/libs/ui/src/lib/date-range-picker/date-utils.ts
+++ b/web/libs/ui/src/lib/date-range-picker/date-utils.ts
@@ -120,15 +120,7 @@ export const mapSelected = (
   );
 };
 
-export const incrementMonth = ({
-  month,
-  year,
-  changeValue,
-}: {
-  month: number;
-  year: number;
-  changeValue: number;
-}) => {
+export const incrementMonth = ({ month, year, changeValue }: { month: number; year: number; changeValue: number }) => {
   const newDate = new Date(year, month, 1);
 
   newDate.setMonth(newDate.getMonth() + changeValue);
@@ -152,13 +144,8 @@ export const compareRangeEquivalencyByNumber = (
 export const isSameMonth = (dateOne: Date, dateTwo: Date) =>
   dateOne.getFullYear() === dateTwo.getFullYear() && dateOne.getMonth() === dateTwo.getMonth();
 
-export const isSameMonthByNumbers = ({
-  start,
-  end,
-}: {
-  start: DateTimeByNumbers;
-  end: DateTimeByNumbers;
-}) => isSameMonth(new Date(start.year, start.month), new Date(end.year, end.month));
+export const isSameMonthByNumbers = ({ start, end }: { start: DateTimeByNumbers; end: DateTimeByNumbers }) =>
+  isSameMonth(new Date(start.year, start.month), new Date(end.year, end.month));
 
 export const calculateDisplayMonthsFromSelection = (dates: {
   start: DateOrDateTimeByNumbers;

--- a/web/libs/ui/src/lib/dropdown/dropdown.stories.tsx
+++ b/web/libs/ui/src/lib/dropdown/dropdown.stories.tsx
@@ -64,13 +64,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 // Sample dropdown content using semantic tokens - styled like Select component
-const MenuContent = ({
-  items = 3,
-  fullWidth = false,
-}: {
-  items?: number;
-  fullWidth?: boolean;
-}) => (
+const MenuContent = ({ items = 3, fullWidth = false }: { items?: number; fullWidth?: boolean }) => (
   <div className={`p-tight flex flex-col gap-tightest ${fullWidth ? "w-full" : "w-max"}`}>
     {Array.from({ length: items }, (_, i) => (
       <button

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "ui:serve": "nx storybook storybook",
     "ui:test:component": "nx test-component ui",
-    "lint": "biome check --apply .",
+    "lint": "biome check --write .",
     "lint-scss": "yarn stylelint '**/*.scss' --fix",
     "ls:dev": "nx run labelstudio:serve:development",
     "ls:watch": "nx run labelstudio:build:development --watch",
@@ -134,7 +134,7 @@
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.13.0",
     "@babel/runtime": "^7.26.10",
-    "@biomejs/biome": "1.9.4",
+    "@biomejs/biome": "2.0.6",
     "@cypress/code-coverage": "^3.12.9",
     "@cypress/webpack-preprocessor": "^5.17.0",
     "@module-federation/dts-plugin": "0.18.0",

--- a/web/tools/design-tokens-converter/design-tokens-converter.mjs
+++ b/web/tools/design-tokens-converter/design-tokens-converter.mjs
@@ -710,12 +710,12 @@ function resolveColor(value, variables, asCssVariable = true) {
     if (asCssVariable) {
       // Remove 'primitive' from CSS variable references
       if (reference.startsWith("@primitives.$color")) {
-        return `var(--color-${reference.replace("@primitives.$color.", "").replace(/[$\.]/g, "-").substring(1)})`;
+        return `var(--color-${reference.replace("@primitives.$color.", "").replace(/[$.]/g, "-").substring(1)})`;
       }
       return `var(--color-${reference
         .replace("@primitives.", "")
         .replace("$color.", "")
-        .replace(/[$\.]/g, "-")
+        .replace(/[$.]/g, "-")
         .substring(1)})`;
     }
 
@@ -727,9 +727,9 @@ function resolveColor(value, variables, asCssVariable = true) {
       } else {
         // If we can't resolve, return the CSS variable equivalent
         if (reference.startsWith("@primitives.$color")) {
-          return `var(--color-${reference.replace("@primitives.$color.", "").replace(/[$\.]/g, "-").substring(1)})`;
+          return `var(--color-${reference.replace("@primitives.$color.", "").replace(/[$.]/g, "-").substring(1)})`;
         }
-        return `var(--color-${reference.replace(/[@$\.]/g, "-").substring(1)})`;
+        return `var(--color-${reference.replace(/[@$.]/g, "-").substring(1)})`;
       }
     }
 

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1103,59 +1103,59 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@biomejs/biome@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/biome/-/biome-1.9.4.tgz#89766281cbc3a0aae865a7ff13d6aaffea2842bf"
-  integrity sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==
+"@biomejs/biome@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@biomejs/biome/-/biome-2.0.6.tgz#23a40836078496a0afd61981830e2cffdd0b7c6a"
+  integrity sha512-RRP+9cdh5qwe2t0gORwXaa27oTOiQRQvrFf49x2PA1tnpsyU7FIHX4ZOFMtBC4QNtyWsN7Dqkf5EDbg4X+9iqA==
   optionalDependencies:
-    "@biomejs/cli-darwin-arm64" "1.9.4"
-    "@biomejs/cli-darwin-x64" "1.9.4"
-    "@biomejs/cli-linux-arm64" "1.9.4"
-    "@biomejs/cli-linux-arm64-musl" "1.9.4"
-    "@biomejs/cli-linux-x64" "1.9.4"
-    "@biomejs/cli-linux-x64-musl" "1.9.4"
-    "@biomejs/cli-win32-arm64" "1.9.4"
-    "@biomejs/cli-win32-x64" "1.9.4"
+    "@biomejs/cli-darwin-arm64" "2.0.6"
+    "@biomejs/cli-darwin-x64" "2.0.6"
+    "@biomejs/cli-linux-arm64" "2.0.6"
+    "@biomejs/cli-linux-arm64-musl" "2.0.6"
+    "@biomejs/cli-linux-x64" "2.0.6"
+    "@biomejs/cli-linux-x64-musl" "2.0.6"
+    "@biomejs/cli-win32-arm64" "2.0.6"
+    "@biomejs/cli-win32-x64" "2.0.6"
 
-"@biomejs/cli-darwin-arm64@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz#dfa376d23a54a2d8f17133c92f23c1bf2e62509f"
-  integrity sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==
+"@biomejs/cli-darwin-arm64@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.0.6.tgz#1121846e8fea18552a29b994a2db69fdd17fa4f1"
+  integrity sha512-AzdiNNjNzsE6LfqWyBvcL29uWoIuZUkndu+wwlXW13EKcBHbbKjNQEZIJKYDc6IL+p7bmWGx3v9ZtcRyIoIz5A==
 
-"@biomejs/cli-darwin-x64@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz#eafc2ce3849d385fc02238aad1ca4a73395a64d9"
-  integrity sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==
+"@biomejs/cli-darwin-x64@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.0.6.tgz#87915d3bae7da978ccae2950939b54e4d434828d"
+  integrity sha512-wJjjP4E7bO4WJmiQaLnsdXMa516dbtC6542qeRkyJg0MqMXP0fvs4gdsHhZ7p9XWTAmGIjZHFKXdsjBvKGIJJQ==
 
-"@biomejs/cli-linux-arm64-musl@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz#d780c3e01758fc90f3268357e3f19163d1f84fca"
-  integrity sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==
+"@biomejs/cli-linux-arm64-musl@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.0.6.tgz#b148603978eebd4828889727b940506891014c6e"
+  integrity sha512-CVPEMlin3bW49sBqLBg2x016Pws7eUXA27XYDFlEtponD0luYjg2zQaMJ2nOqlkKG9fqzzkamdYxHdMDc2gZFw==
 
-"@biomejs/cli-linux-arm64@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz#8ed1dd0e89419a4b66a47f95aefb8c46ae6041c9"
-  integrity sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==
+"@biomejs/cli-linux-arm64@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.0.6.tgz#7ed0943b74ce99e0002da08025fb9d09f591fa78"
+  integrity sha512-ZSVf6TYo5rNMUHIW1tww+rs/krol7U5A1Is/yzWyHVZguuB0lBnIodqyFuwCNqG9aJGyk7xIMS8HG0qGUPz0SA==
 
-"@biomejs/cli-linux-x64-musl@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz#f36982b966bd671a36671e1de4417963d7db15fb"
-  integrity sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==
+"@biomejs/cli-linux-x64-musl@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.0.6.tgz#979cab6bec8e4d5898b4564118fabc9a657270f1"
+  integrity sha512-mKHE/e954hR/hSnAcJSjkf4xGqZc/53Kh39HVW1EgO5iFi0JutTN07TSjEMg616julRtfSNJi0KNyxvc30Y4rQ==
 
-"@biomejs/cli-linux-x64@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz#a0a7f56680c76b8034ddc149dbf398bdd3a462e8"
-  integrity sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==
+"@biomejs/cli-linux-x64@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-x64/-/cli-linux-x64-2.0.6.tgz#13ddebbf0b5e807fbf7d3edad7d8a052459c021e"
+  integrity sha512-geM1MkHTV1Kh2Cs/Xzot9BOF3WBacihw6bkEmxkz4nSga8B9/hWy5BDiOG3gHDGIBa8WxT0nzsJs2f/hPqQIQw==
 
-"@biomejs/cli-win32-arm64@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz#e2ef4e0084e76b7e26f0fc887c5ef1265ea56200"
-  integrity sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==
+"@biomejs/cli-win32-arm64@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.0.6.tgz#cead818d167948c991e5034b76008d7abb99d79e"
+  integrity sha512-290V4oSFoKaprKE1zkYVsDfAdn0An5DowZ+GIABgjoq1ndhvNxkJcpxPsiYtT7slbVe3xmlT0ncdfOsN7KruzA==
 
-"@biomejs/cli-win32-x64@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz#4c7afa90e3970213599b4095e62f87e5972b2340"
-  integrity sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==
+"@biomejs/cli-win32-x64@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-x64/-/cli-win32-x64-2.0.6.tgz#53acf543060bfda18853dfa81b34e6e95fb545a5"
+  integrity sha512-bfM1Bce0d69Ao7pjTjUS+AWSZ02+5UHdiAP85Th8e9yV5xzw6JrHXbL5YWlcEKQ84FIZMdDc7ncuti1wd2sdbw==
 
 "@borewit/text-codec@^0.2.1":
   version "0.2.1"
@@ -18019,16 +18019,7 @@ string-length@^4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -18077,7 +18068,7 @@ stringify-object@^5.0.0:
     is-obj "^3.0.0"
     is-regexp "^3.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -18090,13 +18081,6 @@ strip-ansi@^3.0.0:
   integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.2"
@@ -19771,7 +19755,7 @@ workerpool@^9.2.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-9.3.4.tgz#f6c92395b2141afd78e2a889e80cb338fe9fca41"
   integrity sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -19784,15 +19768,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This PR upgrades the frontend lint/format toolchain from Biome 1 to Biome 2.

All reported errors were rule/format diagnostics, not functional bugs.

Biome 2 introduces updated formatter behavior, so previously valid formatting in Biome 1 is now flagged and rewritten.
The config model changed in v2 (schema + config structure), so rule resolution is stricter and some patterns now fail under the new setup.

