### PR TITLE
fix: FIT-1517: OOM in /api/annotation-history when  is too large

### DIFF
--- a/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.tsx
+++ b/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.tsx
@@ -1,4 +1,5 @@
 import { when } from "mobx";
+import { getEnv } from "mobx-state-tree";
 import { inject, observer } from "mobx-react";
 import { type FC, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
@@ -41,6 +42,7 @@ const injector = inject(({ store }) => {
   const selected = as?.selected;
 
   return {
+    store,
     annotationStore: as,
     selected: as?.selected,
     createdBy: selected?.user ?? { email: selected?.createdBy },
@@ -106,6 +108,7 @@ const DraftState: FC<{
 });
 
 const AnnotationHistoryComponent: FC<any> = ({
+  store,
   annotationStore,
   selectedHistory,
   history,
@@ -167,6 +170,9 @@ const AnnotationHistoryComponent: FC<any> = ({
           const isSelected = isLastItem && !selectedHistory ? !isDraftSelected : selectedHistory?.id === item.id;
           const hiddenUser = infoIsHidden ? { email: currentUser?.id === user.id ? "Me" : "User" } : null;
 
+          const isStub = !!item.is_stub;
+          const disabled = !isStub && item.results.length === 0;
+
           return (
             <HistoryItem
               key={id}
@@ -176,7 +182,7 @@ const AnnotationHistoryComponent: FC<any> = ({
               comment={item.comment}
               acceptedState={item.actionType}
               selected={isSelected}
-              disabled={item.results.length === 0}
+              disabled={disabled}
               hideInfo={infoIsHidden}
               onClick={async () => {
                 if (hasChanges) {
@@ -190,6 +196,24 @@ const AnnotationHistoryComponent: FC<any> = ({
                   annotationStore.selectHistory(null);
                   // if user clicks on last history state we should disable draft to see submitted state
                   annotation.toggleDraft(isSelected);
+                } else if (isStub) {
+                  // Stub item: host (e.g. LSE) fetches full item and calls back; then we hydrate and select.
+                  // item.pk is the numeric history row id (preserved in HistoryItem preProcessSnapshot); item.id is the MST guid.
+                  const historyPk = item.pk;
+                  if (historyPk == null) return;
+                  getEnv(store).events.invoke(
+                    "hydrateHistoryItem",
+                    historyPk,
+                    (fullItem: any) => {
+                      if (fullItem && store.hydrateHistoryItem) {
+                        store.hydrateHistoryItem(historyPk, fullItem);
+                        const hydrated = annotationStore.history.find(
+                          (h: any) => h.pk != null && Number(h.pk) === Number(historyPk),
+                        );
+                        if (hydrated) annotationStore.selectHistory(hydrated);
+                      }
+                    },
+                  );
                 } else {
                   annotationStore.selectHistory(item);
                 }

--- a/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.tsx
+++ b/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.tsx
@@ -204,10 +204,6 @@ const AnnotationHistoryComponent: FC<any> = ({
                   getEnv(store).events.invoke("hydrateHistoryItem", historyPk, (fullItem: any) => {
                     if (fullItem && store.hydrateHistoryItem) {
                       store.hydrateHistoryItem(historyPk, fullItem);
-                      const hydrated = annotationStore.history.find(
-                        (h: any) => h.pk != null && Number(h.pk) === Number(historyPk),
-                      );
-                      if (hydrated) annotationStore.selectHistory(hydrated);
                     }
                   });
                 } else {

--- a/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.tsx
+++ b/web/libs/editor/src/components/CurrentEntity/AnnotationHistory.tsx
@@ -201,19 +201,15 @@ const AnnotationHistoryComponent: FC<any> = ({
                   // item.pk is the numeric history row id (preserved in HistoryItem preProcessSnapshot); item.id is the MST guid.
                   const historyPk = item.pk;
                   if (historyPk == null) return;
-                  getEnv(store).events.invoke(
-                    "hydrateHistoryItem",
-                    historyPk,
-                    (fullItem: any) => {
-                      if (fullItem && store.hydrateHistoryItem) {
-                        store.hydrateHistoryItem(historyPk, fullItem);
-                        const hydrated = annotationStore.history.find(
-                          (h: any) => h.pk != null && Number(h.pk) === Number(historyPk),
-                        );
-                        if (hydrated) annotationStore.selectHistory(hydrated);
-                      }
-                    },
-                  );
+                  getEnv(store).events.invoke("hydrateHistoryItem", historyPk, (fullItem: any) => {
+                    if (fullItem && store.hydrateHistoryItem) {
+                      store.hydrateHistoryItem(historyPk, fullItem);
+                      const hydrated = annotationStore.history.find(
+                        (h: any) => h.pk != null && Number(h.pk) === Number(historyPk),
+                      );
+                      if (hydrated) annotationStore.selectHistory(hydrated);
+                    }
+                  });
                 } else {
                   annotationStore.selectHistory(item);
                 }

--- a/web/libs/editor/src/stores/Annotation/HistoryItem.js
+++ b/web/libs/editor/src/stores/Annotation/HistoryItem.js
@@ -29,15 +29,22 @@ export const HistoryItem = types
        * Action associated with the history item
        */
       actionType: types.optional(types.maybeNull(types.string), null),
+
+      /**
+       * True when this item was returned as a stub (no result); frontend hydrates on click (FIT-720).
+       */
+      is_stub: types.optional(types.boolean, false),
     }),
   )
   .preProcessSnapshot((snapshot) => {
+    const numericPk = snapshot.pk != null && !Number.isNaN(Number(snapshot.pk)) ? snapshot.pk : null;
     return {
       ...snapshot,
-      pk: guidGenerator(),
+      pk: numericPk ?? guidGenerator(),
       user: snapshot.created_by,
       createdDate: snapshot.created_at,
       actionType: snapshot.action ?? snapshot.action_type ?? snapshot.actionType,
+      is_stub: snapshot.is_stub ?? false,
       readonly: true,
       editable: false,
     };

--- a/web/libs/editor/src/stores/Annotation/HistoryItem.js
+++ b/web/libs/editor/src/stores/Annotation/HistoryItem.js
@@ -37,7 +37,7 @@ export const HistoryItem = types
     }),
   )
   .preProcessSnapshot((snapshot) => {
-    const numericPk = snapshot.pk != null && !Number.isNaN(Number(snapshot.pk)) ? snapshot.pk : null;
+    const numericPk = snapshot.pk && !Number.isNaN(Number(snapshot.pk)) ? snapshot.pk : null;
     return {
       ...snapshot,
       pk: numericPk ?? guidGenerator(),

--- a/web/libs/editor/src/stores/Annotation/__tests__/store.test.js
+++ b/web/libs/editor/src/stores/Annotation/__tests__/store.test.js
@@ -173,6 +173,24 @@ describe("Annotation store (store.js)", () => {
       expect(store.annotationStore.history.length).toBe(0);
     });
 
+    it("FIT-720: addHistory preserves numeric pk from API (HistoryItem preProcessSnapshot)", () => {
+      const store = createStore();
+      store.initializeStore({
+        annotations: [{ id: "a1", pk: 100, result: [] }],
+      });
+      store.annotationStore.selectAnnotation(store.annotationStore.annotations[0].id);
+      const historyRowId = 46597;
+      store.annotationStore.addHistory({
+        id: historyRowId,
+        annotation_id: 100,
+        action: "submitted",
+        result: [],
+        is_stub: true,
+      });
+      expect(store.annotationStore.history.length).toBe(1);
+      expect(Number(store.annotationStore.history[0].pk)).toBe(historyRowId);
+    });
+
     it("addAnnotation when root not set initializes root from store config", () => {
       const store = createStore();
       expect(store.annotationStore.root).toBeUndefined();

--- a/web/libs/editor/src/stores/AppStore.js
+++ b/web/libs/editor/src/stores/AppStore.js
@@ -968,7 +968,7 @@ export default types
     function hydrateHistoryItem(historyId, fullItem) {
       const as = self.annotationStore;
       // historyId is the numeric API id (pk); store items have id=guid and pk=numeric from createItem
-      const item = as.history.find((h) => h.pk != null && Number(h.pk) === Number(historyId));
+      const item = as.history.find((h) => h.pk && Number(h.pk) === Number(historyId));
       if (!item) return;
       item.deserializeResults(fullItem?.result ?? [], { hidden: true });
       as.selectHistory(item);

--- a/web/libs/editor/src/stores/AppStore.js
+++ b/web/libs/editor/src/stores/AppStore.js
@@ -961,6 +961,19 @@ export default types
       });
     }
 
+    /**
+     * Hydrate a stubbed history item with full result (FIT-720 lazy load).
+     * Called when the host fetches GET /api/annotation-history/<id>/ and passes the response.
+     */
+    function hydrateHistoryItem(historyId, fullItem) {
+      const as = self.annotationStore;
+      // historyId is the numeric API id (pk); store items have id=guid and pk=numeric from createItem
+      const item = as.history.find((h) => h.pk != null && Number(h.pk) === Number(historyId));
+      if (!item) return;
+      item.deserializeResults(fullItem?.result ?? [], { hidden: true });
+      as.selectHistory(item);
+    }
+
     const setAutoAnnotation = (value) => {
       self._autoAnnotation = value;
       localStorage.setItem("autoAnnotation", value);
@@ -1066,6 +1079,7 @@ export default types
       resetAnnotationStore,
       initializeStore,
       setHistory,
+      hydrateHistoryItem,
       attachHotkeys,
 
       skipTask,

--- a/web/libs/editor/src/stores/__tests__/AppStore.test.js
+++ b/web/libs/editor/src/stores/__tests__/AppStore.test.js
@@ -673,6 +673,63 @@ describe("AppStore", () => {
     });
   });
 
+  describe("FIT-720 stub/hydrate: history item pk and hydrateHistoryItem", () => {
+    it("preserves numeric pk from API in history items so hydrate can use it", () => {
+      const store = createStore();
+      store.initializeStore({
+        annotations: [{ id: "a1", pk: 100, result: [] }],
+      });
+      const historyRowId = 46597;
+      store.setHistory([
+        {
+          id: historyRowId,
+          annotation_id: 100,
+          action: "submitted",
+          result: [],
+          is_stub: true,
+        },
+      ]);
+      expect(store.annotationStore.history.length).toBe(1);
+      const first = store.annotationStore.history[0];
+      expect(Number(first.pk)).toBe(historyRowId);
+    });
+
+    it("hydrateHistoryItem finds item by pk (not MST id) and hydrates then selects", () => {
+      const store = createStore();
+      store.initializeStore({
+        annotations: [{ id: "a1", pk: 100, result: [] }],
+      });
+      const historyRowId = 46597;
+      store.setHistory([
+        {
+          id: historyRowId,
+          annotation_id: 100,
+          action: "submitted",
+          result: [],
+          is_stub: true,
+        },
+      ]);
+      expect(store.annotationStore.history.length).toBe(1);
+      const fullItem = {
+        id: historyRowId,
+        annotation_id: 100,
+        action: "submitted",
+        result: [
+          {
+            value: { choices: ["neg"] },
+            from_name: "label",
+            to_name: "text",
+            type: "choices",
+          },
+        ],
+      };
+      store.hydrateHistoryItem(historyRowId, fullItem);
+      expect(store.annotationStore.selectedHistory).toBe(store.annotationStore.history[0]);
+      expect(store.annotationStore.selectedHistory.pk).toBeDefined();
+      expect(Number(store.annotationStore.selectedHistory.pk)).toBe(historyRowId);
+    });
+  });
+
   describe("version volatile", () => {
     it("exposes version from LSF_VERSION or default", () => {
       const store = createStore();


### PR DESCRIPTION
This pull request introduces support for "stub" annotation history items, enabling lazy loading of full annotation history details only when a user selects a stub entry. This improves performance when dealing with large annotation histories by avoiding the need to load all details up front. The changes include updates to both the UI and the store logic to handle stub items, trigger hydration on click, and update the selected history entry accordingly.

**Annotation history lazy loading (stub hydration):**

* Added support for marking history items as stubs (`is_stub`) in `HistoryItem`, and ensured the `pk` (primary key) is preserved for hydration.
* Updated the `AnnotationHistoryComponent` to check for stub items and, when selected, trigger an event to hydrate the full item from the host before selecting it. [[1]](diffhunk://#diff-eec41d6f0daa6126075cfc7736df0019d7578d8e0e23c880b7a8e1686c4ed804R173-R175) [[2]](diffhunk://#diff-eec41d6f0daa6126075cfc7736df0019d7578d8e0e23c880b7a8e1686c4ed804L179-R185) [[3]](diffhunk://#diff-eec41d6f0daa6126075cfc7736df0019d7578d8e0e23c880b7a8e1686c4ed804R199-R216)
* Added `hydrateHistoryItem` method to `AppStore` to allow the host to inject full history item data and update the store accordingly. [[1]](diffhunk://#diff-7196f6f9f03a172f681f14cfc26e79c8a0012967a0b01fa3efbdc68e88845807R964-R976) [[2]](diffhunk://#diff-7196f6f9f03a172f681f14cfc26e79c8a0012967a0b01fa3efbdc68e88845807R1082)

**Dependency and prop updates:**

* Passed the `store` prop explicitly through the injector and component props to enable access to environment events and hydration logic. [[1]](diffhunk://#diff-eec41d6f0daa6126075cfc7736df0019d7578d8e0e23c880b7a8e1686c4ed804R2) [[2]](diffhunk://#diff-eec41d6f0daa6126075cfc7736df0019d7578d8e0e23c880b7a8e1686c4ed804R45) [[3]](diffhunk://#diff-eec41d6f0daa6126075cfc7736df0019d7578d8e0e23c880b7a8e1686c4ed804R111)