### PR TITLE
fix: UTC-590: Warning message is displayed in background of "You are paused in this project" message

### DIFF
--- a/web/libs/datamanager/src/stores/DataStores/annotations.js
+++ b/web/libs/datamanager/src/stores/DataStores/annotations.js
@@ -23,6 +23,11 @@ export const create = (columns) => {
         });
       }
 
+      // No task when e.g. 403 (paused) or error response
+      if (!remoteTask?.id) {
+        return null;
+      }
+
       annotationID = annotationID ?? remoteTask.id;
 
       const annotation = self.updateItem(annotationID, {

--- a/web/libs/datamanager/src/stores/DataStores/tasks.js
+++ b/web/libs/datamanager/src/stores/DataStores/tasks.js
@@ -197,6 +197,11 @@ export const create = (columns) => {
           return null;
         }
 
+        // No task when e.g. 403 (paused) or error response — avoid using taskData below
+        if (taskData?.$meta?.status === 403 || !taskData?.id) {
+          return null;
+        }
+
         const labelStreamModeChanged =
           self.selected && self.selected.assigned_task !== taskData.assigned_task && taskData.assigned_task === false;
 
@@ -213,7 +218,7 @@ export const create = (columns) => {
           const selectedAnnotationID = getRoot(self).annotationStore.selected?.id;
           if (task && selectedAnnotationID) {
             console.log(
-              `[LABEL STREAM] ${task.queue}, task ${task.id}, project ${getRoot(self)?.SDK?.project?.id}, user ${getRoot(self).LSF.lsf.user.id}${selectedAnnotationID ? `, annotation ${selectedAnnotationID}` : ""}`,
+              `[LABEL STREAM] ${task?.queue ?? ""}, task ${task?.id}, project ${getRoot(self)?.SDK?.project?.id}, user ${getRoot(self).LSF?.lsf?.user?.id ?? ""}${selectedAnnotationID ? `, annotation ${selectedAnnotationID}` : ""}`,
             );
           }
         }


### PR DESCRIPTION
## Summary
Guard task queue references when the next-task API returns 403 (e.g. annotator paused). Prevents "Cannot read properties of undefined (reading 'queue')" in Label Stream when the user is paused.

## Changes (LSO)
- **tasks.js**: Return null early when `taskData?.$meta?.status === 403` or `!taskData?.id`; use optional chaining in LABEL STREAM log (`task?.queue`, `task?.id`).
- **annotations.js**: Return null when `nextTask` response has no task (`!remoteTask?.id`).

## Jira
https://humansignal.atlassian.net/browse/UTC-590

## Test Plan
- [ ] In LSE with annotator eval + "Pause annotator on failed evaluation", trigger pause in Label Stream and confirm only "You are paused in this project" modal appears (no console error).
- [ ] Normal next-task flow still works when not paused.