### PR TITLE
fix: FIT-1410: Mobx commentstore parent error

### DIFF
--- a/web/libs/editor/src/components/Comments/Comments.tsx
+++ b/web/libs/editor/src/components/Comments/Comments.tsx
@@ -35,14 +35,22 @@ export const Comments: FC<{
   const lazyLoadEnabled = isFF(FF_FIT_720_LAZY_LOAD_ANNOTATIONS);
 
   const loadComments = async () => {
+    // Capture the current annotation id before the async call.
+    // The store tree can be replaced while awaiting, so avoid reading
+    // commentStore.annotation after await.
+    const annotationId = commentStore.annotation?.id;
+
     // It prevents blinking on opening comments tab for the same annotation when comments are already there
     const listCommentsOptions: any = { mounted, suppressClearComments: commentStore.isRelevantList };
     await commentStore.listComments(listCommentsOptions);
+
+    if (!mounted.current) return;
+
     if (!isFF(FF_DEV_3034)) {
       commentStore.restoreCommentsFromCache(cacheKey);
     }
     // Track that we loaded comments for this annotation (FIT-720)
-    lastLoadedAnnotationId.current = commentStore.annotation?.id;
+    lastLoadedAnnotationId.current = annotationId ?? null;
   };
 
   useEffect(() => {


### PR DESCRIPTION
This pull request improves the robustness of the comments loading logic in the `Comments` component by ensuring that the correct annotation ID is captured before making asynchronous calls. This prevents potential bugs caused by the store tree being replaced during the async operation.

**Bug fix and code robustness:**

* [`web/libs/editor/src/components/Comments/Comments.tsx`](diffhunk://#diff-da64600b1dfaf0ff4e30dba06c12e6e787158db6641a4eaa830db4f8750e6787R38-R53): Captured the current annotation ID before awaiting the async `listComments` call to avoid referencing a potentially outdated store value after the await, and updated the logic to use this captured value.