### PR TITLE
refactor: ECHO-440: Create validation & transform scripts for SCSS ba…

### DIFF
--- a/web/apps/labelstudio/src/app/App.scss
+++ b/web/apps/labelstudio/src/app/App.scss
@@ -30,13 +30,13 @@ body {
     margin: 32px auto;
   }
 
-  h1 {
+  & h1 {
     text-transform: uppercase;
     text-align: center;
     font-size: 20px;
   }
 
-  h2 {
+  & h2 {
     font-size: 20px;
     color: var(--color-negative-content);
   }
@@ -64,7 +64,7 @@ body {
     display: flex;
     align-items: center;
 
-    img {
+    & img {
       height: 16px;
       width: 16px;
       margin-right: 8px;

--- a/web/apps/labelstudio/src/components/Breadcrumbs/Breadcrumbs.scss
+++ b/web/apps/labelstudio/src/components/Breadcrumbs/Breadcrumbs.scss
@@ -74,7 +74,7 @@
     text-decoration: none;
     color: var(--color-neutral-content);
 
-    a {
+    & a {
       color: var(--color-primary-content);
     }
   }

--- a/web/apps/labelstudio/src/components/Error/Error.scss
+++ b/web/apps/labelstudio/src/components/Error/Error.scss
@@ -78,7 +78,7 @@
     display: flex;
     align-items: center;
 
-    img {
+    & img {
       height: 16px;
       width: 16px;
       margin-right: 8px;

--- a/web/apps/labelstudio/src/components/Form/Elements/Label/Label.scss
+++ b/web/apps/labelstudio/src/components/Form/Elements/Label/Label.scss
@@ -16,7 +16,7 @@
     line-height: 140%;
     white-space: pre-line;  // enable \n support in description texts
 
-    a {
+    & a {
       color: var(--color-primary-content);
       text-decoration: underline;
 
@@ -35,7 +35,7 @@
     white-space: pre-line;  // enable \n support in footer texts
     margin-top: var(--spacing-tightest);
 
-    a {
+    & a {
       color: var(--color-primary-content);
       text-decoration: underline;
 
@@ -67,7 +67,7 @@
     color: var(--color-primary-content);
     margin-left: 4px;
 
-    svg {
+    & svg {
       height: 100%;
       width: 100%;
       fill: var(--color-neutral-icon);
@@ -171,7 +171,7 @@
   }
 
   &_placement_right.label-ls_withDescription &__field {
-    input[type="radio"] {
+    & input[type="radio"] {
       margin: 4px 0 0;
     }
   }

--- a/web/apps/labelstudio/src/components/Hamburger/Hamburger.scss
+++ b/web/apps/labelstudio/src/components/Hamburger/Hamburger.scss
@@ -5,7 +5,7 @@
   position: relative;
   display: inline-block;
 
-  span {
+  & span {
     height: 2px;
     width: 100%;
     display: block;

--- a/web/apps/labelstudio/src/components/HeidiTips/HeidiTip.scss
+++ b/web/apps/labelstudio/src/components/HeidiTips/HeidiTip.scss
@@ -53,8 +53,8 @@
     pointer-events: none;
     color: var(--color-neutral-border);
 
-    svg {
-      path.spike-stroke {
+    & svg {
+      & path.spike-stroke {
         color: red;
       }
 

--- a/web/apps/labelstudio/src/components/Menubar/Menubar.scss
+++ b/web/apps/labelstudio/src/components/Menubar/Menubar.scss
@@ -48,15 +48,15 @@
   }
 
   &__hotkeys-button {
-      button {
-        svg {
+      & button {
+        & svg {
           width: 20px;
           height: 20px;
           color: var(--color-neutral-content-subtler);
         }
 
         &:hover {
-          svg {
+          & svg {
             color: var(--color-neutral-icon);
           }
         }

--- a/web/apps/labelstudio/src/components/Pagination/Pagination.scss
+++ b/web/apps/labelstudio/src/components/Pagination/Pagination.scss
@@ -131,7 +131,7 @@
       opacity: 0.5;
     }
 
-    input {
+    & input {
       width: 100%;
       height: calc(100% - 2px);
       border: none;
@@ -153,7 +153,7 @@
     flex: 1;
     user-select: none;
 
-    span {
+    & span {
       font-weight: normal;
       opacity: 0.4;
     }

--- a/web/apps/labelstudio/src/components/VersionNotifier/VersionNotifier.scss
+++ b/web/apps/labelstudio/src/components/VersionNotifier/VersionNotifier.scss
@@ -6,11 +6,11 @@
   background: var(--color-primary-surface-content);
   border-radius: 5px;
 
-  a {
+  & a {
     display: flex;
   }
 
-  a:visited {
+  & a:visited {
     color: var(--primary_link);
   }
 
@@ -19,7 +19,7 @@
     padding-top: 1px;
     color: var(--primary_link);
 
-    img {
+    & img {
       width: 20px;
       height: 20px;
       margin: 0 auto;

--- a/web/apps/labelstudio/src/pages/CreateProject/Config/Config.scss
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/Config.scss
@@ -70,7 +70,7 @@ $scroll-width: 5px;
   &__sidebar {
     padding: var(--spacing-base) var(--spacing-tight) var(--spacing-base) var(--spacing-wider);
 
-    h3:not(:first-child) {
+    & h3:not(:first-child) {
       margin-top: var(--spacing-wide);
     }
 
@@ -85,7 +85,7 @@ $scroll-width: 5px;
       text-align: left;
     }
 
-    ul {
+    & ul {
       padding: 0;
       list-style: none;
       display: flex;
@@ -116,7 +116,7 @@ $scroll-width: 5px;
       cursor: default;
     }
 
-    svg {
+    & svg {
       margin-left: auto;
       padding-left: 16px;
       width: 24px;
@@ -124,13 +124,13 @@ $scroll-width: 5px;
     }
   }
 
-  main {
+  & main {
     position: relative;
     flex-grow: 1;
     overflow-y: auto;
     height: 100%;
 
-    ul {
+    & ul {
       display: grid;
       padding: 0;
       margin: 16px 8px;
@@ -181,7 +181,7 @@ $scroll-width: 5px;
       transform: translateY(-1px); // Subtle lift effect
     }
 
-    h3 {
+    & h3 {
       margin: 0;
       padding: 12px;
       font-size: 14px;
@@ -190,7 +190,7 @@ $scroll-width: 5px;
       color: var(--color-neutral-content);
     }
 
-    img {
+    & img {
       width: 100%;
       object-fit: cover;
       border-radius: 8px 8px 0 0;
@@ -198,7 +198,7 @@ $scroll-width: 5px;
     }
   }
 
-  footer,
+  & footer,
   .modal__footer {
     grid-column: 1 / span 2;
     padding: 16px 32px;
@@ -316,7 +316,7 @@ $scroll-width: 5px;
     color: var(--color-neutral-content);
   }
 
-  a {
+  & a {
     color: var(--color-primary-content);
 
     &:hover {
@@ -326,8 +326,8 @@ $scroll-width: 5px;
     }
   }
 
-  input,
-  select {
+  & input,
+  & select {
     flex: 1;
     min-width: 160px;
     padding: 4px 8px;
@@ -339,7 +339,7 @@ $scroll-width: 5px;
 }
 
 .wizard .configure__object {
-  h4 {
+  & h4 {
     margin-bottom: 8px;
     color: var(--color-neutral-content);
   }
@@ -352,7 +352,7 @@ $scroll-width: 5px;
     gap: var(--spacing-tight);
     color: var(--color-neutral-content-subtler);
 
-    button {
+    & button {
       min-width: 160px;
       flex: 1;
     }
@@ -369,7 +369,7 @@ $scroll-width: 5px;
     color: var(--color-negative-content);
   }
 
-  input {
+  & input {
     margin-left: 8px;
   }
 }
@@ -397,11 +397,11 @@ $scroll-width: 5px;
   flex: 1;
   min-width: 300px;
 
-  span {
+  & span {
     color: var(--color-neutral-content-subtler);
   }
 
-  textarea {
+  & textarea {
     flex-grow: 1;
     margin: 8px 0;
     border-color: var(--color-neutral-border);
@@ -426,7 +426,7 @@ $scroll-width: 5px;
   margin-right: 8px;
   min-width: 225px;
 
-  h3 {
+  & h3 {
     font-size: 16px;
     padding-bottom: var(--spacing-tighter);
     color: var(--color-neutral-content);
@@ -454,16 +454,16 @@ $scroll-width: 5px;
     }
 
     &_choice {
-      label {
+      & label {
         display: none;
       }
 
-      span {
+      & span {
         background: var(--color-neutral-background);
       }
     }
 
-    label {
+    & label {
       width: 0;
       cursor: pointer;
 
@@ -526,11 +526,11 @@ $scroll-width: 5px;
     &:hover {
       background: var(--color-neutral-surface);
 
-      label::before {
+      & label::before {
         border-radius: 0;
       }
 
-      label::after {
+      & label::after {
         width: 12px;
         left: -12px;
       }
@@ -548,26 +548,26 @@ $scroll-width: 5px;
 .wizard ul.configure__settings {
   padding: 0;
 
-  ul {
+  & ul {
     padding: 0;
   }
 
-  li {
+  & li {
     list-style: none;
     margin: 8px 0 0 8px;
   }
 
-  label {
+  & label {
     cursor: pointer;
     color: var(--color-neutral-content-subtler);
   }
 
-  input[type="checkbox"] {
+  & input[type="checkbox"] {
     margin-right: 8px;
   }
 
-  input[type="text"],
-  select {
+  & input[type="text"],
+  & select {
     font: inherit;
     line-height: 1.2em;
     padding: 4px 8px;
@@ -586,13 +586,13 @@ $scroll-width: 5px;
   color: var(--color-neutral-content);
   height: 100%;
 
-  h3 {
+  & h3 {
     padding: var(--spacing-tight) 0;
     font-size: 16px;
     color: var(--color-neutral-content);
   }
 
-  iframe {
+  & iframe {
     display: block;
     min-width: 100%;
     min-height: 100%;
@@ -616,7 +616,7 @@ $scroll-width: 5px;
     margin-bottom: 16px;
     white-space: pre-line;
 
-    h2 {
+    & h2 {
       font-size: 16px;
     }
   }
@@ -660,11 +660,11 @@ $scroll-width: 5px;
   font-size: 13px;
   line-height: 1.4;
 
-  svg {
+  & svg {
     flex-shrink: 0;
   }
 
-  button {
+  & button {
     margin-left: auto;
     flex-shrink: 0;
   }

--- a/web/apps/labelstudio/src/pages/CreateProject/CreateProject.scss
+++ b/web/apps/labelstudio/src/pages/CreateProject/CreateProject.scss
@@ -49,7 +49,7 @@
     }
   }
 
-  form.project-name {
+  & form.project-name {
     width: 500px;
     margin: 32px auto;
 
@@ -57,12 +57,12 @@
       margin-top: 32px;
     }
 
-    label {
+    & label {
       display: inline-flex;
       align-items: center;
     }
 
-    input, textarea {
+    & input, textarea {
       background: var(--color-neutral-background);
       border: 1px solid var(--color-neutral-border);
       color: var(--color-neutral-content);

--- a/web/apps/labelstudio/src/pages/CreateProject/Import/Import.scss
+++ b/web/apps/labelstudio/src/pages/CreateProject/Import/Import.scss
@@ -46,7 +46,7 @@
     gap: var(--spacing-tight);
   }
 
-  button {
+  & button {
     line-height: 1em;
   }
 
@@ -65,7 +65,7 @@
   &__url-form {
     display: flex;
 
-    input {
+    & input {
       border: 1px solid var(--color-neutral-border);
       background: var(--color-neutral-background);
       color: var(--color-neutral-content);
@@ -83,7 +83,7 @@
       }
     }
 
-    button {
+    & button {
       margin-left: -1px;
       border-radius: 0 var(--corner-radius-smaller) var(--corner-radius-smaller) 0;
     }
@@ -110,23 +110,23 @@
     background-attachment: local, scroll;
   }
 
-  table {
+  & table {
     table-layout: fixed;
     
-    tr {
+    & tr {
       border-bottom: 2px solid var(--color-neutral-background);
       background-color: transparent;
 
-      td:nth-child(2) {
+      & td:nth-child(2) {
         width: 136px;
       }
     }
 
-    tr:nth-child(odd) {
+    & tr:nth-child(odd) {
       background: var(--color-neutral-emphasis-subtle);
     }
 
-    td {
+    & td {
       padding: var(--spacing-tight) var(--spacing-tight);
     }
   }
@@ -213,7 +213,7 @@
       border-radius: 8px;
     }
 
-    label {
+    & label {
       margin-left: 8px;
       cursor: pointer;
     }
@@ -238,7 +238,7 @@
   position: relative;
   display: flex;
 
-  a {
+  & a {
     color: var(--color-primary-content);
 
     &:hover {
@@ -281,7 +281,7 @@
     color: var(--color-primary-icon);
   }
 
-  label {
+  & label {
     display: flex;
     justify-content: center;
   }
@@ -303,30 +303,30 @@
       margin-top: 32px;
     }
 
-    header {
+    & header {
       font-size: 24px;
       line-height: 32px;
       text-align: center;
       color: var(--color-neutral-content);
     }
 
-    dl {
+    & dl {
       display: grid;
       grid-template: auto / auto auto;
       font-size: 14px;
       line-height: 24px;
       gap: 0 30px;
 
-      dt {
+      & dt {
         color: var(--color-neutral-content);
       }
 
-      dd {
+      & dd {
         font-weight: normal;
       }
 
       dt:last-of-type,
-      dd:last-of-type {
+      & dd:last-of-type {
         margin-top: 20px;
       }
     }

--- a/web/apps/labelstudio/src/pages/ExportPage/ExportPage.scss
+++ b/web/apps/labelstudio/src/pages/ExportPage/ExportPage.scss
@@ -3,7 +3,7 @@
     display: grid;
     grid-auto-flow: rows;
 
-    a {
+    & a {
       color: var(--color-primary-content);
       text-decoration: underline;
       font-size: 14px;
@@ -71,7 +71,7 @@
     color: var(--color-neutral-content-subtle);
     line-height: 1.5;
 
-    a {
+    & a {
       color: var(--color-primary-content);
       text-decoration: none;
       border-bottom: 1px solid transparent;
@@ -130,7 +130,7 @@
     list-style: none;
     color: var(--color-neutral-content-subtle);
 
-    li {
+    & li {
       margin: 0 0 14px;
       padding-left: 0;
 
@@ -197,7 +197,7 @@
       border-radius: 4px 0 0 4px;
     }
 
-    code {
+    & code {
       font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
       font-size: 12px;
       color: var(--color-neutral-content-subtle);
@@ -254,7 +254,7 @@
     align-items: center;
     gap: 6px;
 
-    a {
+    & a {
       color: var(--color-primary-content);
       text-decoration: none;
       font-weight: 400;

--- a/web/apps/labelstudio/src/pages/Organization/Models/@components/EmptyList.scss
+++ b/web/apps/labelstudio/src/pages/Organization/Models/@components/EmptyList.scss
@@ -22,7 +22,7 @@
     width: 193px;
     color: var(--color-neutral-background-bold);
 
-    svg {
+    & svg {
       width: 100%;
       height: 100%;
     }

--- a/web/apps/labelstudio/src/pages/Projects/Projects.scss
+++ b/web/apps/labelstudio/src/pages/Projects/Projects.scss
@@ -73,7 +73,7 @@
     color: var(--color-neutral-content);
   }
 
-  p {
+  & p {
     font-size: 1.25rem;
     color: var(--color-neutral-content-subtle);
     margin: 0;

--- a/web/apps/labelstudio/src/pages/Settings/settings.scss
+++ b/web/apps/labelstudio/src/pages/Settings/settings.scss
@@ -97,7 +97,7 @@
   line-height: 16px;
   letter-spacing: 0.4px;
 
-  a {
+  & a {
     color: var(--color-primary-surface-content);
     font-size: 12px;
     font-style: normal;
@@ -115,11 +115,11 @@
   display: flex;
   align-items: flex-start;
 
-  p {
+  & p {
     padding: 0;
     margin: 0;
 
-    a {
+    & a {
       color: var(--color-primary-surface-content);
       font-size: 14px;
       font-style: normal;
@@ -137,7 +137,7 @@
     margin-top: 5px;
   }
 
-  input {
+  & input {
     margin-top: 5px;
   }
 

--- a/web/libs/app-common/src/pages/AccountSettings/AccountSettings.module.scss
+++ b/web/libs/app-common/src/pages/AccountSettings/AccountSettings.module.scss
@@ -9,7 +9,7 @@
     gap: var(--spacing-wide);
     max-width: 660px;
 
-    h1 {
+    & h1 {
       font-size: var(--font-size-header, 28px);
       margin: 0;
     }

--- a/web/libs/app-common/src/pages/AccountSettings/sections/PersonalAccessToken.module.scss
+++ b/web/libs/app-common/src/pages/AccountSettings/sections/PersonalAccessToken.module.scss
@@ -9,7 +9,7 @@
 .label {
   @apply mb-[8px];
 
-  span {
+  & span {
     @apply p-0;
   }
 }

--- a/web/libs/app-common/src/pages/AccountSettings/sections/PersonalJWTToken.module.scss
+++ b/web/libs/app-common/src/pages/AccountSettings/sections/PersonalJWTToken.module.scss
@@ -6,7 +6,7 @@
 .label {
   margin-bottom: 8px;
 
-  span {
+  & span {
     padding: 0;
   }
 }

--- a/web/libs/datamanager/src/components/Common/MediaPlayer/MediaPlayer.scss
+++ b/web/libs/datamanager/src/components/Common/MediaPlayer/MediaPlayer.scss
@@ -9,7 +9,7 @@
   background-color: var(--color-neutral-background);
   box-shadow: 0 0 0 1px var(--color-neutral-border) inset, 0 2px 4px rgba(var(--color-neutral-shadow-raw) / 8%);
 
-  video {
+  & video {
     width: 140px;
     height: 50px;
     border-radius: 4px 0 0 4px;

--- a/web/libs/datamanager/src/components/Common/Menu/Menu.scss
+++ b/web/libs/datamanager/src/components/Common/Menu/Menu.scss
@@ -6,23 +6,23 @@
   flex-direction: column;
   list-style-type: none;
 
-  ul {
+  & ul {
     display: flex;
     flex-direction: column;
     gap: var(--spacing-tighter);
   }
 
-  ul,
-  li {
+  & ul,
+  & li {
     display: block;
     list-style-type: none;
   }
 
-  li {
+  & li {
     padding: 0 var(--spacing-tight);
   }
 
-  li+li:not(.menu-dm__divider) {
+  & li+li:not(.menu-dm__divider) {
     margin-top: 0;
   }
 
@@ -43,7 +43,7 @@
     &[disabled] {
       color: var(--color-neutral-content-subtlest);
 
-      svg {
+      & svg {
         color: var(--color-neutral-content-subtlest) !important;
       }
 
@@ -121,7 +121,7 @@
     padding: var(--spacing-tightest);
     gap: var(--spacing-tightest);
 
-    li {
+    & li {
       padding: 0;
     }
 
@@ -132,7 +132,7 @@
   }
 
   &_size_small {
-    li:not(.menu-dm__divider) {
+    & li:not(.menu-dm__divider) {
       padding: 0;
     }
 
@@ -150,7 +150,7 @@
     .menu-dm__item {
       padding: var(--spacing-tightest) var(--spacing-tight);
 
-      label {
+      & label {
         margin: 0;
         max-height: 18px;
       }

--- a/web/libs/datamanager/src/components/Common/Pagination/Pagination.scss
+++ b/web/libs/datamanager/src/components/Common/Pagination/Pagination.scss
@@ -168,7 +168,7 @@
       width: 70px;
     }
 
-    input {
+    & input {
       width: 100%;
       height: calc(100% - 2px);
       border: none;
@@ -190,7 +190,7 @@
     font-size: var(--font-size);
     line-height: var(--line-height);
 
-    span {
+    & span {
       font-weight: normal;
       opacity: 0.4;
     }

--- a/web/libs/datamanager/src/components/Common/Tabs/Tabs.scss
+++ b/web/libs/datamanager/src/components/Common/Tabs/Tabs.scss
@@ -204,7 +204,7 @@
     align-items: center;
     border-radius: var(--corner-radius-small);
 
-    span {
+    & span {
       border: 1px solid transparent;
     }
 
@@ -221,7 +221,7 @@
       padding-left: var(--spacing-tight);
       padding-right: var(--spacing-tight);
 
-      input {
+      & input {
         height: 24px;
         font-size: 14px;
         padding-left: var(--spacing-tight);

--- a/web/libs/datamanager/src/components/Common/TaskSourceViewer/CodeView.module.scss
+++ b/web/libs/datamanager/src/components/Common/TaskSourceViewer/CodeView.module.scss
@@ -20,7 +20,7 @@
   z-index: 10;
   color: var(--color-neutral-content-subtle);
 
-  svg {
+  & svg {
     width: 20px;
     height: 20px;
   }

--- a/web/libs/datamanager/src/components/DataManager/Toolbar/OrderButton.scss
+++ b/web/libs/datamanager/src/components/DataManager/Toolbar/OrderButton.scss
@@ -1,6 +1,6 @@
 .orderButton {
   // Hide the caret icon when Select is used in ButtonGroup
-  button[data-testid^="select-trigger"] > svg {
+  & button[data-testid^="select-trigger"] > svg {
     display: none;
   }
 }

--- a/web/libs/datamanager/src/components/MainView/GridView/GridPreview.module.scss
+++ b/web/libs/datamanager/src/components/MainView/GridView/GridPreview.module.scss
@@ -16,11 +16,11 @@
   max-width: 300px;
   line-height: 16px;
 
-  p {
+  & p {
     margin-bottom: 4px;
   }
 
-  p:last-child {
+  & p:last-child {
     margin-bottom: 0;
   }
 }

--- a/web/libs/datamanager/src/components/MainView/GridView/GridView.scss
+++ b/web/libs/datamanager/src/components/MainView/GridView/GridView.scss
@@ -38,7 +38,7 @@
       width: 100%;
       min-width: 0;
 
-      img {
+      & img {
         width: 100%;
         height: 100%;
         max-height: 100%;
@@ -55,7 +55,7 @@
       grid-template-columns: 100%;
       }
 
-      img {
+      & img {
         height: 100%;
         max-height: 100%;
         width: auto;

--- a/web/libs/editor/src/common/Menu/Menu.scss
+++ b/web/libs/editor/src/common/Menu/Menu.scss
@@ -6,17 +6,17 @@
   flex-direction: column;
   list-style-type: none;
 
-  ul,
-  li {
+  & ul,
+  & li {
     display: block;
     list-style-type: none;
   }
 
-  li {
+  & li {
     margin: 0.5rem;
   }
 
-  li+li {
+  & li+li {
     margin-top: 0;
   }
 

--- a/web/libs/editor/src/common/Pagination/Pagination.scss
+++ b/web/libs/editor/src/common/Pagination/Pagination.scss
@@ -162,7 +162,7 @@
       min-width: 70px;
     }
 
-    input {
+    & input {
       width: 100%;
       height: calc(100% - 2px);
       border: none;
@@ -184,7 +184,7 @@
     font-size: var(--font-size);
     line-height: var(--line-height);
 
-    span {
+    & span {
       font-weight: normal;
       opacity: 0.4;
     }
@@ -193,7 +193,7 @@
   &_disabled &__page-indicator {
     opacity: 0.4;
 
-    span {
+    & span {
       opacity: 1;
     }
   }
@@ -213,7 +213,7 @@
     }
   }
 
-  select {
+  & select {
     height: 40px;
     min-height: 40px;
     font-size: 16px;

--- a/web/libs/editor/src/common/Range/Range.scss
+++ b/web/libs/editor/src/common/Range/Range.scss
@@ -107,7 +107,7 @@
     align-items: center;
     justify-content: center;
 
-    svg {
+    & svg {
       max-width: 100%;
       max-height: 100%;
     }

--- a/web/libs/editor/src/common/TextArea/TextArea.scss
+++ b/web/libs/editor/src/common/TextArea/TextArea.scss
@@ -54,7 +54,7 @@
       }
     }
 
-    input, textarea {
+    & input, textarea {
       background-color: var(--color-neutral-background);
       padding: var(--spacing-tight) var(--spacing-widest) var(--spacing-tight) var(--spacing-base);
       font-size: var(--font-size-body-small);
@@ -82,7 +82,7 @@
     opacity: 0;
     transition: transform 150ms ease-out, opacity 150ms ease-out;
 
-    button {
+    & button {
       pointer-events: auto;
     }
   }

--- a/web/libs/editor/src/components/AnnotationTabs/AnnotationTabs.scss
+++ b/web/libs/editor/src/components/AnnotationTabs/AnnotationTabs.scss
@@ -114,7 +114,7 @@
     color: var(--color-accent-canteloupe-bold);
     margin-top: -2px;
 
-    path {
+    & path {
       fill-opacity: 1;
       stroke-opacity: 1;
     }

--- a/web/libs/editor/src/components/Annotations/Annotations.module.scss
+++ b/web/libs/editor/src/components/Annotations/Annotations.module.scss
@@ -36,7 +36,7 @@
   color: var(--primary_link);
   font-weight: bold;
 
-  h3 {
+  & h3 {
     margin: 0;
   }
 }

--- a/web/libs/editor/src/components/AnnotationsCarousel/AnnotationButton.scss
+++ b/web/libs/editor/src/components/AnnotationsCarousel/AnnotationButton.scss
@@ -239,7 +239,7 @@
     transition: opacity 150ms ease-out, background-color 150ms ease-out, right 150ms ease-out;
     box-shadow: 2px 0 6px rgb(var(--color-neutral-shadow-raw) / 8%), 1px 0 2px rgb(var(--color-neutral-shadow-raw) / 8%);
 
-    svg {
+    & svg {
       width: 20px;
       height: 20px;
       transform-origin: center;
@@ -252,7 +252,7 @@
       background: var(--color-primary-emphasis);
       border-color: var(--color-primary-border-subtler);
 
-      svg {
+      & svg {
         color: var(--color-neutral-content);
       }
     }
@@ -393,7 +393,7 @@
     &_updated {
       background-color: var(--color-primary-content);
 
-      svg {
+      & svg {
         display: block;
       }
     }

--- a/web/libs/editor/src/components/AnnotationsCarousel/AnnotationsCarousel.scss
+++ b/web/libs/editor/src/components/AnnotationsCarousel/AnnotationsCarousel.scss
@@ -64,7 +64,7 @@
     gap: var(--spacing-tighter);
     padding-right: var(--spacing-tighter);
 
-    button:not(:disabled) {
+    & button:not(:disabled) {
       box-shadow: 0 2px 6px rgba(var(--color-neutral-shadow-raw) / 20%);
     }
   }
@@ -83,7 +83,7 @@
     &_disabled {
       background: var(--color-background-surface);
 
-      svg {
+      & svg {
         opacity: 0.4;
       }
 

--- a/web/libs/editor/src/components/AnnotationsCarousel/ViewAllToggle.scss
+++ b/web/libs/editor/src/components/AnnotationsCarousel/ViewAllToggle.scss
@@ -41,7 +41,7 @@
     justify-content: center;
     flex-shrink: 0;
 
-    svg {
+    & svg {
       width: 16px;
       height: 16px;
     }

--- a/web/libs/editor/src/components/App/Grid.module.scss
+++ b/web/libs/editor/src/components/App/Grid.module.scss
@@ -81,7 +81,7 @@ $gap: 30px;
     justify-content: center;
   }
 
-  svg {
+  & svg {
     width: 16px;
     height: 16px;
   }
@@ -104,7 +104,7 @@ $gap: 30px;
 .grid>div:global(.hover) {
   background: var(--color-primary-emphasis-subtle);
 
-  h4 {
+  & h4 {
     color: var(--primary_link);
   }
 }

--- a/web/libs/editor/src/components/BottomBar/Actions.scss
+++ b/web/libs/editor/src/components/BottomBar/Actions.scss
@@ -12,7 +12,7 @@
       opacity: 0.6;
     }
 
-    svg {
+    & svg {
       display: block;
     }
   }

--- a/web/libs/editor/src/components/BottomBar/Controls.scss
+++ b/web/libs/editor/src/components/BottomBar/Controls.scss
@@ -72,7 +72,7 @@
         justify-content: space-between;
       }
 
-      span {
+      & span {
         width: 100%;
       }
 
@@ -85,7 +85,7 @@
         align-self: stretch;
         border-left: 1px solid rgb(255 255 255 / 16%);
 
-        div {
+        & div {
           width: 100%;
           height: 100%;
           display: flex;
@@ -93,7 +93,7 @@
           justify-content: center;
         }
 
-        svg {
+        & svg {
           pointer-events: none;
           transform: rotate(180deg) scale(1.1);
         }
@@ -107,7 +107,7 @@
       font-weight: 500;
       font-size: 16px;
 
-      svg {
+      & svg {
         color: var(--color-negative-icon);
         margin: 0 8px 0 4px;
       }

--- a/web/libs/editor/src/components/BottomBar/HistoryActions.scss
+++ b/web/libs/editor/src/components/BottomBar/HistoryActions.scss
@@ -8,7 +8,7 @@
       opacity: 0.6;
     }
 
-    svg {
+    & svg {
       display: block;
     }
 

--- a/web/libs/editor/src/components/Comments/Comment/CommentItem.scss
+++ b/web/libs/editor/src/components/Comments/Comment/CommentItem.scss
@@ -99,7 +99,7 @@
       height: 28px !important;
     }
 
-    svg {
+    & svg {
       width: 20px !important;
       height: 20px !important;
     }

--- a/web/libs/editor/src/components/Comments/Comment/LinkState.scss
+++ b/web/libs/editor/src/components/Comments/Comment/LinkState.scss
@@ -34,7 +34,7 @@
       transform: translateY(2px);
     }
 
-    svg {
+    & svg {
       width: 20px;
       height: 20px;
     }
@@ -68,7 +68,7 @@
     color: var(--icon-color);
     flex-grow: 0;
 
-    svg {
+    & svg {
       width: 24px;
       height: 24px;
     }

--- a/web/libs/editor/src/components/ContextMenu/ContextMenu.module.scss
+++ b/web/libs/editor/src/components/ContextMenu/ContextMenu.module.scss
@@ -16,7 +16,7 @@
   justify-content: center;
   margin-inline: 6px;
 
-  svg {
+  & svg {
     flex-shrink: 0;
   }
 }

--- a/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.scss
+++ b/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.scss
@@ -17,7 +17,7 @@
     align-items: center;
     justify-content: space-between;
 
-    span {
+    & span {
       color: var(--color-neutral-content-subtler);
       font-weight: normal;
     }

--- a/web/libs/editor/src/components/CurrentEntity/GroundTruth.scss
+++ b/web/libs/editor/src/components/CurrentEntity/GroundTruth.scss
@@ -28,7 +28,7 @@
     &_active {
       color: var(--canteloupe_400);
 
-      path {
+      & path {
         fill-opacity: 1;
         stroke-opacity: 1;
       }

--- a/web/libs/editor/src/components/ImageView/ImageView.module.scss
+++ b/web/libs/editor/src/components/ImageView/ImageView.module.scss
@@ -99,7 +99,7 @@
     overflow: hidden;
     height: 0;
 
-    img {
+    & img {
       max-width: unset;
     }
   }
@@ -121,7 +121,7 @@
     z-index: 100;
   }
 
-  img {
+  & img {
     position: absolute;
     top: 0;
   }
@@ -143,7 +143,7 @@
   width: 100%;
   padding-bottom: 8px; // for scroll
 
-  img {
+  & img {
     cursor: pointer;
     margin-right: 4px;
     border: 4px solid transparent;

--- a/web/libs/editor/src/components/Node/Node.scss
+++ b/web/libs/editor/src/components/Node/Node.scss
@@ -11,7 +11,7 @@
     margin-left: 5px;
     align-items: center;
 
-    svg {
+    & svg {
       width: 20px;
       height: 17px;
       fill: var(--incomplete-warning-color, var(--persimmon_400));
@@ -37,7 +37,7 @@
     height: 24px;
     margin-right: 5px;
 
-    svg {
+    & svg {
       width: 24px;
       height: 24px;
     }

--- a/web/libs/editor/src/components/Ranker/Ranker.module.scss
+++ b/web/libs/editor/src/components/Ranker/Ranker.module.scss
@@ -33,11 +33,11 @@
     display: flex;
     align-items: center;
 
-    button {
+    & button {
       margin-left: auto;
     }
 
-    h3 {
+    & h3 {
       font-size: 1.5rem; // Special case to override the too restrictive and generalistic Config.scss
     }
   }

--- a/web/libs/editor/src/components/SidePanels/DetailsPanel/DetailsPanel.scss
+++ b/web/libs/editor/src/components/SidePanels/DetailsPanel/DetailsPanel.scss
@@ -37,7 +37,7 @@
         @apply sr-only;
       }
 
-      span {
+      & span {
         color: var(--color-neutral-content-subtler);
         font-weight: normal;
       }

--- a/web/libs/editor/src/components/SidePanels/DetailsPanel/RegionDetails.scss
+++ b/web/libs/editor/src/components/SidePanels/DetailsPanel/RegionDetails.scss
@@ -67,7 +67,7 @@
     transition-timing-function: ease;
 
     &:hover {
-      textarea {
+      & textarea {
         border-color: var(--color-neutral-border);
         background-color: var(--color-neutral-background);
       }
@@ -104,7 +104,7 @@
     order: 0;
     flex-grow: 1;
 
-    svg {
+    & svg {
       width: 20px;
       height: 17px;
       fill: var(--incomplete-warning-color, var(--color-warning-icon));
@@ -147,7 +147,7 @@
   }
 
   &__value {
-    p {
+    & p {
       padding: 0;
       margin-bottom: 4px;
 

--- a/web/libs/editor/src/components/SidePanels/DetailsPanel/Relations.scss
+++ b/web/libs/editor/src/components/SidePanels/DetailsPanel/Relations.scss
@@ -67,7 +67,7 @@
     align-items: center;
     justify-content: center;
 
-    svg {
+    & svg {
       width: 18px;
       height: 18px;
     }

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/TreeView.scss
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/TreeView.scss
@@ -68,7 +68,7 @@
     justify-content: center;
     color: var(--icon-color);
 
-    svg {
+    & svg {
       width: 24px;
       height: 24px;
     }
@@ -178,7 +178,7 @@
     margin-left: 5px;
     align-items: center;
 
-    svg {
+    & svg {
       width: 20px;
       height: 17px;
       fill: var(--incomplete-warning-color, #FA8C16);

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.scss
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/ViewControls.scss
@@ -24,7 +24,7 @@
     align-items: center;
     gap: var(--spacing-tight);
 
-    span {
+    & span {
       display: flex;
       align-items: center;
       color: var(--grape_500);

--- a/web/libs/editor/src/components/SidePanels/PanelBase.scss
+++ b/web/libs/editor/src/components/SidePanels/PanelBase.scss
@@ -162,7 +162,7 @@
     justify-content: center;
     color: var(--grape_500);
 
-    svg {
+    & svg {
       display: block;
     }
 

--- a/web/libs/editor/src/components/SidePanels/TabPanels/PanelTabsBase.scss
+++ b/web/libs/editor/src/components/SidePanels/TabPanels/PanelTabsBase.scss
@@ -43,7 +43,7 @@
 
       --icon-color: var(--color-neutral-icon);
 
-      svg {
+      & svg {
         transform: rotate(180deg);
       }
     }
@@ -176,7 +176,7 @@
       }
     }
 
-    svg {
+    & svg {
       display: block;
       height: 12px;
     }

--- a/web/libs/editor/src/components/Taxonomy/Taxonomy.module.scss
+++ b/web/libs/editor/src/components/Taxonomy/Taxonomy.module.scss
@@ -30,7 +30,7 @@
   flex-wrap: wrap;
   min-height: 28px; // 24px button + 4px margin
 
-  div {
+  & div {
     margin: 0 2px 4px 0;
     background: hsl(0deg 0% 95%);
     padding: 0; // all the right space should be a clickable button, so no padding
@@ -38,12 +38,12 @@
     display: flex;
     align-items: center;
 
-    span {
+    & span {
       padding-inline: 8px;
     }
   }
 
-  input[type="button"] {
+  & input[type="button"] {
     border: none;
     background: none;
     cursor: pointer;
@@ -71,7 +71,7 @@
   border: 1px solid var(--color-neutral-border);
   box-shadow: 0 4px 10px rgb(0 0 0 / 12%);
 
-  input[type="checkbox"] {
+  & input[type="checkbox"] {
     margin-right: 4px;
     font-size: 20px;
     line-height: 30px;
@@ -159,7 +159,7 @@
   pointer-events: all;
   font-family: var(--font-mono);
 
-  svg {
+  & svg {
     transition: transform 0.1s; // visible rotation of arrow
   }
 

--- a/web/libs/editor/src/components/TimeDurationControl/TimeBox.scss
+++ b/web/libs/editor/src/components/TimeDurationControl/TimeBox.scss
@@ -27,7 +27,7 @@
     line-height: 22px;
     text-align: center;
 
-    span {
+    & span {
       color: var(--sand_400);
     }
   }

--- a/web/libs/editor/src/components/Timeline/Controls.scss
+++ b/web/libs/editor/src/components/Timeline/Controls.scss
@@ -39,13 +39,13 @@
     color: var(--color-neutral-content);
     padding: 0 8px;
 
-    span {
+    & span {
       opacity: 0.4;
       padding-left: 5px;
       font-weight: 400;
     }
 
-    input {
+    & input {
       width: 100%;
       height: 100%;
       border: none;
@@ -101,7 +101,7 @@
       padding: 0 8px;
       align-items: center;
 
-      span {
+      & span {
         opacity: 0.48;
 
         &::before {
@@ -123,7 +123,7 @@
   align-items: center;
   color: var(--color-neutral-content-subtler);
 
-  span {
+  & span {
     font-size: 11px;
     min-width: 22px;
     border-radius: 2px;

--- a/web/libs/editor/src/components/Timeline/Controls/Slider.scss
+++ b/web/libs/editor/src/components/Timeline/Controls/Slider.scss
@@ -32,7 +32,7 @@
     align-items: center;
     gap: 8px;
 
-    svg {
+    & svg {
       display: block;
     }
   }
@@ -54,7 +54,7 @@
     }
   }
 
-  input[type="range"]::-webkit-slider-thumb {
+  & input[type="range"]::-webkit-slider-thumb {
     appearance: none;
     height: 12px;
     width: 12px;
@@ -65,7 +65,7 @@
     z-index: 2;
   }
 
-  input[type="range"]::-moz-range-thumb {
+  & input[type="range"]::-moz-range-thumb {
     appearance: none;
     height: 12px;
     width: 12px;
@@ -76,7 +76,7 @@
     transition: background 0.3s ease-in-out;
   }
 
-  input[type="range"]::-ms-thumb {
+  & input[type="range"]::-ms-thumb {
     appearance: none;
     height: 12px;
     width: 12px;
@@ -87,27 +87,27 @@
     transition: background 0.3s ease-in-out;
   }
 
-  input[type="range"]::-webkit-slider-thumb:hover {
+  & input[type="range"]::-webkit-slider-thumb:hover {
     background: var(--button-color);
   }
 
 
-  input[type="range"]::-moz-range-thumb:hover {
+  & input[type="range"]::-moz-range-thumb:hover {
     background: var(--button-color);
   }
 
-  input[type="range"]::-ms-thumb:hover {
+  & input[type="range"]::-ms-thumb:hover {
     background: var(--button-color);
   }
 
-  input[type="range"]::-webkit-slider-runnable-track {
+  & input[type="range"]::-webkit-slider-runnable-track {
     appearance: none;
     box-shadow: none;
     border: none;
     background: transparent;
   }
 
-  input[type="range"]::-moz-range-track {
+  & input[type="range"]::-moz-range-track {
     appearance: none;
     box-shadow: none;
     border: none;
@@ -115,7 +115,7 @@
   }
 
 
-  input[type="range"]::-ms-track {
+  & input[type="range"]::-ms-track {
     appearance: none;
     box-shadow: none;
     border: none;

--- a/web/libs/editor/src/components/Timeline/Controls/SpectrogramControl.scss
+++ b/web/libs/editor/src/components/Timeline/Controls/SpectrogramControl.scss
@@ -60,7 +60,7 @@
     // color: var(--color-neutral-content-subtler);
     white-space: nowrap;
 
-    svg {
+    & svg {
       width: 14px;
       height: 14px;
       color: var(--color-neutral-icon);

--- a/web/libs/editor/src/components/Timeline/SideControls/FramesControl.scss
+++ b/web/libs/editor/src/components/Timeline/SideControls/FramesControl.scss
@@ -13,13 +13,13 @@
   padding: 0 8px;
   border: 1px solid var(--color-neutral-border);
 
-  span {
+  & span {
     color: var(--color-neutral-content-subtler);
     padding-left: 5px;
     font-weight: 400;
   }
 
-  input {
+  & input {
     width: 100%;
     height: 100%;
     border: none;

--- a/web/libs/editor/src/components/Timeline/Views/Frames/Keypoints.scss
+++ b/web/libs/editor/src/components/Timeline/Views/Frames/Keypoints.scss
@@ -119,7 +119,7 @@
   background: var(--color-neutral-background);
   box-shadow: 0 1px 0 rgb(0 0 0 / 10%), 0 0 0 1px rgb(0 0 0 / 15%);
 
-  svg {
+  & svg {
     width: 18px;
     height: 18px;
   }

--- a/web/libs/editor/src/components/Toolbar/FlyoutMenu.scss
+++ b/web/libs/editor/src/components/Toolbar/FlyoutMenu.scss
@@ -26,7 +26,7 @@
     opacity: 0.5;
     color: var(--text-color-hover);
 
-    svg {
+    & svg {
       width: 100%;
       height: 100%;
     }

--- a/web/libs/editor/src/components/Toolbar/Tool.scss
+++ b/web/libs/editor/src/components/Toolbar/Tool.scss
@@ -36,7 +36,7 @@
     border-radius: var(--corner-radius-smaller);
     transition: all 150ms ease-out;
 
-    svg {
+    & svg {
       width: 100%;
       height: 100%;
     }

--- a/web/libs/editor/src/components/TopBar/Controls.scss
+++ b/web/libs/editor/src/components/TopBar/Controls.scss
@@ -8,7 +8,7 @@
     justify-content: flex-end;
 
     &__tooltip-wrapper {
-      button {
+      & button {
         width: 100%;
       }
     }
@@ -20,7 +20,7 @@
       font-weight: 500;
       font-size: 16px;
 
-      svg {
+      & svg {
         margin: 0 8px 0 4px;
       }
     }

--- a/web/libs/editor/src/components/TopBar/HistoryActions.scss
+++ b/web/libs/editor/src/components/TopBar/HistoryActions.scss
@@ -12,7 +12,7 @@
       opacity: 0.6;
     }
 
-    svg {
+    & svg {
       display: block;
     }
 

--- a/web/libs/editor/src/components/VideoCanvas/VideoCanvas.scss
+++ b/web/libs/editor/src/components/VideoCanvas/VideoCanvas.scss
@@ -3,7 +3,7 @@
   height: max-content;
   position: relative;
 
-  canvas {
+  & canvas {
     display: block;
   }
 

--- a/web/libs/editor/src/regions/TextAreaRegion/TextAreaRegion.scss
+++ b/web/libs/editor/src/regions/TextAreaRegion/TextAreaRegion.scss
@@ -40,7 +40,7 @@
   gap: var(--spacing-tight);
 
   // fix antd styles to resize textarea container and fix paddings
-  div[class~="ant-typography-edit-content"] {
+  & div[class~="ant-typography-edit-content"] {
     flex-grow: 1;
     left: -1px;
     padding: 0;
@@ -49,7 +49,7 @@
     background-color: var(--color-neutral-surface);
     border-color: var(--color-neutral-border);
 
-    textarea {
+    & textarea {
       // the same as in .mark, its padding set to 0
       padding: var(--spacing-tight) var(--spacing-base);
     }

--- a/web/libs/editor/src/tags/control/TextArea/TextArea.scss
+++ b/web/libs/editor/src/tags/control/TextArea/TextArea.scss
@@ -25,7 +25,7 @@
       margin-bottom: 0;
     }
 
-    button {
+    & button {
       width: auto !important;
     }
   }

--- a/web/libs/editor/src/tags/object/Text/Text.module.scss
+++ b/web/libs/editor/src/tags/object/Text/Text.module.scss
@@ -10,7 +10,7 @@
 }
 
 :global(.htx-line-numbers) {
-  span.line {
+  & span.line {
     position: relative; // to position line numbers
     display: inline-block; // for alignment and hover highlight
     min-height: 1.2em; // for styling numbers for empty lines

--- a/web/libs/editor/src/tags/object/Video/Video.scss
+++ b/web/libs/editor/src/tags/object/Video/Video.scss
@@ -22,7 +22,7 @@
 }
 
 .video {
-  video {
+  & video {
     max-width: 100%;
   }
 

--- a/web/libs/storybook/.storybook/preview.scss
+++ b/web/libs/storybook/.storybook/preview.scss
@@ -39,27 +39,27 @@ body {
   .docblock-argstable {
     color: var(--color-neutral-content) !important;
 
-    thead,
-    tbody,
-    tr,
-    th,
-    td {
+    & thead,
+    & tbody,
+    & tr,
+    & th,
+    & td {
       color: var(--color-neutral-content) !important;
       background-color: var(--color-neutral-background) !important;
       border-color: var(--color-neutral-border) !important;
     }
 
     // Table header styling
-    th {
+    & th {
       color: var(--color-neutral-content-subtle) !important;
     }
 
     // Property names and descriptions
-    td {
+    & td {
 
-      span,
-      p,
-      div {
+      & span,
+      & p,
+      & div {
         color: var(--color-neutral-content) !important;
       }
     }
@@ -69,18 +69,18 @@ body {
   .sbdocs-content {
     color: var(--color-neutral-content) !important;
 
-    p,
-    span,
-    div,
-    li,
-    code {
+    & p,
+    & span,
+    & div,
+    & li,
+    & code {
       color: inherit !important;
     }
   }
 
   // Code blocks - ensure text is readable on dark backgrounds
-  code,
-  pre {
+  & code,
+  & pre {
     background-color: var(--color-neutral-surface) !important;
     color: var(--color-neutral-content) !important;
   }
@@ -166,10 +166,10 @@ body {
     background-color: var(--color-neutral-surface) !important;
     border-color: var(--color-neutral-border) !important;
 
-    button {
+    & button {
       color: var(--color-neutral-content) !important;
 
-      svg {
+      & svg {
         fill: currentColor !important;
       }
     }

--- a/web/libs/ui/src/lib/ThemeToggle/ThemeToggle.module.scss
+++ b/web/libs/ui/src/lib/ThemeToggle/ThemeToggle.module.scss
@@ -70,7 +70,7 @@
   transition: all 600ms cubic-bezier(0.47, 0, 0.23, 1.30);
   overflow: hidden;
 
-  svg {
+  & svg {
     position: absolute;
   }
 }

--- a/web/libs/ui/src/lib/badge/badge.module.scss
+++ b/web/libs/ui/src/lib/badge/badge.module.scss
@@ -44,7 +44,7 @@
   .icon {
     margin-right: var(--spacing-tightest);
 
-    svg {
+    & svg {
       width: 12px;
       height: 12px;
     }
@@ -380,7 +380,7 @@
     }
     
     .icon {
-      path {
+      & path {
         fill: var(--color-neutral-on-dark-content);
       }
     }
@@ -449,7 +449,7 @@
   align-items: center;
   flex-shrink: 0;
 
-  svg {
+  & svg {
     width: 14px;
     height: 14px;
   }

--- a/web/libs/ui/src/lib/button/button.module.scss
+++ b/web/libs/ui/src/lib/button/button.module.scss
@@ -479,21 +479,21 @@
   &.button-group-collapsed {
     @apply gap-0;
 
-  button:not(:first-child) {
+  & button:not(:first-child) {
     border-left: none;
   }
 
-    button:first-child:not(:only-child) {
+    & button:first-child:not(:only-child) {
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;
     }
 
-    button:last-child:not(:only-child) {
+    & button:last-child:not(:only-child) {
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
     }
 
-    button:not(:first-child, :last-child) {
+    & button:not(:first-child, :last-child) {
       border-radius: 0;
     }
   }

--- a/web/libs/ui/src/lib/code-editor/code-editor.module.scss
+++ b/web/libs/ui/src/lib/code-editor/code-editor.module.scss
@@ -4,7 +4,7 @@
   height: 100%;
   width: 100%;
 
-  textarea,
+  & textarea,
   :global(.react-codemirror2) {
     height: 100%;
     width: 100%;

--- a/web/libs/ui/src/lib/date-range-picker/date-time-input.module.scss
+++ b/web/libs/ui/src/lib/date-range-picker/date-time-input.module.scss
@@ -15,7 +15,7 @@
   }
 
   &.invalid {
-    input {
+    & input {
       color: var(--color-negative-content);
     }
   }

--- a/web/libs/ui/src/lib/enterprise-badge/enterprise-badge.module.scss
+++ b/web/libs/ui/src/lib/enterprise-badge/enterprise-badge.module.scss
@@ -13,7 +13,7 @@
   }
 
   .icon {
-    path {
+    & path {
       fill: var(--color-neutral-on-dark-content);
     }
   }
@@ -54,7 +54,7 @@
   }
 
   .icon {
-    path {
+    & path {
       fill: var(--color-accent-persimmon-base);
     }
   }

--- a/web/libs/ui/src/lib/enterprise-upgrade-overlay/enterprise-upgrade-overlay.module.scss
+++ b/web/libs/ui/src/lib/enterprise-upgrade-overlay/enterprise-upgrade-overlay.module.scss
@@ -68,7 +68,7 @@
   flex-wrap: wrap;
   justify-content: center;
 
-  button {
+  & button {
     white-space: nowrap;
   }
 }

--- a/web/libs/ui/src/lib/json-viewer/json-viewer.module.scss
+++ b/web/libs/ui/src/lib/json-viewer/json-viewer.module.scss
@@ -104,7 +104,7 @@
     color: var(--color-primary-content-hover);
   }
 
-  svg {
+  & svg {
     width: 20px;
     height: 20px;
   }
@@ -147,7 +147,7 @@
   gap: var(--spacing-tighter);
   align-items: center;
 
-  button {
+  & button {
     border-radius: var(--corner-radius-large);
     min-width: 48px;
   }
@@ -297,7 +297,7 @@
         display: none;
       }
 
-      svg {
+      & svg {
         width: 20px;
         height: 20px;
       }

--- a/web/libs/ui/src/lib/json-viewer/reader-view-modal.module.scss
+++ b/web/libs/ui/src/lib/json-viewer/reader-view-modal.module.scss
@@ -64,12 +64,12 @@
 
   // Ensure markdown content is properly styled
   :global {
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
+    & h1,
+    & h2,
+    & h3,
+    & h4,
+    & h5,
+    & h6 {
       margin-top: var(--spacing-wide);
       margin-bottom: var(--spacing-base);
       color: var(--color-neutral-content);
@@ -79,37 +79,37 @@
       }
     }
 
-    p {
+    & p {
       margin-bottom: var(--spacing-base);
     }
 
-    ul,
-    ol {
+    & ul,
+    & ol {
       margin-bottom: var(--spacing-base);
       padding-left: var(--spacing-wider);
     }
 
-    code {
+    & code {
       background: var(--color-neutral-surface-inset);
       padding: var(--spacing-tightest) var(--spacing-tighter);
       border-radius: var(--border-radius-smallest);
       font-family: var(--font-family-monospace, monospace);
     }
 
-    pre {
+    & pre {
       background: var(--color-neutral-surface-inset);
       padding: var(--spacing-base);
       border-radius: var(--border-radius-small);
       overflow-x: auto;
       margin-bottom: var(--spacing-base);
 
-      code {
+      & code {
         background: none;
         padding: 0;
       }
     }
 
-    blockquote {
+    & blockquote {
       border-left: 4px solid var(--color-primary-border);
       padding-left: var(--spacing-base);
       margin-left: 0;
@@ -118,7 +118,7 @@
       font-style: italic;
     }
 
-    a {
+    & a {
       color: var(--color-primary-content);
       text-decoration: underline;
 
@@ -127,25 +127,25 @@
       }
     }
 
-    img {
+    & img {
       max-width: 100%;
       height: auto;
       margin: var(--spacing-base) 0;
     }
 
-    table {
+    & table {
       width: 100%;
       border-collapse: collapse;
       margin-bottom: var(--spacing-base);
 
-      th,
-      td {
+      & th,
+      & td {
         border: 1px solid var(--color-neutral-border);
         padding: var(--spacing-tight);
         text-align: left;
       }
 
-      th {
+      & th {
         background: var(--color-neutral-surface-inset);
         font-weight: var(--font-weight-semibold);
       }
@@ -161,12 +161,12 @@
 
   // Basic HTML styling
   :global {
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
+    & h1,
+    & h2,
+    & h3,
+    & h4,
+    & h5,
+    & h6 {
       margin-top: var(--spacing-wide);
       margin-bottom: var(--spacing-base);
       
@@ -175,17 +175,17 @@
       }
     }
 
-    p {
+    & p {
       margin-bottom: var(--spacing-base);
     }
 
-    ul,
-    ol {
+    & ul,
+    & ol {
       margin-bottom: var(--spacing-base);
       padding-left: var(--spacing-wider);
     }
 
-    a {
+    & a {
       color: var(--color-primary-content);
       text-decoration: underline;
 
@@ -194,45 +194,45 @@
       }
     }
 
-    img {
+    & img {
       max-width: 100%;
       height: auto;
       margin: var(--spacing-base) 0;
     }
 
-    table {
+    & table {
       width: 100%;
       border-collapse: collapse;
       margin-bottom: var(--spacing-base);
 
-      th,
-      td {
+      & th,
+      & td {
         border: 1px solid var(--color-neutral-border);
         padding: var(--spacing-tight);
         text-align: left;
       }
 
-      th {
+      & th {
         background: var(--color-neutral-surface-inset);
         font-weight: var(--font-weight-semibold);
       }
     }
 
-    code {
+    & code {
       background: var(--color-neutral-surface-inset);
       padding: var(--spacing-tightest) var(--spacing-tighter);
       border-radius: var(--border-radius-smallest);
       font-family: var(--font-family-monospace, monospace);
     }
 
-    pre {
+    & pre {
       background: var(--color-neutral-surface-inset);
       padding: var(--spacing-base);
       border-radius: var(--border-radius-small);
       overflow-x: auto;
       margin-bottom: var(--spacing-base);
 
-      code {
+      & code {
         background: none;
         padding: 0;
       }

--- a/web/libs/ui/src/lib/pagination/pagination.module.scss
+++ b/web/libs/ui/src/lib/pagination/pagination.module.scss
@@ -76,7 +76,7 @@
     @apply h-[30px] text-sm;
   }
 
-  input {
+  & input {
     @apply w-full h-full border-none m-0 p-0 outline-none text-center;
     @apply bg-transparent font-medium text-base leading-[19px] text-neutral-content;
 
@@ -93,7 +93,7 @@
     @apply text-sm leading-[15px];
   }
 
-  span {
+  & span {
     @apply font-normal opacity-40;
   }
 }

--- a/web/libs/ui/src/tokens/colors.scss
+++ b/web/libs/ui/src/tokens/colors.scss
@@ -110,7 +110,7 @@
 [data-color-scheme="dark"] {
   --shadow-intensity: 2;
 
-  input[type="date"] {
+  & input[type="date"] {
     color-scheme: dark;
   }
 }

--- a/web/tools/fix-bare-nesting.js
+++ b/web/tools/fix-bare-nesting.js
@@ -1,0 +1,320 @@
+#!/usr/bin/env node
+
+/**
+ * Transforms bare HTML element selectors nested inside CSS/SCSS rules
+ * to use the `&` prefix required by native CSS nesting.
+ *
+ * Before: .parent { div { color: red; } }
+ * After:  .parent { & div { color: red; } }
+ *
+ * Only transforms lines that:
+ * 1. Are indented (nested inside a rule)
+ * 2. Start with a bare HTML element name
+ * 3. Are followed by `{`, `,`, or whitespace+selector continuation
+ *
+ * Leaves alone:
+ * - Lines starting with &, ., #, [, :, >, +, ~, *, @, /
+ * - Top-level (non-indented) selectors
+ * - Lines inside comments
+ * - Property declarations (contain `:` before `{`)
+ *
+ * Usage:
+ *   node tools/fix-bare-nesting.js --dry-run     # Preview changes
+ *   node tools/fix-bare-nesting.js                # Apply changes
+ *   node tools/fix-bare-nesting.js --file path    # Single file
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const WEB_ROOT = path.resolve(__dirname, "..");
+
+const HTML_ELEMENTS = new Set([
+  "a",
+  "abbr",
+  "address",
+  "article",
+  "aside",
+  "audio",
+  "b",
+  "bdi",
+  "bdo",
+  "blockquote",
+  "body",
+  "br",
+  "button",
+  "canvas",
+  "caption",
+  "cite",
+  "code",
+  "col",
+  "colgroup",
+  "data",
+  "datalist",
+  "dd",
+  "del",
+  "details",
+  "dfn",
+  "dialog",
+  "div",
+  "dl",
+  "dt",
+  "em",
+  "embed",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "form",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "head",
+  "header",
+  "hgroup",
+  "hr",
+  "html",
+  "i",
+  "iframe",
+  "img",
+  "input",
+  "ins",
+  "kbd",
+  "label",
+  "legend",
+  "li",
+  "link",
+  "main",
+  "map",
+  "mark",
+  "menu",
+  "meter",
+  "nav",
+  "noscript",
+  "object",
+  "ol",
+  "optgroup",
+  "option",
+  "output",
+  "p",
+  "path",
+  "picture",
+  "pre",
+  "progress",
+  "q",
+  "rect",
+  "rp",
+  "rt",
+  "ruby",
+  "s",
+  "samp",
+  "script",
+  "search",
+  "section",
+  "select",
+  "slot",
+  "small",
+  "source",
+  "span",
+  "strong",
+  "style",
+  "sub",
+  "summary",
+  "sup",
+  "svg",
+  "table",
+  "tbody",
+  "td",
+  "template",
+  "textarea",
+  "tfoot",
+  "th",
+  "thead",
+  "time",
+  "title",
+  "tr",
+  "track",
+  "u",
+  "ul",
+  "var",
+  "video",
+  "wbr",
+  "circle",
+  "ellipse",
+  "g",
+  "line",
+  "polygon",
+  "polyline",
+  "text",
+  "use",
+]);
+
+function findScssFiles(dir, results = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "dist" || entry.name === ".scss-snapshots") continue;
+      findScssFiles(fullPath, results);
+    } else if (entry.isFile() && entry.name.endsWith(".scss")) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+/**
+ * Matches a line that is a bare HTML element selector needing `&` prefix.
+ * Returns the transformed line, or null if no transform needed.
+ */
+function transformLine(line, nestingDepth, inComment) {
+  if (inComment) return null;
+  if (nestingDepth < 1) return null;
+
+  const trimmed = line.trimStart();
+
+  if (trimmed === "" || trimmed.startsWith("//") || trimmed.startsWith("/*") || trimmed.startsWith("*")) return null;
+  if (
+    trimmed.startsWith("&") ||
+    trimmed.startsWith(".") ||
+    trimmed.startsWith("#") ||
+    trimmed.startsWith("[") ||
+    trimmed.startsWith(":") ||
+    trimmed.startsWith(">") ||
+    trimmed.startsWith("+") ||
+    trimmed.startsWith("~") ||
+    trimmed.startsWith("*") ||
+    trimmed.startsWith("@") ||
+    trimmed.startsWith("/") ||
+    trimmed.startsWith("$") ||
+    trimmed.startsWith("-") ||
+    trimmed.startsWith('"') ||
+    trimmed.startsWith("'") ||
+    trimmed.startsWith("#{")
+  )
+    return null;
+
+  const isPropertyDecl = /^[a-z-]+\s*:/.test(trimmed) && !trimmed.includes("{");
+  if (isPropertyDecl) return null;
+
+  const match = trimmed.match(/^([a-zA-Z][a-zA-Z0-9]*)/);
+  if (!match) return null;
+
+  const firstWord = match[1].toLowerCase();
+  if (!HTML_ELEMENTS.has(firstWord)) return null;
+
+  const afterElement = trimmed.slice(match[0].length);
+  const validContinuation =
+    afterElement === "" ||
+    afterElement.startsWith(" ") ||
+    afterElement.startsWith("{") ||
+    afterElement.startsWith(",") ||
+    afterElement.startsWith(".") ||
+    afterElement.startsWith("[") ||
+    afterElement.startsWith(":") ||
+    afterElement.startsWith("#") ||
+    afterElement.startsWith(">") ||
+    afterElement.startsWith("+") ||
+    afterElement.startsWith("~");
+
+  if (!validContinuation) return null;
+
+  const indent = line.slice(0, line.length - line.trimStart().length);
+  return `${indent}& ${trimmed}`;
+}
+
+function processFile(filePath) {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const lines = content.split("\n");
+  const changes = [];
+
+  let nestingDepth = 0;
+  let inBlockComment = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (inBlockComment) {
+      if (line.includes("*/")) inBlockComment = false;
+      continue;
+    }
+
+    if (line.trimStart().startsWith("/*") && !line.includes("*/")) {
+      inBlockComment = true;
+      continue;
+    }
+
+    const transformed = transformLine(line, nestingDepth, inBlockComment);
+    if (transformed !== null) {
+      changes.push({
+        line: i + 1,
+        before: line,
+        after: transformed,
+      });
+      lines[i] = transformed;
+    }
+
+    const stripped = line.replace(/\/\/.*$/, "").replace(/\/\*.*?\*\//g, "");
+    for (const ch of stripped) {
+      if (ch === "{") nestingDepth++;
+      if (ch === "}") nestingDepth = Math.max(0, nestingDepth - 1);
+    }
+  }
+
+  return {
+    original: content,
+    transformed: lines.join("\n"),
+    changes,
+  };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const singleFileIdx = args.indexOf("--file");
+  const singleFile = singleFileIdx !== -1 ? args[singleFileIdx + 1] : null;
+
+  let files;
+  if (singleFile) {
+    files = [path.resolve(singleFile)];
+  } else {
+    files = findScssFiles(WEB_ROOT);
+  }
+
+  console.log(`${dryRun ? "[DRY RUN] " : ""}Processing ${files.length} .scss files...\n`);
+
+  let totalChanges = 0;
+  let filesChanged = 0;
+
+  for (const file of files) {
+    const relative = path.relative(WEB_ROOT, file);
+    const { transformed, changes } = processFile(file);
+
+    if (changes.length === 0) continue;
+
+    filesChanged++;
+    totalChanges += changes.length;
+
+    console.log(`${relative} (${changes.length} changes)`);
+    for (const c of changes) {
+      console.log(`  L${c.line}: ${c.before.trim()}`);
+      console.log(`     → ${c.after.trim()}`);
+    }
+    console.log();
+
+    if (!dryRun) {
+      fs.writeFileSync(file, transformed, "utf-8");
+    }
+  }
+
+  console.log(`\n${dryRun ? "[DRY RUN] " : ""}Summary:`);
+  console.log(`  Files changed: ${filesChanged}`);
+  console.log(`  Total transformations: ${totalChanges}`);
+  if (dryRun) {
+    console.log("\nRe-run without --dry-run to apply changes.");
+  }
+}
+
+main();

--- a/web/tools/validate-scss-transform.js
+++ b/web/tools/validate-scss-transform.js
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+
+/**
+ * Validates that SCSS→CSS compilation output is identical before and after
+ * a source transformation (e.g., adding `&` before bare nested elements).
+ *
+ * Usage:
+ *   # Step 1: Snapshot current compiled output (BEFORE changes)
+ *   node tools/validate-scss-transform.js snapshot
+ *
+ *   # Step 2: Make your changes to .scss files
+ *
+ *   # Step 3: Validate that compiled output is identical
+ *   node tools/validate-scss-transform.js validate
+ *
+ *   # Optional: Clean up snapshot directory
+ *   node tools/validate-scss-transform.js clean
+ */
+
+const sass = require("sass");
+const fs = require("node:fs");
+const path = require("node:path");
+const crypto = require("node:crypto");
+
+const SNAPSHOT_DIR = path.resolve(__dirname, "../.scss-snapshots");
+const WEB_ROOT = path.resolve(__dirname, "..");
+
+function findScssFiles(dir, results = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "dist" || entry.name === ".scss-snapshots") continue;
+      findScssFiles(fullPath, results);
+    } else if (entry.isFile() && entry.name.endsWith(".scss") && !entry.name.startsWith("_")) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+function compileScss(filePath) {
+  try {
+    const result = sass.compile(filePath, {
+      style: "expanded",
+      silenceDeprecations: ["import", "global-builtin", "legacy-js-api", "color-functions"],
+      loadPaths: [WEB_ROOT, path.join(WEB_ROOT, "node_modules")],
+    });
+    return { css: result.css, error: null };
+  } catch (err) {
+    return { css: null, error: err.message };
+  }
+}
+
+function hashContent(content) {
+  return crypto.createHash("sha256").update(content).digest("hex");
+}
+
+/**
+ * Normalize CSS for comparison by collapsing multi-line selector lists
+ * into single lines. SCSS may reformat selector lists when `&` is added
+ * to bare nested selectors — the selectors are semantically identical
+ * but may be placed on one line vs. multiple lines.
+ */
+function normalizeCSS(css) {
+  const lines = css.split("\n");
+  const result = [];
+  let i = 0;
+  while (i < lines.length) {
+    let line = lines[i];
+    while (line.trimEnd().endsWith(",") && i + 1 < lines.length) {
+      i++;
+      line = `${line.trimEnd()} ${lines[i].trimStart()}`;
+    }
+    result.push(line);
+    i++;
+  }
+  return result.join("\n");
+}
+
+function getSnapshotPath(scssPath) {
+  const relative = path.relative(WEB_ROOT, scssPath);
+  return path.join(SNAPSHOT_DIR, relative.replace(/\.scss$/, ".snapshot.json"));
+}
+
+function snapshot() {
+  const files = findScssFiles(WEB_ROOT);
+  console.log(`Found ${files.length} .scss files (excluding partials)`);
+
+  fs.mkdirSync(SNAPSHOT_DIR, { recursive: true });
+
+  let compiled = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (const file of files) {
+    const relative = path.relative(WEB_ROOT, file);
+    const { css, error } = compileScss(file);
+
+    const snapshotPath = getSnapshotPath(file);
+    fs.mkdirSync(path.dirname(snapshotPath), { recursive: true });
+
+    if (error) {
+      fs.writeFileSync(
+        snapshotPath,
+        JSON.stringify(
+          {
+            file: relative,
+            status: "error",
+            error: error,
+            hash: null,
+          },
+          null,
+          2,
+        ),
+      );
+      errors++;
+    } else if (css !== null) {
+      const normalized = normalizeCSS(css);
+      fs.writeFileSync(
+        snapshotPath,
+        JSON.stringify(
+          {
+            file: relative,
+            status: "ok",
+            error: null,
+            hash: hashContent(css),
+            normalizedHash: hashContent(normalized),
+            css: css,
+            normalizedCss: normalized,
+          },
+          null,
+          2,
+        ),
+      );
+      compiled++;
+    } else {
+      skipped++;
+    }
+  }
+
+  console.log("\nSnapshot complete:");
+  console.log(`  Compiled: ${compiled}`);
+  console.log(`  Errors (pre-existing): ${errors}`);
+  console.log(`  Skipped: ${skipped}`);
+  console.log(`  Saved to: ${SNAPSHOT_DIR}`);
+}
+
+function validate() {
+  if (!fs.existsSync(SNAPSHOT_DIR)) {
+    console.error("No snapshots found. Run 'snapshot' first.");
+    process.exit(1);
+  }
+
+  const files = findScssFiles(WEB_ROOT);
+  console.log(`Validating ${files.length} .scss files against snapshots...\n`);
+
+  let pass = 0;
+  let fail = 0;
+  let formatOnly = 0;
+  let newErrors = 0;
+  let fixedErrors = 0;
+  let noSnapshot = 0;
+  const failures = [];
+
+  for (const file of files) {
+    const relative = path.relative(WEB_ROOT, file);
+    const snapshotPath = getSnapshotPath(file);
+
+    if (!fs.existsSync(snapshotPath)) {
+      noSnapshot++;
+      continue;
+    }
+
+    const snapshotData = JSON.parse(fs.readFileSync(snapshotPath, "utf-8"));
+    const { css, error } = compileScss(file);
+
+    if (snapshotData.status === "error") {
+      if (error) {
+        pass++;
+      } else {
+        fixedErrors++;
+        pass++;
+      }
+      continue;
+    }
+
+    if (error) {
+      newErrors++;
+      failures.push({
+        file: relative,
+        reason: "NEW COMPILE ERROR",
+        detail: error,
+      });
+      continue;
+    }
+
+    const newHash = hashContent(css);
+    const normalizedNew = normalizeCSS(css);
+    const normalizedNewHash = hashContent(normalizedNew);
+    const snapshotNormalizedHash = snapshotData.normalizedHash || hashContent(normalizeCSS(snapshotData.css));
+
+    if (newHash === snapshotData.hash) {
+      pass++;
+    } else if (normalizedNewHash === snapshotNormalizedHash) {
+      pass++;
+      formatOnly++;
+    } else {
+      fail++;
+      const oldLines = normalizedNew.split("\n");
+      const snapshotLines = normalizeCSS(snapshotData.css).split("\n");
+      const diffLines = [];
+
+      const maxLen = Math.max(snapshotLines.length, oldLines.length);
+      for (let i = 0; i < maxLen; i++) {
+        const oldLine = snapshotLines[i] ?? "";
+        const newLine = oldLines[i] ?? "";
+        if (oldLine !== newLine) {
+          diffLines.push({
+            line: i + 1,
+            before: oldLine,
+            after: newLine,
+          });
+        }
+      }
+
+      failures.push({
+        file: relative,
+        reason: "CSS OUTPUT CHANGED",
+        diffCount: diffLines.length,
+        firstDiffs: diffLines.slice(0, 5),
+      });
+    }
+  }
+
+  console.log("Results:");
+  console.log(`  ✅ Pass (identical output): ${pass - formatOnly}`);
+  if (formatOnly > 0) console.log(`  ✅ Pass (selector formatting only, semantically identical): ${formatOnly}`);
+  if (fixedErrors > 0) console.log(`  🔧 Fixed (was error, now compiles): ${fixedErrors}`);
+  if (noSnapshot > 0) console.log(`  ⚠️  No snapshot (new file?): ${noSnapshot}`);
+  if (fail > 0) console.log(`  ❌ FAIL (output changed): ${fail}`);
+  if (newErrors > 0) console.log(`  💥 NEW ERRORS (was ok, now fails): ${newErrors}`);
+
+  if (failures.length > 0) {
+    console.log("\n--- FAILURES ---\n");
+    for (const f of failures) {
+      console.log(`File: ${f.file}`);
+      console.log(`  Reason: ${f.reason}`);
+      if (f.detail) {
+        console.log(`  Error: ${f.detail.substring(0, 200)}`);
+      }
+      if (f.firstDiffs) {
+        console.log(`  Changed lines: ${f.diffCount}`);
+        for (const d of f.firstDiffs) {
+          console.log(`    Line ${d.line}:`);
+          console.log(`      before: ${d.before}`);
+          console.log(`      after:  ${d.after}`);
+        }
+        if (f.diffCount > 5) console.log(`    ... and ${f.diffCount - 5} more`);
+      }
+      console.log();
+    }
+  }
+
+  if (fail > 0 || newErrors > 0) {
+    console.log(`\n❌ VALIDATION FAILED — ${fail + newErrors} file(s) have different output`);
+    process.exit(1);
+  } else {
+    console.log("\n✅ VALIDATION PASSED — all compiled CSS output is identical");
+    process.exit(0);
+  }
+}
+
+function clean() {
+  if (fs.existsSync(SNAPSHOT_DIR)) {
+    fs.rmSync(SNAPSHOT_DIR, { recursive: true });
+    console.log(`Cleaned up ${SNAPSHOT_DIR}`);
+  } else {
+    console.log("Nothing to clean.");
+  }
+}
+
+const command = process.argv[2];
+switch (command) {
+  case "snapshot":
+    snapshot();
+    break;
+  case "validate":
+    validate();
+    break;
+  case "clean":
+    clean();
+    break;
+  default:
+    console.log("Usage: node tools/validate-scss-transform.js <snapshot|validate|clean>");
+    process.exit(1);
+}


### PR DESCRIPTION
Created two reusable scripts in web/tools/ for both repos:# validate-scss-transform.js — Compiles every .scss file with Dart Sass, stores CSS output + SHA-256 hash as snapshots. After changes, recompiles and compares against snapshots to prove zero semantic differences. Handles multi-line selector list formatting normalization.

fix-bare-nesting.js — Adds & prefix to bare HTML element selectors nested inside CSS rules (e.g. div {} → & div {}). Covers all standard HTML/SVG elements. Supports --dry-run and --file modes. Skips property declarations, comments, top-level selectors, and selectors already starting with &, ., #, [, :, >, +, ~.

Results:

- LS web: 83 files, 267 transformations — 246/246 validated (240 byte-identical, 6 formatting-only)
- LSE web: 72 files, 245 transformations — 192/192 validated (186 byte-identical, 6 formatting-only)

Scripts location: web/tools/validate-scss-transform.js, web/tools/fix-bare-nesting.js
Snapshot cleanup: node tools/validate-scss-transform.js clean
