### PR TITLE
fix: UTC-644: Restore full-row click area in Select Option component

### DIFF
--- a/web/libs/ui/src/lib/select/select.tsx
+++ b/web/libs/ui/src/lib/select/select.tsx
@@ -733,6 +733,7 @@ const Option = ({
       className={clsx(
         className,
         [
+          "w-full",
           "rounded-4",
           "text-neutral-content-subtle",
           "overflow-hidden",


### PR DESCRIPTION
This pull request makes a small UI adjustment to the `Option` component in the `select.tsx` file, ensuring that each option takes up the full available width for better alignment and consistency.

- UI Improvement:
  * Added the `"w-full"` class to the `Option` component to make it span the full width of its container.