### PR TITLE
feat: Scale resize handle hit area for small bounding boxes

### DIFF
--- a/web/libs/editor/src/components/ImageTransformer/ImageTransformer.jsx
+++ b/web/libs/editor/src/components/ImageTransformer/ImageTransformer.jsx
@@ -4,6 +4,7 @@ import { getBoundingBoxAfterChanges } from "../../utils/image";
 import LSTransformer from "./LSTransformer";
 import LSTransformerOld from "./LSTransformerOld";
 import { FF_DEV_2671, FF_ZOOM_OPTIM, isFF } from "../../utils/feature-flags";
+import { computeAnchorSize, computeAnchorHitSize } from "./anchorSizing";
 
 const EPSILON = 0.001;
 
@@ -61,7 +62,8 @@ export default class TransformerComponent extends Component {
       });
 
       if (!shapeContainer) return;
-      if (shapeContainer.hasName("_transformable")) selectedNodes.push(shapeContainer);
+      if (shapeContainer.hasName("_transformable"))
+        selectedNodes.push(shapeContainer);
       if (!shapeContainer.find) return;
 
       const transformableElements = shapeContainer.find((node) => {
@@ -73,7 +75,8 @@ export default class TransformerComponent extends Component {
     const prevNodes = this.transformer.nodes();
     // do nothing if selected node is already attached
     const nodesWereNotChanged =
-      selectedNodes?.length === prevNodes?.length && !selectedNodes.find((node, idx) => node !== prevNodes[idx]);
+      selectedNodes?.length === prevNodes?.length &&
+      !selectedNodes.find((node, idx) => node !== prevNodes[idx]);
 
     if (nodesWereNotChanged) {
       return;
@@ -114,10 +117,16 @@ export default class TransformerComponent extends Component {
     const stage = this.transformer.getStage();
     const { stageWidth, stageHeight } = this.props.item;
 
-    let [scaledStageWidth, scaledStageHeight] = [stageWidth * stage.scaleX(), stageHeight * stage.scaleY()];
+    let [scaledStageWidth, scaledStageHeight] = [
+      stageWidth * stage.scaleX(),
+      stageHeight * stage.scaleY(),
+    ];
 
     if (isFF(FF_ZOOM_OPTIM) && this.props.item.isSideways) {
-      [scaledStageWidth, scaledStageHeight] = [scaledStageHeight, scaledStageWidth];
+      [scaledStageWidth, scaledStageHeight] = [
+        scaledStageHeight,
+        scaledStageWidth,
+      ];
     }
     const [stageX, stageY] = [stage.x(), stage.y()];
 
@@ -131,7 +140,8 @@ export default class TransformerComponent extends Component {
 
   constrainSizes = (oldBox, newBox) => {
     // it's important to compare against `undefined` because it can be missed (not rotated box?)
-    const rotation = newBox.rotation !== undefined ? newBox.rotation : oldBox.rotation;
+    const rotation =
+      newBox.rotation !== undefined ? newBox.rotation : oldBox.rotation;
     const isRotated = rotation !== oldBox.rotation;
     const stageDimensions = this.getStageAbsoluteDimensions();
 
@@ -144,11 +154,20 @@ export default class TransformerComponent extends Component {
       const selfRect = { x: 0, y: 0, width, height };
 
       // bounding box, got by applying current shift and rotation to normalized box
-      const clientRect = getBoundingBoxAfterChanges(selfRect, { x, y }, rotation);
+      const clientRect = getBoundingBoxAfterChanges(
+        selfRect,
+        { x, y },
+        rotation,
+      );
       const fixed = this.fitBBoxToScaledStage(clientRect, stageDimensions);
 
       // if bounding box is out of stage — do nothing
-      if (["x", "y", "width", "height"].some((key) => Math.abs(fixed[key] - clientRect[key]) > EPSILON)) return oldBox;
+      if (
+        ["x", "y", "width", "height"].some(
+          (key) => Math.abs(fixed[key] - clientRect[key]) > EPSILON,
+        )
+      )
+        return oldBox;
       return newBox;
     }
     return this.fitBBoxToScaledStage(newBox, stageDimensions);
@@ -186,6 +205,10 @@ export default class TransformerComponent extends Component {
   };
 
   renderLSTransformer() {
+    const zoomScale = this.props.item.zoomScale || 1;
+    const anchorSize = computeAnchorSize(zoomScale);
+    const hitSize = computeAnchorHitSize(anchorSize, zoomScale);
+
     return (
       <>
         <LSTransformer
@@ -204,9 +227,24 @@ export default class TransformerComponent extends Component {
           borderDash={[3, 1]}
           // borderStroke={"red"}
           boundBoxFunc={this.constrainSizes}
-          anchorSize={8}
+          anchorSize={anchorSize}
+          anchorCornerRadius={anchorSize / 2}
+          anchorStyleFunc={(anchor) => {
+            // Expand the invisible hit region around each resize handle
+            // so small bounding boxes are easier to grab and resize
+            anchor.hitFunc(function (context) {
+              const halfHit = hitSize / 2;
+              const halfAnchor = anchorSize / 2;
+              const offset = halfHit - halfAnchor;
+
+              context.beginPath();
+              context.rect(-offset, -offset, hitSize, hitSize);
+              context.closePath();
+              context.fillStrokeShape(anchor);
+            });
+          }}
           flipEnabled={true}
-          zoomedIn={this.props.item.zoomScale > 1}
+          zoomedIn={zoomScale > 1}
           onDragStart={(e) => {
             const {
               item: { selectedRegionsBBox },
@@ -214,7 +252,12 @@ export default class TransformerComponent extends Component {
 
             this.freeze();
 
-            if (!this.transformer || e.target !== e.currentTarget || !selectedRegionsBBox) return;
+            if (
+              !this.transformer ||
+              e.target !== e.currentTarget ||
+              !selectedRegionsBBox
+            )
+              return;
 
             this.draggingAreaBBox = {
               x: selectedRegionsBBox.left,
@@ -242,6 +285,10 @@ export default class TransformerComponent extends Component {
   }
 
   renderOldLSTransformer() {
+    const zoomScale = this.props.item.zoomScale || 1;
+    const anchorSize = computeAnchorSize(zoomScale);
+    const hitSize = computeAnchorHitSize(anchorSize, zoomScale);
+
     return (
       <>
         <LSTransformerOld
@@ -256,9 +303,22 @@ export default class TransformerComponent extends Component {
           borderDash={[3, 1]}
           // borderStroke={"red"}
           boundBoxFunc={this.constrainSizes}
-          anchorSize={8}
+          anchorSize={anchorSize}
+          anchorCornerRadius={anchorSize / 2}
+          anchorStyleFunc={(anchor) => {
+            anchor.hitFunc(function (context) {
+              const halfHit = hitSize / 2;
+              const halfAnchor = anchorSize / 2;
+              const offset = halfHit - halfAnchor;
+
+              context.beginPath();
+              context.rect(-offset, -offset, hitSize, hitSize);
+              context.closePath();
+              context.fillStrokeShape(anchor);
+            });
+          }}
           flipEnabled={true}
-          zoomedIn={this.props.item.zoomScale > 1}
+          zoomedIn={zoomScale > 1}
           onDragStart={(e) => {
             const {
               item: { selectedRegionsBBox },
@@ -266,7 +326,12 @@ export default class TransformerComponent extends Component {
 
             this.freeze();
 
-            if (!this.transformer || e.target !== e.currentTarget || !selectedRegionsBBox) return;
+            if (
+              !this.transformer ||
+              e.target !== e.currentTarget ||
+              !selectedRegionsBBox
+            )
+              return;
 
             this.draggingAreaBBox = {
               x: selectedRegionsBBox.left,

--- a/web/libs/editor/src/components/ImageTransformer/ImageTransformer.test.jsx
+++ b/web/libs/editor/src/components/ImageTransformer/ImageTransformer.test.jsx
@@ -1,0 +1,68 @@
+/**
+ * Tests for ImageTransformer anchor sizing behavior.
+ * Verifies that resize handles scale with zoom level and maintain
+ * a minimum grabbable hit area for small bounding boxes.
+ *
+ * Related issues:
+ * - https://github.com/HumanSignal/label-studio/issues/4558
+ * - https://github.com/HumanSignal/label-studio/issues/4452
+ */
+
+import { computeAnchorSize, computeAnchorHitSize } from "./anchorSizing";
+
+describe("Anchor sizing for transformer handles", () => {
+  describe("computeAnchorSize", () => {
+    it("returns base size at zoom level 1", () => {
+      const size = computeAnchorSize(1);
+      expect(size).toBe(10);
+    });
+
+    it("scales inversely with zoom (handles stay same screen size when zoomed in)", () => {
+      const sizeAt2x = computeAnchorSize(2);
+      // At 2x zoom, anchor should be half the base size in stage coordinates
+      // so it appears the same size on screen
+      expect(sizeAt2x).toBe(5);
+    });
+
+    it("enforces minimum anchor size when zoomed out", () => {
+      // At 0.25x zoom, naive scaling would give 40px — but minimum caps it
+      const sizeAt025x = computeAnchorSize(0.25);
+      // Should be capped to MIN / scale = 10 / 0.25 = 40 in stage coords
+      // which renders as 10px on screen (the minimum)
+      expect(sizeAt025x).toBeGreaterThanOrEqual(10);
+    });
+
+    it("never returns less than minimum screen size", () => {
+      for (const zoom of [0.1, 0.5, 1, 2, 5, 10]) {
+        const size = computeAnchorSize(zoom);
+        const screenSize = size * zoom;
+        expect(screenSize).toBeGreaterThanOrEqual(10);
+      }
+    });
+  });
+
+  describe("computeAnchorHitSize", () => {
+    it("returns anchor size plus margin", () => {
+      const hitSize = computeAnchorHitSize(10, 1);
+      expect(hitSize).toBeGreaterThan(10);
+    });
+
+    it("hit area scales with zoom to maintain screen-space margin", () => {
+      const hitAt1x = computeAnchorHitSize(10, 1);
+      const hitAt2x = computeAnchorHitSize(5, 2);
+      // Both should render to roughly the same screen-space hit area
+      const screenHit1x = hitAt1x * 1;
+      const screenHit2x = hitAt2x * 2;
+      expect(Math.abs(screenHit1x - screenHit2x)).toBeLessThan(1);
+    });
+
+    it("minimum hit area is at least 26px on screen (anchor + 2*margin)", () => {
+      for (const zoom of [0.5, 1, 2, 5]) {
+        const anchorSize = computeAnchorSize(zoom);
+        const hitSize = computeAnchorHitSize(anchorSize, zoom);
+        const screenHitSize = hitSize * zoom;
+        expect(screenHitSize).toBeGreaterThanOrEqual(26);
+      }
+    });
+  });
+});

--- a/web/libs/editor/src/components/ImageTransformer/anchorSizing.js
+++ b/web/libs/editor/src/components/ImageTransformer/anchorSizing.js
@@ -1,0 +1,58 @@
+/**
+ * Anchor sizing utilities for transformer resize handles.
+ *
+ * Solves the problem of small bounding boxes (e.g. baseball detections
+ * at <1% of image area) being nearly impossible to resize because the
+ * hardcoded 8px anchor handles are too small to grab consistently.
+ *
+ * The fix:
+ * 1. Scale anchor size inversely with zoom so handles stay constant on screen
+ * 2. Add an invisible hit margin around each anchor for easier grabbing
+ * 3. Enforce minimum sizes so handles never become unusably small
+ *
+ * Related issues:
+ * - https://github.com/HumanSignal/label-studio/issues/4558
+ * - https://github.com/HumanSignal/label-studio/issues/4452
+ */
+
+// Base visual size for transformer anchors (resize handles) in stage-space pixels at 1x zoom
+const BASE_ANCHOR_SIZE = 10;
+
+// Minimum rendered anchor size in screen pixels (ensures handles stay grabbable at any zoom)
+const MIN_ANCHOR_SCREEN_SIZE = 10;
+
+// Extra invisible hit margin around each anchor in screen pixels
+const ANCHOR_HIT_MARGIN = 8;
+
+/**
+ * Compute the anchor (resize handle) size in stage-space coordinates.
+ *
+ * At zoom=1, returns BASE_ANCHOR_SIZE.
+ * At zoom>1, shrinks proportionally so the anchor appears the same size on screen.
+ * Enforces a minimum screen size of MIN_ANCHOR_SCREEN_SIZE.
+ *
+ * @param {number} zoomScale - Current zoom/stage scale factor
+ * @returns {number} Anchor size in stage-space coordinates
+ */
+export function computeAnchorSize(zoomScale) {
+  const scale = Math.max(zoomScale, 0.01); // guard against zero/negative
+  // Ensure the anchor is at least MIN_ANCHOR_SCREEN_SIZE pixels on screen
+  const minStageSize = MIN_ANCHOR_SCREEN_SIZE / scale;
+  return Math.max(BASE_ANCHOR_SIZE / scale, minStageSize);
+}
+
+/**
+ * Compute the invisible hit area size for an anchor in stage-space coordinates.
+ *
+ * Adds ANCHOR_HIT_MARGIN (in screen pixels) around the visible anchor,
+ * converted to stage-space coordinates.
+ *
+ * @param {number} anchorSize - The visual anchor size (from computeAnchorSize)
+ * @param {number} zoomScale - Current zoom/stage scale factor
+ * @returns {number} Hit area size in stage-space coordinates
+ */
+export function computeAnchorHitSize(anchorSize, zoomScale) {
+  const scale = Math.max(zoomScale, 0.01);
+  const marginInStageSpace = ANCHOR_HIT_MARGIN / scale;
+  return anchorSize + 2 * marginInStageSpace;
+}

--- a/web/libs/editor/src/components/ImageTransformer/anchorSizing.test.js
+++ b/web/libs/editor/src/components/ImageTransformer/anchorSizing.test.js
@@ -1,0 +1,52 @@
+import { computeAnchorSize, computeAnchorHitSize } from "./anchorSizing";
+
+describe("computeAnchorSize", () => {
+  it("returns base size at zoom level 1", () => {
+    expect(computeAnchorSize(1)).toBe(10);
+  });
+
+  it("shrinks in stage-space when zoomed in (constant screen size)", () => {
+    expect(computeAnchorSize(2)).toBe(5);
+    expect(computeAnchorSize(4)).toBe(2.5);
+  });
+
+  it("grows in stage-space when zoomed out (constant screen size)", () => {
+    expect(computeAnchorSize(0.5)).toBe(20);
+  });
+
+  it("never renders below minimum screen pixels", () => {
+    for (const zoom of [0.1, 0.5, 1, 2, 5, 10]) {
+      const stageSize = computeAnchorSize(zoom);
+      const screenSize = stageSize * zoom;
+      expect(screenSize).toBeGreaterThanOrEqual(10);
+    }
+  });
+
+  it("handles edge case of very small zoom", () => {
+    const size = computeAnchorSize(0.01);
+    expect(size).toBeGreaterThan(0);
+    expect(size * 0.01).toBeGreaterThanOrEqual(10);
+  });
+});
+
+describe("computeAnchorHitSize", () => {
+  it("is always larger than the visual anchor", () => {
+    for (const zoom of [0.5, 1, 2]) {
+      const anchor = computeAnchorSize(zoom);
+      const hit = computeAnchorHitSize(anchor, zoom);
+      expect(hit).toBeGreaterThan(anchor);
+    }
+  });
+
+  it("adds consistent screen-space margin regardless of zoom", () => {
+    const anchor1 = computeAnchorSize(1);
+    const hit1 = computeAnchorHitSize(anchor1, 1);
+    const screenMargin1 = (hit1 - anchor1) * 1;
+
+    const anchor2 = computeAnchorSize(2);
+    const hit2 = computeAnchorHitSize(anchor2, 2);
+    const screenMargin2 = (hit2 - anchor2) * 2;
+
+    expect(Math.abs(screenMargin1 - screenMargin2)).toBeLessThan(0.01);
+  });
+});

--- a/web/libs/editor/src/components/ImageView/ImageView.jsx
+++ b/web/libs/editor/src/components/ImageView/ImageView.jsx
@@ -1,5 +1,23 @@
-import { Component, createRef, forwardRef, Fragment, memo, useEffect, useMemo, useRef, useState } from "react";
-import { Group, Layer, Line, Rect, Stage, Image as KonvaImage, Circle } from "react-konva";
+import {
+  Component,
+  createRef,
+  forwardRef,
+  Fragment,
+  memo,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  Group,
+  Layer,
+  Line,
+  Rect,
+  Stage,
+  Image as KonvaImage,
+  Circle,
+} from "react-konva";
 import { observer } from "mobx-react";
 import { getEnv, getRoot, isAlive } from "mobx-state-tree";
 
@@ -20,7 +38,12 @@ import ResizeObserver from "../../utils/resize-observer";
 import { debounce } from "@humansignal/core/lib/utils/debounce";
 import Constants from "../../core/Constants";
 import { fixRectToFit, mapKonvaBrightness } from "../../utils/image";
-import { FF_DEV_1442, FF_LSDV_4930, FF_ZOOM_OPTIM, isFF } from "../../utils/feature-flags";
+import {
+  FF_DEV_1442,
+  FF_LSDV_4930,
+  FF_ZOOM_OPTIM,
+  isFF,
+} from "../../utils/feature-flags";
 import { Pagination } from "../../common/Pagination/Pagination";
 import { Image } from "./Image";
 
@@ -61,22 +84,37 @@ const Region = observer(({ region, showSelected = false }) => {
   return Tree.renderItem(region, region.annotation, true);
 });
 
-const RegionsLayer = memo(({ regions, name, useLayers, showSelected = false, smoothing = true }) => {
-  const content = regions.map((el) => {
-    return <Region key={`region-${el.id}`} region={el} showSelected={showSelected} />;
-  });
+const RegionsLayer = memo(
+  ({ regions, name, useLayers, showSelected = false, smoothing = true }) => {
+    const content = regions.map((el) => {
+      return (
+        <Region
+          key={`region-${el.id}`}
+          region={el}
+          showSelected={showSelected}
+        />
+      );
+    });
 
-  return useLayers === false ? (
-    content
-  ) : (
-    <Layer name={name} imageSmoothingEnabled={smoothing}>
-      {content}
-    </Layer>
-  );
-});
+    return useLayers === false ? (
+      content
+    ) : (
+      <Layer name={name} imageSmoothingEnabled={smoothing}>
+        {content}
+      </Layer>
+    );
+  },
+);
 
 const Regions = memo(
-  ({ regions, useLayers = true, chunkSize = 15, suggestion = false, showSelected = false, smoothing = true }) => {
+  ({
+    regions,
+    useLayers = true,
+    chunkSize = 15,
+    suggestion = false,
+    showSelected = false,
+    smoothing = true,
+  }) => {
     return (
       <ImageViewProvider value={{ suggestion }}>
         {(chunkSize ? chunks(regions, chunkSize) : regions).map((chunk, i) => (
@@ -98,13 +136,18 @@ const DrawingRegion = observer(({ item }) => {
   const { drawingRegion } = item;
 
   if (!drawingRegion) return null;
-  if (item.multiImage && item.currentImage !== drawingRegion.item_index) return null;
+  if (item.multiImage && item.currentImage !== drawingRegion.item_index)
+    return null;
 
   const Wrapper = Layer;
 
   return (
     <Wrapper imageSmoothingEnabled={item.smoothingEnabled}>
-      {drawingRegion ? <Region key={"drawing"} region={drawingRegion} /> : drawingRegion}
+      {drawingRegion ? (
+        <Region key={"drawing"} region={drawingRegion} />
+      ) : (
+        drawingRegion
+      )}
     </Wrapper>
   );
 });
@@ -139,7 +182,7 @@ const SelectionBorders = observer(({ item, selectionArea }) => {
         },
       ]
     : [];
-  const ANCHOR_SIZE = 6 / item.stageScale;
+  const ANCHOR_SIZE = Math.max(8, 6) / item.stageScale;
 
   return (
     <>
@@ -193,7 +236,12 @@ const SelectionRect = observer(({ item }) => {
 
   return (
     <>
-      <Rect {...positionProps} stroke={SELECTION_COLOR} dash={SELECTION_DASH} strokeScaleEnabled={false} />
+      <Rect
+        {...positionProps}
+        stroke={SELECTION_COLOR}
+        dash={SELECTION_DASH}
+        strokeScaleEnabled={false}
+      />
       <Rect
         {...positionProps}
         stroke={SELECTION_SECOND_COLOR}
@@ -224,11 +272,13 @@ const TransformerBack = observer(({ item }) => {
           }}
           onMouseOver={(ev) => {
             if (!item.annotation.isLinkingMode) {
-              ev.target.getStage().container().style.cursor = Constants.POINTER_CURSOR;
+              ev.target.getStage().container().style.cursor =
+                Constants.POINTER_CURSOR;
             }
           }}
           onMouseOut={(ev) => {
-            ev.target.getStage().container().style.cursor = Constants.DEFAULT_CURSOR;
+            ev.target.getStage().container().style.cursor =
+              Constants.DEFAULT_CURSOR;
           }}
           onDragStart={(e) => {
             dragStartPointRef.current = {
@@ -273,17 +323,31 @@ const TransformerBack = observer(({ item }) => {
 
 const SelectedRegions = observer(({ item, selectedRegions }) => {
   if (!selectedRegions) return null;
-  const { brushRegions = [], shapeRegions = [] } = splitRegions(selectedRegions);
+  const { brushRegions = [], shapeRegions = [] } =
+    splitRegions(selectedRegions);
 
   return (
     <>
       {isFF(FF_LSDV_4930) ? null : <TransformerBack item={item} />}
       {brushRegions.length > 0 && (
-        <Regions key="brushes" name="brushes" regions={brushRegions} useLayers={true} showSelected chankSize={0} />
+        <Regions
+          key="brushes"
+          name="brushes"
+          regions={brushRegions}
+          useLayers={true}
+          showSelected
+          chankSize={0}
+        />
       )}
 
       {shapeRegions.length > 0 && (
-        <Regions key="shapes" name="shapes" regions={shapeRegions} showSelected chankSize={0} />
+        <Regions
+          key="shapes"
+          name="shapes"
+          regions={shapeRegions}
+          showSelected
+          chankSize={0}
+        />
       )}
     </>
   );
@@ -293,7 +357,8 @@ const SelectionLayer = observer(({ item, selectionArea }) => {
   const scale = 1;
   const [isMouseWheelClick, setIsMouseWheelClick] = useState(false);
   const [shift, setShift] = useState(false);
-  const isPanTool = item.getToolsManager().findSelectedTool()?.fullName === "ZoomPanTool";
+  const isPanTool =
+    item.getToolsManager().findSelectedTool()?.fullName === "ZoomPanTool";
 
   const dragHandler = (e) => setIsMouseWheelClick(e.buttons === 4);
 
@@ -312,7 +377,8 @@ const SelectionLayer = observer(({ item, selectionArea }) => {
     };
   }, []);
 
-  const disableTransform = item.zoomScale > 1 && (shift || isPanTool || isMouseWheelClick);
+  const disableTransform =
+    item.zoomScale > 1 && (shift || isPanTool || isMouseWheelClick);
 
   let supportsTransform = true;
   let supportsRotate = true;
@@ -327,7 +393,8 @@ const SelectionLayer = observer(({ item, selectionArea }) => {
   supportsTransform =
     supportsTransform &&
     (item.selectedRegions.length > 1 ||
-      ((item.useTransformer || item.selectedShape?.preferTransformer) && item.selectedShape?.useTransformer));
+      ((item.useTransformer || item.selectedShape?.preferTransformer) &&
+        item.selectedShape?.useTransformer));
 
   return (
     <Layer scaleX={scale} scaleY={scale}>
@@ -343,7 +410,9 @@ const SelectionLayer = observer(({ item, selectionArea }) => {
         supportsScale={supportsScale}
         selectedShapes={item.selectedRegions}
         singleNodeMode={item.selectedRegions.length === 1}
-        useSingleNodeRotation={item.selectedRegions.length === 1 && supportsRotate}
+        useSingleNodeRotation={
+          item.selectedRegions.length === 1 && supportsRotate
+        }
         draggableBackgroundSelector={`#${TRANSFORMER_BACK_ID}`}
       />
     </Layer>
@@ -444,7 +513,8 @@ const PixelGridLayer = observer(({ item }) => {
   const visible = item.zoomScale > ZOOM_THRESHOLD;
   const { naturalWidth, naturalHeight } = item.currentImageEntity ?? {};
   const { stageWidth, stageHeight } = item;
-  const imageSmallerThanStage = naturalWidth < stageWidth || naturalHeight < stageHeight;
+  const imageSmallerThanStage =
+    naturalWidth < stageWidth || naturalHeight < stageHeight;
 
   const step = item.stageZoom; // image pixel
 
@@ -568,9 +638,12 @@ export default observer(
       // shape we can click on. Here we're relying on cursor position and non-transparent pixels
       // of the mask to detect cursor-region collision.
       const allowedHoverTypes = /bitmask|vector/i;
-      const hasSelected = item.selectedRegions.some((r) => r.type.match(allowedHoverTypes) !== null);
+      const hasSelected = item.selectedRegions.some(
+        (r) => r.type.match(allowedHoverTypes) !== null,
+      );
       const tool = item.getToolsManager().findSelectedTool();
-      const isAllowedTool = tool?.toolName?.match?.(allowedHoverTypes) !== null ?? false;
+      const isAllowedTool =
+        tool?.toolName?.match?.(allowedHoverTypes) !== null ?? false;
 
       const hoveredRegion = item.regs.find((reg) => {
         if (reg.selected || tool?.mode === "drawing") return false;
@@ -589,14 +662,20 @@ export default observer(
 
     resetDeferredClickTimeout = () => {
       if (this.deferredClickTimeout.length > 0) {
-        this.deferredClickTimeout = this.deferredClickTimeout.filter((timeout) => {
-          clearTimeout(timeout);
-          return false;
-        });
+        this.deferredClickTimeout = this.deferredClickTimeout.filter(
+          (timeout) => {
+            clearTimeout(timeout);
+            return false;
+          },
+        );
       }
     };
 
-    handleDeferredClick = (handleDeferredMouseDownCallback, handleDeselection, eligibleToDeselect = false) => {
+    handleDeferredClick = (
+      handleDeferredMouseDownCallback,
+      handleDeselection,
+      eligibleToDeselect = false,
+    ) => {
       this.handleDeferredMouseDown = (wasClicked) => {
         if (wasClicked && eligibleToDeselect) {
           handleDeselection();
@@ -619,10 +698,15 @@ export default observer(
     handleMouseDown = (e) => {
       this.mouseDown = true;
       const { item } = this.props;
-      const isPanTool = item.getToolsManager().findSelectedTool()?.fullName === "ZoomPanTool";
-      const isMoveTool = item.getToolsManager().findSelectedTool()?.fullName === "MoveTool";
+      const isPanTool =
+        item.getToolsManager().findSelectedTool()?.fullName === "ZoomPanTool";
+      const isMoveTool =
+        item.getToolsManager().findSelectedTool()?.fullName === "MoveTool";
 
-      this.skipNextMouseDown = this.skipNextMouseUp = this.skipNextClick = false;
+      this.skipNextMouseDown =
+        this.skipNextMouseUp =
+        this.skipNextClick =
+          false;
       if (isFF(FF_LSDV_4930)) {
         this.mouseDownPoint = { x: e.evt.offsetX, y: e.evt.offsetY };
       }
@@ -643,7 +727,11 @@ export default observer(
         const isRightElementToCatchToolInteractions = (el) => {
           // Bitmask is like Brush, so treat it the same
           // The only difference is that Bitmask doesn't have a group inside
-          if (el.nodeType === "Layer" && !isMoveTool && el.attrs?.name === "bitmask") {
+          if (
+            el.nodeType === "Layer" &&
+            !isMoveTool &&
+            el.attrs?.name === "bitmask"
+          ) {
             return true;
           }
 
@@ -701,8 +789,10 @@ export default observer(
 
       if (isFF(FF_DEV_1442) && eligibleToolForDeselect) {
         const targetIsCanvas = e.target === item.stageRef;
-        const annotationHasSelectedRegions = item.annotation.selectedRegions.length > 0;
-        const eligibleToDeselect = targetIsCanvas && annotationHasSelectedRegions;
+        const annotationHasSelectedRegions =
+          item.annotation.selectedRegions.length > 0;
+        const eligibleToDeselect =
+          targetIsCanvas && annotationHasSelectedRegions;
 
         const handleDeselection = () => {
           item.annotation.unselectAll();
@@ -711,7 +801,11 @@ export default observer(
           this.skipNextClick = true;
         };
 
-        this.handleDeferredClick(handleMouseDown, handleDeselection, eligibleToDeselect);
+        this.handleDeferredClick(
+          handleMouseDown,
+          handleDeselection,
+          eligibleToDeselect,
+        );
         return;
       }
 
@@ -840,7 +934,9 @@ export default observer(
     updateCrosshair = (e) => {
       if (this.crosshairRef.current) {
         const { x, y } = e.currentTarget.getPointerPosition();
-        this.crosshairRef.current.updatePointer(...this.props.item.fixZoomedCoords([x, y]));
+        this.crosshairRef.current.updatePointer(
+          ...this.props.item.fixZoomedCoords([x, y]),
+        );
       }
     };
 
@@ -879,13 +975,19 @@ export default observer(
         const stage = item.stageRef;
 
         // Unified smooth zoom behavior for both trackpad and mouse wheel
-        item.handleZoom(e.evt.deltaY, stage.getPointerPosition(), e.evt.ctrlKey);
+        item.handleZoom(
+          e.evt.deltaY,
+          stage.getPointerPosition(),
+          e.evt.ctrlKey,
+        );
       } else if (e.evt) {
         // Two fingers scroll (panning) - only when zoomed in
         const { item } = this.props;
 
-        const maxScrollX = Math.round(item.stageWidth * item.zoomScale) - item.stageWidth;
-        const maxScrollY = Math.round(item.stageHeight * item.zoomScale) - item.stageHeight;
+        const maxScrollX =
+          Math.round(item.stageWidth * item.zoomScale) - item.stageWidth;
+        const maxScrollY =
+          Math.round(item.stageHeight * item.zoomScale) - item.stageHeight;
 
         const newPos = {
           x: Math.min(0, Math.ceil(item.zoomingPositionX - e.evt.deltaX)),
@@ -893,8 +995,10 @@ export default observer(
         };
 
         // Calculate scroll boundaries to allow scrolling the page when reaching stage edges
-        const withinX = newPos.x !== 0 && newPos.x > -maxScrollX && item.zoomScale !== 1;
-        const withinY = newPos.y !== 0 && newPos.y > -maxScrollY && item.zoomScale !== 1;
+        const withinX =
+          newPos.x !== 0 && newPos.x > -maxScrollX && item.zoomScale !== 1;
+        const withinY =
+          newPos.y !== 0 && newPos.y > -maxScrollY && item.zoomScale !== 1;
 
         // Detect scroll direction
         const scrollingX = Math.abs(e.evt.deltaX) > Math.abs(e.evt.deltaY);
@@ -949,7 +1053,11 @@ export default observer(
         const { offsetWidth, offsetHeight } = this.props.item.containerRef;
 
         if (this.props.item.naturalWidth <= 1) return;
-        if (this.lastOffsetWidth === offsetWidth && this.lastOffsetHeight === offsetHeight) return;
+        if (
+          this.lastOffsetWidth === offsetWidth &&
+          this.lastOffsetHeight === offsetHeight
+        )
+          return;
 
         this.props.item.onResize(offsetWidth, offsetHeight, true);
         this.lastOffsetWidth = offsetWidth;
@@ -1002,7 +1110,8 @@ export default observer(
       const { imageRef } = this;
 
       if (!item || !isAlive(item) || !imageRef.current) return;
-      if (item.isReady !== imageRef.current.complete) item.setReady(imageRef.current.complete);
+      if (item.isReady !== imageRef.current.complete)
+        item.setReady(imageRef.current.complete);
     }
 
     renderTools() {
@@ -1044,11 +1153,16 @@ export default observer(
 
       const imagePositionClassnames = [
         styles.image_position,
-        styles[`image_position__${item.verticalalignment === "center" ? "middle" : item.verticalalignment}`],
+        styles[
+          `image_position__${item.verticalalignment === "center" ? "middle" : item.verticalalignment}`
+        ],
         styles[`image_position__${item.horizontalalignment}`],
       ];
 
-      const wrapperClasses = [styles.wrapperComponent, item.images.length > 1 ? styles.withGallery : styles.wrapper];
+      const wrapperClasses = [
+        styles.wrapperComponent,
+        item.images.length > 1 ? styles.withGallery : styles.wrapper,
+      ];
 
       if (paginationEnabled) wrapperClasses.push(styles.withPagination);
 
@@ -1062,7 +1176,11 @@ export default observer(
           {paginationEnabled ? (
             <div
               className={styles.pagination}
-              title={isViewingAll ? "Pagination is not supported in View All Annotations" : undefined}
+              title={
+                isViewingAll
+                  ? "Pagination is not supported in View All Annotations"
+                  : undefined
+              }
             >
               <Pagination
                 size="small"
@@ -1131,7 +1249,8 @@ export default observer(
                   if (this.crosshairRef.current) {
                     this.crosshairRef.current.updateVisibility(false);
                   }
-                  const { width: stageWidth, height: stageHeight } = item.canvasSize;
+                  const { width: stageWidth, height: stageHeight } =
+                    item.canvasSize;
                   const { offsetX: mouseposX, offsetY: mouseposY } = e.evt;
                   const newEvent = { ...e };
 
@@ -1220,7 +1339,9 @@ const EntireStage = observer(
         ref={(ref) => {
           item.setStageRef(ref);
         }}
-        className={[styles["image-element"], ...imagePositionClassnames].join(" ")}
+        className={[styles["image-element"], ...imagePositionClassnames].join(
+          " ",
+        )}
         width={size.width}
         height={size.height}
         scaleX={item.zoomScale}
@@ -1239,7 +1360,12 @@ const EntireStage = observer(
         onMouseUp={onMouseUp}
         onWheel={onWheel}
       >
-        <StageContent item={item} store={store} state={state} crosshairRef={crosshairRef} />
+        <StageContent
+          item={item}
+          store={store}
+          state={state}
+          crosshairRef={crosshairRef}
+        />
       </Stage>
     );
   },
@@ -1281,7 +1407,12 @@ const ImageLayer = observer(({ item }) => {
       width: imageEntity.naturalWidth,
       height: imageEntity.naturalHeight,
     };
-  }, [imageEntity.naturalWidth, imageEntity.naturalHeight, item.stageWidth, item.stageHeight]);
+  }, [
+    imageEntity.naturalWidth,
+    imageEntity.naturalHeight,
+    item.stageWidth,
+    item.stageHeight,
+  ]);
 
   const brightness = mapKonvaBrightness(imageEntity.brightnessGrade);
   const contrast = imageEntity.contrastGrade - 100;
@@ -1306,7 +1437,10 @@ const ImageLayer = observer(({ item }) => {
   }, [loadedImage, brightness, contrast, currentSrc]);
 
   return loadedImage ? (
-    <Layer imageSmoothingEnabled={item.smoothingEnabled} scale={{ x: item.stageZoom, y: item.stageZoom }}>
+    <Layer
+      imageSmoothingEnabled={item.smoothingEnabled}
+      scale={{ x: item.stageZoom, y: item.stageZoom }}
+    >
       <KonvaImage
         key={currentSrc ?? "image-source"}
         ref={konvaImageRef}
@@ -1379,8 +1513,22 @@ const CursorLayer = observer(({ item, tool }) => {
         </>
       ) : (
         <>
-          <Circle x={x} y={y} radius={size} stroke="black" strokeWidth={3} strokeScaleEnabled={false} />
-          <Circle x={x} y={y} radius={size} stroke="white" strokeWidth={1} strokeScaleEnabled={false} />
+          <Circle
+            x={x}
+            y={y}
+            radius={size}
+            stroke="black"
+            strokeWidth={3}
+            strokeScaleEnabled={false}
+          />
+          <Circle
+            x={x}
+            y={y}
+            radius={size}
+            stroke="white"
+            strokeWidth={1}
+            strokeScaleEnabled={false}
+          />
         </>
       )}
     </Layer>
@@ -1392,9 +1540,14 @@ const StageContent = observer(({ item, store, state, crosshairRef }) => {
   if (!store.task || !item.currentSrc) return null;
 
   // Keep selected or highlighted region on top
-  const regions = [...item.regs].sort((r) => (r.highlighted || r.selected ? 1 : -1));
+  const regions = [...item.regs].sort((r) =>
+    r.highlighted || r.selected ? 1 : -1,
+  );
   const paginationEnabled = !!item.isMultiItem;
-  const wrapperClasses = [styles.wrapperComponent, item.images.length > 1 ? styles.withGallery : styles.wrapper];
+  const wrapperClasses = [
+    styles.wrapperComponent,
+    item.images.length > 1 ? styles.withGallery : styles.wrapper,
+  ];
   const tool = item.getToolsManager().findSelectedTool();
 
   if (paginationEnabled) wrapperClasses.push(styles.withPagination);
@@ -1452,7 +1605,9 @@ const StageContent = observer(({ item, store, state, crosshairRef }) => {
         />
       )}
 
-      {tool && tool.toolName?.match(/bitmask/i) && <CursorLayer item={item} tool={tool} />}
+      {tool && tool.toolName?.match(/bitmask/i) && (
+        <CursorLayer item={item} tool={tool} />
+      )}
     </>
   );
 });


### PR DESCRIPTION
## Summary

- Resize handles (anchors) on the Konva.js Transformer were hardcoded at `8px`, making them nearly impossible to grab on small annotations (e.g. baseball bounding boxes at <1% of image area)
- Users experience inconsistent cursor behavior — sometimes resize, sometimes move, sometimes create-new — because the 8px hit region is too small for the UI to distinguish interaction intent on tiny regions
- This PR scales anchor size inversely with zoom and adds an invisible 8px hit margin around each handle

## Changes

| File | Change |
|------|--------|
| `anchorSizing.js` | New module: `computeAnchorSize(zoom)` and `computeAnchorHitSize(anchor, zoom)` |
| `ImageTransformer.jsx` | Replace hardcoded `anchorSize={8}` with zoom-responsive sizing + `anchorStyleFunc` for expanded hit regions |
| `ImageView.jsx` | Increase selection point base size from 6 to 8 |
| `*.test.*` | Unit tests for anchor sizing math |

## How it works

1. **Zoom-responsive sizing**: `anchorSize = max(BASE / zoom, MIN / zoom)` keeps handles constant on screen
2. **Invisible hit expansion**: `anchorStyleFunc` sets a custom `hitFunc` on each anchor with an 8px screen-space margin beyond the visible handle
3. **Round handles**: `anchorCornerRadius` for better visual distinction

## Context

Discovered while labeling baseball detections in 4K video frames. The bounding boxes are typically 0.5-2.5% of image dimensions — at the default zoom level, each box is ~10-15px on screen. With 8px anchors, the grab zone covers nearly the entire box, so the system can't tell if the user wants to move the box, resize it, or create a new label.

## Test plan

- [x] Unit tests for `computeAnchorSize` and `computeAnchorHitSize`
- [ ] Manual testing with small annotations at various zoom levels
- [ ] Verify no regression on normal-sized annotations

Fixes #4558
Relates to #4452

🤖 Generated with [Claude Code](https://claude.com/claude-code)