### PR TITLE
fix: FIT-1503: Make annotations read-only in Compare All mode

### DIFF
--- a/web/libs/editor/src/components/App/Grid.jsx
+++ b/web/libs/editor/src/components/App/Grid.jsx
@@ -134,6 +134,9 @@ const VirtualizedGrid = observer(({ store, annotations, root }) => {
     if (!isFF(FF_FIT_720_LAZY_LOAD_ANNOTATIONS)) return;
 
     annotations.forEach((annotation) => {
+      // Mark as read-only since Compare All mode should not allow edits
+      annotation.setEditable?.(false);
+
       if (!annotation.pk || annotation.type === "prediction" || annotation.userGenerate) return;
 
       const id = annotation.pk;
@@ -277,6 +280,9 @@ const VirtualizedGrid = observer(({ store, annotations, root }) => {
           // reinitHistory cancels autosave and sets initial values so the hydration
           // isn't treated as a user modification (prevents unwanted draft creation)
           freshAnnotation.reinitHistory?.();
+
+          // Mark as read-only since Compare All mode should not allow edits
+          freshAnnotation.setEditable?.(false);
 
           // Mark as successfully hydrated to avoid re-hydrating
           // Note: Don't directly modify MST model (is_stub) - it causes protection errors

--- a/web/libs/editor/src/components/App/Grid.jsx
+++ b/web/libs/editor/src/components/App/Grid.jsx
@@ -134,9 +134,6 @@ const VirtualizedGrid = observer(({ store, annotations, root }) => {
     if (!isFF(FF_FIT_720_LAZY_LOAD_ANNOTATIONS)) return;
 
     annotations.forEach((annotation) => {
-      // Mark as read-only since Compare All mode should not allow edits
-      annotation.setEditable?.(false);
-
       if (!annotation.pk || annotation.type === "prediction" || annotation.userGenerate) return;
 
       const id = annotation.pk;
@@ -271,6 +268,9 @@ const VirtualizedGrid = observer(({ store, annotations, root }) => {
           freshAnnotation.history?.freeze?.();
           freshAnnotation.deserializeResults?.(fullAnnotation.result);
 
+          // Mark as read-only since Compare All mode should not allow edits
+          freshAnnotation.setEditable?.(false);
+
           // Critical: updateObjects() is required to render visual regions after deserializing
           freshAnnotation.updateObjects?.();
 
@@ -280,9 +280,6 @@ const VirtualizedGrid = observer(({ store, annotations, root }) => {
           // reinitHistory cancels autosave and sets initial values so the hydration
           // isn't treated as a user modification (prevents unwanted draft creation)
           freshAnnotation.reinitHistory?.();
-
-          // Mark as read-only since Compare All mode should not allow edits
-          freshAnnotation.setEditable?.(false);
 
           // Mark as successfully hydrated to avoid re-hydrating
           // Note: Don't directly modify MST model (is_stub) - it causes protection errors

--- a/web/libs/editor/src/components/App/__tests__/Grid.test.jsx
+++ b/web/libs/editor/src/components/App/__tests__/Grid.test.jsx
@@ -699,4 +699,23 @@ describe("Grid", () => {
 
     expect(screen.getByLabelText("Move right")).toBeInTheDocument();
   });
+
+  it("VirtualizedGrid sets annotations to non-editable on mount", () => {
+    mockIsFF.mockReturnValue(true);
+    const ann = {
+      ...createAnnotation({ id: "a1", pk: 1 }),
+      setEditable: jest.fn(),
+    };
+    const annotations = [ann];
+    const store = createStore({ selected: { selected: annotations[0] } });
+    const root = {};
+
+    render(
+      <Provider store={store}>
+        <VirtualizedGrid store={store} annotations={annotations} root={root} />
+      </Provider>,
+    );
+
+    expect(ann.setEditable).toHaveBeenCalledWith(false);
+  });
 });


### PR DESCRIPTION
**Problem**: Annotations loaded in Compare All > Side-by-side mode are NOT read-only.
**Solution**: Explicitly set editable=false for all fetched/hydrated annotations when VirtualizedGrid is rendered.
**Files changed**:
- web/libs/editor/src/components/App/Grid.jsx
- web/libs/editor/src/components/App/__tests__/Grid.test.jsx
**Manual verification**:
- Ran frontend tests and created new grid test case.