### PR TITLE
Quick view hotkey tooltips

### DIFF
--- a/web/libs/editor/src/components/App/App.scss
+++ b/web/libs/editor/src/components/App/App.scss
@@ -91,6 +91,9 @@ body {
 }
 
 .key-group {
+  display: inline-flex;
+  align-items: center;
+
   &__key {
     padding: 0 4px;
     height: 16px;
@@ -105,8 +108,10 @@ body {
     box-shadow: 0 0 0 1px rgb(0 0 0 / 10%), 0 1px 0 rgb(0 0 0 / 8%);
   }
 
-  &__key + &__key {
-    margin-left: 4px;
+  &__separator {
+    margin: 0 2px;
+    font-size: 10px;
+    opacity: 0.6;
   }
 
   & + & {

--- a/web/libs/editor/src/core/Hotkey.ts
+++ b/web/libs/editor/src/core/Hotkey.ts
@@ -462,15 +462,26 @@ Hotkey.Tooltip = inject("store")(
 
       if (enabled) {
         shortcut.split(",").forEach((combination: string) => {
-          const keys = combination.split("+").map((key: string) =>
-            createElement(
-              "kbd",
-              {
-                className: cn("hotkey").elem("key").toClassName(),
-              },
-              key,
-            ),
-          );
+          const keyParts = combination.split("+");
+          const keys: JSX.Element[] = [];
+
+          keyParts.forEach((key: string, i: number) => {
+            if (i > 0) {
+              keys.push(
+                createElement("span", { className: cn("key-group").elem("separator").toClassName(), key: `sep-${i}` }, "+"),
+              );
+            }
+            keys.push(
+              createElement(
+                "kbd",
+                {
+                  className: cn("key-group").elem("key").toClassName(),
+                  key: `key-${i}`,
+                },
+                key,
+              ),
+            );
+          });
 
           hotkeys.push(
             createElement(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
### Reason for change

This PR fixes a long-standing visual bug where hotkey tooltips (e.g., for Play/Pause, Create Relation, Edit Region Meta) displayed key combinations incorrectly, showing "ctrlaltspace" instead of "Ctrl+Alt+Space".

The root causes were:
1.  **CSS class mismatch:** The `<kbd>` elements for hotkeys were rendered with the class `lsf-hotkey__key`, but the corresponding styling in `App.scss` was defined for `lsf-key-group__key`. This resulted in unstyled, unseparated text.
2.  **Missing separators:** There was no explicit `+` symbol rendered between individual keys in multi-key combinations.

### Solution

1.  **`web/libs/editor/src/core/Hotkey.ts`:**
    *   Updated the class name for `<kbd>` elements from `cn("hotkey").elem("key")` to `cn("key-group").elem("key")` to match the existing CSS.
    *   Introduced `<span>+</span>` elements as visual separators between keys in multi-key hotkey combinations.
2.  **`web/libs/editor/src/components/App/App.scss`:**
    *   Added styling for the new `.key-group__separator` elements.
    *   Adjusted `.key-group` display properties for proper alignment.
    *   Removed the now-redundant `&__key + &__key` margin rule.

### Screenshots

*(Please add "Before" and "After" screenshots of affected tooltips, e.g., Play/Pause, Create Relation, Edit Region Meta, to demonstrate the fix.)*

### Rollout strategy

Standard deployment. No feature flags are involved.

### Testing

*   Manually verified that hotkey tooltips for Play/Pause (video/audio), Create Relation, and Edit Region Meta now display correctly with proper key styling and `+` separators.
*   Ran `tsc` and `eslint` to ensure no new compilation or linting issues were introduced.

### Risks

Low. The changes are primarily visual (CSS and minor JSX adjustments) and do not alter the underlying hotkey functionality or logic.

### Reviewer notes

*   Pay close attention to the class name change in `Hotkey.ts` and the addition of separator `<span>` elements.
*   Review the new CSS rules in `App.scss` for the separators and the `key-group` adjustments.

### General notes

This fix applies to all instances where `Hotkey.Tooltip` is used, ensuring a consistent and correct display of hotkey combinations across the Annotation UI.

---
<p><a href="https://cursor.com/agents/bc-e2615fbc-0680-41d4-a4b2-4687c0956a60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2615fbc-0680-41d4-a4b2-4687c0956a60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->