### PR TITLE
fix: FIT-1493: Memory leak in extended labeling sessions by reducing ImageCache maxSize to 10 and defensively clearing image src on unmount

### DIFF
--- a/web/libs/core/src/lib/utils/ImageCache.ts
+++ b/web/libs/core/src/lib/utils/ImageCache.ts
@@ -50,8 +50,8 @@ class ImageCacheManager {
 
   // Cache for 30 minutes by default
   private readonly maxAge = 30 * 60 * 1000;
-  // Maximum cache size (100 images)
-  private readonly maxSize = 100;
+  // Maximum cache size (10 images to prevent large memory overheads, see FIT-1493)
+  private readonly maxSize = 10;
   // Minimum blob size in bytes (reject empty blobs)
   private readonly minBlobSize = 100;
 

--- a/web/libs/editor/src/components/ImageView/ImageView.jsx
+++ b/web/libs/editor/src/components/ImageView/ImageView.jsx
@@ -1272,6 +1272,7 @@ const ImageLayer = observer(({ item }) => {
 
     return () => {
       cancelled = true;
+      img.src = ""; // Defensively immediately clear source to abandon decode and trigger GC
     };
   }, [imageEntity?.downloaded, currentSrc, item.imageCrossOrigin]);
 


### PR DESCRIPTION
This pull request introduces optimizations to the image caching and cleanup logic to reduce memory usage and prevent potential memory leaks. The most important changes are grouped below:

**Image caching policy:**

* Reduced the maximum cache size in `ImageCacheManager` from 100 images to 10 images to minimize memory overhead, as referenced in FIT-1493. (`web/libs/core/src/lib/utils/ImageCache.ts`)

**Image cleanup and memory management:**

* In the `ImageLayer` component, added logic to defensively clear the `img.src` property when the component unmounts or the effect is cleaned up. This helps abandon image decoding and allows garbage collection to reclaim memory more promptly. (`web/libs/editor/src/components/ImageView/ImageView.jsx`)

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
