### PR TITLE
fix: FIT-1487: Prevent element text color inside story preview blocks to be affected by color reset

### DIFF
--- a/web/libs/storybook/.storybook/preview.scss
+++ b/web/libs/storybook/.storybook/preview.scss
@@ -65,15 +65,15 @@ body {
     }
   }
 
-  /* General content area */
+  /* General content area (docs text only; exclude elements inside story preview blocks) */
   .sbdocs-content {
     color: var(--color-neutral-content) !important;
 
-    & p,
-    & span,
-    & div,
-    & li,
-    & code {
+    & p:not(.sbdocs-preview p),
+    & span:not(.sbdocs-preview span),
+    & div:not(.sbdocs-preview div),
+    & li:not(.sbdocs-preview li),
+    & code:not(.sbdocs-preview code) {
       color: inherit !important;
     }
   }


### PR DESCRIPTION
This pull request refines the styling in the Storybook documentation area to ensure that general content text color changes do not unintentionally affect elements inside story preview blocks.

## Screenshots
### Before
<img width="1105" height="408" alt="image" src="https://github.com/user-attachments/assets/01ae0f4c-41a7-43d5-a6f3-3d526f96a086" />
<img width="1148" height="620" alt="image" src="https://github.com/user-attachments/assets/63134eda-fadb-4326-b30c-b18bf7a157de" />
<img width="1195" height="467" alt="image" src="https://github.com/user-attachments/assets/58dfb486-e9b6-4d2b-972a-c52b8230ce4e" />

### After
<img width="1096" height="770" alt="image" src="https://github.com/user-attachments/assets/60235767-43e6-46c4-9540-41bf31cb6149" />
<img width="1114" height="635" alt="image" src="https://github.com/user-attachments/assets/80ba608a-c2db-4552-b772-83dbab1fce70" />
<img width="1156" height="473" alt="image" src="https://github.com/user-attachments/assets/a88fbc2a-11d4-4611-aead-52cd219ee7de" />


Styling improvements:

* Updated the `.sbdocs-content` selector in `preview.scss` to apply text color only to documentation text, explicitly excluding elements within `.sbdocs-preview` blocks to prevent unintended color overrides.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
