### PR TITLE
fix: FIT-1486: Very Slow Data Loading with S3 Integration

### DIFF
--- a/web/libs/datamanager/src/components/CellViews/ImageCell.jsx
+++ b/web/libs/datamanager/src/components/CellViews/ImageCell.jsx
@@ -22,6 +22,7 @@ export const ImageCell = (column) => {
       key={imgSrc}
       src={imgSrc}
       alt="Data"
+      loading="lazy"
       style={{
         maxHeight: "100%",
         maxWidth: "100px",

--- a/web/libs/datamanager/src/components/Common/AnnotationPreview/AnnotationPreview.jsx
+++ b/web/libs/datamanager/src/components/Common/AnnotationPreview/AnnotationPreview.jsx
@@ -127,6 +127,7 @@ export const AnnotationPreview = injector(
         {...imgDefaultProps}
         src={preview[`$${name}`][variant]}
         alt=""
+        loading="lazy"
         style={style}
         width={props.width}
         height={props.height}
@@ -147,6 +148,7 @@ export const AnnotationPreview = injector(
           src={props.fallbackImage}
           style={{ ...(style ?? {}), opacity: 0.5 }}
           alt=""
+          loading="lazy"
           width={props.width}
           height={props.height}
         />

--- a/web/libs/datamanager/src/components/DataGroups/ImageDataGroup.jsx
+++ b/web/libs/datamanager/src/components/DataGroups/ImageDataGroup.jsx
@@ -16,7 +16,7 @@ export const ImageDataGroup = (column) => {
 
   return original.total_annotations === 0 || !root.showPreviews ? (
     <div className={cn("grid-image-wrapper").toClassName()}>
-      <img src={value} width="auto" style={{ height: imageHeight }} alt="" />
+      <img src={value} width="auto" style={{ height: imageHeight }} alt="" loading="lazy" />
     </div>
   ) : (
     <AnnotationPreview

--- a/web/libs/datamanager/src/components/MainView/GridView/ImagePreview.tsx
+++ b/web/libs/datamanager/src/components/MainView/GridView/ImagePreview.tsx
@@ -218,6 +218,7 @@ const ImagePreview = observer(({ task, field }: ImagePreviewProps) => {
           ref={imageRef}
           src={src}
           alt="Task Preview"
+          loading="lazy"
           style={imageStyle}
           className={styles.image}
           onLoad={handleImageLoad}


### PR DESCRIPTION
This pull request optimizes image loading across several components by enabling lazy loading for images. Lazy loading defers the loading of images until they are about to enter the viewport, which can improve page performance and reduce initial load times, especially in data-heavy or image-rich views.

**Image loading optimization:**

* Added `loading="lazy"` to images in `ImageCell.jsx`, `AnnotationPreview.jsx`, `ImageDataGroup.jsx`, and `ImagePreview.tsx` to defer image loading until they are needed. [[1]](diffhunk://#diff-29d991f9688b1e5f892389b7a90aee9a1d19567e71382079eff36af2c8156cb1R25) [[2]](diffhunk://#diff-013980c64a692d48c805f022f81d09d7664b0cb639aabc09793399a3110277c7R130) [[3]](diffhunk://#diff-013980c64a692d48c805f022f81d09d7664b0cb639aabc09793399a3110277c7R151) [[4]](diffhunk://#diff-f66bff49561a45a1c63f6fd75b5124ebc36029bfef9ca8f89486ff938248f726L19-R19) [[5]](diffhunk://#diff-870426350f8a5731fda4fe695750572757ee4dbe371a9a5cea5678fb11986d53R221)