### PR TITLE
ci: add names to Zendesk sync steps for readability

### DIFF
--- a/.github/workflows/zendesk_issue_commented.yml
+++ b/.github/workflows/zendesk_issue_commented.yml
@@ -13,7 +13,8 @@ jobs:
     steps:
       - uses: hmarr/debug-action@v3.0.0
 
-      - env:
+      - name: Post GitHub issue comment to Zendesk ticket
+        env:
           ZENDESK_HOST: ${{ vars.ZENDESK_HOST }}
           ZENDESK_USER: ${{ vars.ZENDESK_USER }}
           ZENDESK_TOKEN: ${{ secrets.ZENDESK_TOKEN }}

--- a/.github/workflows/zendesk_issue_created.yml
+++ b/.github/workflows/zendesk_issue_created.yml
@@ -12,7 +12,8 @@ jobs:
     steps:
       - uses: hmarr/debug-action@v3.0.0
 
-      - env:
+      - name: Create Zendesk ticket from GitHub issue
+        env:
           ZENDESK_HOST: ${{ vars.ZENDESK_HOST }}
           ZENDESK_USER: ${{ vars.ZENDESK_USER }}
           ZENDESK_TOKEN: ${{ secrets.ZENDESK_TOKEN }}


### PR DESCRIPTION
## Problem

In the Zendesk GitHub-issue sync workflows, the main `run` steps are unnamed and longer than **300 characters**. In the GitHub Actions UI those steps collapse into generic labels, which hurts readability when ticket create/comment sync fails.

## Changes

Semantics are unchanged: same env vars, same curl/jq payloads, and the same Zendesk API calls.

### `.github/workflows/zendesk_issue_commented.yml`
- Add `name: Post GitHub issue comment to Zendesk ticket`

### `.github/workflows/zendesk_issue_created.yml`
- Add `name: Create Zendesk ticket from GitHub issue`

## Test plan
- [ ] Confirm the Zendesk search/create/update scripts are unchanged
