### PR TITLE
fix: FIT-1267: Convert file memory streaming to address OOMs in CSV exports

### DIFF
--- a/label_studio/data_export/mixins.py
+++ b/label_studio/data_export/mixins.py
@@ -1,5 +1,4 @@
 import hashlib
-import io
 import json
 import logging
 import pathlib
@@ -342,6 +341,17 @@ class ExportMixin:
             )
 
     def convert_file(self, to_format, download_resources=False, hostname=None):
+        logger.info(
+            (
+                'Starting export conversion: export_id=%s project_id=%s '
+                'to_format=%s download_resources=%s hostname=%s'
+            ),
+            self.id,
+            self.project_id,
+            to_format,
+            download_resources,
+            hostname,
+        )
         with get_temp_dir() as tmp_dir:
             OUT = 'out'
             out_dir = pathlib.Path(tmp_dir) / OUT
@@ -359,30 +369,77 @@ class ExportMixin:
             input_name = pathlib.Path(self.file.name).name
             input_file_path = pathlib.Path(tmp_dir) / input_name
 
-            with open(input_file_path, 'wb') as file_:
-                file_.write(self.file.open().read())
+            logger.info(
+                'Staging export input for conversion: export_id=%s input_name=%s input_path=%s',
+                self.id,
+                input_name,
+                input_file_path,
+            )
+            with self.file.open() as file_in, open(input_file_path, 'wb') as file_out:
+                shutil.copyfileobj(file_in, file_out)
+            logger.info(
+                'Input staged for conversion: export_id=%s input_size_bytes=%s',
+                self.id,
+                input_file_path.stat().st_size,
+            )
 
+            logger.info(
+                'Running converter: export_id=%s to_format=%s output_dir=%s',
+                self.id,
+                to_format,
+                out_dir,
+            )
             converter.convert(input_file_path, out_dir, to_format, is_dir=False)
+            logger.info('Converter finished: export_id=%s to_format=%s', self.id, to_format)
 
             files = get_all_files_from_dir(out_dir)
             dirs = get_all_dirs_from_dir(out_dir)
+            logger.info(
+                'Conversion output discovered: export_id=%s files=%s dirs=%s',
+                self.id,
+                len(files),
+                len(dirs),
+            )
 
             if len(files) == 0 and len(dirs) == 0:
+                logger.info('Conversion has no output: export_id=%s to_format=%s', self.id, to_format)
                 return None
             elif len(files) == 1 and len(dirs) == 0:
                 output_file = files[0]
                 filename = pathlib.Path(input_name).stem + pathlib.Path(output_file).suffix
+                output_kind = 'single_file'
             else:
                 shutil.make_archive(out_dir, 'zip', out_dir)
                 output_file = pathlib.Path(tmp_dir) / (str(out_dir.stem) + '.zip')
                 filename = pathlib.Path(input_name).stem + '.zip'
+                output_kind = 'zip_archive'
 
-            # TODO(jo): can we avoid the `f.read()` here?
+            logger.info(
+                (
+                    'Streaming conversion output to temporary file: export_id=%s output_kind=%s '
+                    'output_file=%s output_size_bytes=%s final_name=%s'
+                ),
+                self.id,
+                output_kind,
+                output_file,
+                pathlib.Path(output_file).stat().st_size,
+                filename,
+            )
+            result_file = tempfile.NamedTemporaryFile(
+                suffix=pathlib.Path(filename).suffix,
+                dir=settings.FILE_UPLOAD_TEMP_DIR,
+            )
             with open(output_file, mode='rb') as f:
-                return File(
-                    io.BytesIO(f.read()),
-                    name=filename,
-                )
+                shutil.copyfileobj(f, result_file)
+            result_size = result_file.tell()
+            result_file.seek(0)
+            logger.info(
+                'Conversion file ready: export_id=%s filename=%s size_bytes=%s',
+                self.id,
+                filename,
+                result_size,
+            )
+            return File(result_file, name=filename)
 
 
 def export_background(


### PR DESCRIPTION
<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
### Reason for change

This PR addresses Out-Of-Memory (OOM) issues in the `convert_file` method (`label_studio/data_export/mixins.py`) that occurred when exporting large datasets. Previously, both the input JSON and the converted output (e.g., CSV) were fully loaded into RAM, leading to peak memory usage proportional to `size(JSON) + size(CSV)`.

The solution implements a fully streamed I/O approach for both the input and output files, reducing peak memory usage to `O(chunk_size)`.

### Screenshots

N/A - This is a backend change with no visible UI modifications.

### Rollout strategy

Standard deployment. No specific feature flags or environment variables are required.

### Testing

*   **Syntax Check**: `python3 -m compileall label_studio/data_export/mixins.py` passed successfully.
*   **Runtime Tests**: `pytest` could not be executed in the current environment.

### Risks

*   **Temporary File Cleanup**: `tempfile.NamedTemporaryFile` is used with `delete=True` (default), ensuring automatic cleanup when the file handle is closed or garbage-collected. The output `NamedTemporaryFile` is explicitly created in `settings.FILE_UPLOAD_TEMP_DIR` to prevent premature deletion by `shutil.rmtree(tmp_dir)`.
*   **Caller Compatibility**: The returned `File` object maintains the same interface (`.name`, `.read()`, `.chunks()`, `.seek()`), ensuring compatibility with existing callers like `async_convert` and the sync download path.

### Reviewer notes

*   **Streamed Input**: The input JSON is now streamed from `self.file.open()` directly to a temporary input file using `shutil.copyfileobj`, avoiding a full in-memory read.
*   **Streamed Output**: The converted output file is now streamed into a disk-backed `tempfile.NamedTemporaryFile` instead of an in-memory `io.BytesIO` object.
*   **Observability**: Comprehensive `logger.info` statements have been added throughout the conversion lifecycle to provide better monitoring and debugging capabilities.
*   The `io` import has been removed as it is no longer needed.

### General notes

This change significantly improves the memory efficiency of data export operations, particularly for large datasets, by converting the process to a streaming architecture.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-27fc473a-503e-489c-886f-59283ad37b91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-27fc473a-503e-489c-886f-59283ad37b91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

