### PR TITLE
fix: FIT-1439: FSM State Manager must not attempt to transition state with Anonymous users it should be None

### DIFF
--- a/label_studio/fsm/state_manager.py
+++ b/label_studio/fsm/state_manager.py
@@ -355,7 +355,7 @@ class StateManager:
                     state=new_state,
                     previous_state=current_state,
                     transition_name=transition_name,
-                    triggered_by=user,
+                    triggered_by=user if getattr(user, 'is_authenticated', False) else None,
                     context_data=context or {},
                     reason=reason,
                     organization_id=organization_id,

--- a/label_studio/fsm/tests/test_fsm_integration.py
+++ b/label_studio/fsm/tests/test_fsm_integration.py
@@ -424,3 +424,26 @@ class TestStateManager(TestCase):
         # Verify state is still CREATED
         current_state = self.StateManager.get_current_state_value(self.task)
         assert current_state == 'CREATED'
+
+    @patch('fsm.state_manager.flag_set')
+    def test_transition_with_anonymous_user(self, mock_flag_set):
+        """Test that transitioning state with AnonymousUser succeeds and sets triggered_by to None."""
+        from django.contrib.auth.models import AnonymousUser
+        from django.core.cache import cache
+
+        cache.clear()
+
+        mock_flag_set.return_value = True
+
+        anon_user = AnonymousUser()
+        success = self.StateManager.transition_state(
+            entity=self.task,
+            new_state='IN_PROGRESS',
+            user=anon_user,
+            transition_name='start_task_anon',
+        )
+        assert success
+
+        current_state_obj = self.StateManager.get_current_state_object(self.task)
+        assert current_state_obj.state == 'IN_PROGRESS'
+        assert current_state_obj.triggered_by is None


### PR DESCRIPTION
This pull request introduces an improvement to how state transitions are handled when triggered by anonymous users, ensuring that the `triggered_by` field is set appropriately. It also adds a new test to verify this behavior.

Enhancement to state transition logic:

* Updated the `transition_state` method in `state_manager.py` to set `triggered_by` to `None` if the user is not authenticated, preventing anonymous users from being incorrectly recorded as the trigger.

Testing improvements:

* Added a test case in `test_fsm_integration.py` to verify that state transitions with an `AnonymousUser` succeed and that `triggered_by` is set to `None`.