### PR TITLE
fix: add scroll for Data Manager filters overflow

### DIFF
--- a/web/libs/datamanager/src/components/Filters/Filters.prefix.css
+++ b/web/libs/datamanager/src/components/Filters/Filters.prefix.css
@@ -5,7 +5,10 @@
   &:not(&_sidebar) {
     padding-top: var(--spacing-tight);
     min-width: 400px;
+    max-height: 70vh;
     border-radius: var(--corner-radius-small);
+    display: flex;
+    flex-direction: column;
     box-shadow:
       0 3px 6px -4px rgb(0 0 0 / 12%),
       0 6px 16px 0 rgb(0 0 0 / 8%),
@@ -63,6 +66,15 @@
       flex-flow: column nowrap;
       gap: var(--spacing-tight);
     }
+  }
+
+  &:not(&_sidebar) &__list {
+    flex: 1;
+    min-height: 0;
+  }
+
+  &:not(&_sidebar) &__list_withFilters {
+    overflow-y: auto;
   }
 
   &_sidebar &__list {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Reason for change
Data Manager filter rows in the dropdown panel can overflow beyond the viewport when many filters are added, making some rows inaccessible.

## What changed
- Updated `web/libs/datamanager/src/components/Filters/Filters.prefix.css`
- For non-sidebar filters panel:
  - added `max-height: 70vh` to cap panel height
  - switched panel container to column flex layout
  - made the filters list area flexible (`flex: 1; min-height: 0`)
  - enabled vertical scrolling on `filters__list_withFilters`

This keeps the action buttons visible while allowing long filter lists to scroll.

## Screenshots
- Not attached from this environment.
- Expected behavior: in Data Manager filter dropdown, when many filters are present, the list scrolls vertically instead of overflowing off-screen.

## Rollout strategy
- Standard frontend CSS change, no feature flags.

## Testing
- Code-level verification via diff and selector scoping review.
- Manual verification recommended in UI:
  1. Open Data Manager filters dropdown.
  2. Add many filters until content exceeds viewport height.
  3. Confirm filter list scrolls and actions remain visible.

## Risks
- Low risk; style changes are scoped to `.filters:not(.filters_sidebar)` and list elements.
- Sidebar behavior is intentionally unchanged.

## Reviewer notes
- This is the same overflow/scroll pattern fix requested for Label Studio, matching behavior already applied in enterprise context.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://humansignal.slack.com/archives/D0A5U320CDR/p1767035607929009?thread_ts=1767035607.929009&cid=D0A5U320CDR)

<div><a href="https://cursor.com/agents/bc-12252b34-d8e6-50d0-8618-45362b505557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12252b34-d8e6-50d0-8618-45362b505557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

