### PR TITLE
fix: UTC-586: Fix expand collapse indicators in Members Selection filters.

### DIFF
--- a/web/libs/ui/src/lib/collapsible-panel/collapsible-panel.tsx
+++ b/web/libs/ui/src/lib/collapsible-panel/collapsible-panel.tsx
@@ -105,7 +105,7 @@ export const CollapsiblePanel = ({
         >
           <IconChevronDown
             size={16}
-            className={cn("transition-transform duration-200", !isExpanded && "-rotate-90")}
+            className={cn("transition-transform ease-out duration-200", !isExpanded && "-rotate-90")}
           />
         </Button>
 

--- a/web/libs/ui/src/lib/collapsible-panel/collapsible-panel.tsx
+++ b/web/libs/ui/src/lib/collapsible-panel/collapsible-panel.tsx
@@ -1,6 +1,6 @@
 import { useState, type ReactNode } from "react";
 import { cn } from "../../utils/utils";
-import { IconChevronDown, IconChevron } from "@humansignal/icons";
+import { IconChevronDown } from "@humansignal/icons";
 import { Button } from "../button/button";
 
 export type CollapsiblePanelProps = {
@@ -103,7 +103,10 @@ export const CollapsiblePanel = ({
           aria-expanded={isExpanded}
           data-testid="collapsible-panel-toggle"
         >
-          {isExpanded ? <IconChevron size={16} /> : <IconChevronDown size={16} />}
+          <IconChevronDown
+            size={16}
+            className={cn("transition-transform duration-200", !isExpanded && "-rotate-90")}
+          />
         </Button>
 
         <div className="flex-1 flex items-center gap-2 truncate" data-testid="collapsible-panel-title">

--- a/web/libs/ui/src/lib/select/select.module.scss
+++ b/web/libs/ui/src/lib/select/select.module.scss
@@ -128,7 +128,7 @@
 }
 
 .selectedItemsCaret {
-  transition: opacity 150ms ease-out;
+  transition: opacity 150ms ease-out, transform 200ms ease-out;
 }
 
 .selectedItemsContent {

--- a/web/libs/ui/src/lib/select/select.module.scss
+++ b/web/libs/ui/src/lib/select/select.module.scss
@@ -128,7 +128,7 @@
 }
 
 .selectedItemsCaret {
-  transition: opacity 150ms ease-out, transform 200ms ease-out;
+  transition: opacity 150ms ease-out;
 }
 
 .selectedItemsContent {

--- a/web/libs/ui/src/lib/select/select.tsx
+++ b/web/libs/ui/src/lib/select/select.tsx
@@ -89,7 +89,7 @@ const SelectedItemsGroup = ({
       >
         {/* Caret icon */}
         <IconChevronDown
-          className={cn(styles.selectedItemsCaret, "transition-transform duration-200", !expanded && "-rotate-90")}
+          className={cn(styles.selectedItemsCaret, "transition-transform ease-out duration-200", !expanded && "-rotate-90")}
           aria-hidden="true"
           style={{ opacity: hasNoItems ? 0.3 : 1 }}
         />

--- a/web/libs/ui/src/lib/select/select.tsx
+++ b/web/libs/ui/src/lib/select/select.tsx
@@ -89,7 +89,11 @@ const SelectedItemsGroup = ({
       >
         {/* Caret icon */}
         <IconChevronDown
-          className={cn(styles.selectedItemsCaret, "transition-transform ease-out duration-200", !expanded && "-rotate-90")}
+          className={cn(
+            styles.selectedItemsCaret,
+            "transition-transform ease-out duration-200",
+            !expanded && "-rotate-90",
+          )}
           aria-hidden="true"
           style={{ opacity: hasNoItems ? 0.3 : 1 }}
         />

--- a/web/libs/ui/src/lib/select/select.tsx
+++ b/web/libs/ui/src/lib/select/select.tsx
@@ -16,7 +16,7 @@ import { isDefined } from "@humansignal/core/lib/utils/helpers";
 import { IconChevron, IconChevronDown } from "@humansignal/icons";
 import clsx from "clsx";
 import styles from "./select.module.scss";
-import { cnm } from "../../utils/utils";
+import { cn, cnm } from "../../utils/utils";
 import { VariableSizeList } from "react-window";
 import InfiniteLoader from "react-window-infinite-loader";
 
@@ -88,19 +88,11 @@ const SelectedItemsGroup = ({
         style={{ cursor: hasNoItems ? "default" : "pointer" }}
       >
         {/* Caret icon */}
-        {expanded ? (
-          <IconChevron
-            className={styles.selectedItemsCaret}
-            aria-hidden="true"
-            style={{ opacity: hasNoItems ? 0.3 : 1 }}
-          />
-        ) : (
-          <IconChevronDown
-            className={styles.selectedItemsCaret}
-            aria-hidden="true"
-            style={{ opacity: hasNoItems ? 0.3 : 1 }}
-          />
-        )}
+        <IconChevronDown
+          className={cn(styles.selectedItemsCaret, "transition-transform duration-200", !expanded && "-rotate-90")}
+          aria-hidden="true"
+          style={{ opacity: hasNoItems ? 0.3 : 1 }}
+        />
 
         {/* Deselect all checkbox */}
         <Checkbox


### PR DESCRIPTION
Replace inconsistent IconChevron/IconChevronDown toggling with a single IconChevronDown that rotates -90deg when collapsed and points down when expanded, with a smooth transition animation. This matches the pattern used in the accordion and other collapsible elements across the app.

Fixes UTC-586


