### PR TITLE
fix: FIT-1502: Large labeling interface causing to freeze LS on Create Project modal

### DIFF
--- a/web/apps/labelstudio/src/pages/CreateProject/Config/Config.jsx
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/Config.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState, useRef } from "react";
 import CM from "codemirror";
-import { Button, cnm } from "@humansignal/ui";
+import { Button, cnm, Typography } from "@humansignal/ui";
 import { IconTrash, IconInfoOutline } from "@humansignal/icons";
 import { ToggleItems } from "../../../components";
 import { Form, Input } from "../../../components/Form";
@@ -11,7 +11,7 @@ import { FF_UNSAVED_CHANGES, isFF } from "../../../utils/feature-flags";
 import { colorNames } from "./colors";
 import "./Config.scss";
 import { Preview } from "./Preview";
-import { ff, LARGE_CONFIG_MESSAGE, LARGE_CONFIG_TAG_THRESHOLD, countConfigTags } from "@humansignal/core";
+import { LARGE_CONFIG_MESSAGE, LARGE_CONFIG_TAG_THRESHOLD, countConfigTags } from "@humansignal/core";
 import { DEFAULT_COLUMN, EMPTY_CONFIG, isEmptyConfig, Template } from "./Template";
 import { TemplatesList } from "./TemplatesList";
 
@@ -29,40 +29,42 @@ const configClass = cn("configure");
  * AdaptivePreview - Shows manual update banner for large configs,
  * normal auto-updating preview for smaller configs.
  *
- * When FF_PREVIEW_PERFORMANCE is enabled and config has >= 200 tags,
- * shows a banner with "Update Preview" button instead of auto-updating.
+ * When config has >= 200 tags, shows a banner with "Update Preview" button
+ * instead of auto-updating (avoids slow re-renders on every keystroke).
  *
- * Controlled by FF_PREVIEW_PERFORMANCE feature flag.
+ * Uses editorConfig when provided to detect large pasted content immediately.
  *
  * Wrapped in React.memo to prevent unnecessary re-renders when parent re-renders.
  */
-const AdaptivePreview = React.memo(({ config, hasPendingUpdate, onUpdatePreview, isUpdating, ...previewProps }) => {
-  const isFeatureEnabled = ff.isActive(ff.FF_PREVIEW_PERFORMANCE);
+const AdaptivePreview = React.memo(
+  ({ config, editorConfig, hasPendingUpdate, onUpdatePreview, isUpdating, previewKey, ...previewProps }) => {
+    // Use editor config for tag count when provided so banner appears as soon as user pastes large content
+    const configForTagCount = editorConfig !== undefined ? editorConfig : config;
+    const tagCount = useMemo(() => countConfigTags(configForTagCount || ""), [configForTagCount]);
+    const isLargeConfig = tagCount >= LARGE_CONFIG_TAG_THRESHOLD;
 
-  // Memoize tag count calculation to avoid re-computing on every render
-  const tagCount = useMemo(() => countConfigTags(config || ""), [config]);
-  const isLargeConfig = tagCount >= LARGE_CONFIG_TAG_THRESHOLD;
+    const showManualUpdateBanner = isLargeConfig;
 
-  // Only show manual update banner when FF is ON and config is large and there are pending updates
-  const showManualUpdateBanner = isFeatureEnabled && isLargeConfig && hasPendingUpdate;
+    const previewKeyProp = previewKey !== undefined ? previewKey : config;
 
-  if (showManualUpdateBanner) {
-    return (
-      <div className={configClass.elem("preview-container").toClassName()}>
-        <div className={configClass.elem("preview-info-banner").toClassName()}>
-          <IconInfoOutline width={16} height={16} />
-          <span>{LARGE_CONFIG_MESSAGE}</span>
-          <Button size="small" onClick={onUpdatePreview} waiting={isUpdating} disabled={isUpdating}>
-            {isUpdating ? "Updating..." : "Update Preview"}
-          </Button>
+    if (showManualUpdateBanner) {
+      return (
+        <div className={configClass.elem("preview-container").toClassName()}>
+          <div className={configClass.elem("preview-info-banner").toClassName()}>
+            <IconInfoOutline width={16} height={16} />
+            <span>{LARGE_CONFIG_MESSAGE}</span>
+            <Button size="small" onClick={onUpdatePreview} waiting={isUpdating} disabled={isUpdating}>
+              {isUpdating ? "Updating..." : "Update Preview"}
+            </Button>
+          </div>
+          <Preview key={previewKeyProp} config={config} {...previewProps} />
         </div>
-        <Preview config={config} {...previewProps} />
-      </div>
-    );
-  }
+      );
+    }
 
-  return <Preview config={config} {...previewProps} />;
-});
+    return <Preview key={previewKeyProp} config={config} {...previewProps} />;
+  },
+);
 
 const EmptyConfigPlaceholder = () => (
   <div className={configClass.elem("empty-config").toClassName()}>
@@ -444,10 +446,11 @@ const Configurator = ({
   const [hasPendingChanges, setHasPendingChanges] = React.useState(false);
   // Track the last config that was successfully validated and displayed
   const lastValidatedConfig = React.useRef(null);
+  // Increment when configToDisplay changes so Preview remounts and LSF initializes with new config (avoids stale/empty main area)
+  const [previewKey, setPreviewKey] = React.useState(0);
 
   const debounceTimer = React.useRef();
   const api = useAPI();
-  const isFeatureEnabled = ff.isActive(ff.FF_PREVIEW_PERFORMANCE);
 
   React.useEffect(() => {
     const tagCount = countConfigTags(config);
@@ -455,10 +458,8 @@ const Configurator = ({
     const hasCompletedFirstValidation = lastValidatedConfig.current !== null;
 
     // Always validate if we haven't completed the first validation yet
-    // This ensures the preview shows something on first load
     if (!hasCompletedFirstValidation) {
-      // Enter manual mode for large configs, but still do the initial validation
-      if (isLargeConfig && isFeatureEnabled) {
+      if (isLargeConfig) {
         setManualUpdateMode(true);
       }
       debounceTimer.current = window.setTimeout(() => {
@@ -467,39 +468,44 @@ const Configurator = ({
       return () => window.clearTimeout(debounceTimer.current);
     }
 
-    // After first validation: if we're in manual mode, just mark pending changes
+    // After first validation: if we're in manual mode, either update (when config became small) or mark pending
     if (manualUpdateMode) {
+      if (!isLargeConfig) {
+        setManualUpdateMode(false);
+        setHasPendingChanges(false);
+        debounceTimer.current = window.setTimeout(() => {
+          setConfigToCheck(config);
+        }, 300);
+        return () => window.clearTimeout(debounceTimer.current);
+      }
       setHasPendingChanges(true);
       return;
     }
 
-    // Enter manual mode for large configs when feature flag is enabled
-    if (isLargeConfig && isFeatureEnabled) {
+    // Enter manual mode for large configs (no auto-update; user clicks "Update Preview")
+    if (isLargeConfig) {
       setManualUpdateMode(true);
       setHasPendingChanges(true);
       return;
     }
 
-    // Normal debounced auto-update for small configs or when feature flag is off
+    // Normal debounced auto-update for small configs
     debounceTimer.current = window.setTimeout(() => {
       setConfigToCheck(config);
     }, 300);
 
     return () => window.clearTimeout(debounceTimer.current);
-  }, [config, manualUpdateMode, isFeatureEnabled]);
+  }, [config, manualUpdateMode]);
 
   // Handler for manual preview update (used for large configs)
   const handleManualUpdate = React.useCallback(() => {
-    // Check if we should stay in manual mode after this update
     const tagCount = countConfigTags(config);
     const isLargeConfig = tagCount >= LARGE_CONFIG_TAG_THRESHOLD;
 
-    // If still large, stay in manual mode but clear pending changes
-    // If now small, exit manual mode
-    setManualUpdateMode(isLargeConfig && isFeatureEnabled);
+    setManualUpdateMode(isLargeConfig);
     setHasPendingChanges(false);
     setConfigToCheck(config);
-  }, [config, isFeatureEnabled]);
+  }, [config]);
 
   React.useEffect(() => {
     const validate = async () => {
@@ -532,6 +538,7 @@ const Configurator = ({
       if (sample && !sample.error) {
         setData(sample.sample_task);
         setConfigToDisplay(configToCheck);
+        setPreviewKey((k) => k + 1);
         // Track that we've completed a successful validation
         lastValidatedConfig.current = configToCheck;
       } else {
@@ -608,6 +615,9 @@ const Configurator = ({
     () => parserError || error || (configure === "code" && warning) || null,
     [parserError, error, configure, warning],
   );
+
+  // When validating a different config, show placeholder to avoid race: old preview + spinners / empty state
+  const showUpdatingPlaceholder = loading && configToCheck != null && configToCheck !== configToDisplay;
 
   const extra = (
     <p className={configClass.elem("tags-link").toClassName()}>
@@ -713,16 +723,29 @@ const Configurator = ({
             constraints={constraints}
             disabled={constraints.minEditorWidth >= constraints.maxEditorWidth}
           />
-          <AdaptivePreview
-            config={configToDisplay}
-            data={data}
-            project={project}
-            loading={loading}
-            error={previewError}
-            hasPendingUpdate={manualUpdateMode}
-            onUpdatePreview={handleManualUpdate}
-            isUpdating={loading}
-          />
+          {showUpdatingPlaceholder ? (
+            <div
+              className={configClass.elem("preview-container").toClassName()}
+              data-testid="preview-updating-placeholder"
+            >
+              <div className={configClass.elem("preview-updating").toClassName()}>
+                <Typography color="secondary">Updating preview…</Typography>
+              </div>
+            </div>
+          ) : (
+            <AdaptivePreview
+              config={configToDisplay}
+              editorConfig={config}
+              data={data}
+              project={project}
+              loading={loading}
+              error={previewError}
+              hasPendingUpdate={manualUpdateMode}
+              onUpdatePreview={handleManualUpdate}
+              isUpdating={loading}
+              previewKey={previewKey}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/web/apps/labelstudio/src/pages/CreateProject/Config/Config.scss
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/Config.scss
@@ -670,6 +670,15 @@ $scroll-width: 5px;
   }
 }
 
+.wizard .configure__preview-updating {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  padding: var(--spacing-wide);
+  min-height: 200px;
+}
+
 div[class^="App_menu"]>div {
   width: 100%;
 }

--- a/web/apps/labelstudio/src/pages/CreateProject/Config/Preview.jsx
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/Preview.jsx
@@ -25,6 +25,7 @@ export const Preview = ({ config, data, error, loading, project }) => {
   const [storeReady, setStoreReady] = useState(false);
   const lsf = useRef(null);
   const rootRef = useRef();
+  const mountedRef = useRef(true);
   const api = useAPI();
   const projectRef = useRef(project);
   projectRef.current = project;
@@ -68,14 +69,16 @@ export const Preview = ({ config, data, error, loading, project }) => {
   }, [config]);
 
   const initLabelStudio = useCallback(async (config, task) => {
-    // wait for dependencies to load, the promise is resolved only once
-    // and is started when the component is mounted for the first time
     await loadDependencies();
 
     if (lsf.current || !task.data) return;
 
+    // Resolve root by id so we don't pass null after remounts; getElementById finds the current DOM node
+    const rootEl = document.getElementById("label-studio") ?? rootRef.current;
+    if (!rootEl) return;
+
     try {
-      lsf.current = new window.LabelStudio(rootRef.current, {
+      lsf.current = new window.LabelStudio(rootEl, {
         config,
         task,
         interfaces: ["side-column"],
@@ -104,35 +107,36 @@ export const Preview = ({ config, data, error, loading, project }) => {
 
   useEffect(() => {
     const opacity = loading || error ? 0.6 : 1;
-    // to avoid rerenders and data loss we do it this way
-
-    document.getElementById("label-studio").style.opacity = opacity;
+    const el = document.getElementById("label-studio");
+    if (el) el.style.opacity = opacity;
   }, [loading, error]);
 
   useEffect(() => {
+    mountedRef.current = true;
     initLabelStudio(currentConfig, currentTask).then(() => {
-      if (storeReady && lsf.current?.store) {
-        const store = lsf.current.store;
+      if (!mountedRef.current || !lsf.current?.store) return;
+      const store = lsf.current.store;
 
-        store.resetState();
-        store.assignTask(currentTask);
-        store.assignConfig(currentConfig);
-        store.initializeStore(currentTask);
+      store.resetState();
+      store.assignTask(currentTask);
+      store.assignConfig(currentConfig);
+      store.initializeStore(currentTask);
 
-        const c = store.annotationStore.addAnnotation({
-          userGenerate: true,
-        });
+      const c = store.annotationStore.addAnnotation({
+        userGenerate: true,
+      });
 
-        store.annotationStore.selectAnnotation(c.id);
-        console.log("LSF updated");
-      }
+      store.annotationStore.selectAnnotation(c.id);
     });
+    return () => {
+      mountedRef.current = false;
+    };
   }, [currentConfig, currentTask, storeReady]);
 
   useEffect(() => {
     return () => {
+      mountedRef.current = false;
       if (lsf.current) {
-        console.info("Destroying LSF");
         lsf.current.destroy();
         lsf.current = null;
       }


### PR DESCRIPTION
This pull request improves the user experience and reliability of the project configuration preview in the Label Studio app, especially for large configurations. The main focus is on making the preview update mechanism more robust, removing a now-unnecessary feature flag, and fixing issues with stale or empty previews after configuration changes. The changes also add a placeholder while the preview updates, and ensure the preview component is properly remounted and initialized.

**Preview update experience and reliability:**

* The manual preview update mode for large configs (≥200 tags) is now always enabled, regardless of feature flags. The preview only updates when the user clicks "Update Preview," preventing slow re-renders on every keystroke. [[1]](diffhunk://#diff-b8cade5f083b7ee986ecfffd94abcf8500ea563ec194ccf3ca3d94f2edda8a89L32-R48) [[2]](diffhunk://#diff-b8cade5f083b7ee986ecfffd94abcf8500ea563ec194ccf3ca3d94f2edda8a89L470-R508)
* The preview component (`Preview`) is now forcibly remounted with a new `key` whenever the displayed config changes, ensuring the Label Studio frontend always initializes with the new config and avoids showing stale or empty previews. [[1]](diffhunk://#diff-b8cade5f083b7ee986ecfffd94abcf8500ea563ec194ccf3ca3d94f2edda8a89R541) [[2]](diffhunk://#diff-b8cade5f083b7ee986ecfffd94abcf8500ea563ec194ccf3ca3d94f2edda8a89R726-R748)
* A placeholder is shown while the preview is updating, preventing flickers and race conditions where the old preview or empty state would show during loading. [[1]](diffhunk://#diff-b8cade5f083b7ee986ecfffd94abcf8500ea563ec194ccf3ca3d94f2edda8a89R619-R621) [[2]](diffhunk://#diff-ff8a3990dde3c08403f325ed9c16889ed489c1bd97830d40ece9078165444a01R673-R681) [[3]](diffhunk://#diff-b8cade5f083b7ee986ecfffd94abcf8500ea563ec194ccf3ca3d94f2edda8a89R726-R748)

**Code and dependency cleanup:**

* The now-unused feature flag logic (`ff` and `FF_PREVIEW_PERFORMANCE`) has been removed from the config page, simplifying the code. [[1]](diffhunk://#diff-b8cade5f083b7ee986ecfffd94abcf8500ea563ec194ccf3ca3d94f2edda8a89L14-R14) [[2]](diffhunk://#diff-b8cade5f083b7ee986ecfffd94abcf8500ea563ec194ccf3ca3d94f2edda8a89L32-R48) [[3]](diffhunk://#diff-b8cade5f083b7ee986ecfffd94abcf8500ea563ec194ccf3ca3d94f2edda8a89R449-R462) [[4]](diffhunk://#diff-b8cade5f083b7ee986ecfffd94abcf8500ea563ec194ccf3ca3d94f2edda8a89L470-R508)

**Preview component robustness:**

* The `Preview` component now ensures the correct DOM node is used for initialization after remounts, and tracks mounting state to avoid updating unmounted components, preventing errors and memory leaks. [[1]](diffhunk://#diff-c884ae2a78e98837ff6a1b4d873182c36b1eb476b7a9135c95349797d6b26e73L71-R81) [[2]](diffhunk://#diff-c884ae2a78e98837ff6a1b4d873182c36b1eb476b7a9135c95349797d6b26e73L107-R117) [[3]](diffhunk://#diff-c884ae2a78e98837ff6a1b4d873182c36b1eb476b7a9135c95349797d6b26e73L127-L135)

These changes collectively make the configuration preview more predictable and user-friendly, especially for users working with large or frequently changing configs.