### PR TITLE
Unfinished polygon submit button

### DIFF
--- a/web/libs/editor/src/components/BottomBar/Controls.tsx
+++ b/web/libs/editor/src/components/BottomBar/Controls.tsx
@@ -44,6 +44,7 @@ type ControlButtonProps = {
 };
 
 export const EMPTY_SUBMIT_TOOLTIP = "Empty annotations denied in this project";
+export const INCOMPLETE_REGION_TOOLTIP = "Complete all regions before submitting";
 
 /**
  * Custom action button component, rendering buttons from store.customButtons
@@ -79,6 +80,7 @@ export const Controls = controlsInjector<{ annotation: MSTAnnotation }>(
     const [isInProgress, setIsInProgress] = useState(false);
     const disabled = !annotationEditable || store.isSubmitting || historySelected || isInProgress;
     const submitDisabled = store.hasInterface("annotations:deny-empty") && results.length === 0;
+    const hasIncompleteRegions = annotation.hasIncompleteRegions;
 
     /** Check all things related to comments and then call the action if all is good */
     const handleActionWithComments = useCallback(
@@ -197,7 +199,7 @@ export const Controls = controlsInjector<{ annotation: MSTAnnotation }>(
 
       // Also disable when overlap is reached (only when feature flag is enabled)
       const overlapDisabled = isFF(FF_FIT_1304_STRICT_OVERLAP) && store.overlapReached === true;
-      const isDisabled = disabled || submitDisabled || overlapDisabled;
+      const isDisabled = disabled || submitDisabled || overlapDisabled || hasIncompleteRegions;
 
       const useExitOption = !isDisabled && isNotQuickView;
 
@@ -237,11 +239,13 @@ export const Controls = controlsInjector<{ annotation: MSTAnnotation }>(
       };
 
       if (userGenerate || (store.explore && !userGenerate && store.hasInterface("submit"))) {
-        const title = overlapDisabled
-          ? store.overlapReachedMessage
-          : submitDisabled
-            ? EMPTY_SUBMIT_TOOLTIP
-            : "Save results: [ Ctrl+Enter ]";
+        const title = hasIncompleteRegions
+          ? INCOMPLETE_REGION_TOOLTIP
+          : overlapDisabled
+            ? store.overlapReachedMessage
+            : submitDisabled
+              ? EMPTY_SUBMIT_TOOLTIP
+              : "Save results: [ Ctrl+Enter ]";
 
         buttons.push(
           <ButtonTooltip key="submit" title={title}>
@@ -291,11 +295,13 @@ export const Controls = controlsInjector<{ annotation: MSTAnnotation }>(
         // no changes were made over previously submitted version — no drafts, no pending changes
         const noChanges = isFF(FF_REVIEWER_FLOW) && !history.canUndo && !annotation.draftId;
         const isUpdateDisabled = isDisabled || noChanges;
-        const updateTitle = overlapDisabled
-          ? store.overlapReachedMessage
-          : noChanges
-            ? "No changes were made"
-            : "Update this task: [ Ctrl+Enter ]";
+        const updateTitle = hasIncompleteRegions
+          ? INCOMPLETE_REGION_TOOLTIP
+          : overlapDisabled
+            ? store.overlapReachedMessage
+            : noChanges
+              ? "No changes were made"
+              : "Update this task: [ Ctrl+Enter ]";
         const button = (
           <ButtonTooltip key="update" title={updateTitle}>
             <ButtonGroup>

--- a/web/libs/editor/src/components/BottomBar/buttons.tsx
+++ b/web/libs/editor/src/components/BottomBar/buttons.tsx
@@ -54,13 +54,18 @@ export const AcceptButton = memo(
     const annotation = store.annotationStore.selected;
     // changes in current sessions or saved draft
     const hasChanges = history.canUndo || annotation.versions.draft;
+    const hasIncompleteRegions = annotation.hasIncompleteRegions;
+    const isDisabled = disabled || hasIncompleteRegions;
+    const tooltip = hasIncompleteRegions
+      ? "Complete all regions before accepting"
+      : "Accept annotation: [ Ctrl+Enter ]";
 
     return (
       <Button
         key="accept"
-        tooltip="Accept annotation: [ Ctrl+Enter ]"
+        tooltip={tooltip}
         aria-label="accept-annotation"
-        disabled={disabled}
+        disabled={isDisabled}
         onClick={async () => {
           annotation.submissionInProgress();
           await store.commentStore.commentFormSubmit();

--- a/web/libs/editor/src/stores/Annotation/Annotation.js
+++ b/web/libs/editor/src/stores/Annotation/Annotation.js
@@ -284,6 +284,14 @@ const _Annotation = types
       return results;
     },
 
+    get hasIncompleteRegions() {
+      if (!isAlive(self)) return false;
+      for (const area of self.areas.values()) {
+        if (area.incomplete) return true;
+      }
+      return false;
+    },
+
     get serialized() {
       // Dirty hack to force MST track changes
       self.areas.toJSON();

--- a/web/libs/editor/src/stores/AppStore.js
+++ b/web/libs/editor/src/stores/AppStore.js
@@ -368,6 +368,7 @@ export default types
           if (annotationStore.viewingAll) return;
           if (isUpdateDisabled) return;
           if (entity.isReadOnly()) return;
+          if (entity.hasIncompleteRegions) return;
 
           entity?.submissionInProgress();
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
### Reason for change

Previously, users could submit, update, or accept an annotation even if it contained an unfinished polygon region. This PR disables the "Submit", "Update", and "Fix & Accept" buttons when an annotation has any incomplete polygon regions, preventing premature submission of incomplete work.

### Screenshots

No direct UI layout changes. Verification involves observing button disabled states and tooltips.

### Rollout strategy

Standard deployment. No feature flags or environment variables are needed.

### Testing

1.  **Create an incomplete polygon:**
    *   Navigate to an annotation task.
    *   Start drawing a polygon region but do not close it (leave it with an open path).
2.  **Verify button states:**
    *   Observe the "Submit", "Update", and "Fix & Accept" buttons in the BottomBar. They should be disabled.
    *   Hover over the disabled buttons. A tooltip stating "Complete all regions before submitting/accepting" should appear.
3.  **Complete the polygon:**
    *   Close the polygon region.
4.  **Verify button states again:**
    *   The "Submit", "Update", and "Fix & Accept" buttons should now be enabled.
5.  **Test with other region types:**
    *   Ensure that creating other region types (e.g., bounding box) does not disable the buttons unless a polygon is also incomplete.

### Risks

Low risk. The changes are localized to the `Annotation` model and the active BottomBar UI components. Legacy UI components were explicitly reverted to ensure minimal impact.

### Reviewer notes

*   **`web/libs/editor/src/stores/Annotation/Annotation.js`**: A new computed view `hasIncompleteRegions` was added. This view iterates over `self.areas` and checks for the `incomplete` property. Only `PolygonRegion` and `VectorRegion` define `incomplete`, ensuring other region types do not trigger this logic.
*   **`web/libs/editor/src/components/BottomBar/Controls.tsx`**: The `isDisabled` logic for the "Submit" and "Update" buttons (and their dropdown variants) now includes `annotation.hasIncompleteRegions`. Tooltips are updated accordingly.
*   **`web/libs/editor/src/components/BottomBar/buttons.tsx`**: The `AcceptButton` component now checks `annotation.hasIncompleteRegions` to determine its disabled state and tooltip.

### General notes

This fix is intentionally scoped to only the active BottomBar UI and the `Annotation` model. No changes were made to legacy UI components or other button types (e.g., Skip, Reject) to keep the impact as minimal and targeted as possible.

<div><a href="https://cursor.com/agents/bc-8b8d7b55-f47c-43b2-b534-d9ab4eef00b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b8d7b55-f47c-43b2-b534-d9ab4eef00b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->