### PR TITLE
fix: FIT-1520: Annotations no longer load in Compare All > Side-by-side mode 

### DIFF
--- a/web/libs/editor/src/components/App/Grid.jsx
+++ b/web/libs/editor/src/components/App/Grid.jsx
@@ -81,7 +81,10 @@ export const VirtualizedAnnotationPanel = observer(
 
     return (
       <div style={{ ...style, paddingRight: PANEL_GAP }}>
-        <div id={`c-${annotation.id}`} style={{ position: "relative", height: "100%" }}>
+        <div
+          id={`c-${annotation.id}`}
+          className="flex h-full flex-col relative"
+        >
           <EntityTab
             entity={annotation}
             onClick={() => onSelect(annotation)}
@@ -91,21 +94,10 @@ export const VirtualizedAnnotationPanel = observer(
           />
           {!wasHydrated && (isStub || isHydrating) ? (
             <div
-              style={{
-                position: "absolute",
-                top: 44,
-                left: 0,
-                width: "100%",
-                height: "calc(100% - 44px)",
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-                justifyContent: "center",
-                background: "var(--color-neutral-surface)",
-              }}
+              className="min-h-0 flex-1 flex flex-col items-center justify-center bg-[var(--color-neutral-surface)]"
             >
               <Spin size="large" />
-              <span style={{ marginTop: 12, color: "#999" }}>
+              <span className="mt-300 text-neutral-content-subtler">
                 {isHydrating ? "Loading annotation..." : "Waiting to load..."}
               </span>
             </div>
@@ -405,7 +397,7 @@ const VirtualizedGrid = observer(({ store, annotations, root }) => {
 
   return (
     <div className={styles.containerVirtualized}>
-      <div className={styles.grid} style={{ overflow: "hidden", height: "100%" }}>
+      <div className={`${styles.grid} overflow-hidden h-full`}>
         <AutoSizer>
           {({ width, height }) => {
             if (width !== containerWidth) {

--- a/web/libs/editor/src/components/App/Grid.jsx
+++ b/web/libs/editor/src/components/App/Grid.jsx
@@ -65,54 +65,58 @@ export class Item extends Component {
 }
 
 // FIT-720: Virtualized annotation panel with lazy hydration (exported for tests)
-export const VirtualizedAnnotationPanel = observer(({ annotation, root, style, onSelect, isHydrating }) => {
-  // Check if annotation has regions - either from original load (versions.result) or from hydration (areas)
-  const versionsResult = annotation.versions?.result;
-  const hasVersionsResult = Array.isArray(versionsResult) && versionsResult.length > 0;
-  // Force MobX to track areas by accessing the regions getter (which iterates areas)
-  const regions = annotation.regions;
-  const hasRegions = regions && regions.length > 0;
-  // Annotation is a stub if it has no data and is not user-generated
-  // After hydration, hasRegions will be true (deserializeResults populates regions)
-  const isStub = !hasVersionsResult && !hasRegions && annotation.pk && !annotation.userGenerate;
+export const VirtualizedAnnotationPanel = observer(
+  ({ annotation, root, style, onSelect, isHydrating, hydratedIdsRef }) => {
+    // Check if annotation has regions - either from original load (versions.result) or from hydration (areas)
+    const versionsResult = annotation.versions?.result;
+    const hasVersionsResult = Array.isArray(versionsResult) && versionsResult.length > 0;
+    // Force MobX to track areas by accessing the regions getter (which iterates areas)
+    const regions = annotation.regions;
+    const hasRegions = regions && regions.length > 0;
+    // Annotation is a stub if it has no data and is not user-generated
+    // After hydration, hasRegions will be true (deserializeResults populates regions)
+    const isStub = !hasVersionsResult && !hasRegions && annotation.pk && !annotation.userGenerate;
+    // Already hydrated (including with empty result) — don't show "Waiting to load..."
+    const wasHydrated = hydratedIdsRef?.current?.has(annotation.id);
 
-  return (
-    <div style={{ ...style, paddingRight: PANEL_GAP }}>
-      <div id={`c-${annotation.id}`} style={{ position: "relative", height: "100%" }}>
-        <EntityTab
-          entity={annotation}
-          onClick={() => onSelect(annotation)}
-          prediction={annotation.type === "prediction"}
-          bordered={false}
-          style={{ height: 44 }}
-        />
-        {isStub || isHydrating ? (
-          <div
-            style={{
-              position: "absolute",
-              top: 44,
-              left: 0,
-              width: "100%",
-              height: "calc(100% - 44px)",
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              justifyContent: "center",
-              background: "var(--color-neutral-surface)",
-            }}
-          >
-            <Spin size="large" />
-            <span style={{ marginTop: 12, color: "#999" }}>
-              {isHydrating ? "Loading annotation..." : "Waiting to load..."}
-            </span>
-          </div>
-        ) : (
-          <Annotation root={root} annotation={annotation} />
-        )}
+    return (
+      <div style={{ ...style, paddingRight: PANEL_GAP }}>
+        <div id={`c-${annotation.id}`} style={{ position: "relative", height: "100%" }}>
+          <EntityTab
+            entity={annotation}
+            onClick={() => onSelect(annotation)}
+            prediction={annotation.type === "prediction"}
+            bordered={false}
+            style={{ height: 44 }}
+          />
+          {!wasHydrated && (isStub || isHydrating) ? (
+            <div
+              style={{
+                position: "absolute",
+                top: 44,
+                left: 0,
+                width: "100%",
+                height: "calc(100% - 44px)",
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                background: "var(--color-neutral-surface)",
+              }}
+            >
+              <Spin size="large" />
+              <span style={{ marginTop: 12, color: "#999" }}>
+                {isHydrating ? "Loading annotation..." : "Waiting to load..."}
+              </span>
+            </div>
+          ) : (
+            <Annotation root={root} annotation={annotation} />
+          )}
+        </div>
       </div>
-    </div>
-  );
-});
+    );
+  },
+);
 
 // FIT-720: Virtualized Grid component
 const VirtualizedGrid = observer(({ store, annotations, root }) => {
@@ -378,6 +382,7 @@ const VirtualizedGrid = observer(({ store, annotations, root }) => {
       root,
       onSelect: select,
       hydratingIds,
+      hydratedIdsRef: hydratedIds,
     }),
     [visibleAnnotations, root, select, hydratingIds],
   );
@@ -393,6 +398,7 @@ const VirtualizedGrid = observer(({ store, annotations, root }) => {
         style={style}
         onSelect={data.onSelect}
         isHydrating={data.hydratingIds.has(annotation.id)}
+        hydratedIdsRef={data.hydratedIdsRef}
       />
     );
   }, []);

--- a/web/libs/editor/src/components/App/Grid.jsx
+++ b/web/libs/editor/src/components/App/Grid.jsx
@@ -81,10 +81,7 @@ export const VirtualizedAnnotationPanel = observer(
 
     return (
       <div style={{ ...style, paddingRight: PANEL_GAP }}>
-        <div
-          id={`c-${annotation.id}`}
-          className="flex h-full flex-col relative"
-        >
+        <div id={`c-${annotation.id}`} className="flex h-full flex-col relative">
           <EntityTab
             entity={annotation}
             onClick={() => onSelect(annotation)}
@@ -93,9 +90,7 @@ export const VirtualizedAnnotationPanel = observer(
             style={{ height: 44 }}
           />
           {!wasHydrated && (isStub || isHydrating) ? (
-            <div
-              className="min-h-0 flex-1 flex flex-col items-center justify-center bg-[var(--color-neutral-surface)]"
-            >
+            <div className="min-h-0 flex-1 flex flex-col items-center justify-center bg-[var(--color-neutral-surface)]">
               <Spin size="large" />
               <span className="mt-300 text-neutral-content-subtler">
                 {isHydrating ? "Loading annotation..." : "Waiting to load..."}

--- a/web/libs/editor/src/components/App/__tests__/Grid.test.jsx
+++ b/web/libs/editor/src/components/App/__tests__/Grid.test.jsx
@@ -435,6 +435,30 @@ describe("Grid", () => {
     expect(screen.getByTestId("annotation-panel")).toBeInTheDocument();
   });
 
+  it("VirtualizedAnnotationPanel shows Annotation when stub but already hydrated (e.g. empty result)", () => {
+    const stubAnnotation = {
+      id: "s1",
+      pk: 1,
+      type: "annotation",
+      userGenerate: false,
+      versions: { result: [] },
+      regions: [],
+    };
+    const hydratedIdsRef = { current: new Set(["s1"]) };
+    render(
+      <VirtualizedAnnotationPanel
+        annotation={stubAnnotation}
+        root={{}}
+        style={{}}
+        onSelect={jest.fn()}
+        isHydrating={false}
+        hydratedIdsRef={hydratedIdsRef}
+      />,
+    );
+    expect(screen.queryByText("Waiting to load...")).not.toBeInTheDocument();
+    expect(screen.getByTestId("annotation-panel")).toBeInTheDocument();
+  });
+
   it("VirtualizedGrid mount skips annotations that already have data (hasDataInMST)", () => {
     mockGetCachedAnnotation.mockClear();
     mockGetCachedAnnotation.mockReturnValue(undefined);


### PR DESCRIPTION
This pull request enhances the behavior of the `VirtualizedAnnotationPanel` component to better handle annotations that have already been hydrated, including those with empty results. It also updates the `VirtualizedGrid` to correctly pass and use this hydration state, and adds a unit test to ensure the new behavior works as intended.

**Improvements to hydration handling:**

* Updated `VirtualizedAnnotationPanel` to accept a new `hydratedIdsRef` prop and use it to determine if an annotation was already hydrated, preventing the "Waiting to load..." message from showing for already hydrated annotations, even if they have empty results. [[1]](diffhunk://#diff-2137e906d68d9c5c8edfd2dc60feabaa9cd61c79b0a318feedfaadb049e6ef3cL68-R69) [[2]](diffhunk://#diff-2137e906d68d9c5c8edfd2dc60feabaa9cd61c79b0a318feedfaadb049e6ef3cR79-R80) [[3]](diffhunk://#diff-2137e906d68d9c5c8edfd2dc60feabaa9cd61c79b0a318feedfaadb049e6ef3cL89-R92) [[4]](diffhunk://#diff-2137e906d68d9c5c8edfd2dc60feabaa9cd61c79b0a318feedfaadb049e6ef3cL115-R119)

**Integration with virtualized grid:**

* Modified `VirtualizedGrid` to pass the `hydratedIdsRef` prop to each `VirtualizedAnnotationPanel`, ensuring consistent hydration state awareness across components. [[1]](diffhunk://#diff-2137e906d68d9c5c8edfd2dc60feabaa9cd61c79b0a318feedfaadb049e6ef3cR385) [[2]](diffhunk://#diff-2137e906d68d9c5c8edfd2dc60feabaa9cd61c79b0a318feedfaadb049e6ef3cR401)

**Testing:**

* Added a unit test to verify that `VirtualizedAnnotationPanel` does not display the "Waiting to load..." message when a stub annotation is already hydrated, even if the result is empty.