### PR TITLE
fix: BROS-843: Fix hotkey styles in tooltips

### DIFF
--- a/web/libs/editor/src/components/App/App.scss
+++ b/web/libs/editor/src/components/App/App.scss
@@ -91,6 +91,9 @@ body {
 }
 
 .key-group {
+  display: inline-flex;
+  align-items: center;
+
   &__key {
     padding: 0 4px;
     height: 16px;
@@ -105,8 +108,10 @@ body {
     box-shadow: 0 0 0 1px rgb(0 0 0 / 10%), 0 1px 0 rgb(0 0 0 / 8%);
   }
 
-  &__key + &__key {
-    margin-left: 4px;
+  &__separator {
+    margin: 0 2px;
+    font-size: 10px;
+    opacity: 0.6;
   }
 
   & + & {

--- a/web/libs/editor/src/components/App/App.scss
+++ b/web/libs/editor/src/components/App/App.scss
@@ -108,11 +108,8 @@ body {
     box-shadow: 0 0 0 1px rgb(0 0 0 / 10%), 0 1px 0 rgb(0 0 0 / 8%);
   }
 
-  &__separator {
-    margin: 0 3px;
-    font-size: 12px;
-    font-weight: bold;
-    opacity: 0.9;
+  &__key + &__key {
+    margin-left: 4px;
   }
 
   & + & {

--- a/web/libs/editor/src/components/App/App.scss
+++ b/web/libs/editor/src/components/App/App.scss
@@ -109,9 +109,10 @@ body {
   }
 
   &__separator {
-    margin: 0 2px;
-    font-size: 10px;
-    opacity: 0.6;
+    margin: 0 3px;
+    font-size: 12px;
+    font-weight: bold;
+    opacity: 0.9;
   }
 
   & + & {

--- a/web/libs/editor/src/core/Hotkey.ts
+++ b/web/libs/editor/src/core/Hotkey.ts
@@ -462,15 +462,30 @@ Hotkey.Tooltip = inject("store")(
 
       if (enabled) {
         shortcut.split(",").forEach((combination: string) => {
-          const keys = combination.split("+").map((key: string) =>
-            createElement(
-              "kbd",
-              {
-                className: cn("hotkey").elem("key").toClassName(),
-              },
-              key,
-            ),
-          );
+          const keyParts = combination.split("+");
+          const keys: JSX.Element[] = [];
+
+          keyParts.forEach((key: string, i: number) => {
+            if (i > 0) {
+              keys.push(
+                createElement(
+                  "span",
+                  { className: cn("key-group").elem("separator").toClassName(), key: `sep-${i}` },
+                  "+",
+                ),
+              );
+            }
+            keys.push(
+              createElement(
+                "kbd",
+                {
+                  className: cn("key-group").elem("key").toClassName(),
+                  key: `key-${i}`,
+                },
+                key,
+              ),
+            );
+          });
 
           hotkeys.push(
             createElement(

--- a/web/libs/editor/src/core/Hotkey.ts
+++ b/web/libs/editor/src/core/Hotkey.ts
@@ -466,15 +466,6 @@ Hotkey.Tooltip = inject("store")(
           const keys: JSX.Element[] = [];
 
           keyParts.forEach((key: string, i: number) => {
-            if (i > 0) {
-              keys.push(
-                createElement(
-                  "span",
-                  { className: cn("key-group").elem("separator").toClassName(), key: `sep-${i}` },
-                  "+",
-                ),
-              );
-            }
             keys.push(
               createElement(
                 "kbd",


### PR DESCRIPTION
The Hotkey.Tooltip component was generating <kbd> elements with the class 'hotkey__key' (via cn('hotkey').elem('key')), but no CSS rule existed for that class. The actual key badge styles are defined under '.key-group__key' in App.scss.

Changes:
- Fix BEM class name in Hotkey.Tooltip from cn('hotkey').elem('key') to cn('key-group').elem('key') so <kbd> elements match existing CSS styles
- Add explicit '+' separator elements between keys in multi-key combos (e.g. Ctrl+Alt+Space) for clarity even without full CSS rendering
- Add .key-group__separator CSS for the plus sign between keys
- Add inline-flex and align-items to .key-group for proper alignment

Affected tooltips: Play/Pause (video/audio), Create Relation, Edit Region Meta, and all other buttons using Hotkey.Tooltip.


Before:
![Playpause](https://github.com/user-attachments/assets/fc071067-8116-4177-b5ee-d8b4b873df70)
![Altm](https://github.com/user-attachments/assets/0a238cee-55ca-4b30-b591-e0b115f8e833)

After:

![VideoPlayDark](https://github.com/user-attachments/assets/0871864d-cdc9-4df7-9610-4f6785fd3c51)
![VideoPlayLight](https://github.com/user-attachments/assets/715d6279-0ee0-4d4b-9a86-3eb652bad4a1)
![AltMFixDark](https://github.com/user-attachments/assets/f7683f01-df34-416a-b0da-f46dee3e2fd0)

