### PR TITLE
fix: match css-loader path on Windows so .prefix.css compiles as CSS modules

### DIFF
--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -157,7 +157,7 @@ module.exports = composePlugins(
         );
 
         const innerTest = oneOfRule.test?.toString() ?? "";
-        const cssLoader = oneOfRule.use.find((use) => use.loader?.includes("/css-loader/"));
+        const cssLoader = oneOfRule.use.find((use) => /[\\/]css-loader[\\/]/.test(use.loader ?? ""));
 
         if (innerTest.includes("module") && cssLoader?.options) {
           cssLoader.options.modules = {
@@ -173,7 +173,7 @@ module.exports = composePlugins(
       rule.oneOf.forEach((oneOfRule, idx) => {
         if (!oneOfRule.test || !oneOfRule.use) return;
         const t = oneOfRule.test.toString();
-        if (/^\/\\\.css\$\/$/.test(t) && oneOfRule.use.some((u) => u.loader?.includes("/css-loader/"))) {
+        if (/^\/\\\.css\$\/$/.test(t) && oneOfRule.use.some((u) => /[\\/]css-loader[\\/]/.test(u.loader ?? ""))) {
           insertions.push(idx);
         }
       });
@@ -183,7 +183,7 @@ module.exports = composePlugins(
         const template = rule.oneOf[idx];
         const prefixUse = template.use.map((u) => {
           if (typeof u === "string") return u;
-          if (u.loader?.includes("/css-loader/")) {
+          if (/[\\/]css-loader[\\/]/.test(u.loader ?? "")) {
             return {
               ...u,
               options: {


### PR DESCRIPTION
## Description

On Windows the production frontend build leaves the **Data Manager and editor completely unstyled**, because their `.prefix.css` files are not compiled as CSS modules.

### Root cause

In `web/webpack.config.js`, the CSS-rule customization detects the css-loader with:

```js
use.loader?.includes("/css-loader/")
```

This only matches POSIX-style loader paths. On Windows the resolved loader path uses backslashes (`...\node_modules\css-loader\...`), so the check never matches. As a consequence:

- the `.module.css` modules options block is skipped, and
- the dedicated `.prefix.css` → CSS-modules rule (`localIdentName: "lsf-[local]"`) is **never inserted**.

Every `.prefix.css` import (`import styles from "./X.prefix.css"`) then resolves to an empty module, producing build warnings like:

```
export 'default' (imported as 'styles') was not found in './Taxonomy.prefix.css' (module has no exports)
```

and `styles.foo` becomes `undefined`, so no class names are applied — the Data Manager and editor render with no styling.

### Fix

Match both path separators when detecting css-loader:

```js
/[\\/]css-loader[\\/]/.test(use.loader ?? "")
```

Applied to all three occurrences. No behavior change on POSIX; on Windows the `.prefix.css` CSS-modules rule is now inserted as intended.

### Verification

- Before: `webpack compiled with 7 warnings` (all `*.prefix.css` "module has no exports"); Data Manager unstyled.
- After: `webpack compiled successfully` (0 such warnings); served `main.css` now contains the `lsf-`-prefixed classes (e.g. `.lsf-datamanager { height: ... }`) and the Data Manager renders styled.

Built on Windows 11 with Node 24 / yarn (`yarn ls:build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
