### PR TITLE
docs: add Skills top-nav section for create-xml-labeling-config + cre…

### DIFF
--- a/docs/source/guide/interfaces-agent.md
+++ b/docs/source/guide/interfaces-agent.md
@@ -14,7 +14,7 @@ You can create Interfaces in two ways:
 
 * **Within Label Studio** - Use Label Studio's out-of-the-box Interface builder to prompt our agent to build and refine your Interface. 
 
-* **Developed locally** - Install the `create-interface-skill` and use an agent of your choice to vibe code an Interface that you can then import into Label Studio. For more information, see [Develop an Interface locally](interfaces-local).
+* **Developed locally** - Install the [`create-interface-skill`](/skills/interface.html) and use an agent of your choice to vibe code an Interface that you can then import into Label Studio. For more information, see [Develop an Interface locally](interfaces-local).
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/pdcZ6HDwpiI?si=ZpeuyeKYx71q1vCR" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 

--- a/docs/source/guide/interfaces-local.md
+++ b/docs/source/guide/interfaces-local.md
@@ -40,7 +40,7 @@ Before you begin, make sure you have:
 To begin, select **Interfaces** in the main menu and then select **Create Interface > Develop Locally**. 
 
 !!! info Tip
-    To iterate on an Interface that already exists in Label Studio, open the Interface details page and click **Develop Locally** in the top bar. The dialog respects the version currently selected in the [version navigator](interface-details#Versions).
+    To iterate on an Interface that already exists in Label Studio, open the Interface details page and click **Develop Locally** in the top bar. The dialog respects the version currently selected in the [version navigator](interfaces-details#Versions).
 
 ## 2. Install the create-interface skill
 
@@ -79,7 +79,7 @@ label-studio-sdk interface preview .
 
 #### Start from an existing Interface
 
-To iterate on an Interface that already exists in Label Studio, open the Interface details page and click **Develop Locally** in the top bar. The dialog respects the version currently selected in the [version navigator](interface-details#Versions).
+To iterate on an Interface that already exists in Label Studio, open the Interface details page and click **Develop Locally** in the top bar. The dialog respects the version currently selected in the [version navigator](interfaces-details#Versions).
 
 Alternatively, you can use:
     

--- a/docs/source/guide/interfaces-local.md
+++ b/docs/source/guide/interfaces-local.md
@@ -44,7 +44,7 @@ To begin, select **Interfaces** in the main menu and then select **Create Interf
 
 ## 2. Install the create-interface skill
 
-Install the `create-interface-skill` for your local coding agent. The skill includes the commands and conventions for working with Interfaces locally so your agent can author a valid Interface module.
+Install the [`create-interface-skill`](/skills/interface.html) for your local coding agent. The skill includes the commands and conventions for working with Interfaces locally so your agent can author a valid Interface module.
 
 In the **Develop Locally** modal, choose your agent and copy the install command:
 

--- a/docs/source/guide/interfaces.md
+++ b/docs/source/guide/interfaces.md
@@ -21,7 +21,7 @@ Instead of choosing a template and tuning [out-of-the-box XML tags](/tags), with
 Interfaces are Label Studio's most powerful UI builder. Use them when:
 
 * [Label Studio's XML tags](/tags) don't support your use case. For example, if you want to annotate data types that do not have a corresponding object tag (3D files, GEOTiff, DICOM, etc). 
-* When you want to be able to vibe code your labeling UI either within Label Studio or using your own tools and agent outside of Label Studio. 
+* When you want to be able to vibe code your labeling UI either within Label Studio or using your own tools and agent outside of Label Studio. To work with a coding agent like Claude Code, Codex, or Cursor, install the [`create-interface-skill`](/skills/interface.html) — or see the full [agent skills overview](/skills/).
 * When you need to be able to version your labeling UIs. 
 * When you need more custom logic. 
 

--- a/docs/source/skills/index.md
+++ b/docs/source/skills/index.md
@@ -17,13 +17,13 @@ Two skills are currently published:
 | Skill | What it does | Tier |
 |---|---|---|
 | [`create-xml-labeling-config-skill`](/skills/xml-config.html) | Drafts a Label Studio XML labeling configuration from a plain-English task description, validates it locally and against your running Label Studio instance, and (after explicit approval) pushes it as a new project or as an update to an existing one. | OSS + Enterprise |
-| 🔒 [`create-interface-skill`](https://github.com/HumanSignal/create-interface-skill) | Generates a HumanSignal Interface — a single-file JSX annotation screen for Label Studio Enterprise — exporting `paramsSchema` / `outputSchema` / `getResults` / `parseResults` and the parenthesized-object-literal trailer the runtime requires. | Enterprise |
+| 🔒 [`create-interface-skill`](/skills/interface.html) | Generates a HumanSignal Interface — a single-file JSX annotation screen for Label Studio Enterprise — exporting `paramsSchema` / `outputSchema` / `getResults` / `parseResults` and the parenthesized-object-literal trailer the runtime requires. | Enterprise |
 
 ## When to use which
 
 - **You want a standard labeling project** — text classification, NER/span labeling, image bounding boxes, audio transcription, taxonomy review, ranking, pairwise comparison, time-series segmentation. Use [`create-xml-labeling-config-skill`](/skills/xml-config.html). It writes an XML config using Label Studio's built-in tags, which is the right runtime for the vast majority of projects.
 
-- **You need a custom React-based UI** — the built-in tags don't cover your case, you're working with data types that don't have a standard object tag (3D, GEOTiff, DICOM), or you want to vibe-code your labeling screen. Use 🔒 [`create-interface-skill`](https://github.com/HumanSignal/create-interface-skill). The output is a single JSX file you can paste into the Label Studio Enterprise Interfaces editor or sync with the [`label-studio-sdk` CLI](https://github.com/HumanSignal/label-studio-sdk).
+- **You need a custom React-based UI** — the built-in tags don't cover your case, you're working with data types that don't have a standard object tag (3D, GEOTiff, DICOM), or you want to vibe-code your labeling screen. Use 🔒 [`create-interface-skill`](/skills/interface.html). The output is a single JSX file you can paste into the Label Studio Enterprise Interfaces editor or sync with the [`label-studio-sdk` CLI](https://github.com/HumanSignal/label-studio-sdk).
 
 If you're not sure which to start with, start with the XML config skill. It's the lighter-weight path and works on every Label Studio install.
 

--- a/docs/source/skills/index.md
+++ b/docs/source/skills/index.md
@@ -1,7 +1,7 @@
 ---
 title: Skills overview
 short: Overview
-tier: all
+tier: enterprise
 type: skills
 order: 1
 meta_title: Label Studio agent skills

--- a/docs/source/skills/index.md
+++ b/docs/source/skills/index.md
@@ -10,20 +10,20 @@ meta_description: Use HumanSignal agent skills to set up labeling projects and c
 
 HumanSignal publishes a small set of **agent skills** that let you set up and iterate on Label Studio projects from inside an AI coding agent (Claude Code, Codex, Cursor, and other agents supported by the `skills` CLI). Each skill is a self-contained package: a workflow prompt, baked-in reference material, and small Python helper scripts that talk to your Label Studio instance over its public API.
 
-> ✨ marks a skill that is for **Label Studio Enterprise** only.
+Skills with the lock emoji 🔒 next to their name are only available for Label Studio Enterprise users.
 
 Two skills are currently published:
 
 | Skill | What it does | Tier |
 |---|---|---|
 | [`create-xml-labeling-config-skill`](/skills/xml-config.html) | Drafts a Label Studio XML labeling configuration from a plain-English task description, validates it locally and against your running Label Studio instance, and (after explicit approval) pushes it as a new project or as an update to an existing one. | OSS + Enterprise |
-| ✨ [`create-interface-skill`](https://github.com/HumanSignal/create-interface-skill) | Generates a HumanSignal Interface — a single-file JSX annotation screen for Label Studio Enterprise — exporting `paramsSchema` / `outputSchema` / `getResults` / `parseResults` and the parenthesized-object-literal trailer the runtime requires. | Enterprise |
+| 🔒 [`create-interface-skill`](https://github.com/HumanSignal/create-interface-skill) | Generates a HumanSignal Interface — a single-file JSX annotation screen for Label Studio Enterprise — exporting `paramsSchema` / `outputSchema` / `getResults` / `parseResults` and the parenthesized-object-literal trailer the runtime requires. | Enterprise |
 
 ## When to use which
 
 - **You want a standard labeling project** — text classification, NER/span labeling, image bounding boxes, audio transcription, taxonomy review, ranking, pairwise comparison, time-series segmentation. Use [`create-xml-labeling-config-skill`](/skills/xml-config.html). It writes an XML config using Label Studio's built-in tags, which is the right runtime for the vast majority of projects.
 
-- **You need a custom React-based UI** — the built-in tags don't cover your case, you're working with data types that don't have a standard object tag (3D, GEOTiff, DICOM), or you want to vibe-code your labeling screen. Use ✨ [`create-interface-skill`](https://github.com/HumanSignal/create-interface-skill). The output is a single JSX file you can paste into the Label Studio Enterprise Interfaces editor or sync with the [`label-studio-sdk` CLI](https://github.com/HumanSignal/label-studio-sdk).
+- **You need a custom React-based UI** — the built-in tags don't cover your case, you're working with data types that don't have a standard object tag (3D, GEOTiff, DICOM), or you want to vibe-code your labeling screen. Use 🔒 [`create-interface-skill`](https://github.com/HumanSignal/create-interface-skill). The output is a single JSX file you can paste into the Label Studio Enterprise Interfaces editor or sync with the [`label-studio-sdk` CLI](https://github.com/HumanSignal/label-studio-sdk).
 
 If you're not sure which to start with, start with the XML config skill. It's the lighter-weight path and works on every Label Studio install.
 

--- a/docs/source/skills/index.md
+++ b/docs/source/skills/index.md
@@ -1,0 +1,86 @@
+---
+title: Skills overview
+short: Overview
+tier: all
+type: skills
+order: 1
+meta_title: Label Studio agent skills
+meta_description: Use HumanSignal agent skills to set up labeling projects and custom interfaces from inside your AI coding agent.
+---
+
+HumanSignal publishes a small set of **agent skills** that let you set up and iterate on Label Studio projects from inside an AI coding agent (Claude Code, Codex, Cursor, and other agents supported by the `skills` CLI). Each skill is a self-contained package: a workflow prompt, baked-in reference material, and small Python helper scripts that talk to your Label Studio instance over its public API.
+
+Two skills are currently published:
+
+| Skill | What it does | Tier |
+|---|---|---|
+| [`create-xml-labeling-config-skill`](/skills/xml-config.html) | Drafts a Label Studio XML labeling configuration from a plain-English task description, validates it locally and against your running Label Studio instance, and (after explicit approval) pushes it as a new project or as an update to an existing one. | OSS + Enterprise |
+| [`create-interface-skill`](/skills/interface.html) | Generates a HumanSignal [Interface](/guide/interfaces.html): a single-file JSX annotation screen for Label Studio Enterprise. Handles `paramsSchema` / `outputSchema` / `getResults` / `parseResults` and the parenthesized-object-literal trailer the runtime requires. | Enterprise |
+
+## When to use which
+
+- **You want a standard labeling project** — text classification, NER/span labeling, image bounding boxes, audio transcription, taxonomy review, ranking, pairwise comparison, time-series segmentation. Use [`create-xml-labeling-config-skill`](/skills/xml-config.html). It writes an XML config using Label Studio's built-in tags, which is the right runtime for the vast majority of projects.
+
+- **You need a custom React-based UI** — the built-in tags don't cover your case, you're working with data types that don't have a standard object tag (3D, GEOTiff, DICOM), or you want to vibe-code your labeling screen. Use [`create-interface-skill`](/skills/interface.html). The output is a single JSX file you can paste into the Interfaces editor or sync with the [`label-studio-sdk` CLI](https://github.com/HumanSignal/label-studio-sdk).
+
+If you're not sure which to start with, start with the XML config skill. It's the lighter-weight path and works on every Label Studio install.
+
+## How a skill run is structured
+
+Both skills follow the same general shape:
+
+1. **You describe the task** in plain English ("NER for legal contracts with labels Party / Date / Amount / Clause type"). The skill asks one or two clarifying questions if it really needs them; otherwise it picks sensible defaults and surfaces its assumptions at the approval gate.
+2. **The agent drafts** the XML config or JSX interface using the skill's baked-in reference material. No external knowledge base or runtime lookup is required.
+3. **Local validation runs automatically.** Both skills ship Python scripts that catch structural issues before anything reaches your Label Studio instance.
+4. **The agent shows you the config / interface, a sample task, and any assumptions it made**, then waits for an explicit yes.
+5. **On approval, the skill pushes to Label Studio.** Either as a new project, or — for the config skill — as an update to an existing `--project-id`.
+
+The approval gate in step 4 is load-bearing: neither skill writes to your Label Studio instance without you explicitly saying yes. If the agent gets an assumption wrong, you redirect at the gate and the skill iterates.
+
+## Install
+
+Both skills install through the `skills` CLI, which targets the agent of your choice.
+
+### `create-xml-labeling-config-skill`
+
+```bash
+# Claude Code
+npx skills add humansignal/create-xml-labeling-config-skill --skill create-xml-labeling-config-skill -g -a claude-code
+
+# Codex
+npx skills add humansignal/create-xml-labeling-config-skill --skill create-xml-labeling-config-skill -g -a codex
+
+# Cursor
+npx skills add humansignal/create-xml-labeling-config-skill --skill create-xml-labeling-config-skill -g -a cursor
+```
+
+### `create-interface-skill`
+
+```bash
+# Claude Code
+npx skills add humansignal/create-interface-skill --skill create-interface-skill -g -a claude-code
+
+# Codex
+npx skills add humansignal/create-interface-skill --skill create-interface-skill -g -a codex
+
+# Cursor
+npx skills add humansignal/create-interface-skill --skill create-interface-skill -g -a cursor
+```
+
+Restart your agent after installing.
+
+## Credentials
+
+Both skills read from a `.env` at the skill root. The variables they look for:
+
+| Variable | Used by | Required? |
+|---|---|---|
+| `LABEL_STUDIO_URL` | both | Yes for the server-side validation and push steps. Defaults to `http://localhost:8080`. |
+| `LABEL_STUDIO_API_KEY` | both | Yes for the server-side validation and push steps. Skip and local validation still runs, but you'll have to upload the config manually. |
+
+Get your API key from **Account & Settings → Access Token** in your Label Studio instance.
+
+## Source
+
+- [github.com/HumanSignal/create-xml-labeling-config-skill](https://github.com/HumanSignal/create-xml-labeling-config-skill)
+- [github.com/HumanSignal/create-interface-skill](https://github.com/HumanSignal/create-interface-skill)

--- a/docs/source/skills/index.md
+++ b/docs/source/skills/index.md
@@ -1,7 +1,7 @@
 ---
 title: Skills overview
 short: Overview
-tier: enterprise
+tier: all
 type: skills
 order: 1
 meta_title: Label Studio agent skills
@@ -10,18 +10,20 @@ meta_description: Use HumanSignal agent skills to set up labeling projects and c
 
 HumanSignal publishes a small set of **agent skills** that let you set up and iterate on Label Studio projects from inside an AI coding agent (Claude Code, Codex, Cursor, and other agents supported by the `skills` CLI). Each skill is a self-contained package: a workflow prompt, baked-in reference material, and small Python helper scripts that talk to your Label Studio instance over its public API.
 
+> ✨ marks a skill that is for **Label Studio Enterprise** only.
+
 Two skills are currently published:
 
 | Skill | What it does | Tier |
 |---|---|---|
 | [`create-xml-labeling-config-skill`](/skills/xml-config.html) | Drafts a Label Studio XML labeling configuration from a plain-English task description, validates it locally and against your running Label Studio instance, and (after explicit approval) pushes it as a new project or as an update to an existing one. | OSS + Enterprise |
-| [`create-interface-skill`](/skills/interface.html) | Generates a HumanSignal [Interface](/guide/interfaces.html): a single-file JSX annotation screen for Label Studio Enterprise. Handles `paramsSchema` / `outputSchema` / `getResults` / `parseResults` and the parenthesized-object-literal trailer the runtime requires. | Enterprise |
+| ✨ [`create-interface-skill`](https://github.com/HumanSignal/create-interface-skill) | Generates a HumanSignal Interface — a single-file JSX annotation screen for Label Studio Enterprise — exporting `paramsSchema` / `outputSchema` / `getResults` / `parseResults` and the parenthesized-object-literal trailer the runtime requires. | Enterprise |
 
 ## When to use which
 
 - **You want a standard labeling project** — text classification, NER/span labeling, image bounding boxes, audio transcription, taxonomy review, ranking, pairwise comparison, time-series segmentation. Use [`create-xml-labeling-config-skill`](/skills/xml-config.html). It writes an XML config using Label Studio's built-in tags, which is the right runtime for the vast majority of projects.
 
-- **You need a custom React-based UI** — the built-in tags don't cover your case, you're working with data types that don't have a standard object tag (3D, GEOTiff, DICOM), or you want to vibe-code your labeling screen. Use [`create-interface-skill`](/skills/interface.html). The output is a single JSX file you can paste into the Interfaces editor or sync with the [`label-studio-sdk` CLI](https://github.com/HumanSignal/label-studio-sdk).
+- **You need a custom React-based UI** — the built-in tags don't cover your case, you're working with data types that don't have a standard object tag (3D, GEOTiff, DICOM), or you want to vibe-code your labeling screen. Use ✨ [`create-interface-skill`](https://github.com/HumanSignal/create-interface-skill). The output is a single JSX file you can paste into the Label Studio Enterprise Interfaces editor or sync with the [`label-studio-sdk` CLI](https://github.com/HumanSignal/label-studio-sdk).
 
 If you're not sure which to start with, start with the XML config skill. It's the lighter-weight path and works on every Label Studio install.
 

--- a/docs/source/skills/interface.md
+++ b/docs/source/skills/interface.md
@@ -1,6 +1,6 @@
 ---
-title: create-interface-skill
-short: Interface builder
+title: create-interface-skill 🔒
+short: Interface builder 🔒
 tier: enterprise
 type: skills
 order: 3

--- a/docs/source/skills/interface.md
+++ b/docs/source/skills/interface.md
@@ -1,14 +1,17 @@
 ---
 title: create-interface-skill 🔒
 short: Interface builder 🔒
-tier: enterprise
+tier: all
 type: skills
 order: 3
 meta_title: Create a Label Studio Enterprise Interface from your AI coding agent
 meta_description: The create-interface-skill generates a HumanSignal Interface — a single-file JSX annotation screen — from a plain-English description, validates it locally, and is ready to paste into the Interfaces editor or sync via the Label Studio SDK CLI.
 ---
 
-`create-interface-skill` is an agent skill that generates a [HumanSignal Interface](/guide/interfaces.html): a single-file JSX annotation screen for Label Studio Enterprise. The output is one `.jsx` source file whose final expression is a parenthesized object literal exporting a `default` React component plus the optional `paramsSchema`, `outputSchema`, `getResults`, and `parseResults` hooks the Interfaces runtime expects.
+`create-interface-skill` is an agent skill that generates a [HumanSignal Interface](https://docs.humansignal.com/guide/interfaces.html): a single-file JSX annotation screen for Label Studio Enterprise. The output is one `.jsx` source file whose final expression is a parenthesized object literal exporting a `default` React component plus the optional `paramsSchema`, `outputSchema`, `getResults`, and `parseResults` hooks the Interfaces runtime expects.
+
+!!! note
+    Interfaces are a Label Studio Enterprise feature. This skill page is visible on the open-source docs so OSS readers can learn what the skill does, but the generated Interface itself only runs on a Label Studio Enterprise instance.
 
 Use this skill when you want an agent to create or iterate on a labeling UI: text classification, NER/span labeling, Document AI workflows, data review screens, or conversions from a React or Claude Design prototype into the Interface format.
 

--- a/docs/source/skills/interface.md
+++ b/docs/source/skills/interface.md
@@ -1,0 +1,184 @@
+---
+title: create-interface-skill
+short: Interface builder
+tier: enterprise
+type: skills
+order: 3
+meta_title: Create a Label Studio Enterprise Interface from your AI coding agent
+meta_description: The create-interface-skill generates a HumanSignal Interface — a single-file JSX annotation screen — from a plain-English description, validates it locally, and is ready to paste into the Interfaces editor or sync via the Label Studio SDK CLI.
+---
+
+`create-interface-skill` is an agent skill that generates a [HumanSignal Interface](/guide/interfaces.html): a single-file JSX annotation screen for Label Studio Enterprise. The output is one `.jsx` source file whose final expression is a parenthesized object literal exporting a `default` React component plus the optional `paramsSchema`, `outputSchema`, `getResults`, and `parseResults` hooks the Interfaces runtime expects.
+
+Use this skill when you want an agent to create or iterate on a labeling UI: text classification, NER/span labeling, Document AI workflows, data review screens, or conversions from a React or Claude Design prototype into the Interface format.
+
+## When to use create-interface-skill instead of the XML config skill
+
+If a standard Label Studio config could do the job — built-in object and control tags, no custom logic — use [`create-xml-labeling-config-skill`](/skills/xml-config.html) instead. It's the lighter-weight path.
+
+Reach for `create-interface-skill` when:
+
+- The built-in tags don't cover your data type or interaction (3D, GEOTiff, DICOM, custom widgets).
+- You need conditional logic, custom validation, or per-task UI variations that classic tags can't express.
+- You want to vibe-code your labeling UI — describe it, see it, tweak it.
+- You're porting a React or Claude Design mockup into a Label Studio annotation screen.
+
+## Install
+
+```bash
+# Claude Code
+npx skills add humansignal/create-interface-skill --skill create-interface-skill -g -a claude-code
+
+# Codex
+npx skills add humansignal/create-interface-skill --skill create-interface-skill -g -a codex
+
+# Cursor
+npx skills add humansignal/create-interface-skill --skill create-interface-skill -g -a cursor
+```
+
+Restart your agent after installing.
+
+## Prerequisites
+
+- A Label Studio Enterprise instance you can publish Interfaces to.
+- Optional but strongly recommended: the [`label-studio-sdk` CLI](https://github.com/HumanSignal/label-studio-sdk) installed and on your `PATH`. The skill uses it to validate, preview, and sync interfaces from the command line. Without the SDK, the skill falls back to static checks against the rules in `references/authoring-rules.md`.
+
+## Use
+
+Ask your agent to use the skill:
+
+```text
+Use $create-interface-skill to build an interface for classifying support tickets by urgency and product area.
+```
+
+Other prompts the skill is designed for:
+
+- *"Use `$create-interface-skill` to convert this Claude Design mockup into a Label Studio interface."*
+- *"Use `$create-interface-skill` to build a Document AI review screen with redactable PII spans and a confidence-score field."*
+- *"Use `$create-interface-skill` to update my existing interface so reviewers can leave per-region comments."*
+
+## Start a local interface
+
+If you have the SDK CLI installed, the recommended pattern is to create a local interface workspace first:
+
+```bash
+label-studio-sdk interface init ./my-interface
+cd ./my-interface
+```
+
+That scaffold gives you three editable files:
+
+```text
+Screen.jsx        # the interface source — what the agent edits
+task.json         # sample task data for local preview and validation
+scenarios.js      # browser-driven interaction checks (optional)
+```
+
+Then point your agent at `Screen.jsx`:
+
+```text
+Use $create-interface-skill to edit Screen.jsx to add a "needs-review" tag toggle per region.
+```
+
+## Local validation and preview
+
+From a local interface directory:
+
+```bash
+# Validate the whole directory
+label-studio-sdk interface validate .
+
+# Validate a single file
+label-studio-sdk interface validate ./Screen.jsx
+
+# Run browser-driven scenarios (if present)
+label-studio-sdk interface validate . --scenario scenarios.js
+
+# JSON output for piping into another tool / agent
+label-studio-sdk interface validate . --json
+
+# Preview in a local browser
+label-studio-sdk interface preview .
+```
+
+When validation passes and the preview looks right, sync back to Label Studio:
+
+```bash
+# Push a draft
+label-studio-sdk interface sync . --message "Describe the change"
+
+# Push and publish in one step
+label-studio-sdk interface sync . --message "Describe the change" --publish
+```
+
+If the SDK CLI isn't installed, the skill still runs and emits the JSX file. It checks the file statically: plain JSX only, no `import` / `require` / `export`, no TypeScript syntax, a trailing parenthesized object literal with `default`, stable region IDs across renders, and aligned `paramsSchema` / `outputSchema` / `getResults` / `parseResults`.
+
+## The Interfaces runtime contract
+
+Every Interface is one `.jsx` source file whose last expression is a parenthesized object literal. Here's the minimal skeleton:
+
+```jsx
+const MyInterface = (props) => {
+  const { task, regions, params, addRegion, updateRegion, deleteRegion, readOnly } = props;
+  const text = getField(task.data, params?.textField ?? "text") ?? "";
+
+  return (
+    <div style={{ padding: 24 }}>
+      <pre style={{ whiteSpace: "pre-wrap" }}>{String(text)}</pre>
+    </div>
+  );
+};
+
+const paramsSchema = {
+  type: "object",
+  properties: {
+    textField: {
+      type: "string",
+      title: "Text field",
+      default: "text",
+    },
+  },
+};
+
+const outputSchema = {
+  type: "object",
+  properties: {},
+};
+
+function getResults(regions, relations) {
+  return [];
+}
+
+function parseResults(results) {
+  return { regions: [], relations: [] };
+}
+
+({
+  default: MyInterface,
+  specVersion: 1,
+  paramsSchema,
+  outputSchema,
+  getResults,
+  parseResults,
+})
+```
+
+A few rules the runtime enforces, which the skill follows automatically:
+
+- **No module syntax.** The source is evaluated as a function body, not as an ES module. No `import`, `require`, or `export`. No TypeScript syntax.
+- **No primary Submit/Update button in the canvas.** The Interfaces shell owns submission. If you need extra bottom-bar actions, use the `BottomBarExtra` slot.
+- **Don't generate new region IDs during render.** Reuse existing IDs from `props.regions`. Mint new IDs only inside event handlers or in `parseResults`.
+- **No persistent `localStorage` / `sessionStorage`.** The sandbox may reset them on iframe remount.
+- **Reference `EditorUI` only inside component render functions.** Admin-time schema extraction may not inject it.
+
+The skill's `references/runtime-contract.md` has the full prop list, region shape, relation shape, and shell-slot reference. The skill loads it on demand for non-trivial interfaces.
+
+## What this skill does NOT do
+
+- **Generate XML configs.** For standard labeling UIs built from Label Studio's classic tags, use [`create-xml-labeling-config-skill`](/skills/xml-config.html).
+- **Use the legacy `<ReactCode>` XML tag.** This is the new JSX-based Interfaces runtime. If you specifically need `<ReactCode>`, ask for it explicitly.
+- **Build a multi-file app, package, or build config.** Interfaces are one `.jsx` file. The skill keeps the output pasteable into the Interfaces editor.
+
+## Source
+
+[github.com/HumanSignal/create-interface-skill](https://github.com/HumanSignal/create-interface-skill)

--- a/docs/source/skills/xml-config.md
+++ b/docs/source/skills/xml-config.md
@@ -144,7 +144,7 @@ A note on updates: if the existing project already has annotations, Label Studio
 ## What this skill does NOT do
 
 - **Import your data.** The skill pushes the labeling configuration only. After you have the project URL, import tasks via Data Manager, the [Label Studio SDK](https://labelstud.io/sdk/) (`ls.projects.import_tasks(...)`), or **Project Settings → Cloud Storage**.
-- **Generate custom React interfaces.** That's 🔒 [`create-interface-skill`](https://github.com/HumanSignal/create-interface-skill)'s job (Label Studio Enterprise only). If your ask mentions ReactCode or a custom interface, this skill hands off to that one.
+- **Generate custom React interfaces.** That's 🔒 [`create-interface-skill`](/skills/interface.html)'s job (Label Studio Enterprise only). If your ask mentions ReactCode or a custom interface, this skill hands off to that one.
 - **Sync changes back from Label Studio.** The flow is one-way: skill → Label Studio. If you tweak the config in the Label Studio UI after pushing, the skill won't pull those changes back.
 
 ## Troubleshooting

--- a/docs/source/skills/xml-config.md
+++ b/docs/source/skills/xml-config.md
@@ -144,7 +144,7 @@ A note on updates: if the existing project already has annotations, Label Studio
 ## What this skill does NOT do
 
 - **Import your data.** The skill pushes the labeling configuration only. After you have the project URL, import tasks via Data Manager, the [Label Studio SDK](https://labelstud.io/sdk/) (`ls.projects.import_tasks(...)`), or **Project Settings → Cloud Storage**.
-- **Generate custom React interfaces.** That's ✨ [`create-interface-skill`](https://github.com/HumanSignal/create-interface-skill)'s job (Label Studio Enterprise only). If your ask mentions ReactCode or a custom interface, this skill hands off to that one.
+- **Generate custom React interfaces.** That's 🔒 [`create-interface-skill`](https://github.com/HumanSignal/create-interface-skill)'s job (Label Studio Enterprise only). If your ask mentions ReactCode or a custom interface, this skill hands off to that one.
 - **Sync changes back from Label Studio.** The flow is one-way: skill → Label Studio. If you tweak the config in the Label Studio UI after pushing, the skill won't pull those changes back.
 
 ## Troubleshooting

--- a/docs/source/skills/xml-config.md
+++ b/docs/source/skills/xml-config.md
@@ -1,7 +1,7 @@
 ---
 title: create-xml-labeling-config-skill
 short: XML labeling config
-tier: all
+tier: enterprise
 type: skills
 order: 2
 meta_title: Create a Label Studio labeling config from your AI coding agent

--- a/docs/source/skills/xml-config.md
+++ b/docs/source/skills/xml-config.md
@@ -1,7 +1,7 @@
 ---
 title: create-xml-labeling-config-skill
 short: XML labeling config
-tier: enterprise
+tier: all
 type: skills
 order: 2
 meta_title: Create a Label Studio labeling config from your AI coding agent
@@ -144,7 +144,7 @@ A note on updates: if the existing project already has annotations, Label Studio
 ## What this skill does NOT do
 
 - **Import your data.** The skill pushes the labeling configuration only. After you have the project URL, import tasks via Data Manager, the [Label Studio SDK](https://labelstud.io/sdk/) (`ls.projects.import_tasks(...)`), or **Project Settings → Cloud Storage**.
-- **Generate custom React interfaces.** That's the [`create-interface-skill`](/skills/interface.html)'s job. If your ask mentions ReactCode or a custom interface, this skill hands off to that one.
+- **Generate custom React interfaces.** That's ✨ [`create-interface-skill`](https://github.com/HumanSignal/create-interface-skill)'s job (Label Studio Enterprise only). If your ask mentions ReactCode or a custom interface, this skill hands off to that one.
 - **Sync changes back from Label Studio.** The flow is one-way: skill → Label Studio. If you tweak the config in the Label Studio UI after pushing, the skill won't pull those changes back.
 
 ## Troubleshooting

--- a/docs/source/skills/xml-config.md
+++ b/docs/source/skills/xml-config.md
@@ -1,0 +1,162 @@
+---
+title: create-xml-labeling-config-skill
+short: XML labeling config
+tier: all
+type: skills
+order: 2
+meta_title: Create a Label Studio labeling config from your AI coding agent
+meta_description: The create-xml-labeling-config-skill drafts a Label Studio XML labeling configuration from a plain-English task description, validates it, and pushes it to your Label Studio instance after you approve.
+---
+
+`create-xml-labeling-config-skill` is an agent skill that drafts a Label Studio XML labeling configuration from a plain-English description of your annotation task, validates the result against your running Label Studio instance, and — after you explicitly approve — pushes the config as a new project or as an update to an existing one.
+
+Use it when you want an agent to create or iterate on a Label Studio project from a labeling brief: text classification, NER/span labeling, image bounding boxes, audio transcription, taxonomy review, ranking, pairwise comparison, time-series segmentation, and so on.
+
+The skill is self-contained. Every rule and template it needs to write a correct config lives inside the skill's `references/config_guide.md`. There's no external knowledge base or MCP lookup at runtime.
+
+## Install
+
+```bash
+# Claude Code
+npx skills add humansignal/create-xml-labeling-config-skill --skill create-xml-labeling-config-skill -g -a claude-code
+
+# Codex
+npx skills add humansignal/create-xml-labeling-config-skill --skill create-xml-labeling-config-skill -g -a codex
+
+# Cursor
+npx skills add humansignal/create-xml-labeling-config-skill --skill create-xml-labeling-config-skill -g -a cursor
+```
+
+Restart your agent after installing.
+
+## Prerequisites
+
+- A running Label Studio instance (community OSS or Enterprise) reachable from this machine. The skill defaults to `http://localhost:8080`.
+- A Label Studio personal API key. Grab one from **Account & Settings → Access Token** in your instance.
+
+If you don't have Label Studio installed yet:
+
+```bash
+pip install label-studio
+label-studio start
+```
+
+Open `http://localhost:8080`, create an account, then copy your token from the Account page.
+
+## Credentials
+
+The skill reads from `.env` at the skill root:
+
+```bash
+cd ~/.skills/create-xml-labeling-config-skill   # or wherever your agent installed it
+cp .env.example .env
+# edit .env with your values
+```
+
+Required:
+
+- `LABEL_STUDIO_URL` — base URL, e.g. `http://localhost:8080`
+- `LABEL_STUDIO_API_KEY` — personal API token from the Account page
+
+`LABEL_STUDIO_API_KEY` is optional in the sense that the skill still runs without it — local structural validation works, and you'll get the config saved to disk. The server-side validation and the push step are skipped with a warning.
+
+## Use
+
+Ask your agent to use the skill:
+
+```text
+Use $create-xml-labeling-config-skill to build a labeling config for
+sentiment classification with labels Positive / Neutral / Negative.
+```
+
+Other example prompts:
+
+- *"Use `$create-xml-labeling-config-skill` to make an NER config for legal contracts with labels Party / Date / Amount / Clause type."*
+- *"Use `$create-xml-labeling-config-skill` to set up a Label Studio project for image bounding boxes — labels Person, Vehicle, Animal."*
+- *"Use `$create-xml-labeling-config-skill` to update project 42 with a 'rationale' text area on the rating config."*
+
+## What a run looks like
+
+For each run, the skill:
+
+1. **Asks one or two quick questions** if it can't pick the object tag, control tags, and labels with confidence. If your brief is unambiguous it skips ahead.
+2. **Drafts the XML** using the baked-in authoring guide. It starts from the closest template and adapts.
+3. **Validates the config locally** with `validate_config.py`. This catches malformed XML, missing/duplicate `name` attributes, `toName` pointing at a non-existent or non-object tag, bad nesting, `style=` / `className=` on the wrong tags, and deprecated tags (`AudioPlus`, `Repeater`).
+4. **Validates the config against your Label Studio instance** when an API key is set. The script posts the config to a throwaway project on your instance, lets Label Studio's own validator run, and deletes the project immediately. This catches engine-level issues — unknown tag combinations, mismatched control/object types, attributes that don't work together.
+5. **Shows you the config, a sample task JSON, any assumptions it made, and validation status.** You review and either approve or redirect.
+6. **Pushes on explicit approval.** Either as a new project (`--title "..." --description "..."`) or as an update to an existing project (`--project-id N`).
+7. **Opens the sample tasks file** so you can drag-and-drop it into the new project's Data Manager.
+
+## What you get per run
+
+- A `.xml` config saved to `/tmp/labeling-config-<slug>-<date>.xml`
+- A sample task JSON at the sibling path `/tmp/labeling-config-<slug>-<date>.tasks.json`, always written as a JSON list so Data Manager imports it without reshaping
+- Local + server-side validation results
+- After your approval: the project URL in your Label Studio instance
+
+## How the validator works
+
+`validate_config.py` runs three layers:
+
+1. **XML well-formedness** — must parse as XML with a single `<View>` root.
+2. **Structural rules** baked from the Label Studio authoring guide:
+   - every object/control tag has a `name`
+   - all `name`s are unique
+   - every control tag's `toName` points at an existing object tag
+   - `<Pairwise>` allows two comma-separated `toName` targets
+   - `<Label>` / `<Choice>` nesting rules
+   - `style=` only on `View` / `Filter` / `Header`; `className=` only on `View`
+   - no deprecated tags
+   - `visibleWhen` consistency between a `<View>` and the controls it wraps
+3. **Server-side** (with `--server`) — posts the config to your Label Studio instance and lets Label Studio's own validator run.
+
+You can run the validator directly on any file:
+
+```bash
+python3 scripts/validate_config.py /tmp/my-config.xml
+python3 scripts/validate_config.py /tmp/my-config.xml --server
+python3 scripts/validate_config.py /tmp/my-config.xml --server --project-id 42
+python3 scripts/validate_config.py - < my-config.xml
+python3 scripts/validate_config.py /tmp/my-config.xml --json   # machine-readable
+```
+
+Exit code is `0` only if every requested check passes.
+
+## How the push works
+
+`push_config.py` either creates a new project from the config or updates an existing project's `label_config`:
+
+```bash
+# New project
+python3 scripts/push_config.py /tmp/my-config.xml --title "Legal NER"
+
+# Update existing
+python3 scripts/push_config.py /tmp/my-config.xml --project-id 42
+
+# Dry-run (no network call)
+python3 scripts/push_config.py /tmp/my-config.xml --title "Test" --dry-run
+```
+
+On success it prints the project URL.
+
+A note on updates: if the existing project already has annotations, Label Studio may reject changes that would invalidate them — for example, renaming a `Choices` tag. Keep the object/control `name`s stable across updates, or create a fresh project if you need a breaking change.
+
+## What this skill does NOT do
+
+- **Import your data.** The skill pushes the labeling configuration only. After you have the project URL, import tasks via Data Manager, the [Label Studio SDK](https://labelstud.io/sdk/) (`ls.projects.import_tasks(...)`), or **Project Settings → Cloud Storage**.
+- **Generate custom React interfaces.** That's the [`create-interface-skill`](/skills/interface.html)'s job. If your ask mentions ReactCode or a custom interface, this skill hands off to that one.
+- **Sync changes back from Label Studio.** The flow is one-way: skill → Label Studio. If you tweak the config in the Label Studio UI after pushing, the skill won't pull those changes back.
+
+## Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---|---|
+| `Could not reach Label Studio at http://localhost:8080` | Label Studio isn't running, or your `LABEL_STUDIO_URL` is wrong. Confirm with `curl http://localhost:8080/health`. |
+| `--server requested but LABEL_STUDIO_API_KEY is not set` | Set `LABEL_STUDIO_API_KEY` in `.env`. Get the token from the Account page. |
+| `Label Studio rejected the config (HTTP 400): label_config: ...` | Label Studio's engine-level validator caught something. The error is usually specific (`toName` mismatch, unknown attribute). Fix and re-validate. |
+| `Label Studio rejected config update for project N (HTTP 400): ... annotations` | The update would invalidate existing annotations. Keep names stable, or create a new project. |
+| Config passes both validators but the Label Studio UI behaves oddly | Almost always a missing attribute on a control tag. Re-read the relevant tag's section in `references/config_guide.md` inside the installed skill. |
+
+## Source
+
+[github.com/HumanSignal/create-xml-labeling-config-skill](https://github.com/HumanSignal/create-xml-labeling-config-skill)

--- a/docs/themes/v2/layout/partials/header.ejs
+++ b/docs/themes/v2/layout/partials/header.ejs
@@ -181,9 +181,9 @@
         tier: "all"
       },
       {
-        label: "Plugins",
-        href: "/plugins/",
-        tier: "enterprise"
+        label: "Skills",
+        href: "/skills/",
+        tier: "all"
       },
       {
         label: "Tags",

--- a/docs/themes/v2/layout/partials/header.ejs
+++ b/docs/themes/v2/layout/partials/header.ejs
@@ -183,7 +183,7 @@
       {
         label: "Skills",
         href: "/skills/",
-        tier: "enterprise"
+        tier: "all"
       },
       {
         label: "Tags",

--- a/docs/themes/v2/layout/partials/header.ejs
+++ b/docs/themes/v2/layout/partials/header.ejs
@@ -183,7 +183,7 @@
       {
         label: "Skills",
         href: "/skills/",
-        tier: "all"
+        tier: "enterprise"
       },
       {
         label: "Tags",


### PR DESCRIPTION
…ate-interface

Two new skills are now published under HumanSignal/* on GitHub — create-xml-labeling-config-skill (OSS + Enterprise) and create-interface-skill (Enterprise). Documents them as a new top-level docs section with the same shape as Templates / Plugins / Tutorials:

  source/skills/index.md         — overview + when-to-use-which + install
  source/skills/xml-config.md    — full reference for the XML config skill
  source/skills/interface.md     — full reference for the Interface skill

The Interfaces pages (overview, agent flow, local flow) get inline links to the new Skills section so the existing "vibe-code your labeling UI" copy points at the agent skill that does it.

Top nav: replaces the Enterprise-only Plugins tab with Skills (tier: all), since Skills are the more cross-cutting entry point.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
