### PR TITLE
fix: FIT-1412: In Interactive task source, Search returns no results when certain filters (All, Annotations, Predictions, Data) are applied

### DIFF
--- a/web/libs/ui/src/lib/json-viewer/json-viewer.test.tsx
+++ b/web/libs/ui/src/lib/json-viewer/json-viewer.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { JsonViewer } from "./json-viewer";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __jsonEditorProps: any;
+}
+
+jest.mock("json-edit-react", () => ({
+  JsonEditor: (props: any) => {
+    global.__jsonEditorProps = props;
+    return <div data-testid="json-editor" />;
+  },
+  defaultTheme: { styles: {} },
+  matchNode: jest.fn(() => false),
+}));
+
+jest.mock("@humansignal/icons", () => ({
+  IconSearch: () => null,
+  IconReset: () => null,
+  IconClose: () => null,
+  IconCopyOutline: () => null,
+}));
+
+jest.mock("../button/button", () => ({
+  Button: ({ children, onClick, ...rest }: any) => (
+    <button type="button" onClick={onClick} {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock("../Tooltip/Tooltip", () => ({
+  Tooltip: ({ children }: any) => <>{children}</>,
+}));
+
+jest.mock("./reader-view-button", () => ({
+  ReaderViewButton: () => null,
+}));
+
+jest.mock("./json-viewer.module.scss", () => ({}));
+
+describe("JsonViewer filtered search", () => {
+  beforeEach(() => {
+    global.__jsonEditorProps = undefined;
+    jest.clearAllMocks();
+  });
+
+  it("finds key names when All filter is explicitly selected", () => {
+    render(<JsonViewer data={{ id: 123, data: { image: "a.png" } }} showCopyButton={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "All" }));
+    fireEvent.change(screen.getByLabelText("Search JSON"), { target: { value: "id" } });
+
+    const { matchNode } = require("json-edit-react");
+    const searchFilter = global.__jsonEditorProps.searchFilter;
+
+    expect(typeof searchFilter).toBe("function");
+    expect(searchFilter({ key: "id", value: 123, path: ["id"] }, "id")).toBe(true);
+    expect(matchNode).toHaveBeenCalled();
+  });
+
+  it("keeps custom filter scope while matching keys in filtered nodes", () => {
+    render(
+      <JsonViewer
+        data={{ id: 123, data: { image: "a.png" } }}
+        showCopyButton={false}
+        customFilters={[
+          {
+            id: "data",
+            label: "Data",
+            filterFn: (nodeData) => {
+              const path = nodeData.path;
+              return path && path.includes("data");
+            },
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Data" }));
+    fireEvent.change(screen.getByLabelText("Search JSON"), { target: { value: "id" } });
+
+    const searchFilter = global.__jsonEditorProps.searchFilter;
+
+    expect(searchFilter({ key: "id", value: 123, path: ["annotations", 0, "id"] }, "id")).toBe(false);
+    expect(searchFilter({ key: "id", value: 123, path: ["data", "id"] }, "id")).toBe(true);
+  });
+});

--- a/web/libs/ui/src/lib/json-viewer/json-viewer.tsx
+++ b/web/libs/ui/src/lib/json-viewer/json-viewer.tsx
@@ -27,6 +27,32 @@ const labelStudioTheme = {
   },
 };
 
+const fallbackNodeMatch = (nodeData: any, searchTerm: string): boolean => {
+  const normalizedTerm = searchTerm.toLowerCase();
+  const nodeKey = typeof nodeData?.key === "string" ? nodeData.key.toLowerCase() : "";
+
+  if (nodeKey.includes(normalizedTerm)) {
+    return true;
+  }
+
+  if (Array.isArray(nodeData?.path)) {
+    const hasPathMatch = nodeData.path.some((segment: string | number) =>
+      String(segment).toLowerCase().includes(normalizedTerm),
+    );
+
+    if (hasPathMatch) {
+      return true;
+    }
+  }
+
+  const nodeValue = nodeData?.value;
+  if (typeof nodeValue === "string" || typeof nodeValue === "number" || typeof nodeValue === "boolean") {
+    return String(nodeValue).toLowerCase().includes(normalizedTerm);
+  }
+
+  return false;
+};
+
 /**
  * JsonViewer - An interactive JSON viewer component
  *
@@ -118,7 +144,7 @@ export const JsonViewer: FC<JsonViewerProps> = ({
       }
       // Also apply search if there's search text
       if (searchTerm) {
-        return matchNode(nodeData, searchTerm);
+        return matchNode(nodeData, searchTerm) || fallbackNodeMatch(nodeData, searchTerm);
       }
       return true;
     };


### PR DESCRIPTION
This pull request adds comprehensive tests for the `JsonViewer` component's filtered search functionality and improves the search logic to provide more robust fallback matching. The main focus is to ensure that searching within the JSON viewer works as expected, even when custom filters are applied or when the default search logic does not match.

**Testing improvements:**

* Added a new test suite in `json-viewer.test.tsx` that verifies the search functionality of `JsonViewer`, including scenarios with custom filters and explicit filter selection.

**Search logic enhancements:**

* Introduced a `fallbackNodeMatch` function in `json-viewer.tsx` to provide additional matching logic when the default `matchNode` does not find a match. This function checks the node's key, path, and value for the search term.
* Updated the `searchFilter` logic in `JsonViewer` to use `fallbackNodeMatch` as a backup when `matchNode` returns false, improving the reliability of search results.