### PR TITLE
fix: UTC-644: Restore full-row click area in Select Option component

### DIFF
--- a/web/libs/ui/src/lib/select/select.tsx
+++ b/web/libs/ui/src/lib/select/select.tsx
@@ -808,6 +808,7 @@ const Option = ({
       className={clsx(
         className,
         [
+          "w-full",
           "rounded-4",
           "text-neutral-content-subtle",
           "overflow-hidden",


### PR DESCRIPTION
The CommandItem wrapper in the Option component was missing w-full, causing its click target to shrink to the content width instead of spanning the full dropdown width. This regressed the Columns dropdown (and all other Select-based dropdowns) after PR #9487 replaced the old Menu.Item approach with Select/CommandItem.

Adding w-full to CommandItem ensures the onSelect hit-target covers the entire row, matching the inner div which already had w-full.
Why it's safe globally (not just for Columns):

Audited every Select usage across the codebase (~25 instances across web/libs/editor, web/libs/datamanager, web/libs/app-common, and web/apps/labelstudio). They break down as:

Category: Count — Risk
Single-select, plain options:	~15	None — items should already be full-width; this makes it explicit
Multi-select (checkboxes):	~5	None — these need full-width rows for proper click targets
Uses groupBy + optionRenderer:	2 (ColumnPicker, FilterLine)	None — the renderers already use w-full internally
Uses contentClassName	1 (FilterDropdown):	None — that class applies to PopoverContent, not options
Virtual list	2 (UserSelect, FilterDropdown):	None — items are absolutely positioned inside the list; w-full works correctly
