### PR TITLE
docs: Support report note on s3 storage

### DIFF
--- a/docs/source/guide/support_reports.md
+++ b/docs/source/guide/support_reports.md
@@ -40,6 +40,12 @@ Once completed, you can use the action icons to:
 
 ![Screenshot of support reports page](/images/admin/support-report-generate.png)
 
+!!! note
+    To download the ZIP file, you need to have at least one project with S3 or S3-compatible storage configured. This is because when generating a support report, Label Studio persists the report artifact using the configured storage backend before it becomes available for download.
+    
+    If you do not have S3-compatible storage configured, or if the credentials are not valid, you will receive a `botocore.exceptions.ClientError` when you try to download the ZIP file. 
+    
+    
 
 ## Configure automatic delivery
 


### PR DESCRIPTION
Add a note on requiring s3 storage to the page on support reports