### PR TITLE
fix: FIT-2359: Playground sample image uses outdated path and fails to load

### DIFF
--- a/web/apps/playground/src/utils/__tests__/generateSampleTask.test.ts
+++ b/web/apps/playground/src/utils/__tests__/generateSampleTask.test.ts
@@ -33,7 +33,7 @@ describe("generateSampleTaskFromConfig", () => {
     `;
     const result = await generateSampleTaskFromConfig(config);
     expect(result.data).toHaveProperty("image");
-    expect(result.data.image).toBe("https://app.heartex.ai/static/samples/sample.jpg");
+    expect(result.data.image).toBe("https://labelstud.io/static/samples/sample.jpg");
   });
 
   it("should generate sample data for audio config", async () => {
@@ -153,5 +153,26 @@ describe("generateSampleTaskFromConfig", () => {
     const result = await generateSampleTaskFromConfig(config);
     expect(result.data).toHaveProperty("videoSource");
     expect(result.data.videoSource).toBe("https://app.heartex.ai/static/samples/opossum_snow_alt.mp4");
+  });
+
+  // app.heartex.ai was retired and now serves 502 for every sample asset, which broke
+  // the playground preview on labelstud.io. Sample hosts must also send CORS headers
+  // because the Image tag loads with crossOrigin="anonymous" by default.
+  it("should not reference the retired app.heartex.ai host in any generated sample data", async () => {
+    const configs = [
+      '<View><Image name="image" value="$image"/></View>',
+      '<View><Image name="image" valueList="$images"/></View>',
+      '<View><Video name="video" value="$video"/></View>',
+      '<View><HyperText name="pdf" value="$pdf"/></View>',
+      '<View><HyperText name="video" value="$video"/></View>',
+      '<View><TimeSeries name="ts" value="$csv" valueType="url" timeColumn="time"><Channel column="value"/></TimeSeries></View>',
+    ];
+
+    for (const config of configs) {
+      const result = await generateSampleTaskFromConfig(config);
+      const values = Object.values(result.data).flat().join(" ");
+
+      expect(values).not.toContain("app.heartex.ai");
+    }
   });
 });

--- a/web/apps/playground/src/utils/generateSampleTask.ts
+++ b/web/apps/playground/src/utils/generateSampleTask.ts
@@ -1,18 +1,23 @@
 import { createUtcFormatter } from "./date";
 
-// Wikimedia Commons public domain sample URLs
-const SAMPLE_IMAGE = "https://app.heartex.ai/static/samples/sample.jpg";
-const SAMPLE_IMAGE2 = "https://app.heartex.ai/static/samples/sample.jpg"; //"https://upload.wikimedia.org/wikipedia/commons/3/3a/Cat03.jpg";
+// Serves `Access-Control-Allow-Origin: *`, which the Image tag needs because it loads
+// with crossOrigin="anonymous" by default, and is same-origin with the deployed playground.
+const SAMPLE_ASSETS_BASE = "https://labelstud.io/static/samples";
+const SAMPLE_IMAGE = `${SAMPLE_ASSETS_BASE}/sample.jpg`;
+const SAMPLE_IMAGE2 = `${SAMPLE_ASSETS_BASE}/sample.jpg`; //"https://upload.wikimedia.org/wikipedia/commons/3/3a/Cat03.jpg";
+// Wikimedia Commons public domain sample URL
 const SAMPLE_AUDIO =
   "https://upload.wikimedia.org/wikipedia/commons/9/9d/Bach_-_Cello_Suite_no._1_in_G_major,_BWV_1007_-_I._Pr%C3%A9lude.ogg";
-const SAMPLE_VIDEO = "https://app.heartex.ai/static/samples/opossum_snow.mp4";
+const SAMPLE_VIDEO = `${SAMPLE_ASSETS_BASE}/opossum_snow.mp4`;
 const SAMPLE_VIDEO_EMBED = `<video src='${SAMPLE_VIDEO}' width=100% controls></video>`;
 const SAMPLE_HTML =
   '<div style="max-width: 750px"><div style="clear: both"><div style="float: right; display: inline-block; border: 1px solid #F2F3F4; background-color: #F8F9F9; border-radius: 5px; padding: 7px; margin: 10px 0;"><p><b>Jules</b>: No no, Mr. Wolfe, it\'s not like that. Your help is definitely appreciated.</p></div></div><div style="clear: both"><div style="float: right; display: inline-block; border: 1px solid #F2F3F4; background-color: #F8F9F9; border-radius: 5px; padding: 7px; margin: 10px 0;"><p><b>Vincent</b>: Look, Mr. Wolfe, I respect you. I just don\'t like people barking orders at me, that\'s all.</p></div></div><div style="clear: both"><div style="display: inline-block; border: 1px solid #D5F5E3; background-color: #EAFAF1; border-radius: 5px; padding: 7px; margin: 10px 0;"><p><b>The Wolf</b>: If I\'m curt with you, it\'s because time is a factor. I think fast, I talk fast, and I need you two guys to act fast if you want to get out of this. So pretty please, with sugar on top, clean the car.</p></div></div></div>';
 const SAMPLE_WEBSITE = "<a href='https://labelstud.io'>https://labelstud.io</a>";
-const SAMPLE_PDF_EMBED = "<embed src='https://app.heartex.ai/static/samples/sample.pdf' width='100%' height='600px'/>";
+const SAMPLE_PDF_EMBED = `<embed src='${SAMPLE_ASSETS_BASE}/sample.pdf' width='100%' height='600px'/>`;
 const SAMPLE_WEBSITE_EMBED = "<iframe src='https://labelstud.io' width='100%' height='600px'/>";
-const SAMPLE_CSV = "https://app.heartex.ai/samples/time-series.csv";
+// Not under SAMPLE_ASSETS_BASE: this endpoint generates the series from query params
+// (time/values/sep/tf/type) and is only served by the app host.
+const SAMPLE_CSV = "https://app.humansignal.com/samples/time-series.csv";
 const SAMPLE_OCR_IMAGE = "https://htx-pub.s3.amazonaws.com/demo/ocr/example.jpg";
 
 const randomFloat = (min: number, max: number) => Math.random() * (max - min) + min;


### PR DESCRIPTION
## Summary
- Point playground sample media URLs away from retired `app.heartex.ai` (502) to `labelstud.io/static/samples` (and timeseries CSV to `app.humansignal.com`)
- Add a regression test that generated sample data never references `app.heartex.ai`
- Temporary backport to `develop` so Netlify's `label-studio-playground` auto-deploy can ship the fix while the Netlify Git source is still pointed at this repo (same change already merged in hs-platform: https://github.com/HumanSignal/hs-platform/pull/2115)

## Test plan
- [x] `npx jest --config apps/playground/jest.config.ts --testPathPatterns generateSampleTask` (11/11 pass)
- [x] Netlify deploy preview has `labelstud.io/static/samples` and no `app.heartex.ai`: https://deploy-preview-9867--label-studio-playground.netlify.app
- [ ] Merge to `develop` and confirm Netlify production deploy for `label-studio-playground` succeeds
- [ ] Hard-reload https://labelstud.io/playground/ and verify polygon image preview loads from `labelstud.io/static/samples/sample.jpg`