### PR TITLE
feat: tag S3 client user agent for request attribution

### DIFF
--- a/label_studio/io_storages/s3/tests/test_user_agent.py
+++ b/label_studio/io_storages/s3/tests/test_user_agent.py
@@ -1,0 +1,34 @@
+"""Tests for the S3 client user agent.
+
+Verifies get_client_and_resource attaches a label-studio user agent to both the
+client and resource while preserving signature_version and a custom endpoint_url
+(the path used for Amazon S3 and any S3-compatible object store such as
+Backblaze B2, Cloudflare R2, or MinIO).
+"""
+
+import unittest
+
+from io_storages.s3.utils import _get_user_agent_extra, get_client_and_resource
+
+
+class TestS3ClientUserAgent(unittest.TestCase):
+    def test_user_agent_extra_format(self):
+        ua = _get_user_agent_extra()
+        assert ua.startswith('label-studio/')
+
+    def test_client_and_resource_carry_user_agent(self):
+        client, resource = get_client_and_resource()
+        expected = _get_user_agent_extra()
+        assert expected in (client.meta.config.user_agent_extra or '')
+        assert expected in (resource.meta.client.meta.config.user_agent_extra or '')
+
+    def test_signature_version_preserved(self):
+        client, _ = get_client_and_resource()
+        assert client.meta.config.signature_version == 's3v4'
+
+    def test_custom_endpoint_preserved(self):
+        endpoint = 'https://your-s3-endpoint.example.com'
+        client, resource = get_client_and_resource(s3_endpoint=endpoint)
+        assert client.meta.endpoint_url == endpoint
+        assert resource.meta.client.meta.endpoint_url == endpoint
+        assert _get_user_agent_extra() in (client.meta.config.user_agent_extra or '')

--- a/label_studio/io_storages/s3/utils.py
+++ b/label_studio/io_storages/s3/utils.py
@@ -2,6 +2,7 @@
 
 import base64
 import fnmatch
+import importlib.metadata
 import logging
 import mimetypes
 import re
@@ -14,6 +15,14 @@ from django.conf import settings
 from tldextract import TLDExtract
 
 logger = logging.getLogger(__name__)
+
+
+def _get_user_agent_extra():
+    try:
+        version = importlib.metadata.version('label-studio')
+    except importlib.metadata.PackageNotFoundError:
+        version = 'dev'
+    return f'label-studio/{version}'
 
 
 def get_client_and_resource(
@@ -37,8 +46,9 @@ def get_client_and_resource(
     s3_endpoint = s3_endpoint or get_env('S3_ENDPOINT')
     if s3_endpoint:
         settings['endpoint_url'] = s3_endpoint
-    client = session.client('s3', config=boto3.session.Config(signature_version='s3v4'), **settings)
-    resource = session.resource('s3', config=boto3.session.Config(signature_version='s3v4'), **settings)
+    config = boto3.session.Config(signature_version='s3v4', user_agent_extra=_get_user_agent_extra())
+    client = session.client('s3', config=config, **settings)
+    resource = session.resource('s3', config=config, **settings)
     return client, resource
 
 


### PR DESCRIPTION
## Reason for change

Label Studio talks to object storage through boto3 in `label_studio/io_storages/s3/utils.py`. When it builds the S3 client and resource, it does not set a `user_agent_extra`, so every request goes out with only the default botocore user agent.

This makes it hard to identify Label Studio traffic against Amazon S3 or any S3-compatible object store (for example Backblaze B2, Cloudflare R2, or MinIO, all reached through the same code path via a custom `endpoint_url`). A stable client marker helps storage-side observability and support when diagnosing connection or throughput issues, without changing any request behavior.

The change attaches a `label-studio/<version>` token to `user_agent_extra` on the S3 client and resource. It follows the common `framework/version` user-agent convention, resolves the version from the installed package metadata, and falls back to `label-studio/dev` when the package is not installed (source checkout).

## Screenshots

N/A. Backend-only change, no UI impact.

## Rollout strategy

No feature flag required. The change is purely additive: it appends a token to the S3 client and resource user agent and leaves `signature_version` (`s3v4`) and the optional custom `endpoint_url` untouched. The client and resource now share a single `boto3.session.Config` instead of constructing two identical ones. No new configuration, environment variable, or dependency is introduced (`importlib.metadata` is standard library).

## Testing

Added a unit test module `label_studio/io_storages/s3/tests/test_user_agent.py` that verifies:

- `_get_user_agent_extra()` returns a `label-studio/` prefixed token.
- both the client and the resource carry that token in `user_agent_extra`.
- `signature_version` stays `s3v4`.
- a custom `endpoint_url` is preserved end to end (using an S3-compatible endpoint as one example, alongside the default AWS S3 path).

Acceptance criteria: when Label Studio issues an S3 request (against AWS S3 or an S3-compatible endpoint), the outgoing user agent contains a `label-studio/<version>` token, and signature version and endpoint configuration are unchanged.

Run locally:

```
cd label_studio
pytest io_storages/s3/tests/test_user_agent.py
```

## Risks

Low. The token only extends the user-agent string that boto3 already sends; it does not alter authentication, signing, or the request path. The existing `test_resolve_s3_url.py` behavior is unaffected. If package metadata cannot be resolved, the code degrades to `label-studio/dev` rather than raising.

## Reviewer notes

Scope is intentionally minimal and additive (two files, one small helper plus the shared `Config`), in line with the contributing guide's preference for small, single-purpose PRs. The PR title uses the `feat:` prefix per the repository's title convention. Happy to guard this behind a flag or adjust the token format if you would prefer a different convention.
