### PR TITLE
fix: UTC-644: Column dropdown rows on Data Manager page are not fully clickable

### DIFF
--- a/web/libs/datamanager/src/components/Common/FieldsButton.jsx
+++ b/web/libs/datamanager/src/components/Common/FieldsButton.jsx
@@ -146,7 +146,13 @@ FieldsButton.Checkbox = observer(({ column, children, disabled, enterpriseBadge 
   return (
     <div className="w-full flex items-center justify-between gap-tight">
       <div className="flex-1 flex items-center min-w-0 overflow-hidden">
-        <Checkbox size="small" checked={!column.is_hidden} onChange={column.toggleVisibility} disabled={shouldDisable}>
+        <Checkbox
+          size="small"
+          checked={!column.is_hidden}
+          onChange={column.toggleVisibility}
+          disabled={shouldDisable}
+          className="w-full"
+        >
           {children}
         </Checkbox>
       </div>


### PR DESCRIPTION
This pull request makes a small UI improvement to the `FieldsButton.Checkbox` component by ensuring the checkbox takes up the full width of its container.

- UI Enhancement:
  * Updated the `Checkbox` in `FieldsButton.Checkbox` to include the `className="w-full"` prop, making the checkbox stretch to the full width of its parent container.