### PR TITLE
ci: link checker netlify stability

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -54,8 +54,8 @@ jobs:
         run: |
           linkchecker \
             -f /tmp/linkcheckerrc \
-            --threads 2 \
-            --timeout 30 \
+            --threads 1 \
+            --timeout 60 \
             --no-status \
             --no-robots \
             --ignore-url="/api" \
@@ -68,8 +68,8 @@ jobs:
         run: |
           linkchecker \
             -f /tmp/linkcheckerrc \
-            --threads 2 \
-            --timeout 30 \
+            --threads 1 \
+            --timeout 60 \
             --no-status \
             --no-robots \
             --ignore-url="/api" \

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -10,22 +10,37 @@ on:
   workflow_dispatch:
 
 jobs:
-  wait_for_netlify:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for Netlify deploy preview to complete
-        run: echo "Netlify deploy preview has passed"
-        if: ${{ contains(github.event.pull_request.head.repo.status.contexts, 'netlify') }}
-
   check_links:
     runs-on: ubuntu-latest
-    needs: wait_for_netlify
     env:
       DEPLOY_PREVIEW_LS: https://deploy-preview-${{ github.event.pull_request.number }}--label-studio-docs-new-theme.netlify.app
       DEPLOY_PREVIEW_HS: https://deploy-preview-${{ github.event.pull_request.number }}--heartex-docs.netlify.app
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Wait for Netlify deploy preview
+        if: ${{ contains(github.event.pull_request.head.repo.status.contexts, 'netlify') }}
+        run: echo "Netlify deploy preview context found"
+
+      - name: Wait for deploy previews to be ready
+        run: |
+          for url in "$DEPLOY_PREVIEW_LS" "$DEPLOY_PREVIEW_HS"; do
+            echo "Waiting for $url ..."
+            for i in $(seq 1 30); do
+              status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$url" || echo "000")
+              if [ "$status" = "200" ] || [ "$status" = "301" ] || [ "$status" = "302" ]; then
+                echo "Ready ($status) after $((i * 10))s"
+                break
+              fi
+              echo "  Attempt $i: status $status, retrying in 10s..."
+              sleep 10
+            done
+            if [ "$status" != "200" ] && [ "$status" != "301" ] && [ "$status" != "302" ]; then
+              echo "Deploy preview not ready after 5 minutes: $url"
+              exit 1
+            fi
+          done
 
       - name: Install linkchecker
         run: pip install linkchecker
@@ -43,6 +58,7 @@ jobs:
             -f /tmp/linkcheckerrc \
             --threads 2 \
             --timeout 30 \
+            --no-status \
             --no-robots \
             --ignore-url="/api" \
             --ignore-url="^mailto:" \
@@ -56,6 +72,7 @@ jobs:
             -f /tmp/linkcheckerrc \
             --threads 2 \
             --timeout 30 \
+            --no-status \
             --no-robots \
             --ignore-url="/api" \
             --ignore-url="^mailto:" \

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -2,8 +2,8 @@ name: Check for broken links
 
 on:
   pull_request:
-    branches: ["develop"]
-    types: [synchronize, opened]
+    branches: [ "develop" ]
+    types: [ synchronize, opened ]
     paths:
       - "docs/**"
       - ".github/workflows/link-check.yml"
@@ -19,11 +19,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Install linkchecker
+        run: pip install linkchecker
+
       - name: Wait for Netlify to deploy current commit
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ""${{ github.token }}"
+          SHA: "${{ github.event.pull_request.head.sha }}"
         run: |
-          SHA="${{ github.event.pull_request.head.sha }}"
           echo "Waiting for Netlify deploy on commit $SHA ..."
           for i in $(seq 1 60); do
             netlify_state=$(gh api "repos/${{ github.repository }}/commits/$SHA/status" \
@@ -39,9 +42,6 @@ jobs:
             echo "Netlify deploy not ready after 10 minutes"
             exit 1
           fi
-
-      - name: Install linkchecker
-        run: pip install linkchecker
 
       - name: Create linkchecker config
         run: |

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -20,36 +20,45 @@ jobs:
   check_links:
     runs-on: ubuntu-latest
     needs: wait_for_netlify
+    env:
+      DEPLOY_PREVIEW_LS: https://deploy-preview-${{ github.event.pull_request.number }}--label-studio-docs-new-theme.netlify.app
+      DEPLOY_PREVIEW_HS: https://deploy-preview-${{ github.event.pull_request.number }}--heartex-docs.netlify.app
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "20"
+      - name: Install linkchecker
+        run: pip install linkchecker
 
-      - name: Install dependencies
-        run: npm install broken-link-checker
-
-      - name: Run broken-link-checker and fail on broken links for Label Studio Docs
+      - name: Create linkchecker config
         run: |
-          npx blc https://deploy-preview-${{ github.event.pull_request.number }}--label-studio-docs-new-theme.netlify.app -roef --exclude "/api" --filter-level 0
-          exit_code=$?  # Capture the exit code
-          echo "Exit code: $exit_code"  # Print the exit code
+          cat > /tmp/linkcheckerrc <<'LCEOF'
+          [filtering]
+          ignorewarnings=http-redirected
+          LCEOF
 
-          if [ $exit_code -ne 0 ]; then
-            echo "Broken links found!"
-            exit 1
-          fi
-
-      - name: Run broken-link-checker and fail on broken links for Human Signal Docs
+      - name: Check links for Label Studio Docs
         run: |
-          npx blc https://deploy-preview-${{ github.event.pull_request.number }}--heartex-docs.netlify.app -roef --exclude "/api" --filter-level 0
-          exit_code=$?  # Capture the exit code
-          echo "Exit code: $exit_code"  # Print the exit code
+          linkchecker \
+            -f /tmp/linkcheckerrc \
+            --threads 2 \
+            --timeout 30 \
+            --no-robots \
+            --ignore-url="/api" \
+            --ignore-url="^mailto:" \
+            --ignore-url="^javascript:" \
+            --ignore-url="\.(png|jpg|jpeg|gif|svg|ico|webp|mp4|webm|ogg|pdf|zip|gz|css|js|woff2?|ttf|eot)$" \
+            "$DEPLOY_PREVIEW_LS"
 
-          if [ $exit_code -ne 0 ]; then
-            echo "Broken links found!"
-            exit 1
-          fi
+      - name: Check links for Human Signal Docs
+        run: |
+          linkchecker \
+            -f /tmp/linkcheckerrc \
+            --threads 2 \
+            --timeout 30 \
+            --no-robots \
+            --ignore-url="/api" \
+            --ignore-url="^mailto:" \
+            --ignore-url="^javascript:" \
+            --ignore-url="\.(png|jpg|jpeg|gif|svg|ico|webp|mp4|webm|ogg|pdf|zip|gz|css|js|woff2?|ttf|eot)$" \
+            "$DEPLOY_PREVIEW_HS"

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -19,28 +19,26 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Wait for Netlify deploy preview
-        if: ${{ contains(github.event.pull_request.head.repo.status.contexts, 'netlify') }}
-        run: echo "Netlify deploy preview context found"
-
-      - name: Wait for deploy previews to be ready
+      - name: Wait for Netlify to deploy current commit
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          for url in "$DEPLOY_PREVIEW_LS" "$DEPLOY_PREVIEW_HS"; do
-            echo "Waiting for $url ..."
-            for i in $(seq 1 30); do
-              status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$url" || echo "000")
-              if [ "$status" = "200" ] || [ "$status" = "301" ] || [ "$status" = "302" ]; then
-                echo "Ready ($status) after $((i * 10))s"
-                break
-              fi
-              echo "  Attempt $i: status $status, retrying in 10s..."
-              sleep 10
-            done
-            if [ "$status" != "200" ] && [ "$status" != "301" ] && [ "$status" != "302" ]; then
-              echo "Deploy preview not ready after 5 minutes: $url"
-              exit 1
+          SHA="${{ github.event.pull_request.head.sha }}"
+          echo "Waiting for Netlify deploy on commit $SHA ..."
+          for i in $(seq 1 60); do
+            netlify_state=$(gh api "repos/${{ github.repository }}/commits/$SHA/status" \
+              --jq '.statuses[] | select(.context | test("netlify"; "i")) | .state' 2>/dev/null | head -1)
+            if [ "$netlify_state" = "success" ]; then
+              echo "Netlify deploy succeeded after $((i * 10))s"
+              break
             fi
+            echo "  Attempt $i: state=$netlify_state, retrying in 10s..."
+            sleep 10
           done
+          if [ "$netlify_state" != "success" ]; then
+            echo "Netlify deploy not ready after 10 minutes"
+            exit 1
+          fi
 
       - name: Install linkchecker
         run: pip install linkchecker

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Wait for Netlify to deploy current commit
         env:
-          GH_TOKEN: ""${{ github.token }}"
+          GH_TOKEN: "${{ github.token }}"
           SHA: "${{ github.event.pull_request.head.sha }}"
         run: |
           echo "Waiting for Netlify deploy on commit $SHA ..."

--- a/docs/source/tags/chat.md
+++ b/docs/source/tags/chat.md
@@ -223,4 +223,3 @@ See the following example:
 - [Chatbot Evaluation](/templates/chatbot)
 - [Red-Teaming in Chat](/templates/chat_red_team)
 - [Evaluate Production Conversations for RLHF](/templates/chat_rlhf)
-- [This page does not exist](/guide/this_page_does_not_exist)

--- a/docs/source/tags/chat.md
+++ b/docs/source/tags/chat.md
@@ -223,3 +223,4 @@ See the following example:
 - [Chatbot Evaluation](/templates/chatbot)
 - [Red-Teaming in Chat](/templates/chat_red_team)
 - [Evaluate Production Conversations for RLHF](/templates/chat_rlhf)
+- [This page does not exist](/guide/this_page_does_not_exist)


### PR DESCRIPTION
## Replace broken-link-checker with linkchecker to fix flaky CI

### Problem

The `link-check.yml` workflow was failing constantly due to `broken-link-checker` (Node.js/`blc`) being fundamentally unsuitable for checking Netlify deploy previews:

- **No rate limiting** — `blc` has no `--rateLimit` option (the flag was silently ignored)
- **Response caching** — a single transient `ECONNRESET` would be cached and reported as broken for every subsequent page that linked to that URL, cascading into 100+ false positives
- **No retry mechanism** — transient network errors were permanent failures
- **Fake wait_for_netlify** — the previous job just echoed a message without actually waiting for Netlify

### Solution

**Switch from `broken-link-checker` (Node.js) to `linkchecker` (Python)**, which has proper connection handling and doesn't cache transient errors.

**Key changes:**

1. **Replace `blc` with `linkchecker`** — mature Python tool with proper HTTP connection management
2. **Wait for Netlify deploy on current commit** — polls the GitHub commit status API for the PR head SHA until Netlify reports `success`, ensuring we check the new deploy and not a stale one
3. **Single-threaded with 60s timeout** — `--threads 1` minimizes pressure on Netlify, `--timeout 60` handles slow responses
4. **Suppress redirect warnings** — Netlify's trailing-slash 301 redirects are expected, only `http-redirected` warnings are ignored via config
5. **Skip asset URLs** — `--ignore-url` pattern excludes images, videos, CSS, JS, fonts (equivalent to `blc --filter-level 0`)
6. **Cleaner output** — `--no-status` removes noisy progress lines, only errors and warnings show

### Test results

| Metric | Before (`blc`) | After (`linkchecker`) |
|--------|---------------|----------------------|
| ECONNRESET errors | 100+ per run | 0 |
| False positives | Constant | None |
| Runtime | ~1-3 min | ~2-3 min |
| Real 404s detected | Yes | Yes |

### Local testing

To test against a Netlify deploy preview locally:

```bash
# Install
pip install linkchecker

# Run 
linkchecker \
  -f /tmp/linkcheckerrc \
  --threads 1 \
  --timeout 60 \
  --no-status \
  --no-robots \
  --ignore-url="/api" \
  --ignore-url="^mailto:" \
  --ignore-url="^javascript:" \
  --ignore-url="\.(png|jpg|jpeg|gif|svg|ico|webp|mp4|webm|ogg|pdf|zip|gz|css|js|woff2?|ttf|eot)$" \
  https://deploy-preview-XXXX--label-studio-docs-new-theme.netlify.app
```
In local you can check also the images removing ignore urls

Error example  https://github.com/HumanSignal/label-studio/actions/runs/22493873892/job/65163052235?pr=9478
