### PR TITLE
fix: tolerant Konva hit-detection for ±1 getImageData color drift (#9810)

### DIFF
--- a/web/libs/editor/src/components/ImageView/ImageView.jsx
+++ b/web/libs/editor/src/components/ImageView/ImageView.jsx
@@ -23,8 +23,13 @@ import { fixRectToFit, mapKonvaBrightness } from "../../utils/image";
 import { FF_DEV_1442, FF_LSDV_4930, FF_ZOOM_OPTIM, isFF } from "../../utils/feature-flags";
 import { Pagination } from "../../common/Pagination/Pagination";
 import { Image } from "./Image";
+import { installTolerantHitDetection } from "../../utils/konva-hit-tolerance";
 
 Konva.showWarnings = false;
+
+// Fix for when some GPU canvas implementations round getImageData by ±1, breaking Konva's
+// exact color-key hit detection (most visibly the Transformer resize handles).
+installTolerantHitDetection(Konva);
 
 const hotkeys = Hotkey("Image");
 const imgDefaultProps = { crossOrigin: "anonymous" };

--- a/web/libs/editor/src/utils/__tests__/konva-hit-tolerance.test.ts
+++ b/web/libs/editor/src/utils/__tests__/konva-hit-tolerance.test.ts
@@ -1,0 +1,111 @@
+import { installTolerantHitDetection } from "../konva-hit-tolerance";
+
+// Konva's color key hex, without the leading '#'. Mirrors Konva.Util._rgbToHex.
+const rgbToHex = (r: number, g: number, b: number) => ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);
+
+/**
+ * Minimal stand-in for Konva that reproduces the exact-color hit lookup the
+ * patch wraps, so we can drive it without a real canvas/GPU.
+ */
+function makeFakeKonva() {
+  const shapes: Record<string, unknown> = {};
+
+  // Faithful reimplementation of Konva.Layer.prototype._getIntersection.
+  function _getIntersection(this: any, pos: { x: number; y: number }) {
+    const ratio = this.hitCanvas.pixelRatio;
+    const p = this.hitCanvas.context.getImageData(Math.round(pos.x * ratio), Math.round(pos.y * ratio), 1, 1).data;
+    if (p[3] === 255) {
+      const shape = shapes[`#${rgbToHex(p[0], p[1], p[2])}`];
+      if (shape) return { shape };
+      return { antialiased: true };
+    }
+    if (p[3] > 0) return { antialiased: true };
+    return {};
+  }
+
+  return {
+    Layer: { prototype: { _getIntersection } },
+    Util: { _rgbToHex: rgbToHex },
+    shapes,
+  } as any;
+}
+
+// Build a fake layer whose hit canvas returns a fixed pixel under the pointer.
+const layerReading = (rgba: [number, number, number, number]) => ({
+  hitCanvas: {
+    pixelRatio: 1,
+    context: { getImageData: () => ({ data: rgba }) },
+  },
+});
+
+const intersect = (konva: any, rgba: [number, number, number, number]) =>
+  konva.Layer.prototype._getIntersection.call(layerReading(rgba), { x: 5, y: 5 });
+
+describe("installTolerantHitDetection", () => {
+  it("leaves exact color-key matches untouched", () => {
+    const konva = makeFakeKonva();
+    const shape = { id: "exact" };
+    konva.shapes[`#${rgbToHex(36, 94, 150)}`] = shape;
+    installTolerantHitDetection(konva);
+
+    expect(intersect(konva, [36, 94, 150, 255]).shape).toBe(shape);
+  });
+
+  it("resolves a shape when the read-back pixel drifts by ±1 per channel", () => {
+    const konva = makeFakeKonva();
+    const shape = { id: "drifted" };
+    konva.shapes[`#${rgbToHex(36, 94, 150)}`] = shape; // registered key
+    installTolerantHitDetection(konva);
+
+    // GPU returned (37,95,150) instead of (36,94,150) — would miss without the patch.
+    expect(intersect(konva, [37, 95, 150, 255]).shape).toBe(shape);
+    // Without the patch this opaque miss is reported as antialiased.
+    const konvaUnpatched = makeFakeKonva();
+    konvaUnpatched.shapes[`#${rgbToHex(36, 94, 150)}`] = shape;
+    expect(intersect(konvaUnpatched, [37, 95, 150, 255]).shape).toBeUndefined();
+  });
+
+  it("does not invent a hit for an opaque pixel with no ±1 neighbor registered", () => {
+    const konva = makeFakeKonva();
+    konva.shapes[`#${rgbToHex(10, 20, 30)}`] = { id: "far-away" };
+    installTolerantHitDetection(konva);
+
+    const res = intersect(konva, [200, 100, 50, 255]);
+    expect(res.shape).toBeUndefined();
+    expect(res.antialiased).toBe(true); // original behaviour preserved
+  });
+
+  it("ignores transparent / partial-alpha pixels (real edges)", () => {
+    const konva = makeFakeKonva();
+    konva.shapes[`#${rgbToHex(36, 94, 150)}`] = { id: "s" };
+    installTolerantHitDetection(konva);
+
+    expect(intersect(konva, [37, 95, 150, 0]).shape).toBeUndefined(); // transparent
+    expect(intersect(konva, [37, 95, 150, 128]).antialiased).toBe(true); // edge
+  });
+
+  it("clamps channel search at the 0/255 boundaries", () => {
+    const konva = makeFakeKonva();
+    const shape = { id: "edge-color" };
+    konva.shapes[`#${rgbToHex(0, 255, 1)}`] = shape;
+    installTolerantHitDetection(konva);
+
+    // Read-back drifted to (1,254,0); neighbor search must not overflow channels.
+    expect(intersect(konva, [1, 254, 0, 255]).shape).toBe(shape);
+  });
+
+  it("is idempotent (does not double-wrap)", () => {
+    const konva = makeFakeKonva();
+    const wrappedOnce = (() => {
+      installTolerantHitDetection(konva);
+      return konva.Layer.prototype._getIntersection;
+    })();
+    installTolerantHitDetection(konva);
+    expect(konva.Layer.prototype._getIntersection).toBe(wrappedOnce);
+  });
+
+  it("no-ops safely when Konva internals are missing", () => {
+    expect(() => installTolerantHitDetection({} as any)).not.toThrow();
+    expect(() => installTolerantHitDetection({ Layer: { prototype: {} } } as any)).not.toThrow();
+  });
+});

--- a/web/libs/editor/src/utils/konva-hit-tolerance.ts
+++ b/web/libs/editor/src/utils/konva-hit-tolerance.ts
@@ -1,0 +1,84 @@
+import Konva from "konva";
+
+/**
+ * Make Konva's color-key hit detection tolerant of ±1 RGB drift.
+ *
+ * Konva identifies which shape is under the pointer by drawing every shape to
+ * an offscreen "hit" canvas filled with a unique color key, then reading the
+ * pixel under the pointer back with `getImageData` and looking the color up in
+ * `Konva.shapes`. This requires `getImageData` to return the *exact* bytes that
+ * were written.
+ *
+ * On some GPU-accelerated canvas implementations (observed on Chrome / Linux,
+ * regardless of `willReadFrequently`) `getImageData` rounds solid colors by ±1
+ * per channel. The exact lookup then misses, and the click "falls through".
+ * This hits small targets hardest — most visibly the 8px image Transformer
+ * resize handles, which become unclickable when zoomed (a non-integer stage
+ * scale makes the miss rate worse), and occasionally drops region-selection
+ * clicks too.
+ *
+ * Konva's built-in recovery (spiral search to neighbouring pixel *positions*)
+ * doesn't help here: the whole anchor footprint reads the same drifted color,
+ * so no nearby position carries the exact key either.
+ *
+ * Fix: on an opaque-pixel miss, search the 26 color keys within ±1 RGB of the
+ * read-back value and resolve to that shape. The true shape's exact key is by
+ * definition one of those neighbours (the read-back drifted from it by ≤1).
+ * Color keys are spread across 16.7M values, so the chance a ±1 neighbour is a
+ * *different* registered shape is negligible (~0.02% worst case, a single-pixel
+ * mishit). The extra work only runs on a miss, so healthy hits pay nothing.
+ */
+
+const PATCH_FLAG = "__lsTolerantHitPatched";
+const HASH = "#";
+
+type HitLayer = {
+  hitCanvas: { pixelRatio: number; context: { getImageData(x: number, y: number, w: number, h: number): ImageData } };
+};
+
+type IntersectionResult = { shape?: unknown; antialiased?: boolean };
+
+export function installTolerantHitDetection(konva: typeof Konva = Konva): void {
+  const konvaAny = konva as unknown as Record<string, any>;
+  const layerProto = konva.Layer?.prototype as unknown as
+    | { _getIntersection?: (pos: { x: number; y: number }) => IntersectionResult }
+    | undefined;
+
+  // Bail out gracefully if already patched or if Konva's internals changed
+  // shape (e.g. after a version upgrade) — never break hit detection.
+  if (!layerProto || typeof layerProto._getIntersection !== "function") return;
+  if (konvaAny[PATCH_FLAG]) return;
+
+  const original = layerProto._getIntersection;
+  const rgbToHex = konva.Util?._rgbToHex?.bind(konva.Util);
+  if (typeof rgbToHex !== "function") return;
+
+  layerProto._getIntersection = function (this: HitLayer, pos: { x: number; y: number }): IntersectionResult {
+    const result = original.call(this, pos);
+    // Exact match (or no opaque pixel) — keep Konva's behaviour untouched.
+    if (result.shape) return result;
+
+    const ratio = this.hitCanvas.pixelRatio;
+    const p = this.hitCanvas.context.getImageData(Math.round(pos.x * ratio), Math.round(pos.y * ratio), 1, 1).data;
+    // Only fully-opaque pixels carry a color key; partial alpha is a real edge.
+    if (p[3] !== 255) return result;
+
+    for (let dr = -1; dr <= 1; dr++) {
+      for (let dg = -1; dg <= 1; dg++) {
+        for (let db = -1; db <= 1; db++) {
+          if (!dr && !dg && !db) continue; // exact key already tried by `original`
+          const r = p[0] + dr;
+          const g = p[1] + dg;
+          const b = p[2] + db;
+          if (r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255) continue;
+          const shape = konvaAny.shapes[HASH + rgbToHex(r, g, b)];
+          if (shape) return { shape };
+        }
+      }
+    }
+
+    return result;
+  };
+
+  konvaAny[PATCH_FLAG] = true;
+}


### PR DESCRIPTION
This pull request fixes a bug where clicking a resize handle or a region in the image editor frequently misses - the click falls through and instead draws a new box, drags the underlying annotation, or does nothing, and the resize cursor never appears. The cause seems to be that some under canvas implementations, `getImageData` rounds color channel values by ±1 per channel, which breaks Konva's exact color-key hit detection. The fix makes that hit lookup tolerant of ±1 drift, and only does extra work when Konva's exact lookup has already missed.

**Bug fix:**

* Added `konva-hit-tolerance.ts`, which wraps `Konva.Layer.prototype._getIntersection` so that, on an opaque-pixel miss, it searches the 26 color keys within ±1 RGB of the read-back pixel and resolves to that shape. Exact hits are untouched.
* Installed the patch once in `ImageView.jsx` so it applies to the image editor's Konva stage.

**Test:**

* Added `konva-hit-tolerance.test.ts`, which drives the patched lookup against a minimal Konva stand-in (no canvas/GPU needed) and covers the exact-match, ±1-drift, no-neighbor, transparent-pixel, channel-boundary, idempotency, and missing-internals cases.

Fixes #9810.

## Reason for change

**Problem.** In the image editor, clicking a Transformer resize handle or clicking a region to select it frequently misses: the pointer "clicks through" the target and instead starts a new selection box or drags the underlying rectangle, and the resize cursor never appears. On an annotation with several regions, some of the 8 resize anchors work and others don't, and *which* ones work changes every time the same box is re-selected. It is worst on large images. It is possibly worse also when there are 100+ annotations or highly zoomed in. 

See #9810 for a video of the misbehaving handles.

**Root cause.** Konva identifies the shape under the pointer by drawing every shape onto an offscreen *hit canvas* in a unique color key, then reading that one pixel back with `getImageData` and looking the exact color up in `Konva.shapes`. This depends on `getImageData` returning the exact bytes that were written. On some canvas implementations (reproduced on Chrome/Chromium/Brave with hardware-accceleration enabled), `getImageData` rounds solid colors by **±1 per channel**. The exact-color lookup then misses and the click falls through. I speculate that small targets, like resize handles,  are more strongly affected by rounding-effect, and non-integer stage scale (zoom) makes the miss rate worse. Konva's own recovery mode (a spiral search to neighbouring pixel positions) doesn't help, because the whole anchor footprint reads the same drifted color.

**Solution.** Wrap `Konva.Layer.prototype._getIntersection` so that, when Konva's exact lookup returns no shape for an opaque pixel, it searches the 26 color keys within ±1 RGB of the read-back value and resolves to that shape. The true shape's key is by definition one of those neighbours (the read-back drifted from it by ≤1). Color keys are spread across 16.7M values, so the odds a ±1 neighbour is a *different* registered shape are negligible (~0.02% worst case). The patch:

- runs the extra search **only on a miss**, so healthy exact hits pay nothing;
- only considers **fully-opaque** pixels, leaving real antialiased edges alone;
- bails out safely (no-op) if Konva's internals aren't shaped as expected (e.g. after a version upgrade), so it can never break hit detection;
- is **idempotent**.  Installing it more than once does nothing.

This is complementary to, but distinct from, the "handles are too small" framing in #4558, #4452, and PR #9700: enlarging a handle's screen-space hit area doesn't help when the entire enlarged footprint reads a uniformly-drifted color and still returns no key.

## Screenshots / recording

The change is behavioral. The canvas looks identical. The recording below shows, on a large image with RectangleLabels regions:

- **Before:** grabbing resize handles is unreliable; the resize cursor often doesn't appear and the click drags/redraws instead. Which handles work changes on each re-select. See video from #9810 
- **After:** every handle grabs on the first click, consistently, across repeated re-selects, and region-selection clicks land reliably.



https://github.com/user-attachments/assets/73155e87-1138-4e3e-bbd2-530450234790




## Rollout strategy

No feature flag or environment variable. The patch is inert on canvases that don't drift (Konva's exact lookup succeeds and the extra path never runs), and it only ever *adds* a hit where Konva would otherwise have returned none. It never removes or changes an existing hit. It ships on by default. If the team would prefer it behind a `flag_set` guard for a staged rollout, it's a one-line wrap to add.


## Testing

**Acceptance criteria (QA):**

- When a user selects a region on a large image and clicks any of its 8 resize handles, then that handle grabs and resizes on the first click _consistently_; including across repeated re-selects, and regardless of browser hardware-acceleration or zoom.
- When a user clicks empty canvas, then no region is selected (no spurious hits are introduced).

**Automated tests.** Added `web/libs/editor/src/utils/__tests__/konva-hit-tolerance.test.ts`, driving the patched lookup against a minimal Konva stand-in (no real canvas/GPU required). It covers:

- exact color-key matches are left untouched;
- a pixel that drifts by ±1 per channel resolves to the correct shape;
- an opaque pixel with no ±1 neighbor registered does **not** invent a hit;
- transparent / partial-alpha pixels (real edges) are ignored;
- the channel search clamps at the 0/255 boundaries;
- the patch is idempotent (no double-wrapping);
- it no-ops safely when Konva's internals are missing.

**Manual verification.** Reproduced the miss on a recent Chromium build on Linux with a large image and confirmed the fix restores reliable handle grabs and region selection. 

## Risks

- **Correctness:** low. The patch only runs on a miss and can only *add* a hit that Konva would otherwise have missed; it never changes an exact hit. The one theoretical downside is a ~0.02%-worst-case single-pixel mishit to an adjacent color key, which is far less disruptive than the current dropped clicks.
- **Performance:** negligible. Healthy hits are untouched; the ≤26-key search runs only when the exact lookup already failed, i.e. on the pixel under a single pointer event.
- **Security:** none.
- **Maintainability:** the patch monkey-patches a Konva internal (`_getIntersection`), so a future Konva upgrade could change its shape. The code guards against that by feature-detecting and no-oping rather than throwing.

## Reviewer notes

- The patch is scoped to the image editor by installing it from `ImageView.jsx`; it wraps the prototype once and is idempotent, so import order and re-mounts are safe.
- The monkey-patch approach was chosen because the drift is in the browser's `getImageData`, below Konva's public API — there is no prop or option to make the color-key lookup tolerant. The wrap is deliberately minimal and defensive.
- Complementary to PR #9700; this addresses the underlying color-key miss rather than handle geometry.

## General notes

- Background on Konva's hit detection: shapes are drawn to an offscreen hit canvas in unique color keys and looked up by reading back the pixel under the pointer. The whole class of "clicks fall through on GPU canvases" bugs stems from `getImageData` not returning the exact bytes written.
- The `konva-hit-tolerance.ts` module docstring documents the mechanism, the ±1 drift, and why the fix is safe, for future maintainers.