### PR TITLE
fix: BROS-803: Disallow deleting last/all points of the shape

### DIFF
--- a/web/libs/editor/src/components/KonvaVector/KonvaVector.tsx
+++ b/web/libs/editor/src/components/KonvaVector/KonvaVector.tsx
@@ -2013,6 +2013,9 @@ export const KonvaVector = forwardRef<KonvaVectorRef, KonvaVectorProps>((props, 
 
       if (indicesToDelete.length === 0) return;
 
+      // Don't allow deleting all points — must keep at least one to avoid an empty region
+      if (indicesToDelete.length >= initialPoints.length) return;
+
       // Create a set of deleted point IDs for quick lookup
       const deletedPointIds = new Set(pointIds);
 

--- a/web/libs/editor/src/components/KonvaVector/pointManagement.ts
+++ b/web/libs/editor/src/components/KonvaVector/pointManagement.ts
@@ -181,6 +181,9 @@ export const deletePoint = (
 ) => {
   if (index < 0 || index >= initialPoints.length) return;
 
+  // Don't allow deleting the last remaining point — it would leave an empty region
+  if (initialPoints.length <= 1) return;
+
   const deletedPoint = initialPoints[index];
   const newPoints = [...initialPoints];
   newPoints.splice(index, 1);


### PR DESCRIPTION
This pull request introduces safeguards to prevent users from deleting all points in a vector region, ensuring that at least one point always remains. This helps maintain data integrity and avoids empty or invalid vector regions.

Validation improvements for point deletion:

* Added a check in `KonvaVector.tsx` to prevent deletion of all points at once, ensuring at least one point remains in the region.
* Updated `deletePoint` in `pointManagement.ts` to block deletion when only one point is left, preventing an empty region.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
