### PR TITLE
fix: BROS-847: Disable Submit/Update/Fix & Accept button when polygon region is unfinished

### DIFF
--- a/web/libs/editor/src/components/BottomBar/Controls.tsx
+++ b/web/libs/editor/src/components/BottomBar/Controls.tsx
@@ -44,6 +44,9 @@ type ControlButtonProps = {
 };
 
 export const EMPTY_SUBMIT_TOOLTIP = "Empty annotations denied in this project";
+export const INCOMPLETE_SUBMIT_TOOLTIP = "Complete all regions before submitting";
+export const INCOMPLETE_UPDATE_TOOLTIP = "Complete all regions before updating";
+export const INCOMPLETE_ACCEPT_TOOLTIP = "Complete all regions before accepting";
 
 /**
  * Custom action button component, rendering buttons from store.customButtons
@@ -79,6 +82,7 @@ export const Controls = controlsInjector<{ annotation: MSTAnnotation }>(
     const [isInProgress, setIsInProgress] = useState(false);
     const disabled = !annotationEditable || store.isSubmitting || historySelected || isInProgress;
     const submitDisabled = store.hasInterface("annotations:deny-empty") && results.length === 0;
+    const hasIncompleteRegions = annotation.hasIncompletePolygons;
 
     /** Check all things related to comments and then call the action if all is good */
     const handleActionWithComments = useCallback(
@@ -197,7 +201,7 @@ export const Controls = controlsInjector<{ annotation: MSTAnnotation }>(
 
       // Also disable when overlap is reached (only when feature flag is enabled)
       const overlapDisabled = isFF(FF_FIT_1304_STRICT_OVERLAP) && store.overlapReached === true;
-      const isDisabled = disabled || submitDisabled || overlapDisabled;
+      const isDisabled = disabled || submitDisabled || overlapDisabled || hasIncompleteRegions;
 
       const useExitOption = !isDisabled && isNotQuickView;
 
@@ -237,14 +241,16 @@ export const Controls = controlsInjector<{ annotation: MSTAnnotation }>(
       };
 
       if (userGenerate || (store.explore && !userGenerate && store.hasInterface("submit"))) {
-        const title = overlapDisabled
-          ? store.overlapReachedMessage
-          : submitDisabled
-            ? EMPTY_SUBMIT_TOOLTIP
-            : "Save results: [ Ctrl+Enter ]";
+        const title = hasIncompleteRegions
+          ? INCOMPLETE_SUBMIT_TOOLTIP
+          : overlapDisabled
+            ? store.overlapReachedMessage
+            : submitDisabled
+              ? EMPTY_SUBMIT_TOOLTIP
+              : "Save results: [ Ctrl+Enter ]";
 
         buttons.push(
-          <ButtonTooltip key="submit" title={title}>
+          <ButtonTooltip key="submit" title={title} className="whitespace-nowrap max-w-none">
             <div className={cn("controls").elem("tooltip-wrapper").toClassName()}>
               <ButtonGroup>
                 <Button
@@ -291,46 +297,50 @@ export const Controls = controlsInjector<{ annotation: MSTAnnotation }>(
         // no changes were made over previously submitted version — no drafts, no pending changes
         const noChanges = isFF(FF_REVIEWER_FLOW) && !history.canUndo && !annotation.draftId;
         const isUpdateDisabled = isDisabled || noChanges;
-        const updateTitle = overlapDisabled
-          ? store.overlapReachedMessage
-          : noChanges
-            ? "No changes were made"
-            : "Update this task: [ Ctrl+Enter ]";
+        const updateTitle = hasIncompleteRegions
+          ? INCOMPLETE_UPDATE_TOOLTIP
+          : overlapDisabled
+            ? store.overlapReachedMessage
+            : noChanges
+              ? "No changes were made"
+              : "Update this task: [ Ctrl+Enter ]";
         const button = (
-          <ButtonTooltip key="update" title={updateTitle}>
-            <ButtonGroup>
-              <Button
-                aria-label="submit"
-                name="submit"
-                className="w-[150px]"
-                disabled={isUpdateDisabled}
-                onClick={async (event) => {
-                  if ((event.target as HTMLButtonElement).classList.contains(dropdownTrigger)) return;
-                  const selected = store.annotationStore?.selected;
+          <ButtonTooltip key="update" title={updateTitle} className="whitespace-nowrap max-w-none">
+            <div className={cn("controls").elem("tooltip-wrapper").toClassName()}>
+              <ButtonGroup>
+                <Button
+                  aria-label="submit"
+                  name="submit"
+                  className="w-[150px]"
+                  disabled={isUpdateDisabled}
+                  onClick={async (event) => {
+                    if ((event.target as HTMLButtonElement).classList.contains(dropdownTrigger)) return;
+                    const selected = store.annotationStore?.selected;
 
-                  selected?.submissionInProgress();
-                  await store.commentStore.commentFormSubmit();
-                  store.updateAnnotation();
-                }}
-                data-testid="bottombar-update-button"
-              >
-                {isUpdate ? "Update" : "Submit"}
-              </Button>
-              {useExitOption ? (
-                <Dropdown.Trigger
-                  alignment="top-right"
-                  content={<SubmitOption onClickMethod={store.updateAnnotation} isUpdate={isUpdate} />}
+                    selected?.submissionInProgress();
+                    await store.commentStore.commentFormSubmit();
+                    store.updateAnnotation();
+                  }}
+                  data-testid="bottombar-update-button"
                 >
-                  <Button
-                    disabled={isUpdateDisabled}
-                    aria-label="Update annotation"
-                    data-testid="bottombar-update-dropdown"
+                  {isUpdate ? "Update" : "Submit"}
+                </Button>
+                {useExitOption ? (
+                  <Dropdown.Trigger
+                    alignment="top-right"
+                    content={<SubmitOption onClickMethod={store.updateAnnotation} isUpdate={isUpdate} />}
                   >
-                    <IconChevronDown />
-                  </Button>
-                </Dropdown.Trigger>
-              ) : null}
-            </ButtonGroup>
+                    <Button
+                      disabled={isUpdateDisabled}
+                      aria-label="Update annotation"
+                      data-testid="bottombar-update-dropdown"
+                    >
+                      <IconChevronDown />
+                    </Button>
+                  </Dropdown.Trigger>
+                ) : null}
+              </ButtonGroup>
+            </div>
           </ButtonTooltip>
         );
 

--- a/web/libs/editor/src/components/BottomBar/buttons.tsx
+++ b/web/libs/editor/src/components/BottomBar/buttons.tsx
@@ -11,6 +11,7 @@ import { Tooltip, Button } from "@humansignal/ui";
 import { IconInfoOutline } from "@humansignal/icons";
 import type { MSTStore } from "../../stores/types";
 import { FF_FIT_1304_STRICT_OVERLAP, isFF } from "../../utils/feature-flags";
+import { INCOMPLETE_ACCEPT_TOOLTIP } from "./Controls";
 
 type MixedInParams = {
   store: MSTStore;
@@ -31,12 +32,13 @@ export function controlsInjector<T extends {}>(fn: (props: T & MixedInParams) =>
 type ButtonTooltipProps = {
   title: string;
   children: JSX.Element;
+  className?: string;
 };
 
 export const ButtonTooltip = controlsInjector<ButtonTooltipProps>(
-  observer(({ store, title, children }) => {
+  observer(({ store, title, children, className }) => {
     return (
-      <Tooltip title={title} disabled={!store.settings.enableTooltips}>
+      <Tooltip title={title} disabled={!store.settings.enableTooltips} className={className}>
         {children}
       </Tooltip>
     );
@@ -54,22 +56,26 @@ export const AcceptButton = memo(
     const annotation = store.annotationStore.selected;
     // changes in current sessions or saved draft
     const hasChanges = history.canUndo || annotation.versions.draft;
+    const hasIncompleteRegions = annotation.hasIncompletePolygons;
+    const isDisabled = disabled || hasIncompleteRegions;
+    const tooltip = hasIncompleteRegions ? INCOMPLETE_ACCEPT_TOOLTIP : "Accept annotation: [ Ctrl+Enter ]";
 
     return (
-      <Button
-        key="accept"
-        tooltip="Accept annotation: [ Ctrl+Enter ]"
-        aria-label="accept-annotation"
-        disabled={disabled}
-        onClick={async () => {
-          annotation.submissionInProgress();
-          await store.commentStore.commentFormSubmit();
-          store.acceptAnnotation();
-        }}
-        data-testid="bottombar-accept-button"
-      >
-        {hasChanges ? "Fix + Accept" : "Accept"}
-      </Button>
+      <Tooltip title={tooltip} disabled={!store.settings.enableTooltips} className="whitespace-nowrap max-w-none">
+        <Button
+          key="accept"
+          aria-label="accept-annotation"
+          disabled={isDisabled}
+          onClick={async () => {
+            annotation.submissionInProgress();
+            await store.commentStore.commentFormSubmit();
+            store.acceptAnnotation();
+          }}
+          data-testid="bottombar-accept-button"
+        >
+          {hasChanges ? "Fix + Accept" : "Accept"}
+        </Button>
+      </Tooltip>
     );
   }),
 );

--- a/web/libs/editor/src/stores/Annotation/Annotation.js
+++ b/web/libs/editor/src/stores/Annotation/Annotation.js
@@ -284,6 +284,14 @@ const _Annotation = types
       return results;
     },
 
+    get hasIncompletePolygons() {
+      if (!isAlive(self)) return false;
+      for (const area of self.areas.values()) {
+        if (area.type === "polygonregion" && area.incomplete) return true;
+      }
+      return false;
+    },
+
     get serialized() {
       // Dirty hack to force MST track changes
       self.areas.toJSON();

--- a/web/libs/editor/src/stores/AppStore.js
+++ b/web/libs/editor/src/stores/AppStore.js
@@ -368,6 +368,7 @@ export default types
           if (annotationStore.viewingAll) return;
           if (isUpdateDisabled) return;
           if (entity.isReadOnly()) return;
+          if (entity.hasIncompletePolygons) return;
 
           entity?.submissionInProgress();
 


### PR DESCRIPTION
This pull request improves the annotation workflow by preventing users from submitting, updating, or accepting annotations that contain incomplete polygon regions. It introduces new tooltips to inform users why these actions are disabled and ensures consistent UX across the bottom bar controls.

**Validation and UX improvements for annotation actions:**

* Added a computed property `hasIncompletePolygons` to the `Annotation` model to detect incomplete polygon regions.
* Updated the logic for enabling/disabling the Submit, Update, and Accept buttons in `Controls.tsx` and `buttons.tsx` to prevent actions when incomplete polygons are present. [[1]](diffhunk://#diff-b4a81b3d87b3eb7a64a19ee5236b3edc64960f5f452a5e481f509f7afb12f4c8R85) [[2]](diffhunk://#diff-b4a81b3d87b3eb7a64a19ee5236b3edc64960f5f452a5e481f509f7afb12f4c8L200-R204) [[3]](diffhunk://#diff-61daea6d183fb62e7e6486096c4c051fdeb9aabd9e81b7923d5c529ff774bd69R59-R68)
* Introduced new tooltips (`INCOMPLETE_SUBMIT_TOOLTIP`, `INCOMPLETE_UPDATE_TOOLTIP`, `INCOMPLETE_ACCEPT_TOOLTIP`) to clearly communicate to the user why an action is disabled when incomplete regions exist. [[1]](diffhunk://#diff-b4a81b3d87b3eb7a64a19ee5236b3edc64960f5f452a5e481f509f7afb12f4c8R47-R49) [[2]](diffhunk://#diff-b4a81b3d87b3eb7a64a19ee5236b3edc64960f5f452a5e481f509f7afb12f4c8L240-R253) [[3]](diffhunk://#diff-b4a81b3d87b3eb7a64a19ee5236b3edc64960f5f452a5e481f509f7afb12f4c8L294-R309) [[4]](diffhunk://#diff-61daea6d183fb62e7e6486096c4c051fdeb9aabd9e81b7923d5c529ff774bd69R14)
* Enhanced the `ButtonTooltip` and tooltip usage to support custom class names for better display of long messages and consistent styling. [[1]](diffhunk://#diff-61daea6d183fb62e7e6486096c4c051fdeb9aabd9e81b7923d5c529ff774bd69R35-R41) [[2]](diffhunk://#diff-61daea6d183fb62e7e6486096c4c051fdeb9aabd9e81b7923d5c529ff774bd69R78)
* Added an extra check in `AppStore.js` to prevent update actions when incomplete polygons exist in the annotation.