### PR TITLE
docs: Remove preview link from ReactCode code example

### DIFF
--- a/docs/source/tags/reactcode.md
+++ b/docs/source/tags/reactcode.md
@@ -312,7 +312,7 @@ Your app runs inside an iframe. Label Studio communicates with it via `postMessa
 
 ### Minimal `src` app template
 
-```html
+```xml
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
ReactCode tag page has an open preview link, when those types of links should not be enabled. 