### PR TITLE
fix: FIT-1466: Missing IconSpark import on General settings page

### DIFF
--- a/web/apps/labelstudio/src/pages/Settings/GeneralSettings.jsx
+++ b/web/apps/labelstudio/src/pages/Settings/GeneralSettings.jsx
@@ -1,4 +1,4 @@
-import { Badge, Button,Select, Typography, Tooltip, EnterpriseBadge } from "@humansignal/ui";
+import { Badge, Button, Select, Typography, Tooltip, EnterpriseBadge } from "@humansignal/ui";
 import { useCallback, useContext } from "react";
 import { IconSpark } from "@humansignal/icons";
 import { Form, Input, TextArea } from "../../components/Form";

--- a/web/apps/labelstudio/src/pages/Settings/GeneralSettings.jsx
+++ b/web/apps/labelstudio/src/pages/Settings/GeneralSettings.jsx
@@ -1,6 +1,6 @@
-import { Badge, Select, Typography, Tooltip, EnterpriseBadge } from "@humansignal/ui";
+import { Badge, Button,Select, Typography, Tooltip, EnterpriseBadge } from "@humansignal/ui";
 import { useCallback, useContext } from "react";
-import { Button } from "@humansignal/ui";
+import { IconSpark } from "@humansignal/icons";
 import { Form, Input, TextArea } from "../../components/Form";
 import { RadioGroup } from "../../components/Form/Elements/RadioGroup/RadioGroup";
 import { ProjectContext } from "../../providers/ProjectProvider";


### PR DESCRIPTION
This pull request makes minor adjustments to the imports in the `GeneralSettings.jsx` file. The changes consolidate UI component imports and add a new icon import, streamlining the code and improving maintainability.

* Imports organization:
  * Moved the `Button` import to the main group of UI components and added `IconSpark` from `@humansignal/icons` to support new icon usage.