### PR TITLE
fix: FIT-1420: Sentry: A [mobx-state-tree] Cannot modify map<string, error occurring

### DIFF
--- a/web/libs/datamanager/src/sdk/lsf-sdk.js
+++ b/web/libs/datamanager/src/sdk/lsf-sdk.js
@@ -15,6 +15,7 @@ import { CommentsSdk } from "./comments-sdk";
 // import { LSFHistory } from "./lsf-history";
 import { annotationToServer, taskToLSFormat } from "./lsf-utils";
 import { when } from "mobx";
+import { isAlive } from "mobx-state-tree";
 import { imageCache } from "@humansignal/core";
 import { invalidateAnnotationCache, invalidateDistributionCache } from "@humansignal/core/lib/utils/annotation-cache";
 
@@ -526,6 +527,10 @@ export class LSFWrapper {
           // Annotation no longer exists in the store
           return fullAnnotation;
         }
+        if (!isAlive(lsfAnnotation) || !isAlive(lsfAnnotation.trackedState)) {
+          // Annotation node was detached while hydration request was in-flight
+          return fullAnnotation;
+        }
 
         // Check if already hydrated while we were fetching
         const versionsResult = lsfAnnotation.versions?.result;
@@ -538,6 +543,7 @@ export class LSFWrapper {
         }
 
         if (fullAnnotation.result) {
+          if (!isAlive(lsfAnnotation) || !isAlive(lsfAnnotation.trackedState)) return fullAnnotation;
           lsfAnnotation.history.freeze();
           lsfAnnotation.deserializeResults(fullAnnotation.result);
           // Critical: updateObjects() is required to render visual regions after deserializing
@@ -1245,6 +1251,10 @@ export class LSFWrapper {
           // Annotation no longer exists in the store
           return;
         }
+        if (!isAlive(freshAnnotation) || !isAlive(freshAnnotation.trackedState)) {
+          // Annotation node was detached while hydration request was in-flight
+          return;
+        }
 
         // Check if annotation was already hydrated while we were fetching
         const freshVersionsResult = freshAnnotation.versions?.result;
@@ -1260,6 +1270,7 @@ export class LSFWrapper {
         freshAnnotation.history?.freeze?.();
 
         // Deserialize the results into the annotation
+        if (!isAlive(freshAnnotation) || !isAlive(freshAnnotation.trackedState)) return;
         freshAnnotation.deserializeResults(fullAnnotation.result);
 
         // Critical: updateObjects() MUST be called to render visual regions after deserializing

--- a/web/libs/datamanager/src/sdk/lsf-sdk.js
+++ b/web/libs/datamanager/src/sdk/lsf-sdk.js
@@ -538,12 +538,7 @@ export class LSFWrapper {
         }
 
         if (fullAnnotation.result) {
-          lsfAnnotation.history.freeze();
-          lsfAnnotation.deserializeResults(fullAnnotation.result);
-          // Critical: updateObjects() is required to render visual regions after deserializing
-          lsfAnnotation.updateObjects();
-          lsfAnnotation.history.safeUnfreeze();
-          lsfAnnotation.history.reinit();
+          this.lsf?.annotationStore?.hydrateAnnotationResults?.(annotationPk, fullAnnotation.result);
         }
 
         return fullAnnotation;
@@ -1256,21 +1251,7 @@ export class LSFWrapper {
           return;
         }
 
-        // Freeze history to prevent undo/redo issues during hydration
-        freshAnnotation.history?.freeze?.();
-
-        // Deserialize the results into the annotation
-        freshAnnotation.deserializeResults(fullAnnotation.result);
-
-        // Critical: updateObjects() MUST be called to render visual regions after deserializing
-        freshAnnotation.updateObjects?.();
-
-        // Unfreeze history
-        freshAnnotation.history?.safeUnfreeze?.();
-
-        // reinitHistory cancels autosave and sets initial values so LSF knows this is the base state
-        // This prevents the hydration from being treated as a user modification
-        freshAnnotation.reinitHistory?.();
+        this.lsf?.annotationStore?.hydrateAnnotationResults?.(annotationPk, fullAnnotation.result);
       }
     } catch {
       // Failed to hydrate annotation - will show stub state

--- a/web/libs/datamanager/src/sdk/lsf-sdk.js
+++ b/web/libs/datamanager/src/sdk/lsf-sdk.js
@@ -538,7 +538,12 @@ export class LSFWrapper {
         }
 
         if (fullAnnotation.result) {
-          this.lsf?.annotationStore?.hydrateAnnotationResults?.(annotationPk, fullAnnotation.result);
+          lsfAnnotation.history.freeze();
+          lsfAnnotation.deserializeResults(fullAnnotation.result);
+          // Critical: updateObjects() is required to render visual regions after deserializing
+          lsfAnnotation.updateObjects();
+          lsfAnnotation.history.safeUnfreeze();
+          lsfAnnotation.history.reinit();
         }
 
         return fullAnnotation;
@@ -1251,7 +1256,21 @@ export class LSFWrapper {
           return;
         }
 
-        this.lsf?.annotationStore?.hydrateAnnotationResults?.(annotationPk, fullAnnotation.result);
+        // Freeze history to prevent undo/redo issues during hydration
+        freshAnnotation.history?.freeze?.();
+
+        // Deserialize the results into the annotation
+        freshAnnotation.deserializeResults(fullAnnotation.result);
+
+        // Critical: updateObjects() MUST be called to render visual regions after deserializing
+        freshAnnotation.updateObjects?.();
+
+        // Unfreeze history
+        freshAnnotation.history?.safeUnfreeze?.();
+
+        // reinitHistory cancels autosave and sets initial values so LSF knows this is the base state
+        // This prevents the hydration from being treated as a user modification
+        freshAnnotation.reinitHistory?.();
       }
     } catch {
       // Failed to hydrate annotation - will show stub state

--- a/web/libs/editor/src/stores/Annotation/store.js
+++ b/web/libs/editor/src/stores/Annotation/store.js
@@ -566,6 +566,24 @@ const AnnotationStoreModel = types
       return c;
     }
 
+    function hydrateAnnotationResults(annotationPk, results) {
+      const annotation = self.annotations.find((item) => String(item.pk) === String(annotationPk));
+      if (!annotation || !Array.isArray(results) || results.length === 0) return false;
+
+      const hasVersionsResult = Array.isArray(annotation.versions?.result) && annotation.versions.result.length > 0;
+      const hasRegions = annotation.areas?.size > 0;
+
+      if (hasVersionsResult || hasRegions) return true;
+
+      annotation.history.freeze();
+      annotation.deserializeResults(results);
+      annotation.updateObjects();
+      annotation.history.safeUnfreeze();
+      annotation.reinitHistory();
+
+      return true;
+    }
+
     /** ERRORS HANDLING */
     const handleErrors = (errors) => {
       self.addErrors(errors);
@@ -624,6 +642,7 @@ const AnnotationStoreModel = types
       addAnnotation,
       createAnnotation,
       addAnnotationFromPrediction,
+      hydrateAnnotationResults,
       addHistory,
       clearHistory,
       selectHistory,

--- a/web/libs/editor/src/stores/Annotation/store.js
+++ b/web/libs/editor/src/stores/Annotation/store.js
@@ -566,24 +566,6 @@ const AnnotationStoreModel = types
       return c;
     }
 
-    function hydrateAnnotationResults(annotationPk, results) {
-      const annotation = self.annotations.find((item) => String(item.pk) === String(annotationPk));
-      if (!annotation || !Array.isArray(results) || results.length === 0) return false;
-
-      const hasVersionsResult = Array.isArray(annotation.versions?.result) && annotation.versions.result.length > 0;
-      const hasRegions = annotation.areas?.size > 0;
-
-      if (hasVersionsResult || hasRegions) return true;
-
-      annotation.history.freeze();
-      annotation.deserializeResults(results);
-      annotation.updateObjects();
-      annotation.history.safeUnfreeze();
-      annotation.reinitHistory();
-
-      return true;
-    }
-
     /** ERRORS HANDLING */
     const handleErrors = (errors) => {
       self.addErrors(errors);
@@ -642,7 +624,6 @@ const AnnotationStoreModel = types
       addAnnotation,
       createAnnotation,
       addAnnotationFromPrediction,
-      hydrateAnnotationResults,
       addHistory,
       clearHistory,
       selectHistory,


### PR DESCRIPTION
This pull request refactors how annotation hydration is handled in the LSF integration by moving the hydration logic from the `LSFWrapper` class to the `AnnotationStore` model. This centralizes the logic, reduces code duplication, and ensures consistent behavior when hydrating annotation results.

**Refactoring and centralization of annotation hydration logic:**

* Added a new `hydrateAnnotationResults` method to the `AnnotationStore` model in `store.js`, encapsulating the logic for freezing history, deserializing results, updating objects, and resetting history state. This method also includes checks to avoid redundant hydration if annotation versions or regions already exist.
* Exposed the `hydrateAnnotationResults` method in the store's public API, making it available for use by other components.

**Simplification of hydration calls in LSFWrapper:**

* Updated the `LSFWrapper` class to delegate annotation hydration to the new `hydrateAnnotationResults` method in the annotation store, replacing the previous inline logic. This change was made in both the main hydration flow and in the fallback hydration logic. [[1]](diffhunk://#diff-679489a404ba3dd06905287db35ee48bccafc5cc6a61567ef7531cb785012595L541-R541) [[2]](diffhunk://#diff-679489a404ba3dd06905287db35ee48bccafc5cc6a61567ef7531cb785012595L1259-R1254)