### PR TITLE
feat: FIT-1443: Add Label Distribution page

### DIFF
--- a/web/libs/core/src/lib/utils/feature-flags/flags.ts
+++ b/web/libs/core/src/lib/utils/feature-flags/flags.ts
@@ -117,3 +117,9 @@ export const FF_PREVIEW_PERFORMANCE = "fflag_fix_all_fit_287_preview_performance
  * @link https://app.launchdarkly.com/default/production/features/fflag_fix_all_fit_720_lazy_load_annotations
  */
 export const FF_FIT_720_LAZY_LOAD_ANNOTATIONS = "fflag_fix_all_fit_720_lazy_load_annotations";
+
+/**
+ * Analytics Label Distribution page
+ */
+export const FF_FIT_1443_ANALYTICS_LABEL_DISTRIBUTION_PAGE =
+  "fflag_feat_all_fit_1443_analytics_label_distribution_page";


### PR DESCRIPTION
This pull request adds a new feature flag for the Analytics Label Distribution page. This enables controlled rollout and testing of the new analytics functionality.

Feature flag additions:

* Added `FF_FIT_1443_ANALYTICS_LABEL_DISTRIBUTION_PAGE` to `flags.ts` for the Analytics Label Distribution page.