### PR TITLE
docs: update archived frontend with info for agents on how to build on top of LSO

### DIFF
--- a/docs/source/guide/frontend.md
+++ b/docs/source/guide/frontend.md
@@ -12,7 +12,9 @@ section: "Integrate & Extend"
 ---
 
 !!! attention
-    As of [Label Studio 1.11.0](https://github.com/HumanSignal/label-studio/releases/tag/1.11.0), the Label Studio frontend has been deprecated as a separate library and is no longer supported as a standalone distribution. For information about using the frontend library within Label Studio, see [the README](https://github.com/HumanSignal/label-studio/blob/develop/web/libs/editor/README.md). 
+    As of [Label Studio 1.11.0](https://github.com/HumanSignal/label-studio/releases/tag/1.11.0), the Label Studio frontend has been deprecated as a separate library and is no longer supported as a standalone distribution. For information about using the frontend library within Label Studio, see [the README](https://github.com/HumanSignal/label-studio/blob/develop/web/libs/editor/README.md).
+
+    Rather than building a new annotation tool from scratch, AI agents can build powerful labeling interfaces on top of Label Studio by combining the [XML labeling config builder skill](https://github.com/HumanSignal/create-xml-labeling-config-skill) with the [Label Studio SDK/CLI](https://api.labelstud.io/api-reference/introduction/getting-started). This lets agents generate optimized labeling configs directly from your specs and wire them into projects programmatically.
 
 The [Label Studio Frontend](https://github.com/HumanSignal/label-studio-frontend) (LSF) is the main labeling interface distributed within Label Studio and as a separate package via NPM and Unpkg. You can integrate the LSF into your projects without Label Studio to provide data labeling capabilities to your users.
 

--- a/docs/source/guide/frontend.md
+++ b/docs/source/guide/frontend.md
@@ -14,7 +14,7 @@ section: "Integrate & Extend"
 !!! attention
     As of [Label Studio 1.11.0](https://github.com/HumanSignal/label-studio/releases/tag/1.11.0), the Label Studio frontend has been deprecated as a separate library and is no longer supported as a standalone distribution. For information about using the frontend library within Label Studio, see [the README](https://github.com/HumanSignal/label-studio/blob/develop/web/libs/editor/README.md).
 
-    Rather than building a new annotation tool from scratch, AI agents can build powerful labeling interfaces on top of Label Studio by combining the [XML labeling config builder skill](https://github.com/HumanSignal/create-xml-labeling-config-skill) with the [Label Studio SDK/CLI](https://api.labelstud.io/api-reference/introduction/getting-started). This lets agents generate optimized labeling configs directly from your specs and wire them into projects programmatically.
+    Rather than building a new labeling application from scratch, AI agents can build powerful labeling interfaces on top of Label Studio by combining the [XML labeling config builder skill](https://github.com/HumanSignal/create-xml-labeling-config-skill) with the [Label Studio SDK/CLI](https://api.labelstud.io/api-reference/introduction/getting-started). This lets agents generate optimized labeling configs directly from your specs and wire them into projects programmatically.
 
 The [Label Studio Frontend](https://github.com/HumanSignal/label-studio-frontend) (LSF) is the main labeling interface distributed within Label Studio and as a separate package via NPM and Unpkg. You can integrate the LSF into your projects without Label Studio to provide data labeling capabilities to your users.
 


### PR DESCRIPTION
It does this:
<img width="981" height="421" alt="Screenshot 2026-05-22 at 13 25 09" src="https://github.com/user-attachments/assets/6bc0e04e-63ad-41f5-ba45-6690fb232e41" />
