### PR TITLE
fix: FIT-1427: Panels twitch when resizing in Labeling Interface on small screens

### DIFF
--- a/web/apps/labelstudio/src/pages/CreateProject/Config/Config.jsx
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/Config.jsx
@@ -711,6 +711,7 @@ const Configurator = ({
             editorWidthPixels={editorWidthPixels}
             onResize={setEditorWidthPixels}
             constraints={constraints}
+            disabled={constraints.minEditorWidth >= constraints.maxEditorWidth}
           />
           <AdaptivePreview
             config={configToDisplay}

--- a/web/apps/labelstudio/src/pages/CreateProject/Config/EditorResizer.module.scss
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/EditorResizer.module.scss
@@ -22,4 +22,15 @@
     width: var(--handle-size-hover);
     background-color: var(--color-primary-border-subtle);
   }
+
+  &.handleDisabled {
+    width: 1px;
+    cursor: default;
+    pointer-events: none;
+
+    &:hover {
+      width: 1px;
+      background-color: var(--color-neutral-border);
+    }
+  }
 }

--- a/web/apps/labelstudio/src/pages/CreateProject/Config/EditorResizer.tsx
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/EditorResizer.tsx
@@ -11,6 +11,8 @@ interface EditorResizerProps {
     minEditorWidth: number;
     maxEditorWidth: number;
   };
+  /** When true, no resize range is available (e.g. container at minimum width). Disables the handle to prevent twitching. */
+  disabled?: boolean;
 }
 
 const calculateEditorWidth = (
@@ -32,11 +34,13 @@ export const EditorResizer: React.FC<EditorResizerProps> = ({
   editorWidthPixels,
   onResize,
   constraints,
+  disabled = false,
 }) => {
   const [isResizing, setIsResizing] = useState(false);
 
   const handlePointerDown = useCallback(
     (evt: React.PointerEvent) => {
+      if (disabled) return;
       evt.stopPropagation();
       evt.preventDefault();
 
@@ -74,10 +78,18 @@ export const EditorResizer: React.FC<EditorResizerProps> = ({
       document.body.style.cursor = "col-resize";
       setIsResizing(true);
     },
-    [containerRef, editorWidthPixels, onResize, constraints],
+    [containerRef, editorWidthPixels, onResize, constraints, disabled],
   );
 
   return (
-    <div className={clsx(styles.handle, { [styles.handleResizing]: isResizing })} onPointerDown={handlePointerDown} />
+    <div
+      className={clsx(styles.handle, {
+        [styles.handleResizing]: isResizing,
+        [styles.handleDisabled]: disabled,
+      })}
+      onPointerDown={handlePointerDown}
+      aria-disabled={disabled}
+      title={disabled ? undefined : "Drag to resize"}
+    />
   );
 };

--- a/web/apps/labelstudio/src/pages/CreateProject/Config/useConfigResizer.js
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/useConfigResizer.js
@@ -67,23 +67,19 @@ export const useConfigResizer = ({ projectId, containerWidth }) => {
         const item = window.localStorage.getItem(currentKey);
         if (item) {
           const parsedValue = JSON.parse(item);
-          // Check if stored width + left menu width exceeds screen width
-          const leftSideExceedsScreen = parsedValue + LEFT_MENU_WIDTH > window.innerWidth;
-          // Check if right column would be too small (only if containerWidth is available)
-          const rightColumnTooSmall =
-            containerWidth !== undefined && containerWidth - parsedValue - COLUMN_GAP < MIN_PREVIEW_WIDTH;
-          // Reset to default if either condition is true
-          if (leftSideExceedsScreen || rightColumnTooSmall) {
-            setEditorWidthPixelsInternal(DEFAULT_EDITOR_WIDTH);
-          } else {
-            setEditorWidthPixelsInternal(parsedValue);
-          }
+          // Clamp to valid range instead of resetting to default so user preference (e.g. smaller editor) is preserved
+          const minEditor = MIN_EDITOR_WIDTH;
+          const maxEditor =
+            containerWidth !== undefined
+              ? Math.max(minEditor, containerWidth - MIN_PREVIEW_WIDTH - COLUMN_GAP)
+              : DEFAULT_EDITOR_WIDTH * 2;
+          const maxAllowed = Math.min(maxEditor, window.innerWidth - LEFT_MENU_WIDTH);
+          const clamped = Math.max(minEditor, Math.min(maxAllowed, parsedValue));
+          setEditorWidthPixelsInternal(clamped);
         } else {
-          // No stored value for this key, use default
           setEditorWidthPixelsInternal(DEFAULT_EDITOR_WIDTH);
         }
       } catch {
-        // Error reading, use default
         setEditorWidthPixelsInternal(DEFAULT_EDITOR_WIDTH);
       }
       prevStorageKeyRef.current = currentKey;
@@ -165,33 +161,34 @@ export const useConfigResizer = ({ projectId, containerWidth }) => {
     prevContainerWidthRef.current = containerWidth;
   }, [containerWidth, constraints.minEditorWidth, constraints.maxEditorWidth, editorWidthPixels]);
 
-  // Reset width when window resizes and current width exceeds screen size or right column is too small
-  // This ensures the resizer remains visible and usable when screen size decreases
+  // Clamp width when current value is out of bounds (window resize or container change)
+  // We clamp to the valid range instead of resetting to default so the user can still
+  // make the editor column smaller by dragging when the screen is small.
   useEffect(() => {
-    const checkAndReset = () => {
-      // Check if current width + left menu width exceeds screen width
-      const leftSideExceedsScreen = editorWidthPixels + LEFT_MENU_WIDTH > window.innerWidth;
+    const checkAndClamp = () => {
+      if (
+        constraints.minEditorWidth === undefined ||
+        constraints.maxEditorWidth === undefined ||
+        containerWidth === undefined
+      ) {
+        return;
+      }
 
-      // Check if right column (preview) width is less than minimum
-      // Right column width = containerWidth - editorWidthPixels - COLUMN_GAP
-      const rightColumnTooSmall =
-        containerWidth !== undefined && containerWidth - editorWidthPixels - COLUMN_GAP < MIN_PREVIEW_WIDTH;
+      const maxAllowed = Math.min(constraints.maxEditorWidth, window.innerWidth - LEFT_MENU_WIDTH);
+      const clampedWidth = Math.max(constraints.minEditorWidth, Math.min(maxAllowed, editorWidthPixels));
 
-      // Reset to default if either condition is true
-      if (leftSideExceedsScreen || rightColumnTooSmall) {
-        setEditorWidthPixelsInternal(DEFAULT_EDITOR_WIDTH);
+      if (clampedWidth !== editorWidthPixels) {
+        setEditorWidthPixelsInternal(clampedWidth);
       }
     };
 
-    // Check immediately when dependencies change
-    checkAndReset();
+    checkAndClamp();
 
-    // Also listen to window resize events
-    window.addEventListener("resize", checkAndReset);
+    window.addEventListener("resize", checkAndClamp);
     return () => {
-      window.removeEventListener("resize", checkAndReset);
+      window.removeEventListener("resize", checkAndClamp);
     };
-  }, [editorWidthPixels, containerWidth]);
+  }, [editorWidthPixels, containerWidth, constraints.minEditorWidth, constraints.maxEditorWidth]);
 
   // Wrapped setter that automatically clamps values to valid constraints
   // This ensures all width updates respect min/max bounds


### PR DESCRIPTION
This pull request improves the editor resizing experience in the project configuration page by making the resizer handle disable itself when resizing is not possible, and by clamping the editor width to valid ranges instead of resetting it to a default value. These changes enhance usability and preserve user preferences even when the container or window size changes.

https://www.loom.com/share/61b360053bdd4df0b74a336d93488fb5

**Editor Resizing UX Improvements**

* The `EditorResizer` handle is now visually disabled and unresponsive when no valid resize range exists (e.g., minimum width equals maximum width), preventing confusing UI behavior. (`EditorResizer.tsx`, `EditorResizer.module.scss`, `Config.jsx`) [[1]](diffhunk://#diff-47525ec1c89d4565fbc3da11a002d860dd5ab7175bd0d5d43f7d1d4c8d44a819R14-R15) [[2]](diffhunk://#diff-47525ec1c89d4565fbc3da11a002d860dd5ab7175bd0d5d43f7d1d4c8d44a819R37-R43) [[3]](diffhunk://#diff-7b2b8405dd77d73492318ab5c7bd6278de27552acc281eb57daea325a4b42509R25-R35) [[4]](diffhunk://#diff-b8cade5f083b7ee986ecfffd94abcf8500ea563ec194ccf3ca3d94f2edda8a89R714)
* The handle's appearance and accessibility attributes update to reflect the disabled state, improving clarity for users. (`EditorResizer.tsx`, `EditorResizer.module.scss`) [[1]](diffhunk://#diff-47525ec1c89d4565fbc3da11a002d860dd5ab7175bd0d5d43f7d1d4c8d44a819R37-R43) [[2]](diffhunk://#diff-7b2b8405dd77d73492318ab5c7bd6278de27552acc281eb57daea325a4b42509R25-R35)

**Editor Width Persistence and Validation**

* When loading a stored editor width, the value is now clamped to valid bounds instead of resetting to a default, preserving user preferences for smaller editor columns. (`useConfigResizer.js`)
* On window resize or container change, the editor width is clamped to valid constraints rather than reset, ensuring the resizer remains usable and user settings are respected. (`useConfigResizer.js`)

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
