### PR TITLE
fix: UTC-664: Per-dimension agreement column header is cut-off by default (on project creation)

### DIFF
--- a/web/libs/datamanager/src/components/MainView/DataView/Table.jsx
+++ b/web/libs/datamanager/src/components/MainView/DataView/Table.jsx
@@ -316,6 +316,14 @@ export const DataView = injector(
         isFF(FF_DEV_2536) && commonDecoration("comment_count", 60, "center"),
         isFF(FF_DEV_2536) && commonDecoration("unresolved_comment_count", 60, "center"),
         {
+          resolver: (col) => col.alias === "agreement",
+          style: { width: 130 },
+        },
+        {
+          resolver: (col) => typeof col.alias === "string" && col.alias.startsWith("dimension_agreement_"),
+          style: { width: 180 },
+        },
+        {
           resolver: (col) => col.type === "Number",
           style(col) {
             return /id/.test(col.id) ? { width: 50 } : { width: 110 };


### PR DESCRIPTION
## Summary
Per-dimension agreement column header is cut-off by default (on project creation)

Agreement column headers (main agreement + per-dimension) were getting fixed narrow widths (50px/110px) from the Number decorator. This adds dedicated decorator entries before the Number resolver: agreement column gets 130px, dimension_agreement_* columns get 180px.

# Before
<img width="799" height="159" alt="Screenshot 2026-03-11 at 16 23 22" src="https://github.com/user-attachments/assets/b2ba04b3-1198-45a3-af8e-6f685d2024cb" />

# After
<img width="1237" height="416" alt="Screenshot 2026-03-11 at 16 22 39" src="https://github.com/user-attachments/assets/70a5b191-fe81-40dd-949e-0fef867054d0" />
