### PR TITLE
fix: BROS-849: Taxonomy is broken. Try 2

### DIFF
--- a/web/libs/editor/src/mixins/SharedChoiceStore/extender.js
+++ b/web/libs/editor/src/mixins/SharedChoiceStore/extender.js
@@ -1,6 +1,18 @@
-import { destroy, detach, types } from "mobx-state-tree";
+import { destroy, detach, getSnapshot, isAlive, types } from "mobx-state-tree";
 import { SharedStoreModel } from "./model";
 import { Stores } from "./mixin";
+
+/**
+ * Safely get a snapshot from a store, handling cases where it may be destroyed.
+ */
+function safeGetSnapshot(store) {
+  try {
+    if (isAlive(store)) return getSnapshot(store);
+  } catch {
+    /* store may be in an inconsistent state */
+  }
+  return null;
+}
 
 /**
  * StoreExtender injects into the AnnotationStore and holds every created SharedStore.
@@ -23,8 +35,19 @@ export const StoreExtender = types
       self.sharedStores.clear();
     },
     afterReset() {
-      Stores.forEach((store) => {
-        self.addSharedStore(store);
+      Stores.forEach((store, key) => {
+        try {
+          self.addSharedStore(store);
+        } catch {
+          // The cached store instance is still attached to another MST tree
+          // (stale reference from a previous LSF lifecycle during SPA navigation).
+          // Recreate from snapshot so we get a fresh, unattached node.
+          const snapshot = safeGetSnapshot(store) ?? { id: key, children: [] };
+          const freshStore = SharedStoreModel.create(snapshot);
+
+          Stores.set(key, freshStore);
+          self.addSharedStore(freshStore);
+        }
       });
     },
     beforeDestroy() {


### PR DESCRIPTION


## Bug: Taxonomy breaks on first open after SPA navigation (no page reload)

### What was broken

When a user creates a new project with a **Taxonomy** label config and opens Quick View (or the labeling interface) **without a full page reload**, the editor fails with:

```
Error: [mobx-state-tree] Cannot add an object to a state tree if it is already
part of the same or another state tree. Tried to assign an object to
'/annotationStore/sharedStores/taxonomy', but it lives already at
'/annotationStore/sharedStores/taxonomy'
```

The UI renders broken. A full page refresh fixes it — until the next new project.

### Root cause

`SharedChoiceStore` (used by Taxonomy and Choices) maintains two **module-level singletons** that live for the lifetime of the browser tab:

```js
export const Stores = new Map();   // SharedStoreModel instances
const StoreIds = new Set();        // IDs of already-created stores
```

These caches are intentional — they let multiple annotations on the same task share one store instance. But they are **never cleared on SPA navigation**.

When the user navigates to a new project without a reload:

1. The old LSF instance is torn down, but `Stores` still holds the old `SharedStoreModel` instance for `"taxonomy"` — an instance that was previously attached to (and detached from) the old MST tree
2. The new LSF initializes, calls `initializeStore` → `afterReset()` → tries to attach the **same stale instance** to the new tree
3. MST sees the node as still "belonging" to another tree and throws

This was further aggravated by a **performance optimization** (PR #9495 / BROS-827) that wrapped `resetState()` and `initializeStore()` in the same `runInAction()` block. Within a single MobX transaction, `detach()` (called by `beforeReset`) doesn't commit before `afterReset` tries to re-attach the same stores — causing the same error even during normal task switching.

### Fix (two changes)

**1. `lsf-sdk.js` — split the `runInAction` batch**

`initializeStore` is moved outside the `runInAction` block so `detach()` commits before `afterReset()` re-attaches shared stores:

```js
// resetState + toggleInterface + assignTask batched together (safe)
runInAction(() => {
  this.lsf.resetState();
  this.lsf.toggleInterface(...);
  this.lsf.assignTask(task);
});

// initializeStore runs AFTER the transaction commits
this.lsf.initializeStore(lsfTask);
```

**2. `extender.js` — defensive `afterReset()`**

`afterReset()` now catches the MST error when a cached store instance is stale (still attached to a dead tree from a previous LSF lifecycle). On failure, it recreates the store from its snapshot and updates the global cache:

```js
afterReset() {
  Stores.forEach((store, key) => {
    try {
      self.addSharedStore(store);
    } catch {
      // Stale instance from previous LSF lifecycle — recreate from snapshot
      const snapshot = safeGetSnapshot(store) ?? { id: key, children: [] };
      const freshStore = SharedStoreModel.create(snapshot);
      Stores.set(key, freshStore);
      self.addSharedStore(freshStore);
    }
  });
},
```

Fix 1 addresses task-switching. Fix 2 addresses first-open after SPA navigation. Together they cover all known paths to this error.