### PR TITLE
fix: HeidiTips fetch timeout Illegal invocation

### DIFF
--- a/web/apps/labelstudio/src/components/HeidiTips/utils.ts
+++ b/web/apps/labelstudio/src/components/HeidiTips/utils.ts
@@ -55,7 +55,7 @@ export const loadLiveTipsCollection = () => {
   const abortController = new AbortController();
 
   // Abort the request after MAX_TIMEOUT milliseconds to ensure we won't wait for too long, something might be wrong with the network or it could be an air-gapped instance
-  const abortTimeout = setTimeout(abortController.abort, MAX_TIMEOUT);
+  const abortTimeout = setTimeout(() => abortController.abort(), MAX_TIMEOUT);
 
   // Fetch from github raw liveContent.json proxied through the server
   fetch("/heidi-tips", {


### PR DESCRIPTION
## Summary
Fix `Illegal invocation` when the Heidi tips live fetch timeout fires after 5 seconds.

## Problem
`setTimeout(abortController.abort, MAX_TIMEOUT)` loses the required `this` binding on host methods.

## Fix
`setTimeout(() => abortController.abort(), MAX_TIMEOUT)`

## Repro
1. Clear `heidi_live_tips_collection` / `heidi_live_tips_collection_fetched_at` in localStorage
2. Open Home page
3. Throttle or block `/heidi-tips` for >5s
4. Console: `Illegal invocation` at `HeidiTips/utils.ts`

## Test plan
- [ ] Slow/blocked `/heidi-tips` — no console error after 5s
- [ ] Normal fetch — tips still load and cache updates