### PR TITLE
fix: FIT-1516: Hide/Show Regions by Group Not Working

### DIFF
--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
@@ -49,8 +49,6 @@ interface OutlinerTreeProps {
 
 const OutlinerTreeComponent: FC<OutlinerTreeProps> = observer(({ regions, footer }) => {
   const rootClass = cn("tree");
-  // Subscribe to each region's hidden state so tree re-renders when visibility changes
-  regions.regions?.forEach((r: any) => void r.hidden);
   const regionsTree = useDataTree({
     regions,
     rootClass,

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
@@ -47,157 +47,161 @@ interface OutlinerTreeProps {
   footer: ReactNode;
 }
 
-const OutlinerTreeComponent: FC<OutlinerTreeProps> = ({ regions, footer }) => {
+const OutlinerTreeComponent: FC<OutlinerTreeProps> = observer(({ regions, footer }) => {
   const rootClass = cn("tree");
+  // Subscribe to each region's hidden state so tree data (and hide/show icons) rebuild when visibility changes
+  const visibilityKey = regions.regions?.map((r: any) => r.hidden).join(",") ?? "";
   const regionsTree = useDataTree({
     regions,
     rootClass,
     footer,
     // that's a trick to have a dependency that causes recalculating of tree data on grouping mode change
-    // it's for rerender OutlinerTreeComponent
     grouping: regions.group,
   });
 
   return (
     <OutlinerContext.Provider value={{ regions }}>
-      <OutlinerInnerTreeComponent regions={regions} regionsTree={regionsTree} />
+      <OutlinerInnerTreeComponent regions={regions} regionsTree={regionsTree} visibilityKey={visibilityKey} />
     </OutlinerContext.Provider>
   );
-};
+});
 
 interface OutlinerInnerTreeProps {
   regions: any;
   regionsTree: any[];
+  visibilityKey?: string;
 }
 
 const iconGetter = ({ entity }: any) => <NodeIconComponent node={entity} />;
 const switcherIconGetter = ({ isLeaf }: any) => <SwitcherIcon isLeaf={isLeaf} />;
-const OutlinerInnerTreeComponent: FC<OutlinerInnerTreeProps> = observer(({ regions, regionsTree }) => {
-  const blockRef = useRef<HTMLElement>();
-  const [height, setHeight] = useState(0);
-  let resizeObserver: ResizeObserver | null = useMemo(() => {
-    let lastHeight = 0;
+const OutlinerInnerTreeComponent: FC<OutlinerInnerTreeProps> = observer(
+  ({ regions, regionsTree, visibilityKey = "" }) => {
+    const blockRef = useRef<HTMLElement>();
+    const [height, setHeight] = useState(0);
+    let resizeObserver: ResizeObserver | null = useMemo(() => {
+      let lastHeight = 0;
 
-    return new ResizeObserver((entities) => {
-      requestAnimationFrame(() => {
-        if (!entities?.[0]?.contentRect || entities?.[0]?.contentRect?.height === lastHeight) {
-          return;
-        }
-        lastHeight = entities?.[0]?.contentRect?.height || 1;
+      return new ResizeObserver((entities) => {
+        requestAnimationFrame(() => {
+          if (!entities?.[0]?.contentRect || entities?.[0]?.contentRect?.height === lastHeight) {
+            return;
+          }
+          lastHeight = entities?.[0]?.contentRect?.height || 1;
 
-        // ensure the component is still mounted
-        if (blockRef.current) {
-          setHeight(lastHeight);
-        }
+          // ensure the component is still mounted
+          if (blockRef.current) {
+            setHeight(lastHeight);
+          }
+        });
       });
-    });
-  }, []);
+    }, []);
 
-  useEffect(() => {
-    return () => {
-      resizeObserver?.disconnect();
-      resizeObserver = null;
-    };
-  }, []);
-  const setRef = useCallback((ref) => {
-    if (ref) {
-      resizeObserver?.observe(ref);
-    } else if (blockRef.current) {
-      resizeObserver?.unobserve(blockRef.current);
+    useEffect(() => {
+      return () => {
+        resizeObserver?.disconnect();
+        resizeObserver = null;
+      };
+    }, []);
+    const setRef = useCallback((ref) => {
+      if (ref) {
+        resizeObserver?.observe(ref);
+      } else if (blockRef.current) {
+        resizeObserver?.unobserve(blockRef.current);
+      }
+      blockRef.current = ref;
+      setHeight(ref?.clientHeight || 1);
+    }, []);
+    const eventHandlers = useEventHandlers();
+    const selectedKeys = regions.selection.keys;
+    const rootClass = cn("tree");
+    let expandedKeys;
+    let onExpand;
+    // It works only for 'label' mode yet.
+    // To enable this feature at other group modes, it needs to set correct pos at regionsTree for these modes
+    // It also doesn't work with nesting level more than 1
+    const isPersistCollapseEnabled = isFF(FF_DEV_2755) && regions.group === "label";
+
+    if (isFF(FF_DEV_2755)) {
+      const [collapsedPos, setCollapsedPos] = useState(
+        localStorage
+          .getItem(localStoreName)
+          ?.split?.(",")
+          ?.filter((pos) => !!pos) ?? [],
+      );
+
+      const updateLocalStorage = (collapsedPos: Array<string>) => {
+        localStorage.setItem(localStoreName, collapsedPos.join(","));
+      };
+
+      const collapse = (pos: string) => {
+        const newCollapsedPos = [...collapsedPos, pos];
+
+        setCollapsedPos(newCollapsedPos);
+        updateLocalStorage(newCollapsedPos);
+      };
+
+      const expand = (pos: string) => {
+        const newCollapsedPos = collapsedPos.filter((cPos) => cPos !== pos);
+
+        setCollapsedPos(newCollapsedPos);
+        updateLocalStorage(newCollapsedPos);
+      };
+
+      expandedKeys =
+        regionsTree.filter((item: any) => !collapsedPos.includes(item.pos)).map((item: any) => item.key) ?? [];
+
+      onExpand = (
+        _internalExpandedKeys: Key[],
+        {
+          node,
+        }: {
+          node: EventDataNode;
+        },
+      ): void => {
+        const region = regionsTree.find((region: any) => region.key === node.key);
+
+        if (!region) return;
+
+        // pos is equal to label name
+        const pos = region.pos;
+
+        collapsedPos.includes(pos) ? expand(pos) : collapse(pos);
+      };
     }
-    blockRef.current = ref;
-    setHeight(ref?.clientHeight || 1);
-  }, []);
-  const eventHandlers = useEventHandlers();
-  const selectedKeys = regions.selection.keys;
-  const rootClass = cn("tree");
-  let expandedKeys;
-  let onExpand;
-  // It works only for 'label' mode yet.
-  // To enable this feature at other group modes, it needs to set correct pos at regionsTree for these modes
-  // It also doesn't work with nesting level more than 1
-  const isPersistCollapseEnabled = isFF(FF_DEV_2755) && regions.group === "label";
 
-  if (isFF(FF_DEV_2755)) {
-    const [collapsedPos, setCollapsedPos] = useState(
-      localStorage
-        .getItem(localStoreName)
-        ?.split?.(",")
-        ?.filter((pos) => !!pos) ?? [],
+    return (
+      <div className={cn("outliner-tree").toClassName()} ref={setRef}>
+        {!!height && (
+          <Tree
+            key={`${regions.group}-${visibilityKey}`}
+            draggable={regions.group === "manual"}
+            multiple
+            defaultExpandAll
+            defaultExpandParent={!isPersistCollapseEnabled}
+            autoExpandParent
+            checkable={false}
+            prefixCls={rootClass.toClassName()}
+            className={rootClass.toClassName()}
+            treeData={regionsTree}
+            selectedKeys={selectedKeys}
+            icon={iconGetter}
+            switcherIcon={switcherIconGetter}
+            virtual
+            itemHeight={MIN_REGIONS_TREE_ROW_HEIGHT}
+            height={height}
+            {...eventHandlers}
+            {...(isPersistCollapseEnabled
+              ? {
+                  expandedKeys,
+                  onExpand,
+                }
+              : {})}
+          />
+        )}
+      </div>
     );
-
-    const updateLocalStorage = (collapsedPos: Array<string>) => {
-      localStorage.setItem(localStoreName, collapsedPos.join(","));
-    };
-
-    const collapse = (pos: string) => {
-      const newCollapsedPos = [...collapsedPos, pos];
-
-      setCollapsedPos(newCollapsedPos);
-      updateLocalStorage(newCollapsedPos);
-    };
-
-    const expand = (pos: string) => {
-      const newCollapsedPos = collapsedPos.filter((cPos) => cPos !== pos);
-
-      setCollapsedPos(newCollapsedPos);
-      updateLocalStorage(newCollapsedPos);
-    };
-
-    expandedKeys =
-      regionsTree.filter((item: any) => !collapsedPos.includes(item.pos)).map((item: any) => item.key) ?? [];
-
-    onExpand = (
-      _internalExpandedKeys: Key[],
-      {
-        node,
-      }: {
-        node: EventDataNode;
-      },
-    ): void => {
-      const region = regionsTree.find((region: any) => region.key === node.key);
-
-      if (!region) return;
-
-      // pos is equal to label name
-      const pos = region.pos;
-
-      collapsedPos.includes(pos) ? expand(pos) : collapse(pos);
-    };
-  }
-
-  return (
-    <div className={cn("outliner-tree").toClassName()} ref={setRef}>
-      {!!height && (
-        <Tree
-          key={regions.group}
-          draggable={regions.group === "manual"}
-          multiple
-          defaultExpandAll
-          defaultExpandParent={!isPersistCollapseEnabled}
-          autoExpandParent
-          checkable={false}
-          prefixCls={rootClass.toClassName()}
-          className={rootClass.toClassName()}
-          treeData={regionsTree}
-          selectedKeys={selectedKeys}
-          icon={iconGetter}
-          switcherIcon={switcherIconGetter}
-          virtual
-          itemHeight={MIN_REGIONS_TREE_ROW_HEIGHT}
-          height={height}
-          {...eventHandlers}
-          {...(isPersistCollapseEnabled
-            ? {
-                expandedKeys,
-                onExpand,
-              }
-            : {})}
-        />
-      )}
-    </div>
-  );
-});
+  },
+);
 
 const titleRenderer = (nodeData: any) => {
   const { key: _key, ...data } = nodeData;
@@ -481,6 +485,14 @@ const MemoizedRootTitle = memo(RootTitle, (prevProps, nextProps) => {
   if (prevProps.idx !== nextProps.idx) return false;
   if (prevProps.isArea !== nextProps.isArea) return false;
   if (prevProps.isGroup !== nextProps.isGroup) return false;
+  // Re-render group when any child's hidden state changes so hide/show icon stays in sync
+  if (nextProps.isGroup && nextProps.children && prevProps.children) {
+    if (prevProps.children.length !== nextProps.children.length) return false;
+    const childHiddenChanged = prevProps.children.some(
+      (c, i) => (nextProps.children?.[i]?.hidden ?? null) !== (c?.hidden ?? null),
+    );
+    if (childHiddenChanged) return false;
+  }
   return true;
 });
 
@@ -507,13 +519,13 @@ const RegionControls: FC<RegionControlsProps> = injector(
 
     const hidden = useMemo(() => {
       if (type?.includes("region") || type?.includes("range") || type?.includes("reactcode")) {
-        return entity.hidden;
+        return entity?.hidden;
       }
       if ((!type || type.includes("label") || type?.includes("tool")) && regions) {
-        return Object.values(regions).every(({ hidden }) => hidden);
+        return Object.values(regions).every(({ hidden: h }) => h);
       }
       return false;
-    }, [entity, type, regions]);
+    }, [entity, entity?.hidden, type, regions]);
 
     const onToggleHidden = useCallback(() => {
       if (type?.includes("region") || type?.includes("range") || type?.includes("reactcode")) {
@@ -576,7 +588,8 @@ const RegionControls: FC<RegionControlsProps> = injector(
                 variant="neutral"
                 look="string"
                 onClick={onToggleHidden}
-                style={hidden ? undefined : { display: "none" }}
+                aria-label={hidden ? "Show" : "Hide"}
+                title={hidden ? "Show" : "Hide"}
               >
                 {hidden ? (
                   <IconEyeClosed style={{ width: 20, height: 20 }} />
@@ -657,4 +670,4 @@ const RegionItemDesc: FC<RegionItemOCSProps> = observer(({ item, collapsed, setC
   );
 });
 
-export const OutlinerTree = observer(OutlinerTreeComponent);
+export const OutlinerTree = OutlinerTreeComponent;

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
@@ -61,7 +61,7 @@ const OutlinerTreeComponent: FC<OutlinerTreeProps> = observer(({ regions, footer
 
   return (
     <OutlinerContext.Provider value={{ regions }}>
-      <OutlinerInnerTreeComponent regions={regions} regionsTree={regionsTree} visibilityKey={visibilityKey} />
+      <OutlinerInnerTreeComponent regions={regions} regionsTree={regionsTree} />
     </OutlinerContext.Provider>
   );
 });
@@ -69,139 +69,136 @@ const OutlinerTreeComponent: FC<OutlinerTreeProps> = observer(({ regions, footer
 interface OutlinerInnerTreeProps {
   regions: any;
   regionsTree: any[];
-  visibilityKey?: string;
 }
 
 const iconGetter = ({ entity }: any) => <NodeIconComponent node={entity} />;
 const switcherIconGetter = ({ isLeaf }: any) => <SwitcherIcon isLeaf={isLeaf} />;
-const OutlinerInnerTreeComponent: FC<OutlinerInnerTreeProps> = observer(
-  ({ regions, regionsTree, visibilityKey = "" }) => {
-    const blockRef = useRef<HTMLElement>();
-    const [height, setHeight] = useState(0);
-    let resizeObserver: ResizeObserver | null = useMemo(() => {
-      let lastHeight = 0;
+const OutlinerInnerTreeComponent: FC<OutlinerInnerTreeProps> = observer(({ regions, regionsTree }) => {
+  const blockRef = useRef<HTMLElement>();
+  const [height, setHeight] = useState(0);
+  let resizeObserver: ResizeObserver | null = useMemo(() => {
+    let lastHeight = 0;
 
-      return new ResizeObserver((entities) => {
-        requestAnimationFrame(() => {
-          if (!entities?.[0]?.contentRect || entities?.[0]?.contentRect?.height === lastHeight) {
-            return;
-          }
-          lastHeight = entities?.[0]?.contentRect?.height || 1;
+    return new ResizeObserver((entities) => {
+      requestAnimationFrame(() => {
+        if (!entities?.[0]?.contentRect || entities?.[0]?.contentRect?.height === lastHeight) {
+          return;
+        }
+        lastHeight = entities?.[0]?.contentRect?.height || 1;
 
-          // ensure the component is still mounted
-          if (blockRef.current) {
-            setHeight(lastHeight);
-          }
-        });
+        // ensure the component is still mounted
+        if (blockRef.current) {
+          setHeight(lastHeight);
+        }
       });
-    }, []);
+    });
+  }, []);
 
-    useEffect(() => {
-      return () => {
-        resizeObserver?.disconnect();
-        resizeObserver = null;
-      };
-    }, []);
-    const setRef = useCallback((ref) => {
-      if (ref) {
-        resizeObserver?.observe(ref);
-      } else if (blockRef.current) {
-        resizeObserver?.unobserve(blockRef.current);
-      }
-      blockRef.current = ref;
-      setHeight(ref?.clientHeight || 1);
-    }, []);
-    const eventHandlers = useEventHandlers();
-    const selectedKeys = regions.selection.keys;
-    const rootClass = cn("tree");
-    let expandedKeys;
-    let onExpand;
-    // It works only for 'label' mode yet.
-    // To enable this feature at other group modes, it needs to set correct pos at regionsTree for these modes
-    // It also doesn't work with nesting level more than 1
-    const isPersistCollapseEnabled = isFF(FF_DEV_2755) && regions.group === "label";
-
-    if (isFF(FF_DEV_2755)) {
-      const [collapsedPos, setCollapsedPos] = useState(
-        localStorage
-          .getItem(localStoreName)
-          ?.split?.(",")
-          ?.filter((pos) => !!pos) ?? [],
-      );
-
-      const updateLocalStorage = (collapsedPos: Array<string>) => {
-        localStorage.setItem(localStoreName, collapsedPos.join(","));
-      };
-
-      const collapse = (pos: string) => {
-        const newCollapsedPos = [...collapsedPos, pos];
-
-        setCollapsedPos(newCollapsedPos);
-        updateLocalStorage(newCollapsedPos);
-      };
-
-      const expand = (pos: string) => {
-        const newCollapsedPos = collapsedPos.filter((cPos) => cPos !== pos);
-
-        setCollapsedPos(newCollapsedPos);
-        updateLocalStorage(newCollapsedPos);
-      };
-
-      expandedKeys =
-        regionsTree.filter((item: any) => !collapsedPos.includes(item.pos)).map((item: any) => item.key) ?? [];
-
-      onExpand = (
-        _internalExpandedKeys: Key[],
-        {
-          node,
-        }: {
-          node: EventDataNode;
-        },
-      ): void => {
-        const region = regionsTree.find((region: any) => region.key === node.key);
-
-        if (!region) return;
-
-        // pos is equal to label name
-        const pos = region.pos;
-
-        collapsedPos.includes(pos) ? expand(pos) : collapse(pos);
-      };
+  useEffect(() => {
+    return () => {
+      resizeObserver?.disconnect();
+      resizeObserver = null;
+    };
+  }, []);
+  const setRef = useCallback((ref) => {
+    if (ref) {
+      resizeObserver?.observe(ref);
+    } else if (blockRef.current) {
+      resizeObserver?.unobserve(blockRef.current);
     }
+    blockRef.current = ref;
+    setHeight(ref?.clientHeight || 1);
+  }, []);
+  const eventHandlers = useEventHandlers();
+  const selectedKeys = regions.selection.keys;
+  const rootClass = cn("tree");
+  let expandedKeys;
+  let onExpand;
+  // It works only for 'label' mode yet.
+  // To enable this feature at other group modes, it needs to set correct pos at regionsTree for these modes
+  // It also doesn't work with nesting level more than 1
+  const isPersistCollapseEnabled = isFF(FF_DEV_2755) && regions.group === "label";
 
-    return (
-      <div className={cn("outliner-tree").toClassName()} ref={setRef}>
-        {!!height && (
-          <Tree
-            key={`${regions.group}-${visibilityKey}`}
-            draggable={regions.group === "manual"}
-            multiple
-            defaultExpandAll
-            defaultExpandParent={!isPersistCollapseEnabled}
-            autoExpandParent
-            checkable={false}
-            prefixCls={rootClass.toClassName()}
-            className={rootClass.toClassName()}
-            treeData={regionsTree}
-            selectedKeys={selectedKeys}
-            icon={iconGetter}
-            switcherIcon={switcherIconGetter}
-            virtual
-            itemHeight={MIN_REGIONS_TREE_ROW_HEIGHT}
-            height={height}
-            {...eventHandlers}
-            {...(isPersistCollapseEnabled
-              ? {
-                  expandedKeys,
-                  onExpand,
-                }
-              : {})}
-          />
-        )}
-      </div>
+  if (isFF(FF_DEV_2755)) {
+    const [collapsedPos, setCollapsedPos] = useState(
+      localStorage
+        .getItem(localStoreName)
+        ?.split?.(",")
+        ?.filter((pos) => !!pos) ?? [],
     );
-  },
-);
+
+    const updateLocalStorage = (collapsedPos: Array<string>) => {
+      localStorage.setItem(localStoreName, collapsedPos.join(","));
+    };
+
+    const collapse = (pos: string) => {
+      const newCollapsedPos = [...collapsedPos, pos];
+
+      setCollapsedPos(newCollapsedPos);
+      updateLocalStorage(newCollapsedPos);
+    };
+
+    const expand = (pos: string) => {
+      const newCollapsedPos = collapsedPos.filter((cPos) => cPos !== pos);
+
+      setCollapsedPos(newCollapsedPos);
+      updateLocalStorage(newCollapsedPos);
+    };
+
+    expandedKeys =
+      regionsTree.filter((item: any) => !collapsedPos.includes(item.pos)).map((item: any) => item.key) ?? [];
+
+    onExpand = (
+      _internalExpandedKeys: Key[],
+      {
+        node,
+      }: {
+        node: EventDataNode;
+      },
+    ): void => {
+      const region = regionsTree.find((region: any) => region.key === node.key);
+
+      if (!region) return;
+
+      // pos is equal to label name
+      const pos = region.pos;
+
+      collapsedPos.includes(pos) ? expand(pos) : collapse(pos);
+    };
+  }
+
+  return (
+    <div className={cn("outliner-tree").toClassName()} ref={setRef}>
+      {!!height && (
+        <Tree
+          key={regions.group}
+          draggable={regions.group === "manual"}
+          multiple
+          defaultExpandAll
+          defaultExpandParent={!isPersistCollapseEnabled}
+          autoExpandParent
+          checkable={false}
+          prefixCls={rootClass.toClassName()}
+          className={rootClass.toClassName()}
+          treeData={regionsTree}
+          selectedKeys={selectedKeys}
+          icon={iconGetter}
+          switcherIcon={switcherIconGetter}
+          virtual
+          itemHeight={MIN_REGIONS_TREE_ROW_HEIGHT}
+          height={height}
+          {...eventHandlers}
+          {...(isPersistCollapseEnabled
+            ? {
+                expandedKeys,
+                onExpand,
+              }
+            : {})}
+        />
+      )}
+    </div>
+  );
+});
 
 const titleRenderer = (nodeData: any) => {
   const { key: _key, ...data } = nodeData;

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
@@ -522,7 +522,7 @@ const RegionControls: FC<RegionControlsProps> = injector(
         return Object.values(regions).every(({ hidden: h }) => h);
       }
       return false;
-    }, [entity, entity?.hidden, type, regions]);
+    }, [entity?.hidden, type, regions]);
 
     const onToggleHidden = useCallback(() => {
       if (type?.includes("region") || type?.includes("range") || type?.includes("reactcode")) {

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
@@ -49,13 +49,13 @@ interface OutlinerTreeProps {
 
 const OutlinerTreeComponent: FC<OutlinerTreeProps> = observer(({ regions, footer }) => {
   const rootClass = cn("tree");
-  // Subscribe to each region's hidden state so tree data (and hide/show icons) rebuild when visibility changes
-  const visibilityKey = regions.regions?.map((r: any) => r.hidden).join(",") ?? "";
+  // Subscribe to each region's hidden state so tree re-renders when visibility changes
+  regions.regions?.forEach((r: any) => void r.hidden);
   const regionsTree = useDataTree({
     regions,
     rootClass,
     footer,
-    // that's a trick to have a dependency that causes recalculating of tree data on grouping mode change
+    // it's for rerender OutlinerTreeComponent
     grouping: regions.group,
   });
 

--- a/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
+++ b/web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
@@ -47,7 +47,7 @@ interface OutlinerTreeProps {
   footer: ReactNode;
 }
 
-const OutlinerTreeComponent: FC<OutlinerTreeProps> = observer(({ regions, footer }) => {
+const OutlinerTreeComponent: FC<OutlinerTreeProps> = ({ regions, footer }) => {
   const rootClass = cn("tree");
   const regionsTree = useDataTree({
     regions,
@@ -62,7 +62,7 @@ const OutlinerTreeComponent: FC<OutlinerTreeProps> = observer(({ regions, footer
       <OutlinerInnerTreeComponent regions={regions} regionsTree={regionsTree} />
     </OutlinerContext.Provider>
   );
-});
+};
 
 interface OutlinerInnerTreeProps {
   regions: any;
@@ -665,4 +665,4 @@ const RegionItemDesc: FC<RegionItemOCSProps> = observer(({ item, collapsed, setC
   );
 });
 
-export const OutlinerTree = OutlinerTreeComponent;
+export const OutlinerTree = observer(OutlinerTreeComponent);

--- a/web/libs/editor/src/stores/RegionStore.js
+++ b/web/libs/editor/src/stores/RegionStore.js
@@ -646,14 +646,30 @@ export default types
     },
 
     setHiddenByTool(shouldBeHidden, label) {
+      // Support both direct region type (e.g. { type: "rectangleregion" }) and
+      // By Tool group entity from asTypeTree (e.g. { type: "tool", value: "rectangle" })
+      const matchType =
+        label?.type === "tool" && label?.value != null
+          ? `${String(label.value).replace(/region$/i, "")}region`
+          : label?.type;
+
+      if (!matchType) return;
+
       self.regions.forEach((area) => {
-        if (area.hidden !== shouldBeHidden && area.type === label.type) {
+        if (area.hidden !== shouldBeHidden && area.type === matchType) {
           area.toggleHidden();
         }
       });
     },
 
     setHiddenByLabel(shouldBeHidden, label) {
+      // Match by label value/id so group hide/show works when entity is from
+      // a different region's selectedLabels (reference equality can fail)
+      const matchByValue =
+        label?.value != null && label?.id != null
+          ? (selected) => selected.some((s) => s.value === label.value && s.id === label.id)
+          : (selected) => selected.includes(label);
+
       self.regions.forEach((area) => {
         if (area.hidden !== shouldBeHidden) {
           const l = area.labeling;
@@ -661,7 +677,7 @@ export default types
           if (l) {
             const selected = l.selectedLabels;
 
-            if (selected.includes(label)) {
+            if (selected && matchByValue(selected)) {
               area.toggleHidden();
             }
           }

--- a/web/libs/editor/src/stores/__tests__/RegionStore.test.js
+++ b/web/libs/editor/src/stores/__tests__/RegionStore.test.js
@@ -538,6 +538,16 @@ describe("RegionStore", () => {
       expect(region.hidden).toBe(!wasHidden);
     });
 
+    it("setHiddenByTool works with By Tool group entity (type tool, value without region suffix)", () => {
+      const { annotation } = createStoreWithOneRectRegion();
+      const region = annotation.regionStore.regions[0];
+      const wasHidden = region.hidden;
+      annotation.regionStore.setHiddenByTool(!wasHidden, { type: "tool", value: "rectangle" });
+      expect(region.hidden).toBe(!wasHidden);
+      annotation.regionStore.setHiddenByTool(wasHidden, { type: "tool", value: "rectangle" });
+      expect(region.hidden).toBe(wasHidden);
+    });
+
     it("sortedRegions with sortOrder desc returns one region", () => {
       const { annotation } = createStoreWithOneRectRegion();
       annotation.regionStore.setSort("date");

--- a/web/libs/editor/tests/integration/e2e/image_segmentation/image_regions.cy.ts
+++ b/web/libs/editor/tests/integration/e2e/image_segmentation/image_regions.cy.ts
@@ -137,6 +137,9 @@ describe("Image Regions scenario", () => {
 
     cy.get("body").focus().trigger("keydown", { altKey: true, keyCode: 72 });
 
+    // Wait for visibility state to be applied (store update + tree re-render)
+    Sidebar.hasHiddenRegion(2);
+
     regions
       .each(($el) => {
         if ($el.parent().hasClass("lsf-tree__node_hidden")) {


### PR DESCRIPTION
This pull request improves the region visibility synchronization and group hide/show logic in the Outliner panel. The main focus is to ensure that tree nodes and group controls in the UI accurately reflect the hidden state of their child regions, especially when toggling visibility for groups by tool or label. There are also enhancements to accessibility and test coverage for these behaviors.

after fix:

[screen-recorder-wed-mar-11-2026-12-13-46.webm](https://github.com/user-attachments/assets/d5fedde1-40e6-487a-b56b-31c33cb52581)


**Region visibility synchronization and UI updates:**

* The `OutlinerTreeComponent` and `OutlinerInnerTreeComponent` are now MobX observers and use a `visibilityKey` (derived from the hidden state of child regions) to force tree re-rendering when region visibility changes, ensuring hide/show icons and group controls stay in sync. (`web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx`) [[1]](diffhunk://#diff-f4db8bd107bcd19f6cfa67c1b88e801a4a5608c73b12b2bae96fea65b34bec08L50-R78) [[2]](diffhunk://#diff-f4db8bd107bcd19f6cfa67c1b88e801a4a5608c73b12b2bae96fea65b34bec08L173-R176) [[3]](diffhunk://#diff-f4db8bd107bcd19f6cfa67c1b88e801a4a5608c73b12b2bae96fea65b34bec08R488-R495)
* The memoization logic for group nodes in the tree was updated to trigger re-renders when any child's hidden state changes, so group-level hide/show controls accurately reflect the current state. (`web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx`)

**Group hide/show logic improvements:**

* The `setHiddenByTool` and `setHiddenByLabel` methods in `RegionStore` now support matching group entities by tool (with or without the "region" suffix) and by label value/id, improving the reliability of group visibility toggling. (`web/libs/editor/src/stores/RegionStore.js`)

**Accessibility and UI enhancements:**

* The hide/show icon button now includes `aria-label` and `title` attributes for better accessibility and user feedback. (`web/libs/editor/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx`)

**Test coverage:**

* Added a test to verify that `setHiddenByTool` works correctly when toggling visibility for a "By Tool" group entity. (`web/libs/editor/src/stores/__tests__/RegionStore.test.js`)