### PR TITLE
fix: Remove feature flag ff_front_dev_1682 to fix Prediction score column showing null

### DIFF
--- a/label_studio/data_manager/managers.py
+++ b/label_studio/data_manager/managers.py
@@ -666,26 +666,15 @@ def annotate_predictions_score(queryset):
     if not first_task:
         return queryset
 
-    # new approach with each ML backend contains it's version
-    if flag_set('ff_front_dev_1682_model_version_dropdown_070622_short', first_task.project.organization.created_by):
-        model_versions = list(
-            first_task.project.ml_backends.filter(project=first_task.project).values_list('model_version', flat=True)
-        )
-        if len(model_versions) == 0:
-            return queryset.annotate(predictions_score=Avg('predictions__score'))
-
-        else:
-            return queryset.annotate(
-                predictions_score=Avg('predictions__score', filter=Q(predictions__model_version__in=model_versions))
-            )
+    model_versions = list(
+        first_task.project.ml_backends.filter(project=first_task.project).values_list('model_version', flat=True)
+    )
+    if len(model_versions) == 0:
+        return queryset.annotate(predictions_score=Avg('predictions__score'))
     else:
-        model_version = first_task.project.model_version
-        if model_version is None:
-            return queryset.annotate(predictions_score=Avg('predictions__score'))
-        else:
-            return queryset.annotate(
-                predictions_score=Avg('predictions__score', filter=Q(predictions__model_version=model_version))
-            )
+        return queryset.annotate(
+            predictions_score=Avg('predictions__score', filter=Q(predictions__model_version__in=model_versions))
+        )
 
 
 def annotate_annotations_ids(queryset):

--- a/label_studio/feature_flags.json
+++ b/label_studio/feature_flags.json
@@ -487,33 +487,6 @@
       "version": 6,
       "deleted": false
     },
-    "ff_front_dev_1682_model_version_dropdown_070622_short": {
-      "key": "ff_front_dev_1682_model_version_dropdown_070622_short",
-      "on": false,
-      "prerequisites": [],
-      "targets": [],
-      "contextTargets": [],
-      "rules": [],
-      "fallthrough": {
-        "variation": 0
-      },
-      "offVariation": 1,
-      "variations": [
-        true,
-        false
-      ],
-      "clientSideAvailability": {
-        "usingMobileKey": false,
-        "usingEnvironmentId": false
-      },
-      "clientSide": false,
-      "salt": "58f4f819d52b461b9e833cdb896311d6",
-      "trackEvents": false,
-      "trackEventsFallthrough": false,
-      "debugEventsUntilDate": null,
-      "version": 9,
-      "deleted": false
-    },
     "ff_front_dev_2186_comments_for_update": {
       "key": "ff_front_dev_2186_comments_for_update",
       "on": false,

--- a/label_studio/tasks/serializers.py
+++ b/label_studio/tasks/serializers.py
@@ -899,9 +899,9 @@ class TaskWithAnnotationsAndPredictionsAndDraftsSerializer(TaskSerializer):
     def get_predictions(self, task):
         predictions = task.predictions
         user = self._get_user()
-        if flag_set('ff_front_dev_1682_model_version_dropdown_070622_short', user=user or 'auto'):
-            active_ml_backends = task.project.get_active_ml_backends()
-            model_versions = active_ml_backends.values_list('model_version', flat=True)
+        active_ml_backends = task.project.get_active_ml_backends()
+        model_versions = active_ml_backends.values_list('model_version', flat=True)
+        if model_versions:
             logger.debug(f'Selecting predictions from active ML backend model versions: {model_versions}')
             predictions = predictions.filter(model_version__in=model_versions)
         elif task.project.model_version:

--- a/label_studio/tests/conftest.py
+++ b/label_studio/tests/conftest.py
@@ -675,18 +675,6 @@ def get_server_url(live_server):
     yield live_server.url
 
 
-@pytest.fixture(name='ff_front_dev_1682_model_version_dropdown_070622_short_off', autouse=True)
-def ff_front_dev_1682_model_version_dropdown_070622_short_off():
-    from core.feature_flags import flag_set
-
-    def fake_flag_set(*args, **kwargs):
-        if args[0] == 'ff_front_dev_1682_model_version_dropdown_070622_short':
-            return False
-        return flag_set(*args, **kwargs)
-
-    with mock.patch('tasks.serializers.flag_set', wraps=fake_flag_set):
-        yield
-
 
 @pytest.fixture(name='async_import_off', autouse=True)
 def async_import_off():

--- a/web/libs/core/src/lib/utils/feature-flags/flags.ts
+++ b/web/libs/core/src/lib/utils/feature-flags/flags.ts
@@ -6,10 +6,6 @@
  */
 export const FF_DEV_1480 = "ff_front_dev_1480_created_on_in_review_180122_short";
 
-/**
- * Model version selector per model backend
- */
-export const FF_DEV_1682 = "ff_front_dev_1682_model_version_dropdown_070622_short";
 
 /**
  * Enables "Enterprise Awareness" features


### PR DESCRIPTION
## Summary

- Remove feature flag `ff_front_dev_1682_model_version_dropdown_070622_short` (default OFF) and make the corrected prediction score filtering logic unconditional
- **Root cause**: `annotate_predictions_score` used `project.model_version` to filter predictions, but this field often stores the ML Backend **title** (e.g., "My ML Backend") rather than the actual `prediction.model_version` (e.g., "v1"), causing a filter mismatch → `predictions_score: null` in Data Manager
- The fix — filtering by `ml_backends.model_version` instead — already existed behind the feature flag but was never enabled for open-source users

### Files changed

| File | Change |
|------|--------|
| `data_manager/managers.py` | Remove flag branch, use ML backend `model_version` to filter prediction scores |
| `tasks/serializers.py` | Remove flag branch, use active ML backend `model_version` with `project.model_version` fallback |
| `feature_flags.json` | Remove flag definition |
| `flags.ts` | Remove `FF_DEV_1682` export (unused in frontend components) |
| `tests/conftest.py` | Remove autouse fixture that force-disabled the flag |

Fixes #7151

## Test plan

- [x] Existing `test_views_ordering` with `predictions_score` ordering passes (no ML backend, predictions with default empty `model_version` — behavior equivalent)
- [x] Verify Prediction score column shows values in Data Manager when ML Backend is connected
- [x] Verify Prediction score column still works for projects with only static predictions (no ML backend)