### PR TITLE
chore: New tool tips for Heidi tips on OSS login page

### DIFF
--- a/web/apps/labelstudio/src/components/HeidiTips/liveContent.json
+++ b/web/apps/labelstudio/src/components/HeidiTips/liveContent.json
@@ -214,7 +214,7 @@
   "authPage": [
     {
       "title": "Vibe code any interface!",
-      "description": "You can use Label Studio's agent or SDK and skills to build any UI for labeling and evaluation.",
+      "description": "Build any UI with Label Studio's agent on the web or skill for local development.",
       "link": {
         "label": "Explore examples",
         "url": "https://docs.humansignal.com/templates/gallery_interfaces",

--- a/web/apps/labelstudio/src/components/HeidiTips/liveContent.json
+++ b/web/apps/labelstudio/src/components/HeidiTips/liveContent.json
@@ -214,7 +214,7 @@
   "authPage": [
     {
       "title": "Vibe code any interface!",
-      "description": "You can use Label Studio's agent or SDK to build any UI for labeling and evaluation. Explore examples",
+      "description": "You can use Label Studio's agent or SDK to build any UI for labeling and evaluation.",
       "link": {
         "label": "Explore examples",
         "url": "https://docs.humansignal.com/templates/gallery_interfaces",
@@ -226,7 +226,7 @@
     },
     {
       "title": "Need help with data creation?",
-      "description": "HumanSignal's data operations experts can create highly-specialized data and add extra capacity to your AI projects. Learn more",
+      "description": "HumanSignal's data operations experts can create highly-specialized data and add extra capacity to your AI projects.",
       "link": {
         "label": "Learn more",
         "url": "https://humansignal.com/data-services/",

--- a/web/apps/labelstudio/src/components/HeidiTips/liveContent.json
+++ b/web/apps/labelstudio/src/components/HeidiTips/liveContent.json
@@ -213,6 +213,30 @@
   ],
   "authPage": [
     {
+      "title": "Vibe code any interface!",
+      "description": "You can use Label Studio's agent or SDK to build any UI for labeling and evaluation. Explore examples",
+      "link": {
+        "label": "Explore examples",
+        "url": "https://docs.humansignal.com/templates/gallery_interfaces",
+        "params": {
+          "experiment": "login_revamp",
+          "treatment": "vibe_coding_interfaces_live"
+        }
+      }
+    },
+    {
+      "title": "Need help with data creation?",
+      "description": "HumanSignal's data operations experts can create highly-specialized data and add extra capacity to your AI projects. Learn more",
+      "link": {
+        "label": "Learn more",
+        "url": "https://humansignal.com/data-services/",
+        "params": {
+          "experiment": "login_revamp",
+          "treatment": "data_services_live"
+        }
+      }
+    },
+    {
       "title": "Are you building agents?",
       "description": "Introducing Human-in-the-Loop Evaluation for Agentic AI Observability",
       "link": {

--- a/web/apps/labelstudio/src/components/HeidiTips/liveContent.json
+++ b/web/apps/labelstudio/src/components/HeidiTips/liveContent.json
@@ -214,7 +214,7 @@
   "authPage": [
     {
       "title": "Vibe code any interface!",
-      "description": "You can use Label Studio's agent or SDK to build any UI for labeling and evaluation.",
+      "description": "You can use Label Studio's agent or SDK and skills to build any UI for labeling and evaluation.",
       "link": {
         "label": "Explore examples",
         "url": "https://docs.humansignal.com/templates/gallery_interfaces",
@@ -225,8 +225,8 @@
       }
     },
     {
-      "title": "Need help with data creation?",
-      "description": "HumanSignal's data operations experts can create highly-specialized data and add extra capacity to your AI projects.",
+      "title": "Need help with data annotation?",
+      "description": "HumanSignal's data services team can run your projects end-to-end, from novel data creation to annotation and evaluation.",
       "link": {
         "label": "Learn more",
         "url": "https://humansignal.com/data-services/",


### PR DESCRIPTION
This request introduces two new tool-tips for the OSS login page:
1. Highlights new Interfaces functionality "Vibe code any interface!"
2. Promotes HumanSignal's Services offering

The intention is for these tool-tips to be live and cycle through as part of the set at /user/login

Note: As I was working on this locally with the app deployed using `yarn dev` and Docker, no matter how many times I hit the /user/login path I was not able to see these new tool-tips live in a preview in my browser. It's unclear to me whether the issue is with my local dev environment or if any part of this .json needs to be updated for the tool-tips to actually go "live"

Attached screenshot is hacked DOM to demonstrate how the text should appear when working as intended

<img width="1114" height="899" alt="Screenshot 2026-06-17 at 3 02 12 PM" src="https://github.com/user-attachments/assets/1cffe0ad-d96f-42e8-a7dc-8e81b003f9ca" />
