### PR TITLE
chore: Address the gap created by the incorrect width on the resizer

### DIFF
--- a/web/libs/datamanager/src/components/Common/Resizer/Resizer.scss
+++ b/web/libs/datamanager/src/components/Common/Resizer/Resizer.scss
@@ -17,7 +17,6 @@
     right: 0;
     cursor: ew-resize;
     z-index: 100;
-    width: var(--handle-interactive-size);
 
     &::before {
       width: var(--handle-size);


### PR DESCRIPTION
Resizer is leaving a gap because of an additional width placed on the container resizer element, instead of just leaving the pseudo ::before to take care of it.