### PR TITLE
feat: FIT-658: Refactor Data Manager and Labeling/Review Stream Empty states to use new Empty State component

### DIFF
--- a/web/libs/editor/src/components/App/App.jsx
+++ b/web/libs/editor/src/components/App/App.jsx
@@ -25,7 +25,7 @@ import "../../tags/Custom";
  * Utils and common components
  */
 import { Space } from "../../common/Space/Space";
-import { Button } from "@humansignal/ui";
+import { Button, EmptyState, IconCheck } from "@humansignal/ui";
 import { isStarterCloudPlan } from "@humansignal/core";
 import { cn } from "../../utils/bem";
 import { FF_BULK_ANNOTATION, FF_LSDV_4620_3_ML, FF_SIMPLE_INIT, isFF } from "../../utils/feature-flags";
@@ -81,22 +81,35 @@ class App extends Component {
   }
 
   renderSuccess() {
+    const messages = getEnv(this.props.store).messages;
     return (
       <div className={cn("editor").toClassName()}>
-        <Result status="success" title={getEnv(this.props.store).messages.DONE} />
+        <EmptyState
+          variant="positive"
+          icon={<IconCheck />}
+          title={messages.DONE}
+          description="Your annotation has been submitted."
+        />
       </div>
     );
   }
 
   renderNoAnnotation() {
+    const messages = getEnv(this.props.store).messages;
     return (
       <div className={cn("editor").toClassName()}>
-        <Result status="success" title={getEnv(this.props.store).messages.NO_COMP_LEFT} />
+        <EmptyState
+          variant="positive"
+          icon={<IconCheck />}
+          title={messages.NO_COMP_LEFT}
+          description="You've viewed all annotations for this task."
+        />
       </div>
     );
   }
 
   renderNothingToLabel(store) {
+    const messages = getEnv(this.props.store).messages;
     return (
       <div
         className={cn("editor").toClassName()}
@@ -108,18 +121,25 @@ class App extends Component {
           paddingBottom: "30vh",
         }}
       >
-        <Result status="success" title={getEnv(this.props.store).messages.NO_NEXT_TASK} />
-        <div className={cn("sub__result").toClassName()}>All tasks in the queue have been completed</div>
-        {store.taskHistory.length > 0 && (
-          <Button
-            onClick={(e) => store.prevTask(e, true)}
-            variant="neutral"
-            className="mx-0 my-4"
-            aria-label="Previous task"
-          >
-            Go to Previous Task
-          </Button>
-        )}
+        <EmptyState
+          variant="positive"
+          icon={<IconCheck />}
+          title={messages.NO_NEXT_TASK}
+          description="All tasks in the queue have been completed"
+          actions={
+            store.taskHistory.length > 0 ? (
+              <Button
+                onClick={(e) => store.prevTask(e, true)}
+                variant="primary"
+                aria-label="Previous task"
+                data-testid="editor-empty-queue-previous-task"
+              >
+                Go to Previous Task
+              </Button>
+            ) : undefined
+          }
+          data-testid="editor-empty-queue"
+        />
       </div>
     );
   }
@@ -132,7 +152,7 @@ class App extends Component {
     );
   }
 
-  renderConfigValidationException(store) {
+  renderConfigValidationException(_store) {
     return (
       <div className={cn("main-view").toClassName()}>
         <div className={cn("main-view").elem("annotation").toClassName()}>

--- a/web/libs/editor/src/utils/messages.jsx
+++ b/web/libs/editor/src/utils/messages.jsx
@@ -6,7 +6,7 @@ const URL_TAGS_DOCS = "https://labelstud.io/tags";
 export default {
   DONE: "Done!",
   NO_COMP_LEFT: "No more annotations",
-  NO_NEXT_TASK: "No More Tasks Left in Queue",
+  NO_NEXT_TASK: "You're all caught up!",
   NO_ACCESS: "You don't have access to this task",
 
   CONFIRM_TO_DELETE_ALL_REGIONS: "Please confirm you want to delete all labeled regions",


### PR DESCRIPTION
This pull request updates the user interface for empty and success states in the annotation editor to use the new `EmptyState` component from the UI library, improving visual consistency and user experience. It also tweaks some messaging for clarity.

## Screenshots
### Before
<img width="1242" height="807" alt="image" src="https://github.com/user-attachments/assets/14443c8f-b075-4cab-871e-2d2ad29b9c65" />
<img width="1240" height="786" alt="image" src="https://github.com/user-attachments/assets/5d1e1f04-7b89-4268-aa84-cd41f84a5b29" />


### After
<img width="1242" height="763" alt="image" src="https://github.com/user-attachments/assets/1c452796-a03b-4886-80dc-d6f5c7a055e6" />
<img width="1246" height="632" alt="image" src="https://github.com/user-attachments/assets/d49f6e7c-03c9-49a9-b794-4208df44bd0c" />


UI improvements for empty and success states:

* Replaced the use of the `Result` component with the new `EmptyState` component in the `renderSuccess`, `renderNoAnnotation`, and `renderNothingToLabel` methods of the `App` component, providing consistent styling, icons, and descriptions for empty and success states. [[1]](diffhunk://#diff-bbac6a55022c600df09f9730a5cd6d74d4e3bb0de5c18142b50f6f0b2a47c84eR84-R112) [[2]](diffhunk://#diff-bbac6a55022c600df09f9730a5cd6d74d4e3bb0de5c18142b50f6f0b2a47c84eL111-R142)
* Updated the action button in the "no next task" state to use a primary variant and improved accessibility with `data-testid` attributes.
* Added imports for `EmptyState` and `IconCheck` from the UI library to support the new component usage.

Messaging updates:

* Changed the `NO_NEXT_TASK` message to "You're all caught up!" for a friendlier tone.

Code maintenance:

* Minor refactor in the `renderConfigValidationException` method to clarify unused parameters.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
