### PR TITLE
fix: FIT-1387: DM Checkboxes display the checkbox when unchecked

### DIFF
--- a/web/libs/ui/src/lib/checkbox/checkbox.module.scss
+++ b/web/libs/ui/src/lib/checkbox/checkbox.module.scss
@@ -187,9 +187,4 @@ $check-icon: "data:image/svg+xml;charset=UTF-8,%3csvg width='13' height='10' vie
       }
     }
   }
-
-  &__input:checked + &__check::before {
-    opacity: 1;
-  }
-
 }


### PR DESCRIPTION
This pull request makes a minor change to the checkbox styles by removing the rule that displayed the check icon when the input was checked. This simplifies the styling and may affect how the checkbox appears when selected.

## Screenshots
### Before
<img width="67" height="216" alt="image" src="https://github.com/user-attachments/assets/aa669ce4-20e6-4287-9953-12a72ada7edd" />
<img width="70" height="216" alt="image" src="https://github.com/user-attachments/assets/b05905d9-b88d-47ee-b97b-76df35d3fcb7" />


### After
<img width="77" height="215" alt="image" src="https://github.com/user-attachments/assets/ff16a9c6-629e-4c2b-b6e9-f088ff1288eb" />

<img width="156" height="219" alt="image" src="https://github.com/user-attachments/assets/ecd8989f-db4f-4137-9559-eb0ce6c4f9e3" />


<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
