### PR TITLE
fix: FIT-1426: Resizer continues to function after mouse release in Labeling Interface

### DIFF
--- a/web/apps/labelstudio/src/pages/CreateProject/Config/EditorResizer.tsx
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/EditorResizer.tsx
@@ -35,41 +35,41 @@ export const EditorResizer: React.FC<EditorResizerProps> = ({
 }) => {
   const [isResizing, setIsResizing] = useState(false);
 
-  const handleMouseDown = useCallback(
-    (evt: React.MouseEvent) => {
+  const handlePointerDown = useCallback(
+    (evt: React.PointerEvent) => {
       evt.stopPropagation();
       evt.preventDefault();
 
       const container = containerRef.current;
       if (!container) return;
 
+      const handleEl = evt.currentTarget as HTMLElement;
+      handleEl.setPointerCapture(evt.pointerId);
+
       const initialX = evt.pageX;
       const initialWidth = editorWidthPixels;
-      let newWidth = editorWidthPixels;
 
-      const onMouseMove = (e: MouseEvent) => {
-        newWidth = calculateEditorWidth(
+      const onPointerMove = (e: PointerEvent) => {
+        const newWidth = calculateEditorWidth(
           initialWidth,
           initialX,
           e.pageX,
           constraints.minEditorWidth,
           constraints.maxEditorWidth,
         );
-
         onResize(newWidth);
       };
 
-      const onMouseUp = () => {
-        document.removeEventListener("mousemove", onMouseMove);
-        document.removeEventListener("mouseup", onMouseUp);
+      const onPointerUp = () => {
+        handleEl.removeEventListener("pointermove", onPointerMove);
+        handleEl.removeEventListener("pointerup", onPointerUp);
         document.body.style.removeProperty("user-select");
         document.body.style.removeProperty("cursor");
-
         setIsResizing(false);
       };
 
-      document.addEventListener("mousemove", onMouseMove);
-      document.addEventListener("mouseup", onMouseUp);
+      handleEl.addEventListener("pointermove", onPointerMove);
+      handleEl.addEventListener("pointerup", onPointerUp);
       document.body.style.userSelect = "none";
       document.body.style.cursor = "col-resize";
       setIsResizing(true);
@@ -77,5 +77,10 @@ export const EditorResizer: React.FC<EditorResizerProps> = ({
     [containerRef, editorWidthPixels, onResize, constraints],
   );
 
-  return <div className={clsx(styles.handle, { [styles.handleResizing]: isResizing })} onMouseDown={handleMouseDown} />;
+  return (
+    <div
+      className={clsx(styles.handle, { [styles.handleResizing]: isResizing })}
+      onPointerDown={handlePointerDown}
+    />
+  );
 };

--- a/web/apps/labelstudio/src/pages/CreateProject/Config/EditorResizer.tsx
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/EditorResizer.tsx
@@ -78,9 +78,6 @@ export const EditorResizer: React.FC<EditorResizerProps> = ({
   );
 
   return (
-    <div
-      className={clsx(styles.handle, { [styles.handleResizing]: isResizing })}
-      onPointerDown={handlePointerDown}
-    />
+    <div className={clsx(styles.handle, { [styles.handleResizing]: isResizing })} onPointerDown={handlePointerDown} />
   );
 };

--- a/web/libs/datamanager/src/components/Common/Resizer/Resizer.jsx
+++ b/web/libs/datamanager/src/components/Common/Resizer/Resizer.jsx
@@ -34,28 +34,30 @@ export const Resizer = ({
     onResizeCallback?.(newWidth);
   }, []);
 
-  /** @param {MouseEvent} evt */
+  /** @param {React.PointerEvent} evt */
   const handleResize = React.useCallback(
     (evt) => {
       evt.stopPropagation();
+      evt.preventDefault();
+      const handleEl = evt.currentTarget;
+      handleEl.setPointerCapture(evt.pointerId);
+
       const initialX = evt.pageX;
-      let newWidth = width;
 
-      /** @param {MouseEvent} evt */
-      const onResize = (evt) => {
-        newWidth = calculateWidth(width, minWidth, maxWidth, initialX, evt.pageX);
-
+      /** @param {PointerEvent} e */
+      const onResize = (e) => {
+        const newWidth = calculateWidth(width, minWidth, maxWidth, initialX, e.pageX);
         setWidth(newWidth);
         onResizeCallback?.(newWidth);
       };
 
-      const stopResize = (evt) => {
-        document.removeEventListener("mousemove", onResize);
-        document.removeEventListener("mouseup", stopResize);
+      /** @param {PointerEvent} e */
+      const stopResize = (e) => {
+        handleEl.removeEventListener("pointermove", onResize);
+        handleEl.removeEventListener("pointerup", stopResize);
         document.body.style.removeProperty("user-select");
 
-        newWidth = calculateWidth(width, minWidth, maxWidth, initialX, evt.pageX);
-
+        const newWidth = calculateWidth(width, minWidth, maxWidth, initialX, e.pageX);
         setIsResizing(false);
 
         if (newWidth !== width) {
@@ -64,8 +66,8 @@ export const Resizer = ({
         }
       };
 
-      document.addEventListener("mousemove", onResize);
-      document.addEventListener("mouseup", stopResize);
+      handleEl.addEventListener("pointermove", onResize);
+      handleEl.addEventListener("pointerup", stopResize);
       document.body.style.userSelect = "none";
       setIsResizing(true);
     },
@@ -85,7 +87,7 @@ export const Resizer = ({
           .toClassName()}
         ref={resizeHandler}
         style={handleStyle}
-        onMouseDown={handleResize}
+        onPointerDown={handleResize}
         onDoubleClick={() => onReset?.()}
       />
     </div>


### PR DESCRIPTION
This pull request updates the resizer components in both the Label Studio editor and the Data Manager library to use the Pointer Events API instead of Mouse Events. This change makes the resizer work even while hovering over an iframe, such as the one used for ReactCode.

**Migration to Pointer Events for Resizing Functionality:**

* Changed event handlers from mouse events (`onMouseDown`, `mousemove`, `mouseup`) to pointer events (`onPointerDown`, `pointermove`, `pointerup`) in both `EditorResizer.tsx` and `Resizer.jsx`, improving support for touch and pen input devices. [[1]](diffhunk://#diff-47525ec1c89d4565fbc3da11a002d860dd5ab7175bd0d5d43f7d1d4c8d44a819L38-R82) [[2]](diffhunk://#diff-0a167d19bdf7deee2654a669f8442db8a77533f640e996b09771c8539dc31e47L37-R60) [[3]](diffhunk://#diff-0a167d19bdf7deee2654a669f8442db8a77533f640e996b09771c8539dc31e47L67-R70) [[4]](diffhunk://#diff-0a167d19bdf7deee2654a669f8442db8a77533f640e996b09771c8539dc31e47L88-R90)
* Updated logic to use `setPointerCapture` and attach listeners directly to the handle element, ensuring proper event tracking and cleanup during resizing. [[1]](diffhunk://#diff-47525ec1c89d4565fbc3da11a002d860dd5ab7175bd0d5d43f7d1d4c8d44a819L38-R82) [[2]](diffhunk://#diff-0a167d19bdf7deee2654a669f8442db8a77533f640e996b09771c8539dc31e47L37-R60) [[3]](diffhunk://#diff-0a167d19bdf7deee2654a669f8442db8a77533f640e996b09771c8539dc31e47L67-R70)

**User Experience Improvements:**

* Added `preventDefault()` and improved cleanup of event listeners and style changes during resizing, reducing potential UI glitches and improving usability. [[1]](diffhunk://#diff-47525ec1c89d4565fbc3da11a002d860dd5ab7175bd0d5d43f7d1d4c8d44a819L38-R82) [[2]](diffhunk://#diff-0a167d19bdf7deee2654a669f8442db8a77533f640e996b09771c8539dc31e47L37-R60) [[3]](diffhunk://#diff-0a167d19bdf7deee2654a669f8442db8a77533f640e996b09771c8539dc31e47L67-R70)

These changes modernize the resizer components, making them more robust and accessible across different input devices.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
