### PR TITLE
fix: FIT-270: Overlap of Annotations Surpassing Settings

### DIFF
--- a/label_studio/io_storages/base_models.py
+++ b/label_studio/io_storages/base_models.py
@@ -454,13 +454,19 @@ class ImportStorage(Storage):
             else:
                 data.pop('data')
 
+        # When overlap_cohort_percentage < 100, only a subset of tasks should have
+        # overlap=maximum_annotations. Create new tasks with overlap=1 so that
+        # update_tasks_states() -> _rearrange_overlap_cohort() can assign the
+        # correct cohort after sync. When 100%, all tasks get maximum_annotations.
+        overlap = maximum_annotations if getattr(project, 'overlap_cohort_percentage', 100) >= 100 else 1
+
         with transaction.atomic():
             # Create task without skip_fsm (it's not a model field)
             task = Task(
                 data=data,
                 project=project,
-                overlap=maximum_annotations,
-                is_labeled=len(annotations) >= maximum_annotations,
+                overlap=overlap,
+                is_labeled=len(annotations) >= overlap,
                 total_predictions=len(predictions),
                 total_annotations=len(annotations) - cancelled_annotations,
                 cancelled_annotations=cancelled_annotations,

--- a/label_studio/io_storages/tests/test_multitask_import.py
+++ b/label_studio/io_storages/tests/test_multitask_import.py
@@ -14,6 +14,7 @@ from io_storages.utils import StorageObject, load_tasks_json
 from moto import mock_s3
 from projects.tests.factories import ProjectFactory
 from rest_framework.test import APIClient
+from tasks.models import Task
 from tests.utils import azure_client_mock, gcs_client_mock, redis_client_mock
 
 #
@@ -161,6 +162,83 @@ def test_storagelink_fields(project, common_task_data):
         assert storage_links[0].row_group is None
         assert storage_links[1].row_index == 1
         assert storage_links[1].row_group is None
+
+
+def test_storage_sync_respects_overlap_cohort_percentage(project):
+    project.maximum_annotations = 2
+    project.overlap_cohort_percentage = 10
+    project.save(update_fields=['maximum_annotations', 'overlap_cohort_percentage'])
+
+    imported_tasks = [{'data': {'text': f'Task {idx}'}} for idx in range(10)]
+
+    with mock_s3():
+        s3 = boto3.client('s3', region_name='us-east-1')
+        bucket_name = 'pytest-s3-overlap-cohort'
+        s3.create_bucket(Bucket=bucket_name)
+        s3.put_object(Bucket=bucket_name, Key='tasks.json', Body=json.dumps(imported_tasks))
+
+        storage = S3ImportStorage(
+            project=project,
+            bucket=bucket_name,
+            aws_access_key_id='example',
+            aws_secret_access_key='example',
+            use_blob_urls=False,
+            recursive_scan=True,
+        )
+        storage.save()
+
+        import mock
+
+        with mock.patch('io_storages.base_models.redis_connected', return_value=False):
+            storage.sync()
+
+    tasks = Task.objects.filter(project=project)
+    assert tasks.count() == 10
+    assert tasks.filter(overlap=2).count() == 1
+    assert tasks.filter(overlap=1).count() == 9
+
+
+def test_quality_settings_applied_after_sync_rearranges_overlap_cohort(project):
+    imported_tasks = [{'data': {'text': f'Task {idx}'}} for idx in range(10)]
+
+    with mock_s3():
+        s3 = boto3.client('s3', region_name='us-east-1')
+        bucket_name = 'pytest-s3-overlap-after-sync'
+        s3.create_bucket(Bucket=bucket_name)
+        s3.put_object(Bucket=bucket_name, Key='tasks.json', Body=json.dumps(imported_tasks))
+
+        storage = S3ImportStorage(
+            project=project,
+            bucket=bucket_name,
+            aws_access_key_id='example',
+            aws_secret_access_key='example',
+            use_blob_urls=False,
+            recursive_scan=True,
+        )
+        storage.save()
+
+        import mock
+
+        with mock.patch('io_storages.base_models.redis_connected', return_value=False):
+            storage.sync()
+
+    # Initial import with default settings should keep overlap at 1 for all tasks.
+    tasks = Task.objects.filter(project=project)
+    assert tasks.count() == 10
+    assert tasks.filter(overlap=1).count() == 10
+
+    # Simulate applying quality settings after sync.
+    project.maximum_annotations = 2
+    project.overlap_cohort_percentage = 10
+    project.save(update_fields=['maximum_annotations', 'overlap_cohort_percentage'])
+    project._update_tasks_states(
+        maximum_annotations_changed=True,
+        overlap_cohort_percentage_changed=True,
+        tasks_number_changed=False,
+    )
+
+    assert tasks.filter(overlap=2).count() == 1
+    assert tasks.filter(overlap=1).count() == 9
 
 
 #
@@ -397,3 +475,43 @@ def test_allow_skip_false_is_saved(storage):
     # Create one task via cloud import pathway
     task = S3ImportStorage.add_task(project, 1, 1, s3_storage, params, S3ImportStorageLink)
     assert task.allow_skip is False
+
+
+def test_add_task_respects_overlap_cohort_percentage():
+    """Storage sync creates tasks with overlap=1 when overlap_cohort_percentage < 100 so
+    update_tasks_states -> _rearrange_overlap_cohort can assign the correct cohort after sync.
+    """
+    task_data = {'data': {'text': 'Task for overlap test'}}
+    params = StorageObject(key='test.json', task_data=task_data)
+
+    # When overlap_cohort_percentage < 100, new tasks get overlap=1 (cohort assigned later)
+    project_partial = ProjectFactory(
+        maximum_annotations=2,
+        overlap_cohort_percentage=10,
+    )
+    s3_storage_partial = S3ImportStorage(
+        project=project_partial,
+        bucket='example',
+        aws_access_key_id='example',
+        aws_secret_access_key='example',
+        use_blob_urls=False,
+    )
+    s3_storage_partial.save()
+    task_partial = S3ImportStorage.add_task(project_partial, 2, 1, s3_storage_partial, params, S3ImportStorageLink)
+    assert task_partial.overlap == 1
+
+    # When overlap_cohort_percentage >= 100, all tasks get maximum_annotations
+    project_full = ProjectFactory(
+        maximum_annotations=2,
+        overlap_cohort_percentage=100,
+    )
+    s3_storage_full = S3ImportStorage(
+        project=project_full,
+        bucket='example2',
+        aws_access_key_id='example',
+        aws_secret_access_key='example',
+        use_blob_urls=False,
+    )
+    s3_storage_full.save()
+    task_full = S3ImportStorage.add_task(project_full, 2, 1, s3_storage_full, params, S3ImportStorageLink)
+    assert task_full.overlap == 2


### PR DESCRIPTION
This pull request updates how task overlap is handled during storage sync, specifically to respect the `overlap_cohort_percentage` project setting. Now, when `overlap_cohort_percentage` is less than 100, new tasks are created with `overlap=1`, allowing the correct cohort assignment after synchronization. The PR also adds comprehensive tests to ensure this behavior and to verify that quality settings applied after sync rearrange the overlap as expected.

**Core logic update:**

* Modified `add_task` in `base_models.py` so that tasks are created with `overlap=1` when `overlap_cohort_percentage` is less than 100, enabling correct cohort assignment after sync. If the percentage is 100 or more, tasks get the full `maximum_annotations` overlap.

**Testing improvements:**

* Added tests to verify that storage sync respects `overlap_cohort_percentage`, ensuring only the correct proportion of tasks get the maximum overlap.
* Added tests to confirm that applying quality settings after sync correctly rearranges the overlap cohort among tasks.
* Added a direct unit test for the `add_task` logic to check that overlap is set according to the cohort percentage during task creation.
* Included necessary imports for the new tests, such as the `Task` model.