### PR TITLE
docs: fix export disable env var in 2.34 notes

### DIFF
--- a/docs/source/guide/release_notes/onprem/2.34.0.md
+++ b/docs/source/guide/release_notes/onprem/2.34.0.md
@@ -248,7 +248,7 @@ You can also configure allowed origins and which browser features that iframes c
 There is a new environment variable you can set to disable the **Export** button in the Data Manager for Administrators and/or Managers:
 
 ```
-DISABLE_EXPORTS_FOR=AD,MA
+DISABLE_EXPORT_FOR=AD,MA
 ```
 #### Google Cloud Platform support for custom agreement metrics
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Reason for change
The 2.34 on-prem release notes documented the export-disabling env var as `DISABLE_EXPORTS_FOR`, but the implementation uses `DISABLE_EXPORT_FOR`.

## What changed
- Updated `docs/source/guide/release_notes/onprem/2.34.0.md` to show `DISABLE_EXPORT_FOR=AD,MA`.

## Testing
- Ran exact-string verification:
  - `rg -n "DISABLE_EXPORT_FOR=AD,MA" docs/source/guide/release_notes/onprem/2.34.0.md`
  - Confirmed `DISABLE_EXPORTS_FOR` no longer appears in that release-note file.
- Verified implementation reference via Automax enterprise code index: `settings.DISABLE_EXPORT_FOR` is used in `label_studio_enterprise/htx/permissions.py`; `DISABLE_EXPORTS_FOR` has no enterprise code matches.

## Risks
Low risk: docs-only correction.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://humansignal.slack.com/archives/C03DQ8U76PP/p1784624123625329?thread_ts=1784624123.625329&cid=C03DQ8U76PP)

<div><a href="https://cursor.com/agents/bc-7108cbbb-acd3-5f60-91e5-f82bbfc4e954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7108cbbb-acd3-5f60-91e5-f82bbfc4e954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

