### PR TITLE
fix: BROS-847: Disable Submit/Update/Fix & Accept button when polygon region is unfinished

### DIFF
--- a/web/libs/editor/src/components/BottomBar/Controls.tsx
+++ b/web/libs/editor/src/components/BottomBar/Controls.tsx
@@ -250,7 +250,7 @@ export const Controls = controlsInjector<{ annotation: MSTAnnotation }>(
               : "Save results: [ Ctrl+Enter ]";
 
         buttons.push(
-          <ButtonTooltip key="submit" title={title}>
+          <ButtonTooltip key="submit" title={title} className="whitespace-nowrap">
             <div className={cn("controls").elem("tooltip-wrapper").toClassName()}>
               <ButtonGroup>
                 <Button
@@ -305,14 +305,13 @@ export const Controls = controlsInjector<{ annotation: MSTAnnotation }>(
               ? "No changes were made"
               : "Update this task: [ Ctrl+Enter ]";
         const button = (
-          <ButtonTooltip key="update" title={updateTitle}>
+          <ButtonTooltip key="update" title={updateTitle} className="whitespace-nowrap">
             <ButtonGroup>
               <Button
                 aria-label="submit"
                 name="submit"
                 className="w-[150px]"
                 disabled={isUpdateDisabled}
-                tooltip={updateTitle}
                 onClick={async (event) => {
                   if ((event.target as HTMLButtonElement).classList.contains(dropdownTrigger)) return;
                   const selected = store.annotationStore?.selected;

--- a/web/libs/editor/src/components/BottomBar/Controls.tsx
+++ b/web/libs/editor/src/components/BottomBar/Controls.tsx
@@ -250,7 +250,7 @@ export const Controls = controlsInjector<{ annotation: MSTAnnotation }>(
               : "Save results: [ Ctrl+Enter ]";
 
         buttons.push(
-          <ButtonTooltip key="submit" title={title} className="whitespace-nowrap">
+          <ButtonTooltip key="submit" title={title} className="whitespace-nowrap max-w-none">
             <div className={cn("controls").elem("tooltip-wrapper").toClassName()}>
               <ButtonGroup>
                 <Button

--- a/web/libs/editor/src/components/BottomBar/Controls.tsx
+++ b/web/libs/editor/src/components/BottomBar/Controls.tsx
@@ -44,7 +44,9 @@ type ControlButtonProps = {
 };
 
 export const EMPTY_SUBMIT_TOOLTIP = "Empty annotations denied in this project";
-export const INCOMPLETE_REGION_TOOLTIP = "Complete all regions before submitting";
+export const INCOMPLETE_SUBMIT_TOOLTIP = "Complete all regions before\nsubmitting";
+export const INCOMPLETE_UPDATE_TOOLTIP = "Complete all regions before\nupdating";
+export const INCOMPLETE_ACCEPT_TOOLTIP = "Complete all regions before\naccepting";
 
 /**
  * Custom action button component, rendering buttons from store.customButtons
@@ -240,7 +242,7 @@ export const Controls = controlsInjector<{ annotation: MSTAnnotation }>(
 
       if (userGenerate || (store.explore && !userGenerate && store.hasInterface("submit"))) {
         const title = hasIncompleteRegions
-          ? INCOMPLETE_REGION_TOOLTIP
+          ? INCOMPLETE_SUBMIT_TOOLTIP
           : overlapDisabled
             ? store.overlapReachedMessage
             : submitDisabled
@@ -296,7 +298,7 @@ export const Controls = controlsInjector<{ annotation: MSTAnnotation }>(
         const noChanges = isFF(FF_REVIEWER_FLOW) && !history.canUndo && !annotation.draftId;
         const isUpdateDisabled = isDisabled || noChanges;
         const updateTitle = hasIncompleteRegions
-          ? INCOMPLETE_REGION_TOOLTIP
+          ? INCOMPLETE_UPDATE_TOOLTIP
           : overlapDisabled
             ? store.overlapReachedMessage
             : noChanges
@@ -310,6 +312,7 @@ export const Controls = controlsInjector<{ annotation: MSTAnnotation }>(
                 name="submit"
                 className="w-[150px]"
                 disabled={isUpdateDisabled}
+                tooltip={updateTitle}
                 onClick={async (event) => {
                   if ((event.target as HTMLButtonElement).classList.contains(dropdownTrigger)) return;
                   const selected = store.annotationStore?.selected;

--- a/web/libs/editor/src/components/BottomBar/Controls.tsx
+++ b/web/libs/editor/src/components/BottomBar/Controls.tsx
@@ -305,40 +305,42 @@ export const Controls = controlsInjector<{ annotation: MSTAnnotation }>(
               ? "No changes were made"
               : "Update this task: [ Ctrl+Enter ]";
         const button = (
-          <ButtonTooltip key="update" title={updateTitle} className="whitespace-nowrap">
-            <ButtonGroup>
-              <Button
-                aria-label="submit"
-                name="submit"
-                className="w-[150px]"
-                disabled={isUpdateDisabled}
-                onClick={async (event) => {
-                  if ((event.target as HTMLButtonElement).classList.contains(dropdownTrigger)) return;
-                  const selected = store.annotationStore?.selected;
+          <ButtonTooltip key="update" title={updateTitle} className="whitespace-nowrap max-w-none">
+            <div className={cn("controls").elem("tooltip-wrapper").toClassName()}>
+              <ButtonGroup>
+                <Button
+                  aria-label="submit"
+                  name="submit"
+                  className="w-[150px]"
+                  disabled={isUpdateDisabled}
+                  onClick={async (event) => {
+                    if ((event.target as HTMLButtonElement).classList.contains(dropdownTrigger)) return;
+                    const selected = store.annotationStore?.selected;
 
-                  selected?.submissionInProgress();
-                  await store.commentStore.commentFormSubmit();
-                  store.updateAnnotation();
-                }}
-                data-testid="bottombar-update-button"
-              >
-                {isUpdate ? "Update" : "Submit"}
-              </Button>
-              {useExitOption ? (
-                <Dropdown.Trigger
-                  alignment="top-right"
-                  content={<SubmitOption onClickMethod={store.updateAnnotation} isUpdate={isUpdate} />}
+                    selected?.submissionInProgress();
+                    await store.commentStore.commentFormSubmit();
+                    store.updateAnnotation();
+                  }}
+                  data-testid="bottombar-update-button"
                 >
-                  <Button
-                    disabled={isUpdateDisabled}
-                    aria-label="Update annotation"
-                    data-testid="bottombar-update-dropdown"
+                  {isUpdate ? "Update" : "Submit"}
+                </Button>
+                {useExitOption ? (
+                  <Dropdown.Trigger
+                    alignment="top-right"
+                    content={<SubmitOption onClickMethod={store.updateAnnotation} isUpdate={isUpdate} />}
                   >
-                    <IconChevronDown />
-                  </Button>
-                </Dropdown.Trigger>
-              ) : null}
-            </ButtonGroup>
+                    <Button
+                      disabled={isUpdateDisabled}
+                      aria-label="Update annotation"
+                      data-testid="bottombar-update-dropdown"
+                    >
+                      <IconChevronDown />
+                    </Button>
+                  </Dropdown.Trigger>
+                ) : null}
+              </ButtonGroup>
+            </div>
           </ButtonTooltip>
         );
 

--- a/web/libs/editor/src/components/BottomBar/Controls.tsx
+++ b/web/libs/editor/src/components/BottomBar/Controls.tsx
@@ -80,7 +80,7 @@ export const Controls = controlsInjector<{ annotation: MSTAnnotation }>(
     const [isInProgress, setIsInProgress] = useState(false);
     const disabled = !annotationEditable || store.isSubmitting || historySelected || isInProgress;
     const submitDisabled = store.hasInterface("annotations:deny-empty") && results.length === 0;
-    const hasIncompleteRegions = annotation.hasIncompleteRegions;
+    const hasIncompleteRegions = annotation.hasIncompletePolygons;
 
     /** Check all things related to comments and then call the action if all is good */
     const handleActionWithComments = useCallback(

--- a/web/libs/editor/src/components/BottomBar/Controls.tsx
+++ b/web/libs/editor/src/components/BottomBar/Controls.tsx
@@ -44,6 +44,7 @@ type ControlButtonProps = {
 };
 
 export const EMPTY_SUBMIT_TOOLTIP = "Empty annotations denied in this project";
+export const INCOMPLETE_REGION_TOOLTIP = "Complete all regions before submitting";
 
 /**
  * Custom action button component, rendering buttons from store.customButtons
@@ -79,6 +80,7 @@ export const Controls = controlsInjector<{ annotation: MSTAnnotation }>(
     const [isInProgress, setIsInProgress] = useState(false);
     const disabled = !annotationEditable || store.isSubmitting || historySelected || isInProgress;
     const submitDisabled = store.hasInterface("annotations:deny-empty") && results.length === 0;
+    const hasIncompleteRegions = annotation.hasIncompleteRegions;
 
     /** Check all things related to comments and then call the action if all is good */
     const handleActionWithComments = useCallback(
@@ -197,7 +199,7 @@ export const Controls = controlsInjector<{ annotation: MSTAnnotation }>(
 
       // Also disable when overlap is reached (only when feature flag is enabled)
       const overlapDisabled = isFF(FF_FIT_1304_STRICT_OVERLAP) && store.overlapReached === true;
-      const isDisabled = disabled || submitDisabled || overlapDisabled;
+      const isDisabled = disabled || submitDisabled || overlapDisabled || hasIncompleteRegions;
 
       const useExitOption = !isDisabled && isNotQuickView;
 
@@ -237,11 +239,13 @@ export const Controls = controlsInjector<{ annotation: MSTAnnotation }>(
       };
 
       if (userGenerate || (store.explore && !userGenerate && store.hasInterface("submit"))) {
-        const title = overlapDisabled
-          ? store.overlapReachedMessage
-          : submitDisabled
-            ? EMPTY_SUBMIT_TOOLTIP
-            : "Save results: [ Ctrl+Enter ]";
+        const title = hasIncompleteRegions
+          ? INCOMPLETE_REGION_TOOLTIP
+          : overlapDisabled
+            ? store.overlapReachedMessage
+            : submitDisabled
+              ? EMPTY_SUBMIT_TOOLTIP
+              : "Save results: [ Ctrl+Enter ]";
 
         buttons.push(
           <ButtonTooltip key="submit" title={title}>
@@ -291,11 +295,13 @@ export const Controls = controlsInjector<{ annotation: MSTAnnotation }>(
         // no changes were made over previously submitted version — no drafts, no pending changes
         const noChanges = isFF(FF_REVIEWER_FLOW) && !history.canUndo && !annotation.draftId;
         const isUpdateDisabled = isDisabled || noChanges;
-        const updateTitle = overlapDisabled
-          ? store.overlapReachedMessage
-          : noChanges
-            ? "No changes were made"
-            : "Update this task: [ Ctrl+Enter ]";
+        const updateTitle = hasIncompleteRegions
+          ? INCOMPLETE_REGION_TOOLTIP
+          : overlapDisabled
+            ? store.overlapReachedMessage
+            : noChanges
+              ? "No changes were made"
+              : "Update this task: [ Ctrl+Enter ]";
         const button = (
           <ButtonTooltip key="update" title={updateTitle}>
             <ButtonGroup>

--- a/web/libs/editor/src/components/BottomBar/Controls.tsx
+++ b/web/libs/editor/src/components/BottomBar/Controls.tsx
@@ -44,9 +44,9 @@ type ControlButtonProps = {
 };
 
 export const EMPTY_SUBMIT_TOOLTIP = "Empty annotations denied in this project";
-export const INCOMPLETE_SUBMIT_TOOLTIP = "Complete all regions before\nsubmitting";
-export const INCOMPLETE_UPDATE_TOOLTIP = "Complete all regions before\nupdating";
-export const INCOMPLETE_ACCEPT_TOOLTIP = "Complete all regions before\naccepting";
+export const INCOMPLETE_SUBMIT_TOOLTIP = "Complete all regions before submitting";
+export const INCOMPLETE_UPDATE_TOOLTIP = "Complete all regions before updating";
+export const INCOMPLETE_ACCEPT_TOOLTIP = "Complete all regions before accepting";
 
 /**
  * Custom action button component, rendering buttons from store.customButtons

--- a/web/libs/editor/src/components/BottomBar/buttons.tsx
+++ b/web/libs/editor/src/components/BottomBar/buttons.tsx
@@ -54,13 +54,18 @@ export const AcceptButton = memo(
     const annotation = store.annotationStore.selected;
     // changes in current sessions or saved draft
     const hasChanges = history.canUndo || annotation.versions.draft;
+    const hasIncompleteRegions = annotation.hasIncompleteRegions;
+    const isDisabled = disabled || hasIncompleteRegions;
+    const tooltip = hasIncompleteRegions
+      ? "Complete all regions before accepting"
+      : "Accept annotation: [ Ctrl+Enter ]";
 
     return (
       <Button
         key="accept"
-        tooltip="Accept annotation: [ Ctrl+Enter ]"
+        tooltip={tooltip}
         aria-label="accept-annotation"
-        disabled={disabled}
+        disabled={isDisabled}
         onClick={async () => {
           annotation.submissionInProgress();
           await store.commentStore.commentFormSubmit();

--- a/web/libs/editor/src/components/BottomBar/buttons.tsx
+++ b/web/libs/editor/src/components/BottomBar/buttons.tsx
@@ -61,11 +61,7 @@ export const AcceptButton = memo(
     const tooltip = hasIncompleteRegions ? INCOMPLETE_ACCEPT_TOOLTIP : "Accept annotation: [ Ctrl+Enter ]";
 
     return (
-      <Tooltip
-        title={tooltip}
-        disabled={!store.settings.enableTooltips}
-        className="whitespace-nowrap"
-      >
+      <Tooltip title={tooltip} disabled={!store.settings.enableTooltips} className="whitespace-nowrap">
         <Button
           key="accept"
           aria-label="accept-annotation"

--- a/web/libs/editor/src/components/BottomBar/buttons.tsx
+++ b/web/libs/editor/src/components/BottomBar/buttons.tsx
@@ -54,7 +54,7 @@ export const AcceptButton = memo(
     const annotation = store.annotationStore.selected;
     // changes in current sessions or saved draft
     const hasChanges = history.canUndo || annotation.versions.draft;
-    const hasIncompleteRegions = annotation.hasIncompleteRegions;
+    const hasIncompleteRegions = annotation.hasIncompletePolygons;
     const isDisabled = disabled || hasIncompleteRegions;
     const tooltip = hasIncompleteRegions
       ? "Complete all regions before accepting"

--- a/web/libs/editor/src/components/BottomBar/buttons.tsx
+++ b/web/libs/editor/src/components/BottomBar/buttons.tsx
@@ -32,12 +32,13 @@ export function controlsInjector<T extends {}>(fn: (props: T & MixedInParams) =>
 type ButtonTooltipProps = {
   title: string;
   children: JSX.Element;
+  className?: string;
 };
 
 export const ButtonTooltip = controlsInjector<ButtonTooltipProps>(
-  observer(({ store, title, children }) => {
+  observer(({ store, title, children, className }) => {
     return (
-      <Tooltip title={title} disabled={!store.settings.enableTooltips}>
+      <Tooltip title={title} disabled={!store.settings.enableTooltips} className={className}>
         {children}
       </Tooltip>
     );
@@ -60,20 +61,25 @@ export const AcceptButton = memo(
     const tooltip = hasIncompleteRegions ? INCOMPLETE_ACCEPT_TOOLTIP : "Accept annotation: [ Ctrl+Enter ]";
 
     return (
-      <Button
-        key="accept"
-        tooltip={tooltip}
-        aria-label="accept-annotation"
-        disabled={isDisabled}
-        onClick={async () => {
-          annotation.submissionInProgress();
-          await store.commentStore.commentFormSubmit();
-          store.acceptAnnotation();
-        }}
-        data-testid="bottombar-accept-button"
+      <Tooltip
+        title={tooltip}
+        disabled={!store.settings.enableTooltips}
+        className="whitespace-nowrap"
       >
-        {hasChanges ? "Fix + Accept" : "Accept"}
-      </Button>
+        <Button
+          key="accept"
+          aria-label="accept-annotation"
+          disabled={isDisabled}
+          onClick={async () => {
+            annotation.submissionInProgress();
+            await store.commentStore.commentFormSubmit();
+            store.acceptAnnotation();
+          }}
+          data-testid="bottombar-accept-button"
+        >
+          {hasChanges ? "Fix + Accept" : "Accept"}
+        </Button>
+      </Tooltip>
     );
   }),
 );

--- a/web/libs/editor/src/components/BottomBar/buttons.tsx
+++ b/web/libs/editor/src/components/BottomBar/buttons.tsx
@@ -61,7 +61,7 @@ export const AcceptButton = memo(
     const tooltip = hasIncompleteRegions ? INCOMPLETE_ACCEPT_TOOLTIP : "Accept annotation: [ Ctrl+Enter ]";
 
     return (
-      <Tooltip title={tooltip} disabled={!store.settings.enableTooltips} className="whitespace-nowrap">
+      <Tooltip title={tooltip} disabled={!store.settings.enableTooltips} className="whitespace-nowrap max-w-none">
         <Button
           key="accept"
           aria-label="accept-annotation"

--- a/web/libs/editor/src/components/BottomBar/buttons.tsx
+++ b/web/libs/editor/src/components/BottomBar/buttons.tsx
@@ -11,6 +11,7 @@ import { Tooltip, Button } from "@humansignal/ui";
 import { IconInfoOutline } from "@humansignal/icons";
 import type { MSTStore } from "../../stores/types";
 import { FF_FIT_1304_STRICT_OVERLAP, isFF } from "../../utils/feature-flags";
+import { INCOMPLETE_ACCEPT_TOOLTIP } from "./Controls";
 
 type MixedInParams = {
   store: MSTStore;
@@ -56,9 +57,7 @@ export const AcceptButton = memo(
     const hasChanges = history.canUndo || annotation.versions.draft;
     const hasIncompleteRegions = annotation.hasIncompletePolygons;
     const isDisabled = disabled || hasIncompleteRegions;
-    const tooltip = hasIncompleteRegions
-      ? "Complete all regions before accepting"
-      : "Accept annotation: [ Ctrl+Enter ]";
+    const tooltip = hasIncompleteRegions ? INCOMPLETE_ACCEPT_TOOLTIP : "Accept annotation: [ Ctrl+Enter ]";
 
     return (
       <Button

--- a/web/libs/editor/src/stores/Annotation/Annotation.js
+++ b/web/libs/editor/src/stores/Annotation/Annotation.js
@@ -284,10 +284,10 @@ const _Annotation = types
       return results;
     },
 
-    get hasIncompleteRegions() {
+    get hasIncompletePolygons() {
       if (!isAlive(self)) return false;
       for (const area of self.areas.values()) {
-        if (area.incomplete) return true;
+        if (area.type === "polygonregion" && area.incomplete) return true;
       }
       return false;
     },

--- a/web/libs/editor/src/stores/Annotation/Annotation.js
+++ b/web/libs/editor/src/stores/Annotation/Annotation.js
@@ -284,6 +284,14 @@ const _Annotation = types
       return results;
     },
 
+    get hasIncompleteRegions() {
+      if (!isAlive(self)) return false;
+      for (const area of self.areas.values()) {
+        if (area.incomplete) return true;
+      }
+      return false;
+    },
+
     get serialized() {
       // Dirty hack to force MST track changes
       self.areas.toJSON();

--- a/web/libs/editor/src/stores/AppStore.js
+++ b/web/libs/editor/src/stores/AppStore.js
@@ -368,6 +368,7 @@ export default types
           if (annotationStore.viewingAll) return;
           if (isUpdateDisabled) return;
           if (entity.isReadOnly()) return;
+          if (entity.hasIncompleteRegions) return;
 
           entity?.submissionInProgress();
 

--- a/web/libs/editor/src/stores/AppStore.js
+++ b/web/libs/editor/src/stores/AppStore.js
@@ -368,7 +368,7 @@ export default types
           if (annotationStore.viewingAll) return;
           if (isUpdateDisabled) return;
           if (entity.isReadOnly()) return;
-          if (entity.hasIncompleteRegions) return;
+          if (entity.hasIncompletePolygons) return;
 
           entity?.submissionInProgress();
 


### PR DESCRIPTION
**Reason for change**
Users could previously submit, update, or accept an annotation even when it contained an unfinished (unclosed) polygon region. This change disables the Submit, Update, and Fix & Accept buttons — as well as the Ctrl+Enter hotkey — when an annotation has any incomplete polygon.

**Scope**
The fix is intentionally minimal and localized:

- Only polygon regions are checked (area.type === "polygonregion"). Vector regions and all other region types are not affected.
- Only the active BottomBar UI is changed. Legacy/deprecated UI components are not touched.
- Only submission-related buttons (Submit, Update, Fix & Accept) and the submit hotkey are gated. Skip, Reject, and all other buttons remain unchanged.

**Changes (4 files)**
File - Change

- Annotation.js - Added hasIncompletePolygons computed view — returns true only if any area with type === "polygonregion" has incomplete === true
- BottomBar/Controls.tsx - Added hasIncompletePolygons to isDisabled for Submit/Update buttons; updated tooltips
- BottomBar/buttons.tsx - AcceptButton checks hasIncompletePolygons for disabled state and tooltip
- AppStore.js - Added early-return guard entity.hasIncompletePolygons in annotation:submit hotkey handler

**Before**

https://github.com/user-attachments/assets/77d2244e-68ce-453b-8263-be30490a0ab4


**After**



**Testing**

1. Start drawing a polygon but do not close it.
2. Verify Submit / Update / Fix & Accept buttons are disabled with tooltip "Complete all regions before submitting/accepting".
3. Verify Ctrl+Enter hotkey does nothing.
4. Close the polygon — buttons and hotkey should work again.
5. Verify other region types (bounding box, rectangle, etc.) do not trigger the disabled state.

**Risks**
Low. Changes are scoped to 4 files with no modifications to region models, legacy UI, or non-polygon logic.****