### PR TITLE
fix: FIT-1422: image is sometimes not rendering properly when we navigate from an annotation and coming back

### DIFF
--- a/web/libs/editor/src/components/ImageView/ImageView.jsx
+++ b/web/libs/editor/src/components/ImageView/ImageView.jsx
@@ -1247,14 +1247,32 @@ const EntireStage = observer(
 const ImageLayer = observer(({ item }) => {
   const imageEntity = item.currentImageEntity;
   const konvaImageRef = useRef();
+  const currentSrc = imageEntity?.currentSrc;
+  const [loadedImage, setLoadedImage] = useState(null);
 
-  // Reuse the <img> DOM element that <ImageRenderer> already loaded.
-  // item.imageRef is set via item.setImageRef() in ImageView's render.
-  // imageEntity.imageLoaded (observable) is true once the <img> onload fires,
-  // and imageIsLoaded gates <EntireStage> — so by the time this component renders,
-  // item.imageRef is guaranteed to point to a fully-loaded HTMLImageElement.
-  // This eliminates the redundant Image() load that previously happened here.
-  const loadedImage = imageEntity?.imageLoaded ? item.imageRef : null;
+  useEffect(() => {
+    if (!imageEntity?.downloaded || !currentSrc) {
+      setLoadedImage(null);
+      return;
+    }
+
+    let cancelled = false;
+    const img = new window.Image();
+
+    if (item.imageCrossOrigin) img.crossOrigin = item.imageCrossOrigin;
+
+    img.onload = () => {
+      if (!cancelled) setLoadedImage(img);
+    };
+    img.onerror = () => {
+      if (!cancelled) setLoadedImage(null);
+    };
+    img.src = currentSrc;
+
+    return () => {
+      cancelled = true;
+    };
+  }, [imageEntity?.downloaded, currentSrc, item.imageCrossOrigin]);
 
   const { width, height } = useMemo(() => {
     return {
@@ -1269,17 +1287,32 @@ const ImageLayer = observer(({ item }) => {
   useEffect(() => {
     const node = konvaImageRef.current;
     if (node && loadedImage) {
-      node.cache({ pixelRatio: 1 });
-      node.filters([Konva.Filters.Brighten, Konva.Filters.Contrast]);
-      node.brightness(brightness);
-      node.contrast(contrast);
+      try {
+        // Force Konva cache reset and redraw when source/filters change.
+        node.clearCache();
+        node.cache({ pixelRatio: 1 });
+        node.filters([Konva.Filters.Brighten, Konva.Filters.Contrast]);
+        node.brightness(brightness);
+        node.contrast(contrast);
+      } catch {
+        // Fallback to plain image draw if cache/filter pipeline fails.
+        node.clearCache();
+        node.filters([]);
+      }
       node.getLayer()?.batchDraw();
     }
-  }, [loadedImage, brightness, contrast]);
+  }, [loadedImage, brightness, contrast, currentSrc]);
 
   return loadedImage ? (
     <Layer imageSmoothingEnabled={item.smoothingEnabled} scale={{ x: item.stageZoom, y: item.stageZoom }}>
-      <KonvaImage ref={konvaImageRef} image={loadedImage} width={width} height={height} listening={false} />
+      <KonvaImage
+        key={currentSrc ?? "image-source"}
+        ref={konvaImageRef}
+        image={loadedImage}
+        width={width}
+        height={height}
+        listening={false}
+      />
     </Layer>
   ) : null;
 });


### PR DESCRIPTION
This pull request refactors how images are loaded and rendered in the `ImageView` component to improve reliability and ensure that image filters and cache are properly reset when the image source changes. The main changes involve switching from reusing a preloaded `<img>` DOM element to explicitly loading images with a new `Image()` instance and updating the Konva image layer handling.

before:

[screen-recorder-fri-feb-20-2026-10-55-12.webm](https://github.com/user-attachments/assets/46a8138b-dba2-47a5-8cf7-99cbf3d708c7)


after:

[screen-recorder-fri-feb-20-2026-10-54-02.webm](https://github.com/user-attachments/assets/b4eee719-953d-4b60-a2c3-b1def4c2fc77)



**Image loading and rendering improvements:**

* The `ImageLayer` component now loads images using a new `window.Image()` instance instead of reusing an existing `<img>` element, ensuring that image loading is handled consistently and avoiding reliance on external state.
* Added a `useEffect` hook to manage the image loading lifecycle, including cleanup on unmount or source change, and to handle errors gracefully by setting the loaded image to `null` on failure.

**Konva cache and filter handling:**

* Updated the effect that applies Konva filters to explicitly clear the cache and reset filters if an error occurs, improving robustness when the image source or filter parameters change.
* The `KonvaImage` component now uses a `key` prop based on the current image source to force a remount when the source changes, ensuring the canvas is properly updated.