### PR TITLE
feat: UTC-500: Add model predictions to agreement v2

### DIFF
--- a/label_studio/core/migration_helpers.py
+++ b/label_studio/core/migration_helpers.py
@@ -72,9 +72,7 @@ def make_sql_migration(
 
     def forwards(apps, schema_editor):  # noqa: ARG001
         # Early return for linter to not actually run code
-        if getattr(schema_editor, 'collect_sql', False):
-            # Still causing issues with SeperatedatabaseandStateOperations in migration linter
-            # schema_editor.collected_sql.append(sql_forwards)
+        if getattr(schema_editor, 'collect_sql', False) is True:
             return
         if schema_editor.connection.vendor == 'sqlite' and not apply_on_sqlite:
             logger.info('Skipping migration for SQLite (apply_on_sqlite=False)')
@@ -98,9 +96,7 @@ def make_sql_migration(
 
     def backwards(apps, schema_editor):  # noqa: ARG001
         # Early return for linter to not actually run code
-        if getattr(schema_editor, 'collect_sql', False):
-            # Still causing issues with SeperatedatabaseandStateOperations in migration linter
-            # schema_editor.collected_sql.append(sql_backwards)
+        if getattr(schema_editor, 'collect_sql', False) is True:
             return
         start_job_async_or_sync(
             execute_sql_job,

--- a/label_studio/core/migration_helpers.py
+++ b/label_studio/core/migration_helpers.py
@@ -71,6 +71,10 @@ def make_sql_migration(
     mig_key = migration_name
 
     def forwards(apps, schema_editor):  # noqa: ARG001
+        # Early return for linter to not actually run code
+        if getattr(schema_editor, 'collect_sql', False):
+            schema_editor.collected_sql.append(sql_forwards)
+            return
         if schema_editor.connection.vendor == 'sqlite' and not apply_on_sqlite:
             logger.info('Skipping migration for SQLite (apply_on_sqlite=False)')
             return
@@ -92,6 +96,10 @@ def make_sql_migration(
             )
 
     def backwards(apps, schema_editor):  # noqa: ARG001
+        # Early return for linter to not actually run code
+        if getattr(schema_editor, 'collect_sql', False):
+            schema_editor.collected_sql.append(sql_backwards)
+            return
         start_job_async_or_sync(
             execute_sql_job,
             migration_name=mig_key,

--- a/label_studio/core/migration_helpers.py
+++ b/label_studio/core/migration_helpers.py
@@ -73,7 +73,8 @@ def make_sql_migration(
     def forwards(apps, schema_editor):  # noqa: ARG001
         # Early return for linter to not actually run code
         if getattr(schema_editor, 'collect_sql', False):
-            schema_editor.collected_sql.append(sql_forwards)
+            # Still causing issues with SeperatedatabaseandStateOperations in migration linter
+            # schema_editor.collected_sql.append(sql_forwards)
             return
         if schema_editor.connection.vendor == 'sqlite' and not apply_on_sqlite:
             logger.info('Skipping migration for SQLite (apply_on_sqlite=False)')
@@ -98,7 +99,8 @@ def make_sql_migration(
     def backwards(apps, schema_editor):  # noqa: ARG001
         # Early return for linter to not actually run code
         if getattr(schema_editor, 'collect_sql', False):
-            schema_editor.collected_sql.append(sql_backwards)
+            # Still causing issues with SeperatedatabaseandStateOperations in migration linter
+            # schema_editor.collected_sql.append(sql_backwards)
             return
         start_job_async_or_sync(
             execute_sql_job,


### PR DESCRIPTION
Changing behavior of make_sql_migration in order to support the migration linter in LSE 

I am using SeparateDatabaseAndState in my migration such that we can still define the index to be created in the model, but also still use our helper to run the SQL async. This was causing an issue with the linter, it was trying to actually execute the code within the helper and getting an error that the relation core_asyncmigrationstatus does not exist. We do not need the linter to get this far in the code. 