### PR TITLE
fix: FIT-1489: Text in annotation status badge is not centered properly

### DIFF
--- a/web/libs/editor/src/components/AnnotationsCarousel/AnnotationButton.scss
+++ b/web/libs/editor/src/components/AnnotationsCarousel/AnnotationButton.scss
@@ -312,20 +312,20 @@
     margin-bottom: 8px;
     flex-wrap: wrap;
 
-    // Force light mode colors for better readability in dark mode tooltips
+    // Force light mode colors for better readability when tooltip has white background (dark theme)
     // Override the CSS variables to always use light mode values
-    --color-accent-grape-subtle: var(--color-grape-100);
+    --color-accent-grape-subtlest: var(--color-grape-100);
+    --color-accent-grape-subtle: var(--color-grape-200);
     --color-accent-grape-bold: var(--color-grape-700);
-    --color-accent-kale-subtle: var(--color-kale-100);
+    --color-accent-kale-subtlest: var(--color-kale-100);
+    --color-accent-kale-subtle: var(--color-kale-200);
     --color-accent-kale-bold: var(--color-kale-700);
-    --color-accent-canteloupe-subtle: var(--color-canteloupe-100);
+    --color-accent-canteloupe-subtlest: var(--color-canteloupe-100);
+    --color-accent-canteloupe-subtle: var(--color-canteloupe-200);
     --color-accent-canteloupe-bold: var(--color-canteloupe-700);
-    --color-accent-persimmon-subtle: var(--color-persimmon-100);
+    --color-accent-persimmon-subtlest: var(--color-persimmon-100);
+    --color-accent-persimmon-subtle: var(--color-persimmon-200);
     --color-accent-persimmon-bold: var(--color-persimmon-700);
-  }
-
-  &__tooltipStatusBadge {
-    display: inline-block;
   }
 
   &__tooltipContainerTitle {

--- a/web/libs/editor/src/components/AnnotationsCarousel/AnnotationButton.tsx
+++ b/web/libs/editor/src/components/AnnotationsCarousel/AnnotationButton.tsx
@@ -148,20 +148,6 @@ const injector = inject(({ store }) => {
 
 const hoverIntentDelay = 300;
 
-// Helper function to create badge style objects with consistent CSS variable pattern
-// Note: CSS variables are overridden in SCSS to always use light mode values for tooltip badges
-const createBadgeStyle = (label: string, colorName: string) => ({
-  label,
-  backgroundColor: `var(--color-accent-${colorName}-subtle)`,
-  color: `var(--color-accent-${colorName}-bold)`,
-});
-
-// Helper function to get just the CSS variable style properties
-const getBadgeColors = (colorName: string) => ({
-  backgroundColor: `var(--color-accent-${colorName}-subtle)`,
-  color: `var(--color-accent-${colorName}-bold)`,
-});
-
 function AnnotationButtonTooltip({
   displayUsername,
   isDraft,
@@ -209,24 +195,24 @@ function AnnotationButtonTooltip({
     // Check for both ephemeral drafts (isDraft) and saved drafts (isDraftSaved)
     // Exception: If Draft AND Skipped, show both Draft and Skipped
     if (isDraft || isDraftSaved) {
-      return createBadgeStyle("Draft", "grape");
+      return { label: "Draft", variant: "primary" as const };
     }
     if (acceptedState) {
       switch (acceptedState) {
         case "accepted":
-          return createBadgeStyle("Accepted", "kale");
+          return { label: "Accepted", variant: "positive" as const };
         case "rejected":
-          return createBadgeStyle("Rejected", "persimmon");
+          return { label: "Rejected", variant: "negative" as const };
         case "fixed":
         case "fixed_and_accepted":
-          return createBadgeStyle("Fixed", "canteloupe");
+          return { label: "Fixed", variant: "warning" as const };
         default:
           break;
       }
     }
     // Exception: If Submitted AND Skipped, only show Skipped (don't show Submitted)
     if (isSubmitted && !isSkipped) {
-      return createBadgeStyle("Submitted", "kale");
+      return { label: "Submitted", variant: "positive" as const };
     }
 
     return null;
@@ -276,8 +262,16 @@ function AnnotationButtonTooltip({
     return rows;
   }, [annotationId, isPrediction, predictionScore, lastUpdated, formatDate]);
 
+  const tooltipBadges = useMemo(() => {
+    const badges: Array<{ label: string; variant: "primary" | "positive" | "negative" | "warning" }> = [];
+    if (statusBadge) badges.push(statusBadge);
+    if (isSkipped) badges.push({ label: "Skipped", variant: "negative" });
+    if (isGroundTruth) badges.push({ label: "Ground Truth", variant: "warning" });
+    return badges;
+  }, [statusBadge, isSkipped, isGroundTruth]);
+
   const isRenderable =
-    tooltipData.length > 0 || !!displayUsername || !!statusBadge || !!isSkipped || !!isGroundTruth || !!annotationId;
+    tooltipData.length > 0 || !!displayUsername || tooltipBadges.length > 0 || !!annotationId;
 
   if (!isRenderable) {
     return null;
@@ -299,45 +293,13 @@ function AnnotationButtonTooltip({
         left: `${position.left}px`,
       }}
     >
-      {(statusBadge || isSkipped || isGroundTruth) && (
+      {(tooltipBadges.length > 0) && (
         <div className={cn("annotation-button").elem("tooltipBadges").toClassName()}>
-          {/* Draft/Submitted badges shown first */}
-          {statusBadge && (
-            <Badge
-              className={cn("annotation-button").elem("tooltipStatusBadge").toClassName()}
-              style={{
-                backgroundColor: statusBadge.backgroundColor,
-                color: statusBadge.color,
-                border: "none",
-              }}
-            >
-              {statusBadge.label}
+          {tooltipBadges.map(({ label, variant }) => (
+            <Badge key={label} variant={variant} shape="rounded">
+              {label}
             </Badge>
-          )}
-          {/* Skipped badge shown after Draft/Submitted */}
-          {isSkipped && (
-            <Badge
-              className={cn("annotation-button").elem("tooltipStatusBadge").toClassName()}
-              style={{
-                ...getBadgeColors("persimmon"),
-                border: "none",
-              }}
-            >
-              Skipped
-            </Badge>
-          )}
-          {/* Ground Truth badge shown last */}
-          {isGroundTruth && (
-            <Badge
-              className={cn("annotation-button").elem("tooltipStatusBadge").toClassName()}
-              style={{
-                ...getBadgeColors("canteloupe"),
-                border: "none",
-              }}
-            >
-              Ground Truth
-            </Badge>
-          )}
+          ))}
         </div>
       )}
       {displayUsername && (

--- a/web/libs/editor/src/components/AnnotationsCarousel/AnnotationButton.tsx
+++ b/web/libs/editor/src/components/AnnotationsCarousel/AnnotationButton.tsx
@@ -270,8 +270,7 @@ function AnnotationButtonTooltip({
     return badges;
   }, [statusBadge, isSkipped, isGroundTruth]);
 
-  const isRenderable =
-    tooltipData.length > 0 || !!displayUsername || tooltipBadges.length > 0 || !!annotationId;
+  const isRenderable = tooltipData.length > 0 || !!displayUsername || tooltipBadges.length > 0 || !!annotationId;
 
   if (!isRenderable) {
     return null;
@@ -293,7 +292,7 @@ function AnnotationButtonTooltip({
         left: `${position.left}px`,
       }}
     >
-      {(tooltipBadges.length > 0) && (
+      {tooltipBadges.length > 0 && (
         <div className={cn("annotation-button").elem("tooltipBadges").toClassName()}>
           {tooltipBadges.map(({ label, variant }) => (
             <Badge key={label} variant={variant} shape="rounded">


### PR DESCRIPTION
This pull request refactors how status badges are handled and styled in the annotation tooltips to improve consistency, maintainability, and visual clarity—especially in dark mode. The main changes include simplifying badge logic in the TypeScript code, updating how badge colors are managed in SCSS, and switching to a variant-based approach for badge appearance.

## Screenshots
### Before
<img width="319" height="239" alt="image" src="https://github.com/user-attachments/assets/74332197-58f7-43b9-bacc-5556998d915d" />
<img width="339" height="234" alt="image" src="https://github.com/user-attachments/assets/20297025-3b41-44cd-a33e-0541e0c5a99b" />

### After
<img width="351" height="249" alt="image" src="https://github.com/user-attachments/assets/076cfecc-b1b9-4ab8-b50d-4e16e0361fdf" />
<img width="392" height="276" alt="image" src="https://github.com/user-attachments/assets/fe703c53-c042-49d3-8d7d-eec51d385e95" />


**Badge logic and rendering improvements:**

* Replaced inline badge style logic in `AnnotationButton.tsx` with a variant-based system, mapping statuses to semantic variants like `"primary"`, `"positive"`, `"negative"`, and `"warning"` for use with the `Badge` component. This removes custom color handling from the component logic and leverages the design system's variants instead.
* Consolidated badge rendering by collecting all relevant badges (`statusBadge`, `Skipped`, `Ground Truth`) into an array (`tooltipBadges`) and rendering them in a loop, simplifying the JSX and ensuring consistent order and appearance. [[1]](diffhunk://#diff-ef873179597f217159c06cb03e519cae3037c8d2d7ca19aaa9905729405aaa6eL279-R273) [[2]](diffhunk://#diff-ef873179597f217159c06cb03e519cae3037c8d2d7ca19aaa9905729405aaa6eL302-R301)
* Removed now-unnecessary helper functions for badge styling from `AnnotationButton.tsx`, further simplifying the component.

**Styling updates for badge colors:**

* Updated SCSS variables in `AnnotationButton.scss` to include both `-subtle` and `-subtlest` color levels for accent colors, and clarified comments to indicate these overrides ensure readability when tooltips have a white background (especially in dark theme).

These changes collectively make the badge system more robust, easier to maintain, and visually consistent across themes.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
