### PR TITLE
fix: FIT-1401: Comments section remains in perpetual loading state for tasks that do not yet have comments (in recent build)

### DIFF
--- a/web/apps/labelstudio/src/pages/CreateProject/Config/UnsavedChanges.tsx
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/UnsavedChanges.tsx
@@ -44,7 +44,7 @@ export const unsavedChangesModal = ({
   body = "Would you like to save them before leaving?",
   ...props
 }: UnsavedChangesModalProps) => {
-  let modalInstance: any = undefined;
+  let modalInstance: any;
   const saveAndLeave = async () => {
     await onSave?.();
     modalInstance?.close();

--- a/web/libs/editor/src/components/Comments/Comments.tsx
+++ b/web/libs/editor/src/components/Comments/Comments.tsx
@@ -66,8 +66,7 @@ export const Comments: FC<{
     // remain the same when user submit draft, so no unneeded calls.
   }, [commentStore.annotation?.id, isActive, lazyLoadEnabled]);
 
-  // FIT-720: Show skeleton loader while fetching comments (only when lazy loading enabled)
-  const isLoading = lazyLoadEnabled && commentStore.isListLoading;
+  const isLoading = lazyLoadEnabled && commentStore.isListLoading && !!commentStore.annotation;
 
   useEffect(() => {
     const confirmCommentsLoss = (e: any) => {

--- a/web/libs/editor/src/stores/Comment/CommentStore.js
+++ b/web/libs/editor/src/stores/Comment/CommentStore.js
@@ -381,7 +381,11 @@ export const CommentStore = types
     }
 
     const listComments = flow(function* ({ mounted = { current: true }, suppressClearComments } = {}) {
-      if (!self.draftId && !self.annotationId) return;
+      if (!self.draftId && !self.annotationId) {
+        if (!suppressClearComments) self.setComments([]);
+        if (mounted.current) self.setLoading(null);
+        return;
+      }
 
       // FIT-720: Deduplicate concurrent listComments calls for the same annotation.
       // This prevents double API calls when both the prefetch (on annotation selection)


### PR DESCRIPTION
This pull request introduces improvements to the comments loading logic and the unsaved changes modal. The main focus is on handling loading states more accurately and ensuring comments are cleared appropriately when there is no annotation or draft selected.

**Comments Loading Improvements:**

* Improved the `isLoading` logic in `Comments.tsx` to only show the skeleton loader when there is a valid annotation, preventing unnecessary loading indicators.
* Updated the `listComments` method in `CommentStore.js` to clear comments and reset the loading state when neither `draftId` nor `annotationId` is set, unless suppressed. This ensures the UI does not show stale comments or remain in a loading state when not needed.

**Minor Code Cleanup:**

* Removed unnecessary initialization of `modalInstance` in `UnsavedChanges.tsx` for cleaner code.