### PR TITLE
fix: UTC-616: Add New Tags field doesn't work with copy/ paste comma separated values

### DIFF
--- a/web/libs/ui/src/lib/tag-autocomplete/tag-autocomplete.stories.tsx
+++ b/web/libs/ui/src/lib/tag-autocomplete/tag-autocomplete.stories.tsx
@@ -1,38 +1,39 @@
-import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { Button } from "../button/button";
+import { Typography } from "../typography/typography";
 import { TagAutocomplete } from "./tag-autocomplete";
 import type { TagOption } from "./types";
-import { Typography } from "../typography/typography";
-import { Button } from "../button/button";
 
 const meta: Meta<typeof TagAutocomplete> = {
-  component: TagAutocomplete,
-  title: "UI/TagAutocomplete",
-  argTypes: {
-    disabled: {
-      control: "boolean",
-    },
-    isLoading: {
-      control: "boolean",
-    },
-    minSearchLength: {
-      control: "number",
-    },
-  },
-  parameters: {
-    docs: {
-      description: {
-        component: `
+	component: TagAutocomplete,
+	title: "UI/TagAutocomplete",
+	argTypes: {
+		disabled: {
+			control: "boolean",
+		},
+		isLoading: {
+			control: "boolean",
+		},
+		minSearchLength: {
+			control: "number",
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component: `
 A tag-like autocomplete component that allows users to select multiple tags from a predefined list.
 
 ## Features
-- **Typeahead search** - Filter options by typing (minimum 2 characters by default)
-- **Keyboard navigation** - Full keyboard support for selecting and removing tags
-- **Multiline tags** - Tags automatically wrap to multiple lines when needed
-- **Highlighted search** - Search text is highlighted in matching options
-- **Tag creation** - Allow users to create new tags on the fly (with allowCreate prop)
-- **Loading state** - Displays a spinner in the dropdown while fetching options
-- **Form integration** - Works with standard HTML forms via name prop
+- **Typeahead search**: Filter options by typing (minimum 2 characters by default)
+- **Keyboard navigation**: Full keyboard support for selecting and removing tags
+- **Multiline tags**: Tags automatically wrap to multiple lines when needed
+- **Highlighted search**: Search text is highlighted in matching options
+- **Tag creation**: Allow users to create new tags on the fly (with allowCreate prop)
+- **Paste support**: Paste comma-separated values to create multiple tags at once (only when \`allowCreate\` is enabled)
+- **Loading state**: Displays a spinner in the dropdown while fetching options
+- **Form integration**: Works with standard HTML forms via name prop
 
 ## Keyboard Shortcuts
 | Key | Action |
@@ -40,31 +41,41 @@ A tag-like autocomplete component that allows users to select multiple tags from
 | Arrow Left/Right | Navigate between tags |
 | Arrow Up/Down | Navigate dropdown options |
 | Enter / Comma | Select highlighted option or create new tag |
+| Paste (comma-separated) | Create multiple tags from clipboard (requires \`allowCreate\`) |
 | Backspace/Delete | Remove focused tag |
 | Escape | Close dropdown |
         `,
-      },
-    },
-  },
+			},
+		},
+	},
 };
 
 export default meta;
 type Story = StoryObj<typeof TagAutocomplete>;
 
 const sampleTags: TagOption<string>[] = [
-  { value: "frontend", label: "Frontend" },
-  { value: "backend", label: "Backend" },
-  { value: "devops", label: "DevOps" },
-  { value: "design", label: "Design" },
-  { value: "qa", label: "QA" },
-  { value: "mobile", label: "Mobile" },
-  { value: "data-science", label: "Data Science" },
-  { value: "machine-learning", label: "Machine Learning" },
-  { value: "security", label: "Security" },
-  { value: "cloud", label: "Cloud" },
+	{ value: "frontend", label: "Frontend" },
+	{ value: "backend", label: "Backend" },
+	{ value: "devops", label: "DevOps" },
+	{ value: "design", label: "Design" },
+	{ value: "qa", label: "QA" },
+	{ value: "mobile", label: "Mobile" },
+	{ value: "data-science", label: "Data Science" },
+	{ value: "machine-learning", label: "Machine Learning" },
+	{ value: "security", label: "Security" },
+	{ value: "cloud", label: "Cloud" },
 ];
 
-const simpleTags = ["React", "Vue", "Angular", "Svelte", "Next.js", "Nuxt", "Remix", "Astro"];
+const simpleTags = [
+	"React",
+	"Vue",
+	"Angular",
+	"Svelte",
+	"Next.js",
+	"Nuxt",
+	"Remix",
+	"Astro",
+];
 
 /**
  * Default TagAutocomplete
@@ -72,57 +83,89 @@ const simpleTags = ["React", "Vue", "Angular", "Svelte", "Next.js", "Nuxt", "Rem
  * Basic usage with a list of options. Users need to type at least 2 characters to see the dropdown.
  */
 export const Default: Story = {
-  render: () => {
-    const [value, setValue] = useState<string[]>([]);
-    return (
-      <div className="w-full">
-        <TagAutocomplete
-          triggerClassName="w-96"
-          options={sampleTags}
-          value={value}
-          onChange={setValue as any}
-          placeholder="Type at least 2 characters to search..."
-        />
-        <div className="mt-base">
-          <Typography variant="body" size="small" className="text-neutral-content-subtle">
-            <strong>Available:</strong> {sampleTags.map((tag) => tag.label).join(", ")}
-          </Typography>
-          <Typography variant="body" size="small" className="text-neutral-content-subtle">
-            <strong>Selected:</strong> {value.length > 0 ? value.join(", ") : "None"}
-          </Typography>
-        </div>
-        <div className="mt-base p-base bg-neutral-surface rounded text-sm w-[400px]">
-          <Typography variant="body" size="small" className="mb-tight">
-            <strong>Keyboard shortcuts:</strong>
-          </Typography>
-          <ul className="space-y-tight text-neutral-content-subtle">
-            <li>
-              • <kbd className="px-tight bg-neutral-surface-bold rounded">←</kbd> /{" "}
-              <kbd className="px-tight bg-neutral-surface-bold rounded">→</kbd> Navigate between tags
-            </li>
-            <li>
-              • <kbd className="px-tight bg-neutral-surface-bold rounded">↑</kbd> /{" "}
-              <kbd className="px-tight bg-neutral-surface-bold rounded">↓</kbd> Navigate dropdown options
-            </li>
-            <li>
-              • <kbd className="px-tight bg-neutral-surface-bold rounded">Enter</kbd> /{" "}
-              <kbd className="px-tight bg-neutral-surface-bold rounded">,</kbd> Select highlighted option or create new
-              tag
-            </li>
-            <li>
-              • <kbd className="px-tight bg-neutral-surface-bold rounded">Backspace</kbd> Remove tag or focus last tag
-            </li>
-            <li>
-              • <kbd className="px-tight bg-neutral-surface-bold rounded">Delete</kbd> Remove focused tag
-            </li>
-            <li>
-              • <kbd className="px-tight bg-neutral-surface-bold rounded">Esc</kbd> Close dropdown
-            </li>
-          </ul>
-        </div>
-      </div>
-    );
-  },
+	render: () => {
+		const [value, setValue] = useState<string[]>([]);
+		return (
+			<div className="w-full">
+				<TagAutocomplete
+					triggerClassName="w-96"
+					options={sampleTags}
+					value={value}
+					onChange={setValue as any}
+					placeholder="Type at least 2 characters to search..."
+				/>
+				<div className="mt-base">
+					<Typography
+						variant="body"
+						size="small"
+						className="text-neutral-content-subtle"
+					>
+						<strong>Available:</strong>{" "}
+						{sampleTags.map((tag) => tag.label).join(", ")}
+					</Typography>
+					<Typography
+						variant="body"
+						size="small"
+						className="text-neutral-content-subtle"
+					>
+						<strong>Selected:</strong>{" "}
+						{value.length > 0 ? value.join(", ") : "None"}
+					</Typography>
+				</div>
+				<div className="mt-base p-base bg-neutral-surface rounded text-sm w-[400px]">
+					<Typography variant="body" size="small" className="mb-tight">
+						<strong>Keyboard shortcuts:</strong>
+					</Typography>
+					<ul className="space-y-tight text-neutral-content-subtle">
+						<li>
+							•{" "}
+							<kbd className="px-tight bg-neutral-surface-bold rounded">←</kbd>{" "}
+							/{" "}
+							<kbd className="px-tight bg-neutral-surface-bold rounded">→</kbd>{" "}
+							Navigate between tags
+						</li>
+						<li>
+							•{" "}
+							<kbd className="px-tight bg-neutral-surface-bold rounded">↑</kbd>{" "}
+							/{" "}
+							<kbd className="px-tight bg-neutral-surface-bold rounded">↓</kbd>{" "}
+							Navigate dropdown options
+						</li>
+						<li>
+							•{" "}
+							<kbd className="px-tight bg-neutral-surface-bold rounded">
+								Enter
+							</kbd>{" "}
+							/{" "}
+							<kbd className="px-tight bg-neutral-surface-bold rounded">,</kbd>{" "}
+							Select highlighted option or create new tag
+						</li>
+						<li>
+							•{" "}
+							<kbd className="px-tight bg-neutral-surface-bold rounded">
+								Backspace
+							</kbd>{" "}
+							Remove tag or focus last tag
+						</li>
+						<li>
+							•{" "}
+							<kbd className="px-tight bg-neutral-surface-bold rounded">
+								Delete
+							</kbd>{" "}
+							Remove focused tag
+						</li>
+						<li>
+							•{" "}
+							<kbd className="px-tight bg-neutral-surface-bold rounded">
+								Esc
+							</kbd>{" "}
+							Close dropdown
+						</li>
+					</ul>
+				</div>
+			</div>
+		);
+	},
 };
 
 /**
@@ -131,19 +174,19 @@ export const Default: Story = {
  * Options can be simple strings instead of objects.
  */
 export const SimpleStrings: Story = {
-  render: () => {
-    const [value, setValue] = useState<string[]>(["React", "Next.js"]);
-    return (
-      <div className="w-96">
-        <TagAutocomplete
-          options={simpleTags}
-          value={value}
-          onChange={setValue as any}
-          placeholder="Select frameworks..."
-        />
-      </div>
-    );
-  },
+	render: () => {
+		const [value, setValue] = useState<string[]>(["React", "Next.js"]);
+		return (
+			<div className="w-96">
+				<TagAutocomplete
+					options={simpleTags}
+					value={value}
+					onChange={setValue as any}
+					placeholder="Select frameworks..."
+				/>
+			</div>
+		);
+	},
 };
 
 /**
@@ -152,31 +195,35 @@ export const SimpleStrings: Story = {
  * When many tags are selected, they automatically wrap to multiple lines.
  */
 export const MultipleTagsWrapping: Story = {
-  render: () => {
-    const [value, setValue] = useState<string[]>([
-      "frontend",
-      "backend",
-      "devops",
-      "design",
-      "qa",
-      "mobile",
-      "data-science",
-      "machine-learning",
-    ]);
-    return (
-      <div className="w-96">
-        <TagAutocomplete
-          options={sampleTags}
-          value={value}
-          onChange={setValue as any}
-          placeholder="Type to search..."
-        />
-        <Typography variant="body" size="small" className="mt-tight text-neutral-content-subtle">
-          All {value.length} tags are shown and wrap to multiple lines
-        </Typography>
-      </div>
-    );
-  },
+	render: () => {
+		const [value, setValue] = useState<string[]>([
+			"frontend",
+			"backend",
+			"devops",
+			"design",
+			"qa",
+			"mobile",
+			"data-science",
+			"machine-learning",
+		]);
+		return (
+			<div className="w-96">
+				<TagAutocomplete
+					options={sampleTags}
+					value={value}
+					onChange={setValue as any}
+					placeholder="Type to search..."
+				/>
+				<Typography
+					variant="body"
+					size="small"
+					className="mt-tight text-neutral-content-subtle"
+				>
+					All {value.length} tags are shown and wrap to multiple lines
+				</Typography>
+			</div>
+		);
+	},
 };
 
 /**
@@ -187,66 +234,80 @@ export const MultipleTagsWrapping: Story = {
  * like Zod, Yup, or React Hook Form.
  */
 export const FormValidationPattern: Story = {
-  render: () => {
-    const [value, setValue] = useState<string[]>(["frontend"]);
-    const [error, setError] = useState<string>("");
-    const [touched, setTouched] = useState(false);
-    const [submittedTags, setSubmittedTags] = useState<string[]>([]);
+	render: () => {
+		const [value, setValue] = useState<string[]>(["frontend"]);
+		const [error, setError] = useState<string>("");
+		const [touched, setTouched] = useState(false);
+		const [submittedTags, setSubmittedTags] = useState<string[]>([]);
 
-    // Validation logic (could be Zod, Yup, etc.)
-    const validate = (values: string[]) => {
-      if (values.length === 0) return "At least one tag is required";
-      if (values.length > 3) return "Maximum 3 tags allowed";
-      return "";
-    };
+		// Validation logic (could be Zod, Yup, etc.)
+		const validate = (values: string[]) => {
+			if (values.length === 0) return "At least one tag is required";
+			if (values.length > 3) return "Maximum 3 tags allowed";
+			return "";
+		};
 
-    const handleChange = (newValues: string[]) => {
-      setValue(newValues);
-      setTouched(true);
-      const validationError = validate(newValues);
-      setError(validationError);
-    };
+		const handleChange = (newValues: string[]) => {
+			setValue(newValues);
+			setTouched(true);
+			const validationError = validate(newValues);
+			setError(validationError);
+		};
 
-    const handleSubmit = (e: React.FormEvent) => {
-      e.preventDefault();
-      const validationError = validate(value);
-      if (validationError) {
-        setError(validationError);
-        setTouched(true);
-        return;
-      }
-      setSubmittedTags(value);
-    };
+		const handleSubmit = (e: React.FormEvent) => {
+			e.preventDefault();
+			const validationError = validate(value);
+			if (validationError) {
+				setError(validationError);
+				setTouched(true);
+				return;
+			}
+			setSubmittedTags(value);
+		};
 
-    return (
-      <form onSubmit={handleSubmit} className="w-96">
-        <TagAutocomplete
-          options={sampleTags}
-          value={value}
-          onChange={handleChange as any}
-          placeholder="Select 1-3 skills..."
-        />
-        {touched && error && <div className="mt-tight text-xs text-danger-content">{error}</div>}
-        <Typography variant="body" size="small" className="mt-tight text-neutral-content-subtle">
-          {value.length}/3 selected
-        </Typography>
-        <Button type="submit" variant="primary" className="mt-base">
-          Submit
-        </Button>
+		return (
+			<form onSubmit={handleSubmit} className="w-96">
+				<TagAutocomplete
+					options={sampleTags}
+					value={value}
+					onChange={handleChange as any}
+					placeholder="Select 1-3 skills..."
+				/>
+				{touched && error && (
+					<div className="mt-tight text-xs text-danger-content">{error}</div>
+				)}
+				<Typography
+					variant="body"
+					size="small"
+					className="mt-tight text-neutral-content-subtle"
+				>
+					{value.length}/3 selected
+				</Typography>
+				<Button type="submit" variant="primary" className="mt-base">
+					Submit
+				</Button>
 
-        {submittedTags.length > 0 && (
-          <div className="mt-base p-base bg-neutral-surface rounded">
-            <Typography variant="body" size="small" className="font-medium mb-tight">
-              Submitted Tags:
-            </Typography>
-            <Typography variant="body" size="small" className="text-neutral-content-subtle">
-              {submittedTags.join(", ")}
-            </Typography>
-          </div>
-        )}
-      </form>
-    );
-  },
+				{submittedTags.length > 0 && (
+					<div className="mt-base p-base bg-neutral-surface rounded">
+						<Typography
+							variant="body"
+							size="small"
+							className="font-medium mb-tight"
+						>
+							Submitted Tags:
+						</Typography>
+						<Typography
+							variant="body"
+							size="small"
+							className="text-neutral-content-subtle"
+						>
+							{submittedTags.join(", ")}
+						</Typography>
+					</div>
+				)}
+			</form>
+		);
+	},
 };
 
 /**
@@ -255,24 +316,28 @@ export const FormValidationPattern: Story = {
  * Shows a spinner in the dropdown while options are being loaded.
  */
 export const LoadingState: Story = {
-  render: () => {
-    const [value, setValue] = useState<string[]>(["frontend"]);
-    return (
-      <div className="w-96">
-        <TagAutocomplete
-          options={sampleTags}
-          value={value}
-          onChange={setValue as any}
-          placeholder="Type to search..."
-          isLoading={true}
-          minSearchLength={1}
-        />
-        <Typography variant="body" size="small" className="mt-tight text-neutral-content-subtle">
-          Type to see the loading spinner in the dropdown
-        </Typography>
-      </div>
-    );
-  },
+	render: () => {
+		const [value, setValue] = useState<string[]>(["frontend"]);
+		return (
+			<div className="w-96">
+				<TagAutocomplete
+					options={sampleTags}
+					value={value}
+					onChange={setValue as any}
+					placeholder="Type to search..."
+					isLoading={true}
+					minSearchLength={1}
+				/>
+				<Typography
+					variant="body"
+					size="small"
+					className="mt-tight text-neutral-content-subtle"
+				>
+					Type to see the loading spinner in the dropdown
+				</Typography>
+			</div>
+		);
+	},
 };
 
 /**
@@ -281,36 +346,36 @@ export const LoadingState: Story = {
  * Simulates loading options from an API based on search query.
  */
 export const AsyncSearch: Story = {
-  render: () => {
-    const [value, setValue] = useState<string[]>([]);
-    const [options, setOptions] = useState(sampleTags);
-    const [isLoading, setIsLoading] = useState(false);
+	render: () => {
+		const [value, setValue] = useState<string[]>([]);
+		const [options, setOptions] = useState(sampleTags);
+		const [isLoading, setIsLoading] = useState(false);
 
-    const handleSearch = (query: string) => {
-      setIsLoading(true);
-      // Simulate API delay
-      setTimeout(() => {
-        const filtered = sampleTags.filter((tag) =>
-          (tag.label ?? tag.value).toLowerCase().includes(query.toLowerCase()),
-        );
-        setOptions(filtered);
-        setIsLoading(false);
-      }, 500);
-    };
+		const handleSearch = (query: string) => {
+			setIsLoading(true);
+			// Simulate API delay
+			setTimeout(() => {
+				const filtered = sampleTags.filter((tag) =>
+					(tag.label ?? tag.value).toLowerCase().includes(query.toLowerCase()),
+				);
+				setOptions(filtered);
+				setIsLoading(false);
+			}, 500);
+		};
 
-    return (
-      <div className="w-96">
-        <TagAutocomplete
-          options={options}
-          value={value}
-          onChange={setValue as any}
-          onSearch={handleSearch}
-          isLoading={isLoading}
-          placeholder="Type to search (simulated 500ms delay)..."
-        />
-      </div>
-    );
-  },
+		return (
+			<div className="w-96">
+				<TagAutocomplete
+					options={options}
+					value={value}
+					onChange={setValue as any}
+					onSearch={handleSearch}
+					isLoading={isLoading}
+					placeholder="Type to search (simulated 500ms delay)..."
+				/>
+			</div>
+		);
+	},
 };
 
 /**
@@ -319,24 +384,28 @@ export const AsyncSearch: Story = {
  * Allow users to create new tags that don't exist in the list.
  */
 export const WithTagCreation: Story = {
-  render: () => {
-    const [value, setValue] = useState<string[]>(["frontend"]);
+	render: () => {
+		const [value, setValue] = useState<string[]>(["frontend"]);
 
-    return (
-      <div className="w-96">
-        <TagAutocomplete
-          options={sampleTags}
-          value={value}
-          onChange={setValue as any}
-          allowCreate={true}
-          placeholder="Type to search or create new tags..."
-        />
-        <Typography variant="body" size="small" className="mt-base text-neutral-content-subtle">
-          Selected: {value.join(", ")}
-        </Typography>
-      </div>
-    );
-  },
+		return (
+			<div className="w-96">
+				<TagAutocomplete
+					options={sampleTags}
+					value={value}
+					onChange={setValue as any}
+					allowCreate={true}
+					placeholder="Type to search or create new tags..."
+				/>
+				<Typography
+					variant="body"
+					size="small"
+					className="mt-base text-neutral-content-subtle"
+				>
+					Selected: {value.join(", ")}
+				</Typography>
+			</div>
+		);
+	},
 };
 
 /**
@@ -345,19 +414,19 @@ export const WithTagCreation: Story = {
  * Component in disabled state.
  */
 export const Disabled: Story = {
-  render: () => {
-    return (
-      <div className="w-96">
-        <TagAutocomplete
-          options={sampleTags}
-          value={["frontend", "backend"]}
-          onChange={() => {}}
-          placeholder="Select tags..."
-          disabled
-        />
-      </div>
-    );
-  },
+	render: () => {
+		return (
+			<div className="w-96">
+				<TagAutocomplete
+					options={sampleTags}
+					value={["frontend", "backend"]}
+					onChange={() => {}}
+					placeholder="Select tags..."
+					disabled
+				/>
+			</div>
+		);
+	},
 };
 
 /**
@@ -366,19 +435,19 @@ export const Disabled: Story = {
  * Component with no pre-selected values.
  */
 export const EmptyState: Story = {
-  render: () => {
-    const [value, setValue] = useState<string[]>([]);
-    return (
-      <div className="w-96">
-        <TagAutocomplete
-          options={sampleTags}
-          value={value}
-          onChange={setValue as any}
-          placeholder="Click or type to add tags..."
-        />
-      </div>
-    );
-  },
+	render: () => {
+		const [value, setValue] = useState<string[]>([]);
+		return (
+			<div className="w-96">
+				<TagAutocomplete
+					options={sampleTags}
+					value={value}
+					onChange={setValue as any}
+					placeholder="Click or type to add tags..."
+				/>
+			</div>
+		);
+	},
 };
 
 /**
@@ -387,31 +456,35 @@ export const EmptyState: Story = {
  * Some options can be disabled.
  */
 export const DisabledOptions: Story = {
-  render: () => {
-    const [value, setValue] = useState<string[]>(["frontend"]);
-    const optionsWithDisabled = [
-      { value: "frontend", label: "Frontend" },
-      { value: "backend", label: "Backend" },
-      { value: "devops", label: "DevOps", disabled: true },
-      { value: "design", label: "Design" },
-      { value: "qa", label: "QA", disabled: true },
-      { value: "mobile", label: "Mobile" },
-    ];
+	render: () => {
+		const [value, setValue] = useState<string[]>(["frontend"]);
+		const optionsWithDisabled = [
+			{ value: "frontend", label: "Frontend" },
+			{ value: "backend", label: "Backend" },
+			{ value: "devops", label: "DevOps", disabled: true },
+			{ value: "design", label: "Design" },
+			{ value: "qa", label: "QA", disabled: true },
+			{ value: "mobile", label: "Mobile" },
+		];
 
-    return (
-      <div className="w-96">
-        <TagAutocomplete
-          options={optionsWithDisabled}
-          value={value}
-          onChange={setValue as any}
-          placeholder="Select tags..."
-        />
-        <Typography variant="body" size="small" className="mt-tight text-neutral-content-subtle">
-          DevOps and QA options are disabled
-        </Typography>
-      </div>
-    );
-  },
+		return (
+			<div className="w-96">
+				<TagAutocomplete
+					options={optionsWithDisabled}
+					value={value}
+					onChange={setValue as any}
+					placeholder="Select tags..."
+				/>
+				<Typography
+					variant="body"
+					size="small"
+					className="mt-tight text-neutral-content-subtle"
+				>
+					DevOps and QA options are disabled
+				</Typography>
+			</div>
+		);
+	},
 };
 
 /**
@@ -420,78 +493,103 @@ export const DisabledOptions: Story = {
  * Example of TagAutocomplete with tag creation and submission.
  */
 export const InFormContext: Story = {
-  render: () => {
-    const [skills, setSkills] = useState<string[]>([]);
-    const [submittedTags, setSubmittedTags] = useState<string[]>([]);
+	render: () => {
+		const [skills, setSkills] = useState<string[]>([]);
+		const [submittedTags, setSubmittedTags] = useState<string[]>([]);
 
-    const handleSkillsChange = (values: string[]) => {
-      setSkills(values);
-    };
+		const handleSkillsChange = (values: string[]) => {
+			setSkills(values);
+		};
 
-    const handleAdd = () => {
-      // Validation checks
-      if (skills.length === 0) return;
+		const handleAdd = () => {
+			// Validation checks
+			if (skills.length === 0) return;
 
-      // Distinguish between existing and new tags
-      const existingSkills = skills.filter((skill) => sampleTags.some((tag) => tag.value === skill));
-      const newSkills = skills.filter((skill) => !sampleTags.some((tag) => tag.value === skill));
+			// Distinguish between existing and new tags
+			const existingSkills = skills.filter((skill) =>
+				sampleTags.some((tag) => tag.value === skill),
+			);
+			const newSkills = skills.filter(
+				(skill) => !sampleTags.some((tag) => tag.value === skill),
+			);
 
-      console.log("Existing skills:", existingSkills);
-      console.log("New skills to create:", newSkills);
-      console.log("All skills:", skills);
+			console.log("Existing skills:", existingSkills);
+			console.log("New skills to create:", newSkills);
+			console.log("All skills:", skills);
 
-      setSubmittedTags(skills);
-      setSkills([]);
-    };
+			setSubmittedTags(skills);
+			setSkills([]);
+		};
 
-    return (
-      <div className="w-full max-w-2xl space-y-wide">
-        <div>
-          <Typography variant="body" size="small" className="font-medium mb-tight">
-            Skills
-          </Typography>
-          <form
-            className="flex gap-tight items-start"
-            onSubmit={(e) => {
-              e.preventDefault();
-              handleAdd();
-            }}
-          >
-            <div className="flex-1">
-              <TagAutocomplete
-                name="skills"
-                options={sampleTags}
-                value={skills}
-                onChange={handleSkillsChange as any}
-                allowCreate={true}
-                placeholder="Type to add skills..."
-              />
-            </div>
-            <Button type="submit" variant="primary" disabled={skills.length === 0}>
-              Add
-            </Button>
-          </form>
-        </div>
+		return (
+			<div className="w-full max-w-2xl space-y-wide">
+				<div>
+					<Typography
+						variant="body"
+						size="small"
+						className="font-medium mb-tight"
+					>
+						Skills
+					</Typography>
+					<form
+						className="flex gap-tight items-start"
+						onSubmit={(e) => {
+							e.preventDefault();
+							handleAdd();
+						}}
+					>
+						<div className="flex-1">
+							<TagAutocomplete
+								name="skills"
+								options={sampleTags}
+								value={skills}
+								onChange={handleSkillsChange as any}
+								allowCreate={true}
+								placeholder="Type to add skills..."
+							/>
+						</div>
+						<Button
+							type="submit"
+							variant="primary"
+							disabled={skills.length === 0}
+						>
+							Add
+						</Button>
+					</form>
+				</div>
 
-        <div className="mt-base">
-          <Typography variant="body" size="small" className="text-neutral-content-subtle">
-            Available: {sampleTags.map((tag) => tag.label).join(", ") || "All selected"}
-          </Typography>
-        </div>
+				<div className="mt-base">
+					<Typography
+						variant="body"
+						size="small"
+						className="text-neutral-content-subtle"
+					>
+						Available:{" "}
+						{sampleTags.map((tag) => tag.label).join(", ") || "All selected"}
+					</Typography>
+				</div>
 
-        {submittedTags.length > 0 && (
-          <div className="p-base bg-neutral-surface rounded">
-            <Typography variant="body" size="small" className="font-medium mb-tight">
-              Submitted Tags:
-            </Typography>
-            <Typography variant="body" size="small" className="text-neutral-content-subtle">
-              {submittedTags.join(", ")}
-            </Typography>
-          </div>
-        )}
-      </div>
-    );
-  },
+				{submittedTags.length > 0 && (
+					<div className="p-base bg-neutral-surface rounded">
+						<Typography
+							variant="body"
+							size="small"
+							className="font-medium mb-tight"
+						>
+							Submitted Tags:
+						</Typography>
+						<Typography
+							variant="body"
+							size="small"
+							className="text-neutral-content-subtle"
+						>
+							{submittedTags.join(", ")}
+						</Typography>
+					</div>
+				)}
+			</div>
+		);
+	},
 };
 
 /**
@@ -500,21 +598,32 @@ export const InFormContext: Story = {
  * Tags with long labels are truncated.
  */
 export const LongLabels: Story = {
-  render: () => {
-    const [value, setValue] = useState<string[]>(["long-1", "long-2"]);
-    const longOptions = [
-      { value: "long-1", label: "This is a very long tag label that should be truncated" },
-      { value: "long-2", label: "Another extremely long label for demonstration" },
-      { value: "long-3", label: "Short" },
-      { value: "long-4", label: "Medium length label" },
-    ];
+	render: () => {
+		const [value, setValue] = useState<string[]>(["long-1", "long-2"]);
+		const longOptions = [
+			{
+				value: "long-1",
+				label: "This is a very long tag label that should be truncated",
+			},
+			{
+				value: "long-2",
+				label: "Another extremely long label for demonstration",
+			},
+			{ value: "long-3", label: "Short" },
+			{ value: "long-4", label: "Medium length label" },
+		];
 
-    return (
-      <div className="w-96">
-        <TagAutocomplete options={longOptions} value={value} onChange={setValue as any} placeholder="Select tags..." />
-      </div>
-    );
-  },
+		return (
+			<div className="w-96">
+				<TagAutocomplete
+					options={longOptions}
+					value={value}
+					onChange={setValue as any}
+					placeholder="Select tags..."
+				/>
+			</div>
+		);
+	},
 };
 
 /**
@@ -523,27 +632,31 @@ export const LongLabels: Story = {
  * Component with a large list of options.
  */
 export const ManyOptions: Story = {
-  render: () => {
-    const [value, setValue] = useState<string[]>([]);
-    const manyOptions = Array.from({ length: 50 }, (_, i) => ({
-      value: `option-${i + 1}`,
-      label: `Option ${i + 1}`,
-    }));
+	render: () => {
+		const [value, setValue] = useState<string[]>([]);
+		const manyOptions = Array.from({ length: 50 }, (_, i) => ({
+			value: `option-${i + 1}`,
+			label: `Option ${i + 1}`,
+		}));
 
-    return (
-      <div className="w-96">
-        <TagAutocomplete
-          options={manyOptions}
-          value={value}
-          onChange={setValue as any}
-          placeholder="Search 50 options..."
-        />
-        <Typography variant="body" size="small" className="mt-tight text-neutral-content-subtle">
-          50 options available - use search to filter
-        </Typography>
-      </div>
-    );
-  },
+		return (
+			<div className="w-96">
+				<TagAutocomplete
+					options={manyOptions}
+					value={value}
+					onChange={setValue as any}
+					placeholder="Search 50 options..."
+				/>
+				<Typography
+					variant="body"
+					size="small"
+					className="mt-tight text-neutral-content-subtle"
+				>
+					50 options available - use search to filter
+				</Typography>
+			</div>
+		);
+	},
 };
 
 /**
@@ -552,27 +665,27 @@ export const ManyOptions: Story = {
  * Using a custom search filter function.
  */
 export const CustomFilter: Story = {
-  render: () => {
-    const [value, setValue] = useState<string[]>([]);
+	render: () => {
+		const [value, setValue] = useState<string[]>([]);
 
-    // Custom filter that matches start of string only
-    const startsWithFilter = (option: any, query: string) => {
-      const label = option.label || option;
-      return label.toLowerCase().startsWith(query.toLowerCase());
-    };
+		// Custom filter that matches start of string only
+		const startsWithFilter = (option: any, query: string) => {
+			const label = option.label || option;
+			return label.toLowerCase().startsWith(query.toLowerCase());
+		};
 
-    return (
-      <div className="w-96">
-        <TagAutocomplete
-          options={sampleTags}
-          value={value}
-          onChange={setValue as any}
-          searchFilter={startsWithFilter}
-          placeholder="Custom filter: matches start only (type 'f' for Frontend)..."
-        />
-      </div>
-    );
-  },
+		return (
+			<div className="w-96">
+				<TagAutocomplete
+					options={sampleTags}
+					value={value}
+					onChange={setValue as any}
+					searchFilter={startsWithFilter}
+					placeholder="Custom filter: matches start only (type 'f' for Frontend)..."
+				/>
+			</div>
+		);
+	},
 };
 
 /**
@@ -581,21 +694,149 @@ export const CustomFilter: Story = {
  * Configure the minimum number of characters required before showing the dropdown.
  */
 export const CustomMinSearchLength: Story = {
-  render: () => {
-    const [value, setValue] = useState<string[]>([]);
-    return (
-      <div className="w-96">
-        <TagAutocomplete
-          options={sampleTags}
-          value={value}
-          onChange={setValue as any}
-          minSearchLength={3}
-          placeholder="Minimum 3 character to search..."
-        />
-        <Typography variant="body" size="small" className="mt-base text-neutral-content-subtle">
-          <strong>Available:</strong> {sampleTags.map((tag) => tag.label).join(", ")}
-        </Typography>
-      </div>
-    );
-  },
+	render: () => {
+		const [value, setValue] = useState<string[]>([]);
+		return (
+			<div className="w-96">
+				<TagAutocomplete
+					options={sampleTags}
+					value={value}
+					onChange={setValue as any}
+					minSearchLength={3}
+					placeholder="Minimum 3 character to search..."
+				/>
+				<Typography
+					variant="body"
+					size="small"
+					className="mt-base text-neutral-content-subtle"
+				>
+					<strong>Available:</strong>{" "}
+					{sampleTags.map((tag) => tag.label).join(", ")}
+				</Typography>
+			</div>
+		);
+	},
+};
+
+/**
+ * Paste With Creation (allowCreate=true)
+ *
+ * When allowCreate is enabled, pasting a comma-separated string creates each value
+ * as a new tag immediately — no existing options required.
+ *
+ * Try pasting: `React, Vue, Angular, Svelte`
+ */
+export const PasteWithCreation: Story = {
+	render: () => {
+		const [value, setValue] = useState<string[]>([]);
+		return (
+			<div className="w-full max-w-lg space-y-base">
+				<TagAutocomplete
+					options={[]}
+					value={value}
+					onChange={setValue as any}
+					allowCreate={true}
+					placeholder="Paste comma-separated values to create tags..."
+				/>
+				<div className="p-base bg-neutral-surface rounded-md space-y-tight">
+					<Typography variant="body" size="small" className="font-medium">
+						Try it:
+					</Typography>
+					<Typography
+						variant="body"
+						size="small"
+						className="text-neutral-content-subtle"
+					>
+						Copy and paste this into the field above:
+					</Typography>
+					<Typography
+						variant="body"
+						size="small"
+						className="font-mono bg-neutral-surface-bold rounded px-tight py-1"
+					>
+						React, Vue, Angular, Svelte
+					</Typography>
+					<Typography
+						variant="body"
+						size="small"
+						className="text-neutral-content-subtle mt-tight"
+					>
+						Each comma-separated value is created as a new tag instantly.
+					</Typography>
+				</div>
+				{value.length > 0 && (
+					<Typography
+						variant="body"
+						size="small"
+						className="text-neutral-content-subtle"
+					>
+						<strong>Selected:</strong> {value.join(", ")}
+					</Typography>
+				)}
+			</div>
+		);
+	},
+};
+
+/**
+ * Paste Blocked (allowCreate=false)
+ *
+ * When allowCreate is disabled (e.g. the field searches a server-side list),
+ * pasting comma-separated values is not supported. A validation error is shown
+ * below the input prompting the user to search and select tags individually.
+ *
+ * Try pasting: `Frontend, Backend, DevOps`
+ */
+export const PasteBlocked: Story = {
+	render: () => {
+		const [value, setValue] = useState<string[]>([]);
+		return (
+			<div className="w-full max-w-lg space-y-base">
+				<TagAutocomplete
+					options={sampleTags}
+					value={value}
+					onChange={setValue as any}
+					allowCreate={false}
+					minSearchLength={0}
+					placeholder="Search and select tags..."
+				/>
+				<div className="p-base bg-neutral-surface rounded-md space-y-tight">
+					<Typography variant="body" size="small" className="font-medium">
+						Try it:
+					</Typography>
+					<Typography
+						variant="body"
+						size="small"
+						className="text-neutral-content-subtle"
+					>
+						Paste the following into the field above and a validation error will
+						appear:
+					</Typography>
+					<Typography
+						variant="body"
+						size="small"
+						className="font-mono bg-neutral-surface-bold rounded px-tight py-1"
+					>
+						Frontend, Backend, DevOps
+					</Typography>
+					<Typography
+						variant="body"
+						size="small"
+						className="text-neutral-content-subtle mt-tight"
+					>
+						To add tags, type in the field and select from the dropdown.
+					</Typography>
+				</div>
+				{value.length > 0 && (
+					<Typography
+						variant="body"
+						size="small"
+						className="text-neutral-content-subtle"
+					>
+						<strong>Selected:</strong> {value.join(", ")}
+					</Typography>
+				)}
+			</div>
+		);
+	},
 };

--- a/web/libs/ui/src/lib/tag-autocomplete/tag-autocomplete.stories.tsx
+++ b/web/libs/ui/src/lib/tag-autocomplete/tag-autocomplete.stories.tsx
@@ -6,23 +6,23 @@ import { TagAutocomplete } from "./tag-autocomplete";
 import type { TagOption } from "./types";
 
 const meta: Meta<typeof TagAutocomplete> = {
-	component: TagAutocomplete,
-	title: "UI/TagAutocomplete",
-	argTypes: {
-		disabled: {
-			control: "boolean",
-		},
-		isLoading: {
-			control: "boolean",
-		},
-		minSearchLength: {
-			control: "number",
-		},
-	},
-	parameters: {
-		docs: {
-			description: {
-				component: `
+  component: TagAutocomplete,
+  title: "UI/TagAutocomplete",
+  argTypes: {
+    disabled: {
+      control: "boolean",
+    },
+    isLoading: {
+      control: "boolean",
+    },
+    minSearchLength: {
+      control: "number",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: `
 A tag-like autocomplete component that allows users to select multiple tags from a predefined list.
 
 ## Features
@@ -45,37 +45,28 @@ A tag-like autocomplete component that allows users to select multiple tags from
 | Backspace/Delete | Remove focused tag |
 | Escape | Close dropdown |
         `,
-			},
-		},
-	},
+      },
+    },
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof TagAutocomplete>;
 
 const sampleTags: TagOption<string>[] = [
-	{ value: "frontend", label: "Frontend" },
-	{ value: "backend", label: "Backend" },
-	{ value: "devops", label: "DevOps" },
-	{ value: "design", label: "Design" },
-	{ value: "qa", label: "QA" },
-	{ value: "mobile", label: "Mobile" },
-	{ value: "data-science", label: "Data Science" },
-	{ value: "machine-learning", label: "Machine Learning" },
-	{ value: "security", label: "Security" },
-	{ value: "cloud", label: "Cloud" },
+  { value: "frontend", label: "Frontend" },
+  { value: "backend", label: "Backend" },
+  { value: "devops", label: "DevOps" },
+  { value: "design", label: "Design" },
+  { value: "qa", label: "QA" },
+  { value: "mobile", label: "Mobile" },
+  { value: "data-science", label: "Data Science" },
+  { value: "machine-learning", label: "Machine Learning" },
+  { value: "security", label: "Security" },
+  { value: "cloud", label: "Cloud" },
 ];
 
-const simpleTags = [
-	"React",
-	"Vue",
-	"Angular",
-	"Svelte",
-	"Next.js",
-	"Nuxt",
-	"Remix",
-	"Astro",
-];
+const simpleTags = ["React", "Vue", "Angular", "Svelte", "Next.js", "Nuxt", "Remix", "Astro"];
 
 /**
  * Default TagAutocomplete
@@ -83,89 +74,57 @@ const simpleTags = [
  * Basic usage with a list of options. Users need to type at least 2 characters to see the dropdown.
  */
 export const Default: Story = {
-	render: () => {
-		const [value, setValue] = useState<string[]>([]);
-		return (
-			<div className="w-full">
-				<TagAutocomplete
-					triggerClassName="w-96"
-					options={sampleTags}
-					value={value}
-					onChange={setValue as any}
-					placeholder="Type at least 2 characters to search..."
-				/>
-				<div className="mt-base">
-					<Typography
-						variant="body"
-						size="small"
-						className="text-neutral-content-subtle"
-					>
-						<strong>Available:</strong>{" "}
-						{sampleTags.map((tag) => tag.label).join(", ")}
-					</Typography>
-					<Typography
-						variant="body"
-						size="small"
-						className="text-neutral-content-subtle"
-					>
-						<strong>Selected:</strong>{" "}
-						{value.length > 0 ? value.join(", ") : "None"}
-					</Typography>
-				</div>
-				<div className="mt-base p-base bg-neutral-surface rounded text-sm w-[400px]">
-					<Typography variant="body" size="small" className="mb-tight">
-						<strong>Keyboard shortcuts:</strong>
-					</Typography>
-					<ul className="space-y-tight text-neutral-content-subtle">
-						<li>
-							•{" "}
-							<kbd className="px-tight bg-neutral-surface-bold rounded">←</kbd>{" "}
-							/{" "}
-							<kbd className="px-tight bg-neutral-surface-bold rounded">→</kbd>{" "}
-							Navigate between tags
-						</li>
-						<li>
-							•{" "}
-							<kbd className="px-tight bg-neutral-surface-bold rounded">↑</kbd>{" "}
-							/{" "}
-							<kbd className="px-tight bg-neutral-surface-bold rounded">↓</kbd>{" "}
-							Navigate dropdown options
-						</li>
-						<li>
-							•{" "}
-							<kbd className="px-tight bg-neutral-surface-bold rounded">
-								Enter
-							</kbd>{" "}
-							/{" "}
-							<kbd className="px-tight bg-neutral-surface-bold rounded">,</kbd>{" "}
-							Select highlighted option or create new tag
-						</li>
-						<li>
-							•{" "}
-							<kbd className="px-tight bg-neutral-surface-bold rounded">
-								Backspace
-							</kbd>{" "}
-							Remove tag or focus last tag
-						</li>
-						<li>
-							•{" "}
-							<kbd className="px-tight bg-neutral-surface-bold rounded">
-								Delete
-							</kbd>{" "}
-							Remove focused tag
-						</li>
-						<li>
-							•{" "}
-							<kbd className="px-tight bg-neutral-surface-bold rounded">
-								Esc
-							</kbd>{" "}
-							Close dropdown
-						</li>
-					</ul>
-				</div>
-			</div>
-		);
-	},
+  render: () => {
+    const [value, setValue] = useState<string[]>([]);
+    return (
+      <div className="w-full">
+        <TagAutocomplete
+          triggerClassName="w-96"
+          options={sampleTags}
+          value={value}
+          onChange={setValue as any}
+          placeholder="Type at least 2 characters to search..."
+        />
+        <div className="mt-base">
+          <Typography variant="body" size="small" className="text-neutral-content-subtle">
+            <strong>Available:</strong> {sampleTags.map((tag) => tag.label).join(", ")}
+          </Typography>
+          <Typography variant="body" size="small" className="text-neutral-content-subtle">
+            <strong>Selected:</strong> {value.length > 0 ? value.join(", ") : "None"}
+          </Typography>
+        </div>
+        <div className="mt-base p-base bg-neutral-surface rounded text-sm w-[400px]">
+          <Typography variant="body" size="small" className="mb-tight">
+            <strong>Keyboard shortcuts:</strong>
+          </Typography>
+          <ul className="space-y-tight text-neutral-content-subtle">
+            <li>
+              • <kbd className="px-tight bg-neutral-surface-bold rounded">←</kbd> /{" "}
+              <kbd className="px-tight bg-neutral-surface-bold rounded">→</kbd> Navigate between tags
+            </li>
+            <li>
+              • <kbd className="px-tight bg-neutral-surface-bold rounded">↑</kbd> /{" "}
+              <kbd className="px-tight bg-neutral-surface-bold rounded">↓</kbd> Navigate dropdown options
+            </li>
+            <li>
+              • <kbd className="px-tight bg-neutral-surface-bold rounded">Enter</kbd> /{" "}
+              <kbd className="px-tight bg-neutral-surface-bold rounded">,</kbd> Select highlighted option or create new
+              tag
+            </li>
+            <li>
+              • <kbd className="px-tight bg-neutral-surface-bold rounded">Backspace</kbd> Remove tag or focus last tag
+            </li>
+            <li>
+              • <kbd className="px-tight bg-neutral-surface-bold rounded">Delete</kbd> Remove focused tag
+            </li>
+            <li>
+              • <kbd className="px-tight bg-neutral-surface-bold rounded">Esc</kbd> Close dropdown
+            </li>
+          </ul>
+        </div>
+      </div>
+    );
+  },
 };
 
 /**
@@ -174,19 +133,19 @@ export const Default: Story = {
  * Options can be simple strings instead of objects.
  */
 export const SimpleStrings: Story = {
-	render: () => {
-		const [value, setValue] = useState<string[]>(["React", "Next.js"]);
-		return (
-			<div className="w-96">
-				<TagAutocomplete
-					options={simpleTags}
-					value={value}
-					onChange={setValue as any}
-					placeholder="Select frameworks..."
-				/>
-			</div>
-		);
-	},
+  render: () => {
+    const [value, setValue] = useState<string[]>(["React", "Next.js"]);
+    return (
+      <div className="w-96">
+        <TagAutocomplete
+          options={simpleTags}
+          value={value}
+          onChange={setValue as any}
+          placeholder="Select frameworks..."
+        />
+      </div>
+    );
+  },
 };
 
 /**
@@ -195,35 +154,31 @@ export const SimpleStrings: Story = {
  * When many tags are selected, they automatically wrap to multiple lines.
  */
 export const MultipleTagsWrapping: Story = {
-	render: () => {
-		const [value, setValue] = useState<string[]>([
-			"frontend",
-			"backend",
-			"devops",
-			"design",
-			"qa",
-			"mobile",
-			"data-science",
-			"machine-learning",
-		]);
-		return (
-			<div className="w-96">
-				<TagAutocomplete
-					options={sampleTags}
-					value={value}
-					onChange={setValue as any}
-					placeholder="Type to search..."
-				/>
-				<Typography
-					variant="body"
-					size="small"
-					className="mt-tight text-neutral-content-subtle"
-				>
-					All {value.length} tags are shown and wrap to multiple lines
-				</Typography>
-			</div>
-		);
-	},
+  render: () => {
+    const [value, setValue] = useState<string[]>([
+      "frontend",
+      "backend",
+      "devops",
+      "design",
+      "qa",
+      "mobile",
+      "data-science",
+      "machine-learning",
+    ]);
+    return (
+      <div className="w-96">
+        <TagAutocomplete
+          options={sampleTags}
+          value={value}
+          onChange={setValue as any}
+          placeholder="Type to search..."
+        />
+        <Typography variant="body" size="small" className="mt-tight text-neutral-content-subtle">
+          All {value.length} tags are shown and wrap to multiple lines
+        </Typography>
+      </div>
+    );
+  },
 };
 
 /**
@@ -234,80 +189,66 @@ export const MultipleTagsWrapping: Story = {
  * like Zod, Yup, or React Hook Form.
  */
 export const FormValidationPattern: Story = {
-	render: () => {
-		const [value, setValue] = useState<string[]>(["frontend"]);
-		const [error, setError] = useState<string>("");
-		const [touched, setTouched] = useState(false);
-		const [submittedTags, setSubmittedTags] = useState<string[]>([]);
+  render: () => {
+    const [value, setValue] = useState<string[]>(["frontend"]);
+    const [error, setError] = useState<string>("");
+    const [touched, setTouched] = useState(false);
+    const [submittedTags, setSubmittedTags] = useState<string[]>([]);
 
-		// Validation logic (could be Zod, Yup, etc.)
-		const validate = (values: string[]) => {
-			if (values.length === 0) return "At least one tag is required";
-			if (values.length > 3) return "Maximum 3 tags allowed";
-			return "";
-		};
+    // Validation logic (could be Zod, Yup, etc.)
+    const validate = (values: string[]) => {
+      if (values.length === 0) return "At least one tag is required";
+      if (values.length > 3) return "Maximum 3 tags allowed";
+      return "";
+    };
 
-		const handleChange = (newValues: string[]) => {
-			setValue(newValues);
-			setTouched(true);
-			const validationError = validate(newValues);
-			setError(validationError);
-		};
+    const handleChange = (newValues: string[]) => {
+      setValue(newValues);
+      setTouched(true);
+      const validationError = validate(newValues);
+      setError(validationError);
+    };
 
-		const handleSubmit = (e: React.FormEvent) => {
-			e.preventDefault();
-			const validationError = validate(value);
-			if (validationError) {
-				setError(validationError);
-				setTouched(true);
-				return;
-			}
-			setSubmittedTags(value);
-		};
+    const handleSubmit = (e: React.FormEvent) => {
+      e.preventDefault();
+      const validationError = validate(value);
+      if (validationError) {
+        setError(validationError);
+        setTouched(true);
+        return;
+      }
+      setSubmittedTags(value);
+    };
 
-		return (
-			<form onSubmit={handleSubmit} className="w-96">
-				<TagAutocomplete
-					options={sampleTags}
-					value={value}
-					onChange={handleChange as any}
-					placeholder="Select 1-3 skills..."
-				/>
-				{touched && error && (
-					<div className="mt-tight text-xs text-danger-content">{error}</div>
-				)}
-				<Typography
-					variant="body"
-					size="small"
-					className="mt-tight text-neutral-content-subtle"
-				>
-					{value.length}/3 selected
-				</Typography>
-				<Button type="submit" variant="primary" className="mt-base">
-					Submit
-				</Button>
+    return (
+      <form onSubmit={handleSubmit} className="w-96">
+        <TagAutocomplete
+          options={sampleTags}
+          value={value}
+          onChange={handleChange as any}
+          placeholder="Select 1-3 skills..."
+        />
+        {touched && error && <div className="mt-tight text-xs text-danger-content">{error}</div>}
+        <Typography variant="body" size="small" className="mt-tight text-neutral-content-subtle">
+          {value.length}/3 selected
+        </Typography>
+        <Button type="submit" variant="primary" className="mt-base">
+          Submit
+        </Button>
 
-				{submittedTags.length > 0 && (
-					<div className="mt-base p-base bg-neutral-surface rounded">
-						<Typography
-							variant="body"
-							size="small"
-							className="font-medium mb-tight"
-						>
-							Submitted Tags:
-						</Typography>
-						<Typography
-							variant="body"
-							size="small"
-							className="text-neutral-content-subtle"
-						>
-							{submittedTags.join(", ")}
-						</Typography>
-					</div>
-				)}
-			</form>
-		);
-	},
+        {submittedTags.length > 0 && (
+          <div className="mt-base p-base bg-neutral-surface rounded">
+            <Typography variant="body" size="small" className="font-medium mb-tight">
+              Submitted Tags:
+            </Typography>
+            <Typography variant="body" size="small" className="text-neutral-content-subtle">
+              {submittedTags.join(", ")}
+            </Typography>
+          </div>
+        )}
+      </form>
+    );
+  },
 };
 
 /**
@@ -316,28 +257,24 @@ export const FormValidationPattern: Story = {
  * Shows a spinner in the dropdown while options are being loaded.
  */
 export const LoadingState: Story = {
-	render: () => {
-		const [value, setValue] = useState<string[]>(["frontend"]);
-		return (
-			<div className="w-96">
-				<TagAutocomplete
-					options={sampleTags}
-					value={value}
-					onChange={setValue as any}
-					placeholder="Type to search..."
-					isLoading={true}
-					minSearchLength={1}
-				/>
-				<Typography
-					variant="body"
-					size="small"
-					className="mt-tight text-neutral-content-subtle"
-				>
-					Type to see the loading spinner in the dropdown
-				</Typography>
-			</div>
-		);
-	},
+  render: () => {
+    const [value, setValue] = useState<string[]>(["frontend"]);
+    return (
+      <div className="w-96">
+        <TagAutocomplete
+          options={sampleTags}
+          value={value}
+          onChange={setValue as any}
+          placeholder="Type to search..."
+          isLoading={true}
+          minSearchLength={1}
+        />
+        <Typography variant="body" size="small" className="mt-tight text-neutral-content-subtle">
+          Type to see the loading spinner in the dropdown
+        </Typography>
+      </div>
+    );
+  },
 };
 
 /**
@@ -346,36 +283,36 @@ export const LoadingState: Story = {
  * Simulates loading options from an API based on search query.
  */
 export const AsyncSearch: Story = {
-	render: () => {
-		const [value, setValue] = useState<string[]>([]);
-		const [options, setOptions] = useState(sampleTags);
-		const [isLoading, setIsLoading] = useState(false);
+  render: () => {
+    const [value, setValue] = useState<string[]>([]);
+    const [options, setOptions] = useState(sampleTags);
+    const [isLoading, setIsLoading] = useState(false);
 
-		const handleSearch = (query: string) => {
-			setIsLoading(true);
-			// Simulate API delay
-			setTimeout(() => {
-				const filtered = sampleTags.filter((tag) =>
-					(tag.label ?? tag.value).toLowerCase().includes(query.toLowerCase()),
-				);
-				setOptions(filtered);
-				setIsLoading(false);
-			}, 500);
-		};
+    const handleSearch = (query: string) => {
+      setIsLoading(true);
+      // Simulate API delay
+      setTimeout(() => {
+        const filtered = sampleTags.filter((tag) =>
+          (tag.label ?? tag.value).toLowerCase().includes(query.toLowerCase()),
+        );
+        setOptions(filtered);
+        setIsLoading(false);
+      }, 500);
+    };
 
-		return (
-			<div className="w-96">
-				<TagAutocomplete
-					options={options}
-					value={value}
-					onChange={setValue as any}
-					onSearch={handleSearch}
-					isLoading={isLoading}
-					placeholder="Type to search (simulated 500ms delay)..."
-				/>
-			</div>
-		);
-	},
+    return (
+      <div className="w-96">
+        <TagAutocomplete
+          options={options}
+          value={value}
+          onChange={setValue as any}
+          onSearch={handleSearch}
+          isLoading={isLoading}
+          placeholder="Type to search (simulated 500ms delay)..."
+        />
+      </div>
+    );
+  },
 };
 
 /**
@@ -384,28 +321,24 @@ export const AsyncSearch: Story = {
  * Allow users to create new tags that don't exist in the list.
  */
 export const WithTagCreation: Story = {
-	render: () => {
-		const [value, setValue] = useState<string[]>(["frontend"]);
+  render: () => {
+    const [value, setValue] = useState<string[]>(["frontend"]);
 
-		return (
-			<div className="w-96">
-				<TagAutocomplete
-					options={sampleTags}
-					value={value}
-					onChange={setValue as any}
-					allowCreate={true}
-					placeholder="Type to search or create new tags..."
-				/>
-				<Typography
-					variant="body"
-					size="small"
-					className="mt-base text-neutral-content-subtle"
-				>
-					Selected: {value.join(", ")}
-				</Typography>
-			</div>
-		);
-	},
+    return (
+      <div className="w-96">
+        <TagAutocomplete
+          options={sampleTags}
+          value={value}
+          onChange={setValue as any}
+          allowCreate={true}
+          placeholder="Type to search or create new tags..."
+        />
+        <Typography variant="body" size="small" className="mt-base text-neutral-content-subtle">
+          Selected: {value.join(", ")}
+        </Typography>
+      </div>
+    );
+  },
 };
 
 /**
@@ -414,19 +347,19 @@ export const WithTagCreation: Story = {
  * Component in disabled state.
  */
 export const Disabled: Story = {
-	render: () => {
-		return (
-			<div className="w-96">
-				<TagAutocomplete
-					options={sampleTags}
-					value={["frontend", "backend"]}
-					onChange={() => {}}
-					placeholder="Select tags..."
-					disabled
-				/>
-			</div>
-		);
-	},
+  render: () => {
+    return (
+      <div className="w-96">
+        <TagAutocomplete
+          options={sampleTags}
+          value={["frontend", "backend"]}
+          onChange={() => {}}
+          placeholder="Select tags..."
+          disabled
+        />
+      </div>
+    );
+  },
 };
 
 /**
@@ -435,19 +368,19 @@ export const Disabled: Story = {
  * Component with no pre-selected values.
  */
 export const EmptyState: Story = {
-	render: () => {
-		const [value, setValue] = useState<string[]>([]);
-		return (
-			<div className="w-96">
-				<TagAutocomplete
-					options={sampleTags}
-					value={value}
-					onChange={setValue as any}
-					placeholder="Click or type to add tags..."
-				/>
-			</div>
-		);
-	},
+  render: () => {
+    const [value, setValue] = useState<string[]>([]);
+    return (
+      <div className="w-96">
+        <TagAutocomplete
+          options={sampleTags}
+          value={value}
+          onChange={setValue as any}
+          placeholder="Click or type to add tags..."
+        />
+      </div>
+    );
+  },
 };
 
 /**
@@ -456,35 +389,31 @@ export const EmptyState: Story = {
  * Some options can be disabled.
  */
 export const DisabledOptions: Story = {
-	render: () => {
-		const [value, setValue] = useState<string[]>(["frontend"]);
-		const optionsWithDisabled = [
-			{ value: "frontend", label: "Frontend" },
-			{ value: "backend", label: "Backend" },
-			{ value: "devops", label: "DevOps", disabled: true },
-			{ value: "design", label: "Design" },
-			{ value: "qa", label: "QA", disabled: true },
-			{ value: "mobile", label: "Mobile" },
-		];
+  render: () => {
+    const [value, setValue] = useState<string[]>(["frontend"]);
+    const optionsWithDisabled = [
+      { value: "frontend", label: "Frontend" },
+      { value: "backend", label: "Backend" },
+      { value: "devops", label: "DevOps", disabled: true },
+      { value: "design", label: "Design" },
+      { value: "qa", label: "QA", disabled: true },
+      { value: "mobile", label: "Mobile" },
+    ];
 
-		return (
-			<div className="w-96">
-				<TagAutocomplete
-					options={optionsWithDisabled}
-					value={value}
-					onChange={setValue as any}
-					placeholder="Select tags..."
-				/>
-				<Typography
-					variant="body"
-					size="small"
-					className="mt-tight text-neutral-content-subtle"
-				>
-					DevOps and QA options are disabled
-				</Typography>
-			</div>
-		);
-	},
+    return (
+      <div className="w-96">
+        <TagAutocomplete
+          options={optionsWithDisabled}
+          value={value}
+          onChange={setValue as any}
+          placeholder="Select tags..."
+        />
+        <Typography variant="body" size="small" className="mt-tight text-neutral-content-subtle">
+          DevOps and QA options are disabled
+        </Typography>
+      </div>
+    );
+  },
 };
 
 /**
@@ -493,103 +422,78 @@ export const DisabledOptions: Story = {
  * Example of TagAutocomplete with tag creation and submission.
  */
 export const InFormContext: Story = {
-	render: () => {
-		const [skills, setSkills] = useState<string[]>([]);
-		const [submittedTags, setSubmittedTags] = useState<string[]>([]);
+  render: () => {
+    const [skills, setSkills] = useState<string[]>([]);
+    const [submittedTags, setSubmittedTags] = useState<string[]>([]);
 
-		const handleSkillsChange = (values: string[]) => {
-			setSkills(values);
-		};
+    const handleSkillsChange = (values: string[]) => {
+      setSkills(values);
+    };
 
-		const handleAdd = () => {
-			// Validation checks
-			if (skills.length === 0) return;
+    const handleAdd = () => {
+      // Validation checks
+      if (skills.length === 0) return;
 
-			// Distinguish between existing and new tags
-			const existingSkills = skills.filter((skill) =>
-				sampleTags.some((tag) => tag.value === skill),
-			);
-			const newSkills = skills.filter(
-				(skill) => !sampleTags.some((tag) => tag.value === skill),
-			);
+      // Distinguish between existing and new tags
+      const existingSkills = skills.filter((skill) => sampleTags.some((tag) => tag.value === skill));
+      const newSkills = skills.filter((skill) => !sampleTags.some((tag) => tag.value === skill));
 
-			console.log("Existing skills:", existingSkills);
-			console.log("New skills to create:", newSkills);
-			console.log("All skills:", skills);
+      console.log("Existing skills:", existingSkills);
+      console.log("New skills to create:", newSkills);
+      console.log("All skills:", skills);
 
-			setSubmittedTags(skills);
-			setSkills([]);
-		};
+      setSubmittedTags(skills);
+      setSkills([]);
+    };
 
-		return (
-			<div className="w-full max-w-2xl space-y-wide">
-				<div>
-					<Typography
-						variant="body"
-						size="small"
-						className="font-medium mb-tight"
-					>
-						Skills
-					</Typography>
-					<form
-						className="flex gap-tight items-start"
-						onSubmit={(e) => {
-							e.preventDefault();
-							handleAdd();
-						}}
-					>
-						<div className="flex-1">
-							<TagAutocomplete
-								name="skills"
-								options={sampleTags}
-								value={skills}
-								onChange={handleSkillsChange as any}
-								allowCreate={true}
-								placeholder="Type to add skills..."
-							/>
-						</div>
-						<Button
-							type="submit"
-							variant="primary"
-							disabled={skills.length === 0}
-						>
-							Add
-						</Button>
-					</form>
-				</div>
+    return (
+      <div className="w-full max-w-2xl space-y-wide">
+        <div>
+          <Typography variant="body" size="small" className="font-medium mb-tight">
+            Skills
+          </Typography>
+          <form
+            className="flex gap-tight items-start"
+            onSubmit={(e) => {
+              e.preventDefault();
+              handleAdd();
+            }}
+          >
+            <div className="flex-1">
+              <TagAutocomplete
+                name="skills"
+                options={sampleTags}
+                value={skills}
+                onChange={handleSkillsChange as any}
+                allowCreate={true}
+                placeholder="Type to add skills..."
+              />
+            </div>
+            <Button type="submit" variant="primary" disabled={skills.length === 0}>
+              Add
+            </Button>
+          </form>
+        </div>
 
-				<div className="mt-base">
-					<Typography
-						variant="body"
-						size="small"
-						className="text-neutral-content-subtle"
-					>
-						Available:{" "}
-						{sampleTags.map((tag) => tag.label).join(", ") || "All selected"}
-					</Typography>
-				</div>
+        <div className="mt-base">
+          <Typography variant="body" size="small" className="text-neutral-content-subtle">
+            Available: {sampleTags.map((tag) => tag.label).join(", ") || "All selected"}
+          </Typography>
+        </div>
 
-				{submittedTags.length > 0 && (
-					<div className="p-base bg-neutral-surface rounded">
-						<Typography
-							variant="body"
-							size="small"
-							className="font-medium mb-tight"
-						>
-							Submitted Tags:
-						</Typography>
-						<Typography
-							variant="body"
-							size="small"
-							className="text-neutral-content-subtle"
-						>
-							{submittedTags.join(", ")}
-						</Typography>
-					</div>
-				)}
-			</div>
-		);
-	},
+        {submittedTags.length > 0 && (
+          <div className="p-base bg-neutral-surface rounded">
+            <Typography variant="body" size="small" className="font-medium mb-tight">
+              Submitted Tags:
+            </Typography>
+            <Typography variant="body" size="small" className="text-neutral-content-subtle">
+              {submittedTags.join(", ")}
+            </Typography>
+          </div>
+        )}
+      </div>
+    );
+  },
 };
 
 /**
@@ -598,32 +502,27 @@ export const InFormContext: Story = {
  * Tags with long labels are truncated.
  */
 export const LongLabels: Story = {
-	render: () => {
-		const [value, setValue] = useState<string[]>(["long-1", "long-2"]);
-		const longOptions = [
-			{
-				value: "long-1",
-				label: "This is a very long tag label that should be truncated",
-			},
-			{
-				value: "long-2",
-				label: "Another extremely long label for demonstration",
-			},
-			{ value: "long-3", label: "Short" },
-			{ value: "long-4", label: "Medium length label" },
-		];
+  render: () => {
+    const [value, setValue] = useState<string[]>(["long-1", "long-2"]);
+    const longOptions = [
+      {
+        value: "long-1",
+        label: "This is a very long tag label that should be truncated",
+      },
+      {
+        value: "long-2",
+        label: "Another extremely long label for demonstration",
+      },
+      { value: "long-3", label: "Short" },
+      { value: "long-4", label: "Medium length label" },
+    ];
 
-		return (
-			<div className="w-96">
-				<TagAutocomplete
-					options={longOptions}
-					value={value}
-					onChange={setValue as any}
-					placeholder="Select tags..."
-				/>
-			</div>
-		);
-	},
+    return (
+      <div className="w-96">
+        <TagAutocomplete options={longOptions} value={value} onChange={setValue as any} placeholder="Select tags..." />
+      </div>
+    );
+  },
 };
 
 /**
@@ -632,31 +531,27 @@ export const LongLabels: Story = {
  * Component with a large list of options.
  */
 export const ManyOptions: Story = {
-	render: () => {
-		const [value, setValue] = useState<string[]>([]);
-		const manyOptions = Array.from({ length: 50 }, (_, i) => ({
-			value: `option-${i + 1}`,
-			label: `Option ${i + 1}`,
-		}));
+  render: () => {
+    const [value, setValue] = useState<string[]>([]);
+    const manyOptions = Array.from({ length: 50 }, (_, i) => ({
+      value: `option-${i + 1}`,
+      label: `Option ${i + 1}`,
+    }));
 
-		return (
-			<div className="w-96">
-				<TagAutocomplete
-					options={manyOptions}
-					value={value}
-					onChange={setValue as any}
-					placeholder="Search 50 options..."
-				/>
-				<Typography
-					variant="body"
-					size="small"
-					className="mt-tight text-neutral-content-subtle"
-				>
-					50 options available - use search to filter
-				</Typography>
-			</div>
-		);
-	},
+    return (
+      <div className="w-96">
+        <TagAutocomplete
+          options={manyOptions}
+          value={value}
+          onChange={setValue as any}
+          placeholder="Search 50 options..."
+        />
+        <Typography variant="body" size="small" className="mt-tight text-neutral-content-subtle">
+          50 options available - use search to filter
+        </Typography>
+      </div>
+    );
+  },
 };
 
 /**
@@ -665,27 +560,27 @@ export const ManyOptions: Story = {
  * Using a custom search filter function.
  */
 export const CustomFilter: Story = {
-	render: () => {
-		const [value, setValue] = useState<string[]>([]);
+  render: () => {
+    const [value, setValue] = useState<string[]>([]);
 
-		// Custom filter that matches start of string only
-		const startsWithFilter = (option: any, query: string) => {
-			const label = option.label || option;
-			return label.toLowerCase().startsWith(query.toLowerCase());
-		};
+    // Custom filter that matches start of string only
+    const startsWithFilter = (option: any, query: string) => {
+      const label = option.label || option;
+      return label.toLowerCase().startsWith(query.toLowerCase());
+    };
 
-		return (
-			<div className="w-96">
-				<TagAutocomplete
-					options={sampleTags}
-					value={value}
-					onChange={setValue as any}
-					searchFilter={startsWithFilter}
-					placeholder="Custom filter: matches start only (type 'f' for Frontend)..."
-				/>
-			</div>
-		);
-	},
+    return (
+      <div className="w-96">
+        <TagAutocomplete
+          options={sampleTags}
+          value={value}
+          onChange={setValue as any}
+          searchFilter={startsWithFilter}
+          placeholder="Custom filter: matches start only (type 'f' for Frontend)..."
+        />
+      </div>
+    );
+  },
 };
 
 /**
@@ -694,28 +589,23 @@ export const CustomFilter: Story = {
  * Configure the minimum number of characters required before showing the dropdown.
  */
 export const CustomMinSearchLength: Story = {
-	render: () => {
-		const [value, setValue] = useState<string[]>([]);
-		return (
-			<div className="w-96">
-				<TagAutocomplete
-					options={sampleTags}
-					value={value}
-					onChange={setValue as any}
-					minSearchLength={3}
-					placeholder="Minimum 3 character to search..."
-				/>
-				<Typography
-					variant="body"
-					size="small"
-					className="mt-base text-neutral-content-subtle"
-				>
-					<strong>Available:</strong>{" "}
-					{sampleTags.map((tag) => tag.label).join(", ")}
-				</Typography>
-			</div>
-		);
-	},
+  render: () => {
+    const [value, setValue] = useState<string[]>([]);
+    return (
+      <div className="w-96">
+        <TagAutocomplete
+          options={sampleTags}
+          value={value}
+          onChange={setValue as any}
+          minSearchLength={3}
+          placeholder="Minimum 3 character to search..."
+        />
+        <Typography variant="body" size="small" className="mt-base text-neutral-content-subtle">
+          <strong>Available:</strong> {sampleTags.map((tag) => tag.label).join(", ")}
+        </Typography>
+      </div>
+    );
+  },
 };
 
 /**
@@ -727,55 +617,39 @@ export const CustomMinSearchLength: Story = {
  * Try pasting: `React, Vue, Angular, Svelte`
  */
 export const PasteWithCreation: Story = {
-	render: () => {
-		const [value, setValue] = useState<string[]>([]);
-		return (
-			<div className="w-full max-w-lg space-y-base">
-				<TagAutocomplete
-					options={[]}
-					value={value}
-					onChange={setValue as any}
-					allowCreate={true}
-					placeholder="Paste comma-separated values to create tags..."
-				/>
-				<div className="p-base bg-neutral-surface rounded-md space-y-tight">
-					<Typography variant="body" size="small" className="font-medium">
-						Try it:
-					</Typography>
-					<Typography
-						variant="body"
-						size="small"
-						className="text-neutral-content-subtle"
-					>
-						Copy and paste this into the field above:
-					</Typography>
-					<Typography
-						variant="body"
-						size="small"
-						className="font-mono bg-neutral-surface-bold rounded px-tight py-1"
-					>
-						React, Vue, Angular, Svelte
-					</Typography>
-					<Typography
-						variant="body"
-						size="small"
-						className="text-neutral-content-subtle mt-tight"
-					>
-						Each comma-separated value is created as a new tag instantly.
-					</Typography>
-				</div>
-				{value.length > 0 && (
-					<Typography
-						variant="body"
-						size="small"
-						className="text-neutral-content-subtle"
-					>
-						<strong>Selected:</strong> {value.join(", ")}
-					</Typography>
-				)}
-			</div>
-		);
-	},
+  render: () => {
+    const [value, setValue] = useState<string[]>([]);
+    return (
+      <div className="w-full max-w-lg space-y-base">
+        <TagAutocomplete
+          options={[]}
+          value={value}
+          onChange={setValue as any}
+          allowCreate={true}
+          placeholder="Paste comma-separated values to create tags..."
+        />
+        <div className="p-base bg-neutral-surface rounded-md space-y-tight">
+          <Typography variant="body" size="small" className="font-medium">
+            Try it:
+          </Typography>
+          <Typography variant="body" size="small" className="text-neutral-content-subtle">
+            Copy and paste this into the field above:
+          </Typography>
+          <Typography variant="body" size="small" className="font-mono bg-neutral-surface-bold rounded px-tight py-1">
+            React, Vue, Angular, Svelte
+          </Typography>
+          <Typography variant="body" size="small" className="text-neutral-content-subtle mt-tight">
+            Each comma-separated value is created as a new tag instantly.
+          </Typography>
+        </div>
+        {value.length > 0 && (
+          <Typography variant="body" size="small" className="text-neutral-content-subtle">
+            <strong>Selected:</strong> {value.join(", ")}
+          </Typography>
+        )}
+      </div>
+    );
+  },
 };
 
 /**
@@ -788,55 +662,38 @@ export const PasteWithCreation: Story = {
  * Try pasting: `Frontend, Backend, DevOps`
  */
 export const PasteBlocked: Story = {
-	render: () => {
-		const [value, setValue] = useState<string[]>([]);
-		return (
-			<div className="w-full max-w-lg space-y-base">
-				<TagAutocomplete
-					options={sampleTags}
-					value={value}
-					onChange={setValue as any}
-					allowCreate={false}
-					minSearchLength={0}
-					placeholder="Search and select tags..."
-				/>
-				<div className="p-base bg-neutral-surface rounded-md space-y-tight">
-					<Typography variant="body" size="small" className="font-medium">
-						Try it:
-					</Typography>
-					<Typography
-						variant="body"
-						size="small"
-						className="text-neutral-content-subtle"
-					>
-						Paste the following into the field above and a validation error will
-						appear:
-					</Typography>
-					<Typography
-						variant="body"
-						size="small"
-						className="font-mono bg-neutral-surface-bold rounded px-tight py-1"
-					>
-						Frontend, Backend, DevOps
-					</Typography>
-					<Typography
-						variant="body"
-						size="small"
-						className="text-neutral-content-subtle mt-tight"
-					>
-						To add tags, type in the field and select from the dropdown.
-					</Typography>
-				</div>
-				{value.length > 0 && (
-					<Typography
-						variant="body"
-						size="small"
-						className="text-neutral-content-subtle"
-					>
-						<strong>Selected:</strong> {value.join(", ")}
-					</Typography>
-				)}
-			</div>
-		);
-	},
+  render: () => {
+    const [value, setValue] = useState<string[]>([]);
+    return (
+      <div className="w-full max-w-lg space-y-base">
+        <TagAutocomplete
+          options={sampleTags}
+          value={value}
+          onChange={setValue as any}
+          allowCreate={false}
+          minSearchLength={0}
+          placeholder="Search and select tags..."
+        />
+        <div className="p-base bg-neutral-surface rounded-md space-y-tight">
+          <Typography variant="body" size="small" className="font-medium">
+            Try it:
+          </Typography>
+          <Typography variant="body" size="small" className="text-neutral-content-subtle">
+            Paste the following into the field above and a validation error will appear:
+          </Typography>
+          <Typography variant="body" size="small" className="font-mono bg-neutral-surface-bold rounded px-tight py-1">
+            Frontend, Backend, DevOps
+          </Typography>
+          <Typography variant="body" size="small" className="text-neutral-content-subtle mt-tight">
+            To add tags, type in the field and select from the dropdown.
+          </Typography>
+        </div>
+        {value.length > 0 && (
+          <Typography variant="body" size="small" className="text-neutral-content-subtle">
+            <strong>Selected:</strong> {value.join(", ")}
+          </Typography>
+        )}
+      </div>
+    );
+  },
 };

--- a/web/libs/ui/src/lib/tag-autocomplete/tag-autocomplete.tsx
+++ b/web/libs/ui/src/lib/tag-autocomplete/tag-autocomplete.tsx
@@ -9,7 +9,7 @@ import React, {
 } from "react";
 import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList } from "@humansignal/shad/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@humansignal/shad/components/ui/popover";
-import { Badge, Spinner } from "@humansignal/ui";
+import { Badge, Spinner, Typography } from "@humansignal/ui";
 import { IconPlus } from "@humansignal/icons";
 import { cnm } from "../../utils/utils";
 import { useTagAutocomplete } from "./use-tag-autocomplete";
@@ -52,7 +52,9 @@ export const TagAutocomplete = forwardRef(
       setFocusedTagIndex,
       setHighlightedOptionIndex,
       handleKeyDown,
+      handlePaste,
       focusInput,
+      error,
     } = useTagAutocomplete({ ...props, createTagCallbackRef });
 
     // --- NEW: control cmdk selection so first item is always highlighted ---
@@ -286,6 +288,7 @@ export const TagAutocomplete = forwardRef(
                   className={styles.input}
                   value={query}
                   onChange={handleInputChange}
+                  onPaste={handlePaste}
                   onFocus={() => {
                     setFocusedTagIndex(null);
                     // Don't automatically open dropdown on focus - wait for user to type
@@ -366,6 +369,12 @@ export const TagAutocomplete = forwardRef(
             </CommandList>
           </PopoverContent>
         </Popover>
+
+        {error && (
+          <Typography variant="body" size="small" className="text-negative-content mt-tight" role="alert">
+            {error}
+          </Typography>
+        )}
 
         {/* Hidden select for form integration */}
         <select

--- a/web/libs/ui/src/lib/tag-autocomplete/use-tag-autocomplete.ts
+++ b/web/libs/ui/src/lib/tag-autocomplete/use-tag-autocomplete.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type React from "react";
 import type { TagAutocompleteOption, TagAutocompleteProps, NormalizedTagOption } from "./types";
 import { normalizeOption } from "./types";
 
@@ -29,7 +30,11 @@ export interface UseTagAutocompleteReturn<T> {
   setFocusedTagIndex: (index: number | null) => void;
   setHighlightedOptionIndex: (index: number) => void;
   handleKeyDown: (e: React.KeyboardEvent) => void;
+  handlePaste: (e: React.ClipboardEvent) => void;
   focusInput: () => void;
+
+  // Validation
+  error: string | null;
 }
 
 export function useTagAutocomplete<T = string>(
@@ -207,6 +212,43 @@ export function useTagAutocomplete<T = string>(
     inputRef.current?.focus();
     setFocusedTagIndex(null);
   }, []);
+
+  // Validation error (e.g. paste not supported)
+  const [error, setError] = useState<string | null>(null);
+
+  // Paste handler: only supported when allowCreate=true (no server-side search).
+  // When allowCreate=false the user must search and select tags individually.
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent) => {
+      const text = e.clipboardData.getData("text");
+      if (!text.includes(",")) return;
+
+      e.preventDefault();
+
+      if (!props.allowCreate) {
+        setError("Pasting multiple values is not supported here. Please search and select tags individually.");
+        return;
+      }
+
+      setError(null);
+      const parts = text
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+
+      // Build all new values at once to avoid stale-closure issues with selectOption
+      const newParts = (parts as T[]).filter((p) => !selectedValues.includes(p));
+      if (newParts.length > 0) {
+        const newValues = [...selectedValues, ...newParts];
+        if (controlledValue === undefined) {
+          setInternalValue(newValues);
+        }
+        onChange?.(newValues);
+      }
+      setQueryState("");
+    },
+    [props.allowCreate, selectedValues, controlledValue, onChange],
+  );
 
   // Keyboard handler
   const handleKeyDown = useCallback(
@@ -411,6 +453,10 @@ export function useTagAutocomplete<T = string>(
     setFocusedTagIndex,
     setHighlightedOptionIndex,
     handleKeyDown,
+    handlePaste,
     focusInput,
+
+    // Validation
+    error,
   };
 }


### PR DESCRIPTION
## Summary
- Fixed paste handling in `TagAutocomplete` so comma-separated values pasted into the **Add New Tags** field (Org Settings → Member Tags) are split and created as individual tags
- For fields where tag creation is disabled (`allowCreate=false`, e.g. Bulk CSV import), pasting a comma-separated list now shows a clear validation error prompting the user to search and select tags individually instead
- Updated Storybook with `PasteWithCreation` and `PasteBlocked` stories documenting both behaviors

<img width="1050" height="959" alt="Screenshot 2026-03-17 at 14 05 05" src="https://github.com/user-attachments/assets/31830b21-fe86-460f-9c33-f0799b4a4434" />
