### PR TITLE
fix: Redis export path prefix and task list User reference crash

### DIFF
--- a/label_studio/io_storages/redis/form_layout.yml
+++ b/label_studio/io_storages/redis/form_layout.yml
@@ -58,5 +58,7 @@ ImportStorage:
             label: "Tasks - Treat each JSON or JSONL file as a task definition (one or more tasks per file)"
 
 ExportStorage:
+  - columnCount: 1
+    fields: *redis_title
   - columnCount: 2
     fields: *redis_params

--- a/label_studio/io_storages/redis/models.py
+++ b/label_studio/io_storages/redis/models.py
@@ -135,8 +135,10 @@ class RedisExportStorage(RedisStorageMixin, ExportStorage):
         logger.debug(f'Creating new object on {self.__class__.__name__} Storage {self} for annotation {annotation}')
         ser_annotation = self._get_serialized_data(annotation)
 
-        # get key that identifies this object in storage
+        # get key that identifies this object in storage, prepend path prefix if set
         key = RedisExportStorageLink.get_key(annotation)
+        if self.path:
+            key = str(self.path).rstrip('/') + '/' + key
 
         # put object into storage
         client.set(key, json.dumps(ser_annotation))

--- a/label_studio/io_storages/redis/models.py
+++ b/label_studio/io_storages/redis/models.py
@@ -85,7 +85,7 @@ class RedisImportStorageBase(ImportStorage, RedisStorageMixin):
 
     def iter_objects(self):
         client = self.get_client()
-        path = str(self.path)
+        path = str(self.path or "")
         for key in client.keys(path + '*'):
             yield key
 

--- a/web/apps/labelstudio/src/pages/Settings/StorageSettings/providers/redis.ts
+++ b/web/apps/labelstudio/src/pages/Settings/StorageSettings/providers/redis.ts
@@ -39,15 +39,14 @@ export const redisProvider: ProviderConfig = {
       schema: z.string().default("6379"),
     },
     {
-      name: "prefix",
+      name: "path",
       type: "text",
       label: "Bucket prefix",
       placeholder: "path/to/files",
       schema: z.string().optional().default(""),
-      target: "export",
     },
   ],
-  layout: [{ fields: ["host", "port", "db", "password"] }, { fields: ["prefix"] }],
+  layout: [{ fields: ["host", "port", "db", "password"] }, { fields: ["path"] }],
 };
 
 export default redisProvider;

--- a/web/libs/datamanager/src/stores/AppStore.js
+++ b/web/libs/datamanager/src/stores/AppStore.js
@@ -576,12 +576,12 @@ export const AppStore = types
 
       self.viewsStore.fetchColumns();
 
-      const requests = [self.fetchProject()];
-
-      // Only fetch all users if not disabled globally
+      // Fetch users before tabs so annotator/reviewer references in task data can be resolved.
       if (!isFF(FF_DISABLE_GLOBAL_USER_FETCHING)) {
-        requests.push(self.fetchUsers());
+        yield self.fetchUsers();
       }
+
+      const requests = [self.fetchProject()];
 
       if (!isLabelStream || (self.project?.show_annotation_history && task)) {
         if (self.SDK.settings?.onlyVirtualTabs && self.project?.show_annotation_history && !task) {

--- a/web/libs/datamanager/src/stores/Assignee.js
+++ b/web/libs/datamanager/src/stores/Assignee.js
@@ -3,6 +3,10 @@ import { User } from "./Users";
 import { StringOrNumberID } from "./types";
 import { FF_DISABLE_GLOBAL_USER_FETCHING, isFF } from "../utils/feature-flags";
 
+// Use safeReference so that unresolved user IDs (race condition during initial load)
+// return undefined instead of throwing an MST error.
+const userSafeReference = types.safeReference(User);
+
 // Create a union type that can handle both user references and direct user objects
 const UserOrReference = types.union({
   dispatcher: (snapshot) => {
@@ -11,11 +15,11 @@ const UserOrReference = types.union({
       return User;
     }
     // Otherwise, it's a reference to a user ID
-    return types.reference(User);
+    return userSafeReference;
   },
   cases: {
     [User.name]: User,
-    reference: types.reference(User),
+    reference: userSafeReference,
   },
 });
 
@@ -29,28 +33,28 @@ export const Assignee = types
   })
   .views((self) => ({
     get firstName() {
-      return self.user.firstName;
+      return self.user?.firstName ?? "";
     },
     get lastName() {
-      return self.user.lastName;
+      return self.user?.lastName ?? "";
     },
     get username() {
-      return self.user.username;
+      return self.user?.username ?? "";
     },
     get email() {
-      return self.user.email;
+      return self.user?.email ?? "";
     },
     get lastActivity() {
-      return self.user.lastActivity;
+      return self.user?.lastActivity ?? "";
     },
     get avatar() {
-      return self.user.avatar;
+      return self.user?.avatar ?? null;
     },
     get initials() {
-      return self.user.initials;
+      return self.user?.initials ?? "";
     },
     get fullName() {
-      return self.user.fullName;
+      return self.user?.fullName ?? "";
     },
   }))
   .preProcessSnapshot((sn) => {


### PR DESCRIPTION


**Redis export storage prefix (models.py, providers/redis.ts)**
The new StorageProviderForm wizard was submitting the prefix as prefix but the backend model stores it as path, so the value was silently dropped. Renamed the field in the frontend provider config to path. On the backend, save_annotation now prepends self.path to the Redis key before writing (matching how S3 handles its prefix).

**Task list User reference crash (AppStore.js, Assignee.js)**
After labeling a task, returning to the overview threw Failed to resolve reference 'X' to type 'User' because fetchUsers and fetchTabs ran in parallel — tasks with annotator references could be applied to the MST tree before users were loaded. Fixed by awaiting fetchUsers before dispatching the tab/task fetch. As belt-and-suspenders, changed types.reference(User) to types.safeReference(User) in Assignee and added null guards on all user property views, so any future race or single-task refresh that bypasses fetchData degrades gracefully instead of crashing.
