### PR TITLE
fix: FIT-1488: Makes search, filters and Resolve URIs controls on Task Source Viewer be saved per project

### DIFF
--- a/web/libs/datamanager/src/components/Common/Table/RowContextMenu/RowContextMenu.tsx
+++ b/web/libs/datamanager/src/components/Common/Table/RowContextMenu/RowContextMenu.tsx
@@ -4,7 +4,7 @@ import { Dropdown, DropdownContext, IconViewAll, IconCopyOutline, IconBraces, Ic
 // @ts-expect-error - Menu is from JS module
 import { Menu } from "../../Menu/Menu";
 import { modal } from "../../Modal/Modal";
-import { TaskSourceViewer } from "../../TaskSourceViewer";
+import { TaskSourceViewer, getTaskSourceViewerStorageKey } from "../../TaskSourceViewer";
 // @ts-expect-error - utils is JS module
 import { getProperty } from "../utils";
 
@@ -25,6 +25,8 @@ export interface RowContextMenuProps {
   cursorPosition?: { x: number; y: number };
   /** Callback when menu closes */
   onClose: () => void;
+  /** Optional project ID for project-scoped TaskSourceViewer storage */
+  projectId?: string | number | null;
 }
 
 export const RowContextMenu: FC<RowContextMenuProps> = ({
@@ -36,6 +38,7 @@ export const RowContextMenu: FC<RowContextMenuProps> = ({
   onViewAnalytics,
   cursorPosition,
   onClose,
+  projectId,
 }) => {
   // Columns that should not have copy cell content option
   const excludedColumns = [
@@ -185,7 +188,7 @@ export const RowContextMenu: FC<RowContextMenuProps> = ({
           content={taskData}
           onTaskLoad={onTaskLoad}
           sdkType={sdkType}
-          storageKey="dm:tasksource"
+          storageKey={getTaskSourceViewerStorageKey(projectId)}
           renderToggle={(toggle) => {
             // Update modal header with toggle
             modalInstance?.update({ header: toggle });
@@ -195,7 +198,7 @@ export const RowContextMenu: FC<RowContextMenuProps> = ({
     });
 
     onClose();
-  }, [row, api, sdkType, onClose]);
+  }, [row, api, sdkType, onClose, projectId]);
 
   // 5. View annotator performance (LSE-only)
   const handleViewAnalytics = useCallback(() => {

--- a/web/libs/datamanager/src/components/Common/Table/Table.jsx
+++ b/web/libs/datamanager/src/components/Common/Table/Table.jsx
@@ -18,7 +18,7 @@ import { cn } from "../../../utils/bem";
 import { FieldsButton } from "../FieldsButton";
 import { FF_LOPS_E_3, isFF } from "../../../utils/feature-flags";
 import { DensityToggle } from "../../DataManager/Toolbar/DensityToggle";
-import { TaskSourceViewer } from "../TaskSourceViewer";
+import { TaskSourceViewer, getTaskSourceViewerStorageKey } from "../TaskSourceViewer";
 
 const Decorator = (decoration) => {
   return {
@@ -62,7 +62,7 @@ export const Table = observer(
     const [colOrder, setColOrder] = useState(JSON.parse(localStorage.getItem(colOrderKey)) ?? {});
     const listRef = useRef();
     const Decoration = useMemo(() => Decorator(decoration), [decoration]);
-    const { api, type } = useSDK();
+    const { api, type, projectId } = useSDK();
     const toolbarHeight = 41;
     const isQuickView = view.root.isLabeling;
     const [toolbarVisible, setToolbarVisible] = useState(true);
@@ -194,7 +194,7 @@ export const Table = observer(
                     content={out}
                     onTaskLoad={onTaskLoad}
                     sdkType={type}
-                    storageKey="dm:tasksource"
+                    storageKey={getTaskSourceViewerStorageKey(projectId)}
                     renderToggle={(toggle) => {
                       // Update modal header with toggle
                       modalInstance?.update({ header: toggle });
@@ -640,7 +640,7 @@ const innerElementType = forwardRef(({ children, ...rest }, ref) => {
 const ContextMenuPortal = memo(
   ({ contextMenu, view, onViewAnalytics, onViewReviewerAnalytics, onClose, RowContextMenuComponent }) => {
     const MenuComponent = RowContextMenuComponent || RowContextMenu;
-    const { api, type } = useSDK();
+    const { api, type, projectId } = useSDK();
 
     return (
       <MenuComponent
@@ -649,6 +649,7 @@ const ContextMenuPortal = memo(
         view={view}
         api={api}
         sdkType={type}
+        projectId={projectId}
         onViewAnalytics={onViewAnalytics}
         onViewReviewerAnalytics={onViewReviewerAnalytics}
         cursorPosition={{ x: contextMenu.x, y: contextMenu.y }}

--- a/web/libs/datamanager/src/components/Common/TaskSourceViewer/TaskSourceViewer.test.tsx
+++ b/web/libs/datamanager/src/components/Common/TaskSourceViewer/TaskSourceViewer.test.tsx
@@ -67,6 +67,8 @@ jest.mock("./TaskSourceViewer.module.scss", () => ({
 }));
 
 describe("TaskSourceViewer Component", () => {
+  // View uses global key; resolveUrls and JSON viewer use project-scoped key (storageKey prop)
+  const GLOBAL_STORAGE_KEY = "dm:tasksource";
   const mockTaskData = {
     id: 123,
     data: {
@@ -133,7 +135,7 @@ describe("TaskSourceViewer Component", () => {
     });
 
     it("should show resolve URI toggle in JsonViewer toolbar for interactive view", async () => {
-      localStorage.setItem("test:tasksource:view", "interactive");
+      localStorage.setItem(`${GLOBAL_STORAGE_KEY}:view`, "interactive");
 
       render(<TaskSourceViewer {...defaultProps} />);
 
@@ -145,7 +147,7 @@ describe("TaskSourceViewer Component", () => {
     });
 
     it("should reload task data when resolve URIs toggle changes", async () => {
-      localStorage.setItem("test:tasksource:view", "interactive");
+      localStorage.setItem(`${GLOBAL_STORAGE_KEY}:view`, "interactive");
       const user = userEvent.setup();
       const mockOnTaskLoad = jest.fn().mockResolvedValue(mockTaskData);
 
@@ -166,7 +168,7 @@ describe("TaskSourceViewer Component", () => {
     });
 
     it("should save resolve URIs preference to localStorage", async () => {
-      localStorage.setItem("test:tasksource:view", "interactive");
+      localStorage.setItem(`${GLOBAL_STORAGE_KEY}:view`, "interactive");
       const user = userEvent.setup();
 
       render(<TaskSourceViewer {...defaultProps} />);
@@ -193,7 +195,7 @@ describe("TaskSourceViewer Component", () => {
     });
 
     it("should respect stored view preference from localStorage", async () => {
-      localStorage.setItem("test:tasksource:view", "interactive");
+      localStorage.setItem(`${GLOBAL_STORAGE_KEY}:view`, "interactive");
 
       render(<TaskSourceViewer {...defaultProps} />);
 
@@ -237,7 +239,7 @@ describe("TaskSourceViewer Component", () => {
       capturedOnViewChange!("interactive");
 
       await waitFor(() => {
-        expect(localStorage.getItem("test:tasksource:view")).toBe("interactive");
+        expect(localStorage.getItem(`${GLOBAL_STORAGE_KEY}:view`)).toBe("interactive");
         expect(screen.getByTestId("json-viewer")).toBeInTheDocument();
       });
     });

--- a/web/libs/datamanager/src/components/Common/TaskSourceViewer/TaskSourceViewer.tsx
+++ b/web/libs/datamanager/src/components/Common/TaskSourceViewer/TaskSourceViewer.tsx
@@ -7,6 +7,17 @@ import { ViewToggle, type ViewMode } from "./ViewToggle";
 
 export type { ViewMode };
 
+/** Build project-scoped localStorage key for JSON viewer search and filter state. Returns undefined when projectId is missing. */
+export function getTaskSourceViewerStorageKey(
+  projectId: string | number | null | undefined,
+): string | undefined {
+  if (projectId == null || projectId === "") return undefined;
+  return `dm:tasksource:${projectId}`;
+}
+
+/** Global key for view mode (Code/Interactive) only — shared across all projects. */
+const TASK_SOURCE_VIEWER_GLOBAL_KEY = "dm:tasksource";
+
 /** Options passed to onTaskLoad callback */
 export interface TaskLoadOptions {
   /** Whether to resolve storage URIs to proxy URLs (default: false) */
@@ -20,7 +31,7 @@ export interface TaskSourceViewerProps {
   onTaskLoad: (options?: TaskLoadOptions) => Promise<any>;
   /** SDK type (e.g., "DE" for Data Explorer) */
   sdkType?: string;
-  /** Storage key for localStorage persistence */
+  /** Storage key for project-scoped persistence (JSON viewer search/filters and Resolve URIs). View mode stays global. */
   storageKey?: string;
   /** Render toggle in external location (e.g., modal header) */
   renderToggle?: (toggle: React.ReactNode) => void;
@@ -64,7 +75,7 @@ export const TaskSourceViewer: FC<TaskSourceViewerProps> = ({
   content,
   onTaskLoad,
   sdkType,
-  storageKey = "dm:tasksource",
+  storageKey,
   renderToggle,
 }) => {
   const isInteractiveViewerEnabled = isFF(FF_INTERACTIVE_JSON_VIEWER);
@@ -72,27 +83,20 @@ export const TaskSourceViewer: FC<TaskSourceViewerProps> = ({
   const [taskData, setTaskData] = useState(content);
   const [loading, setLoading] = useState(true);
 
-  // Manage view state internally
+  // View mode (Code/Interactive) — global key so preference is shared across projects
   const [view, setView] = useState<ViewMode>(() =>
-    storageKey ? (localStorage.getItem(`${storageKey}:view`) as ViewMode) || "code" : "code",
+    (localStorage.getItem(`${TASK_SOURCE_VIEWER_GLOBAL_KEY}:view`) as ViewMode) || "code",
   );
 
-  // Manage resolve URIs state - default OFF to show original storage URIs
+  // Resolve URIs — per project when storageKey is set (same key as JSON viewer search/filters)
   const [resolveUrls, setResolveUrls] = useState<boolean>(() =>
     storageKey ? localStorage.getItem(`${storageKey}:resolveUrls`) === "true" : false,
   );
 
-  const handleViewChange = useCallback(
-    (newView: ViewMode) => {
-      setView(newView);
-
-      // Save to localStorage
-      if (storageKey) {
-        localStorage.setItem(`${storageKey}:view`, newView);
-      }
-    },
-    [storageKey],
-  );
+  const handleViewChange = useCallback((newView: ViewMode) => {
+    setView(newView);
+    localStorage.setItem(`${TASK_SOURCE_VIEWER_GLOBAL_KEY}:view`, newView);
+  }, []);
 
   // Load full task data
   useEffect(() => {

--- a/web/libs/datamanager/src/components/Common/TaskSourceViewer/TaskSourceViewer.tsx
+++ b/web/libs/datamanager/src/components/Common/TaskSourceViewer/TaskSourceViewer.tsx
@@ -8,9 +8,7 @@ import { ViewToggle, type ViewMode } from "./ViewToggle";
 export type { ViewMode };
 
 /** Build project-scoped localStorage key for JSON viewer search and filter state. Returns undefined when projectId is missing. */
-export function getTaskSourceViewerStorageKey(
-  projectId: string | number | null | undefined,
-): string | undefined {
+export function getTaskSourceViewerStorageKey(projectId: string | number | null | undefined): string | undefined {
   if (projectId == null || projectId === "") return undefined;
   return `dm:tasksource:${projectId}`;
 }
@@ -84,8 +82,8 @@ export const TaskSourceViewer: FC<TaskSourceViewerProps> = ({
   const [loading, setLoading] = useState(true);
 
   // View mode (Code/Interactive) — global key so preference is shared across projects
-  const [view, setView] = useState<ViewMode>(() =>
-    (localStorage.getItem(`${TASK_SOURCE_VIEWER_GLOBAL_KEY}:view`) as ViewMode) || "code",
+  const [view, setView] = useState<ViewMode>(
+    () => (localStorage.getItem(`${TASK_SOURCE_VIEWER_GLOBAL_KEY}:view`) as ViewMode) || "code",
   );
 
   // Resolve URIs — per project when storageKey is set (same key as JSON viewer search/filters)

--- a/web/libs/datamanager/src/components/Common/TaskSourceViewer/index.ts
+++ b/web/libs/datamanager/src/components/Common/TaskSourceViewer/index.ts
@@ -1,2 +1,2 @@
-export { TaskSourceViewer } from "./TaskSourceViewer";
+export { TaskSourceViewer, getTaskSourceViewerStorageKey } from "./TaskSourceViewer";
 export type { TaskSourceViewerProps } from "./TaskSourceViewer";


### PR DESCRIPTION
Cherry pick

This pull request updates the way localStorage keys are managed for the `TaskSourceViewer` component, introducing project-scoped storage for certain viewer preferences while keeping the view mode preference global. The changes ensure that search, filter, and "resolve URIs" states are isolated per project, while the view mode (Code/Interactive) is shared across all projects. Several components and tests are updated to use the new key management.

**LocalStorage key management improvements:**

* Added a new utility function `getTaskSourceViewerStorageKey` to generate project-scoped storage keys for the JSON viewer's search, filter, and "resolve URIs" preferences. This ensures these preferences are isolated per project. (`web/libs/datamanager/src/components/Common/TaskSourceViewer/TaskSourceViewer.tsx`, `web/libs/datamanager/src/components/Common/TaskSourceViewer/index.ts`) [[1]](diffhunk://#diff-68897bc0cb6e15525adf822db6208e68d16a97c3f4c033326cbc095f40a47f75R10-R18) [[2]](diffhunk://#diff-27edd637fde2f95fadd5bd144b3f645e4a53a289cb488d2178cd63d7881c6e7aL1-R1)
* Updated the `TaskSourceViewer` component to use the global key (`dm:tasksource`) for view mode preference, making it consistent across projects, while using the project-scoped key for other persistent states. (`web/libs/datamanager/src/components/Common/TaskSourceViewer/TaskSourceViewer.tsx`)

**Component and prop updates:**

* Modified `RowContextMenu` and `Table` components to accept and pass `projectId` so that the correct storage key is used for each project. (`web/libs/datamanager/src/components/Common/Table/RowContextMenu/RowContextMenu.tsx`, `web/libs/datamanager/src/components/Common/Table/Table.jsx`) [[1]](diffhunk://#diff-75e91f9cb0f8056fd8f6a80dc431683c3f1ce2fe444f71a46542b4d305f2dc2aR28-R29) [[2]](diffhunk://#diff-48b6bcad2c2fed9de478fb8e01bc194bb39a2253bf45a1f8404ff92ef7390732L65-R65) [[3]](diffhunk://#diff-48b6bcad2c2fed9de478fb8e01bc194bb39a2253bf45a1f8404ff92ef7390732L643-R643) [[4]](diffhunk://#diff-48b6bcad2c2fed9de478fb8e01bc194bb39a2253bf45a1f8404ff92ef7390732R652)
* Updated the `TaskSourceViewerProps` interface to clarify the distinction between global and project-scoped storage keys. (`web/libs/datamanager/src/components/Common/TaskSourceViewer/TaskSourceViewer.tsx`)

**Test adjustments:**

* Refactored tests for `TaskSourceViewer` to use the new global storage key for view mode, ensuring test consistency with the updated component logic. (`web/libs/datamanager/src/components/Common/TaskSourceViewer/TaskSourceViewer.test.tsx`) [[1]](diffhunk://#diff-4b91d4cebd35534ccac76999c12107a93fd601eb107be1e0778888671094d3f4R70-R71) [[2]](diffhunk://#diff-4b91d4cebd35534ccac76999c12107a93fd601eb107be1e0778888671094d3f4L136-R138) [[3]](diffhunk://#diff-4b91d4cebd35534ccac76999c12107a93fd601eb107be1e0778888671094d3f4L148-R150) [[4]](diffhunk://#diff-4b91d4cebd35534ccac76999c12107a93fd601eb107be1e0778888671094d3f4L169-R171) [[5]](diffhunk://#diff-4b91d4cebd35534ccac76999c12107a93fd601eb107be1e0778888671094d3f4L196-R198) [[6]](diffhunk://#diff-4b91d4cebd35534ccac76999c12107a93fd601eb107be1e0778888671094d3f4L240-R242)

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
