### PR TITLE
fix: FIT-1428: Extra line is displayed in annotation tab

### DIFF
--- a/web/libs/editor/src/components/AnnotationsCarousel/AnnotationButton.scss
+++ b/web/libs/editor/src/components/AnnotationsCarousel/AnnotationButton.scss
@@ -111,7 +111,7 @@
     top: -1px;
     left: 0;
     width: 100%;
-    height: 8px;
+    height: 10px;
     border-top-style: solid;
     border-top-width: 2px;
     border-top-left-radius: var(--corner-radius-small);


### PR DESCRIPTION
This pull request makes a minor visual adjustment to the `AnnotationButton` component. The height of the top border area has been slightly increased to avoid a visual artifact that occurs when the top border radii are the same or higher than the height of the element.

## Screenshots
### Before
<img width="354" height="100" alt="image" src="https://github.com/user-attachments/assets/d8a2ea65-c3f9-4fc7-aa64-3a24f3d05831" />

### After
<img width="286" height="108" alt="image" src="https://github.com/user-attachments/assets/6a3e2dde-6df0-4938-bae3-6b0783b60582" />


<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
